### PR TITLE
auth: 增加可选的内存快速调度器，优化账号选择热路径

### DIFF
--- a/auth/fast_scheduler.go
+++ b/auth/fast_scheduler.go
@@ -1,0 +1,284 @@
+package auth
+
+import (
+	"sort"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+var fastSchedulerTierOrder = []AccountHealthTier{
+	HealthTierHealthy,
+	HealthTierWarm,
+	HealthTierRisky,
+}
+
+type fastSchedulerEntry struct {
+	acc   *Account
+	dbID  int64
+	score float64
+}
+
+type fastSchedulerPosition struct {
+	tier  AccountHealthTier
+	index int
+}
+
+// FastScheduler 是一个仅使用本地内存的调度器 POC。
+// 它不在请求热路径内重算全量 score，而是直接复用 Account 上已缓存的
+// HealthTier / SchedulerScore / DynamicConcurrencyLimit。
+//
+// 这让我们可以先验证“增量维护 + 热路径轻量化”是否值得正式接管 Store.Next。
+type FastScheduler struct {
+	mu        sync.RWMutex
+	baseLimit int64
+	buckets   map[AccountHealthTier][]fastSchedulerEntry
+	positions map[int64]fastSchedulerPosition
+	cursors   [3]atomic.Uint64
+}
+
+func NewFastScheduler(baseLimit int64) *FastScheduler {
+	if baseLimit <= 0 {
+		baseLimit = 1
+	}
+	return &FastScheduler{
+		baseLimit: baseLimit,
+		buckets: map[AccountHealthTier][]fastSchedulerEntry{
+			HealthTierHealthy: nil,
+			HealthTierWarm:    nil,
+			HealthTierRisky:   nil,
+		},
+		positions: make(map[int64]fastSchedulerPosition),
+	}
+}
+
+// BuildFastScheduler 用当前 Store 快照构建一个独立 scheduler。
+// 该方法不会影响现有生产流量路径，只用于 POC/benchmark/灰度验证。
+func (s *Store) BuildFastScheduler() *FastScheduler {
+	if s == nil {
+		return NewFastScheduler(1)
+	}
+	scheduler := NewFastScheduler(atomic.LoadInt64(&s.maxConcurrency))
+
+	s.mu.RLock()
+	accounts := make([]*Account, len(s.accounts))
+	copy(accounts, s.accounts)
+	s.mu.RUnlock()
+
+	scheduler.Rebuild(accounts)
+	return scheduler
+}
+
+func (s *FastScheduler) Rebuild(accounts []*Account) {
+	if s == nil {
+		return
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.buckets = map[AccountHealthTier][]fastSchedulerEntry{
+		HealthTierHealthy: nil,
+		HealthTierWarm:    nil,
+		HealthTierRisky:   nil,
+	}
+	s.positions = make(map[int64]fastSchedulerPosition, len(accounts))
+
+	now := time.Now()
+	for _, acc := range accounts {
+		s.insertLocked(acc, now)
+	}
+}
+
+func (s *FastScheduler) Update(acc *Account) {
+	if s == nil || acc == nil {
+		return
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.removeLocked(acc.DBID)
+	s.insertLocked(acc, time.Now())
+}
+
+func (s *FastScheduler) Remove(dbID int64) {
+	if s == nil || dbID == 0 {
+		return
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.removeLocked(dbID)
+}
+
+func (s *FastScheduler) SetBaseLimit(baseLimit int64) {
+	if s == nil {
+		return
+	}
+	if baseLimit <= 0 {
+		baseLimit = 1
+	}
+	s.mu.Lock()
+	s.baseLimit = baseLimit
+	s.mu.Unlock()
+}
+
+func (s *FastScheduler) Acquire() *Account {
+	if s == nil {
+		return nil
+	}
+
+	now := time.Now()
+
+	s.mu.RLock()
+	baseLimit := s.baseLimit
+	for tierIdx, tier := range fastSchedulerTierOrder {
+		bucket := s.buckets[tier]
+		if len(bucket) == 0 {
+			continue
+		}
+
+		start := int(s.cursors[tierIdx].Add(1)-1) % len(bucket)
+		for offset := 0; offset < len(bucket); offset++ {
+			entry := bucket[(start+offset)%len(bucket)]
+			if entry.acc == nil {
+				continue
+			}
+
+			_, _, limit, available := entry.acc.fastSchedulerSnapshot(baseLimit, now)
+			if !available || limit <= 0 {
+				continue
+			}
+			if !tryAcquireAccount(entry.acc, limit) {
+				continue
+			}
+			s.mu.RUnlock()
+			return entry.acc
+		}
+	}
+	s.mu.RUnlock()
+	return nil
+}
+
+func (s *FastScheduler) Release(acc *Account) {
+	if acc == nil {
+		return
+	}
+	atomic.AddInt64(&acc.ActiveRequests, -1)
+}
+
+func (s *FastScheduler) BucketSizes() map[AccountHealthTier]int {
+	if s == nil {
+		return nil
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return map[AccountHealthTier]int{
+		HealthTierHealthy: len(s.buckets[HealthTierHealthy]),
+		HealthTierWarm:    len(s.buckets[HealthTierWarm]),
+		HealthTierRisky:   len(s.buckets[HealthTierRisky]),
+	}
+}
+
+func (s *FastScheduler) insertLocked(acc *Account, now time.Time) {
+	if acc == nil || acc.DBID == 0 {
+		return
+	}
+
+	tier, score, limit, available := acc.fastSchedulerSnapshot(s.baseLimit, now)
+	if !available || limit <= 0 {
+		return
+	}
+	if tier != HealthTierHealthy && tier != HealthTierWarm && tier != HealthTierRisky {
+		return
+	}
+
+	entries := append(s.buckets[tier], fastSchedulerEntry{
+		acc:   acc,
+		dbID:  acc.DBID,
+		score: score,
+	})
+	sort.SliceStable(entries, func(i, j int) bool {
+		if entries[i].score == entries[j].score {
+			return entries[i].dbID < entries[j].dbID
+		}
+		return entries[i].score > entries[j].score
+	})
+	s.buckets[tier] = entries
+	s.rebuildPositionsLocked(tier)
+}
+
+func (s *FastScheduler) removeLocked(dbID int64) {
+	pos, ok := s.positions[dbID]
+	if !ok {
+		return
+	}
+
+	entries := s.buckets[pos.tier]
+	if pos.index < 0 || pos.index >= len(entries) {
+		delete(s.positions, dbID)
+		return
+	}
+
+	copy(entries[pos.index:], entries[pos.index+1:])
+	entries = entries[:len(entries)-1]
+	s.buckets[pos.tier] = entries
+	delete(s.positions, dbID)
+	s.rebuildPositionsLocked(pos.tier)
+}
+
+func (s *FastScheduler) rebuildPositionsLocked(tier AccountHealthTier) {
+	for idx, entry := range s.buckets[tier] {
+		s.positions[entry.dbID] = fastSchedulerPosition{
+			tier:  tier,
+			index: idx,
+		}
+	}
+}
+
+func (a *Account) fastSchedulerSnapshot(baseLimit int64, now time.Time) (AccountHealthTier, float64, int64, bool) {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+
+	tier := a.healthTierLocked()
+	score := a.SchedulerScore
+	limit := a.DynamicConcurrencyLimit
+
+	if score == 0 && tier != HealthTierBanned && a.AccessToken != "" && a.Status != StatusError {
+		score = 100
+	}
+	if limit <= 0 {
+		limit = concurrencyLimitForTier(baseLimit, tier)
+	}
+
+	available := a.Status != StatusError && tier != HealthTierBanned && a.AccessToken != ""
+	if a.Status == StatusCooldown && now.Before(a.CooldownUtil) {
+		available = false
+	}
+
+	return tier, score, limit, available
+}
+
+func tryAcquireAccount(acc *Account, limit int64) bool {
+	if acc == nil {
+		return false
+	}
+
+	if limit <= 0 {
+		return false
+	}
+
+	for {
+		current := atomic.LoadInt64(&acc.ActiveRequests)
+		if current >= limit {
+			return false
+		}
+		if atomic.CompareAndSwapInt64(&acc.ActiveRequests, current, current+1) {
+			atomic.AddInt64(&acc.TotalRequests, 1)
+			atomic.StoreInt64(&acc.LastUsedAt, time.Now().UnixNano())
+			return true
+		}
+	}
+}

--- a/auth/fast_scheduler_test.go
+++ b/auth/fast_scheduler_test.go
@@ -1,0 +1,374 @@
+package auth
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func newFastSchedulerTestAccount(id int64, tier AccountHealthTier, score float64, limit int64) *Account {
+	return &Account{
+		DBID:                    id,
+		AccessToken:             "token",
+		Status:                  StatusReady,
+		HealthTier:              tier,
+		SchedulerScore:          score,
+		DynamicConcurrencyLimit: limit,
+	}
+}
+
+func TestFastSchedulerAcquirePrefersHealthyTier(t *testing.T) {
+	warm := newFastSchedulerTestAccount(1, HealthTierWarm, 90, 2)
+	healthy := newFastSchedulerTestAccount(2, HealthTierHealthy, 80, 2)
+
+	scheduler := NewFastScheduler(2)
+	scheduler.Rebuild([]*Account{warm, healthy})
+
+	got := scheduler.Acquire()
+	if got == nil {
+		t.Fatal("Acquire() returned nil")
+	}
+	defer scheduler.Release(got)
+
+	if got.DBID != healthy.DBID {
+		t.Fatalf("Acquire() picked dbID=%d, want %d", got.DBID, healthy.DBID)
+	}
+}
+
+func TestFastSchedulerRespectsConcurrencyLimit(t *testing.T) {
+	acc := newFastSchedulerTestAccount(1, HealthTierHealthy, 100, 1)
+
+	scheduler := NewFastScheduler(1)
+	scheduler.Rebuild([]*Account{acc})
+
+	first := scheduler.Acquire()
+	if first == nil {
+		t.Fatal("first Acquire() returned nil")
+	}
+
+	second := scheduler.Acquire()
+	if second != nil {
+		t.Fatal("second Acquire() should be nil when concurrency limit is reached")
+	}
+
+	scheduler.Release(first)
+	third := scheduler.Acquire()
+	if third == nil {
+		t.Fatal("third Acquire() returned nil after Release()")
+	}
+	scheduler.Release(third)
+}
+
+func TestFastSchedulerRoundRobinWithinTier(t *testing.T) {
+	a1 := newFastSchedulerTestAccount(1, HealthTierHealthy, 100, 4)
+	a2 := newFastSchedulerTestAccount(2, HealthTierHealthy, 100, 4)
+	a3 := newFastSchedulerTestAccount(3, HealthTierHealthy, 100, 4)
+
+	scheduler := NewFastScheduler(4)
+	scheduler.Rebuild([]*Account{a1, a2, a3})
+
+	var got []int64
+	for i := 0; i < 3; i++ {
+		acc := scheduler.Acquire()
+		if acc == nil {
+			t.Fatalf("Acquire() returned nil at iteration %d", i)
+		}
+		got = append(got, acc.DBID)
+		scheduler.Release(acc)
+	}
+
+	want := []int64{1, 2, 3}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("round robin mismatch: got=%v want=%v", got, want)
+		}
+	}
+}
+
+func TestFastSchedulerUpdateMovesAccountBetweenBuckets(t *testing.T) {
+	acc := newFastSchedulerTestAccount(1, HealthTierHealthy, 100, 2)
+	scheduler := NewFastScheduler(2)
+	scheduler.Rebuild([]*Account{acc})
+
+	sizes := scheduler.BucketSizes()
+	if sizes[HealthTierHealthy] != 1 {
+		t.Fatalf("healthy bucket size = %d, want 1", sizes[HealthTierHealthy])
+	}
+
+	acc.SetCooldownUntil(time.Now().Add(10*time.Minute), "rate_limited")
+	scheduler.Update(acc)
+
+	sizes = scheduler.BucketSizes()
+	if sizes[HealthTierHealthy] != 0 || sizes[HealthTierWarm] != 0 || sizes[HealthTierRisky] != 0 {
+		t.Fatalf("expected cooldown account to be removed from all buckets, got %#v", sizes)
+	}
+
+	acc.mu.Lock()
+	acc.Status = StatusReady
+	acc.CooldownUtil = time.Time{}
+	acc.CooldownReason = ""
+	acc.HealthTier = HealthTierWarm
+	acc.DynamicConcurrencyLimit = 1
+	acc.mu.Unlock()
+	scheduler.Update(acc)
+
+	sizes = scheduler.BucketSizes()
+	if sizes[HealthTierWarm] != 1 {
+		t.Fatalf("warm bucket size = %d, want 1", sizes[HealthTierWarm])
+	}
+}
+
+func TestFastSchedulerSkipsStaleBucketEntryWithoutUpdate(t *testing.T) {
+	acc := newFastSchedulerTestAccount(1, HealthTierHealthy, 100, 1)
+	scheduler := NewFastScheduler(1)
+	scheduler.Rebuild([]*Account{acc})
+
+	acc.SetCooldownUntil(time.Now().Add(5*time.Minute), "rate_limited")
+
+	got := scheduler.Acquire()
+	if got != nil {
+		t.Fatalf("Acquire() = %+v, want nil for stale cooldown account", got)
+	}
+}
+
+func TestBuildFastSchedulerFromStore(t *testing.T) {
+	store := &Store{
+		accounts: []*Account{
+			newFastSchedulerTestAccount(1, HealthTierHealthy, 100, 4),
+			newFastSchedulerTestAccount(2, HealthTierWarm, 80, 2),
+		},
+		maxConcurrency: 4,
+	}
+
+	scheduler := store.BuildFastScheduler()
+	sizes := scheduler.BucketSizes()
+	if sizes[HealthTierHealthy] != 1 || sizes[HealthTierWarm] != 1 {
+		t.Fatalf("unexpected bucket sizes: %#v", sizes)
+	}
+}
+
+func TestStoreFastSchedulerToggle(t *testing.T) {
+	cooling := newFastSchedulerTestAccount(1, HealthTierWarm, 80, 1)
+	cooling.Status = StatusCooldown
+	cooling.CooldownUtil = time.Now().Add(5 * time.Minute)
+	cooling.CooldownReason = "rate_limited"
+
+	store := &Store{
+		accounts: []*Account{
+			cooling,
+			newFastSchedulerTestAccount(2, HealthTierHealthy, 100, 1),
+		},
+		maxConcurrency: 2,
+	}
+
+	if store.FastSchedulerEnabled() {
+		t.Fatal("FastSchedulerEnabled() should be false by default")
+	}
+
+	store.SetFastSchedulerEnabled(true)
+	if !store.FastSchedulerEnabled() {
+		t.Fatal("FastSchedulerEnabled() should be true after SetFastSchedulerEnabled(true)")
+	}
+	if store.fastScheduler.Load() == nil {
+		t.Fatal("expected fast scheduler instance to be created")
+	}
+
+	acc := store.Next()
+	if acc == nil {
+		t.Fatal("Next() returned nil with fast scheduler enabled")
+	}
+	if acc.DBID != 2 {
+		t.Fatalf("Next() picked dbID=%d, want 2", acc.DBID)
+	}
+	store.Release(acc)
+
+	store.SetFastSchedulerEnabled(false)
+	if store.FastSchedulerEnabled() {
+		t.Fatal("FastSchedulerEnabled() should be false after disabling")
+	}
+	if store.fastScheduler.Load() != nil {
+		t.Fatal("expected fast scheduler instance to be cleared after disabling")
+	}
+}
+
+func TestStoreFastSchedulerTracksCooldownTransition(t *testing.T) {
+	acc := newFastSchedulerTestAccount(1, HealthTierHealthy, 100, 2)
+	store := &Store{
+		accounts:       []*Account{acc},
+		maxConcurrency: 2,
+	}
+	store.SetFastSchedulerEnabled(true)
+
+	got := store.Next()
+	if got == nil {
+		t.Fatal("Next() returned nil before cooldown")
+	}
+	store.Release(got)
+
+	store.MarkCooldown(acc, 5*time.Minute, "rate_limited")
+	if got = store.Next(); got != nil {
+		t.Fatalf("Next() = %+v, want nil after cooldown", got)
+	}
+
+	store.ClearCooldown(acc)
+	if got = store.Next(); got == nil {
+		t.Fatal("Next() returned nil after ClearCooldown()")
+	}
+	store.Release(got)
+}
+
+func TestFastSchedulerEnabledFromEnv(t *testing.T) {
+	t.Setenv("FAST_SCHEDULER_ENABLED", "")
+	t.Setenv("CODEX_FAST_SCHEDULER", "")
+	if fastSchedulerEnabledFromEnv() {
+		t.Fatal("fastSchedulerEnabledFromEnv() should be false when env is empty")
+	}
+
+	t.Setenv("FAST_SCHEDULER_ENABLED", "true")
+	if !fastSchedulerEnabledFromEnv() {
+		t.Fatal("fastSchedulerEnabledFromEnv() should be true for FAST_SCHEDULER_ENABLED=true")
+	}
+
+	t.Setenv("FAST_SCHEDULER_ENABLED", "")
+	t.Setenv("CODEX_FAST_SCHEDULER", "1")
+	if !fastSchedulerEnabledFromEnv() {
+		t.Fatal("fastSchedulerEnabledFromEnv() should be true for CODEX_FAST_SCHEDULER=1")
+	}
+}
+
+func BenchmarkStoreNext1000(b *testing.B) {
+	benchmarkStoreNext(b, 1000)
+}
+
+func BenchmarkStoreNext2813(b *testing.B) {
+	benchmarkStoreNext(b, 2813)
+}
+
+func BenchmarkFastSchedulerAcquire1000(b *testing.B) {
+	benchmarkFastSchedulerAcquire(b, 1000)
+}
+
+func BenchmarkFastSchedulerAcquire2813(b *testing.B) {
+	benchmarkFastSchedulerAcquire(b, 2813)
+}
+
+func BenchmarkStoreNextParallel1000(b *testing.B) {
+	benchmarkStoreNextParallel(b, 1000)
+}
+
+func BenchmarkFastSchedulerAcquireParallel1000(b *testing.B) {
+	benchmarkFastSchedulerAcquireParallel(b, 1000)
+}
+
+func benchmarkStoreNext(b *testing.B, total int) {
+	store := newBenchmarkStore(total, 64)
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		acc := store.Next()
+		if acc == nil {
+			b.Fatal("Next() returned nil")
+		}
+		store.Release(acc)
+	}
+}
+
+func benchmarkFastSchedulerAcquire(b *testing.B, total int) {
+	store := newBenchmarkStore(total, 64)
+	scheduler := store.BuildFastScheduler()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		acc := scheduler.Acquire()
+		if acc == nil {
+			b.Fatal("Acquire() returned nil")
+		}
+		scheduler.Release(acc)
+	}
+}
+
+func benchmarkStoreNextParallel(b *testing.B, total int) {
+	store := newBenchmarkStore(total, 64)
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			acc := store.Next()
+			if acc == nil {
+				b.Fatal("Next() returned nil")
+			}
+			store.Release(acc)
+		}
+	})
+}
+
+func benchmarkFastSchedulerAcquireParallel(b *testing.B, total int) {
+	store := newBenchmarkStore(total, 64)
+	scheduler := store.BuildFastScheduler()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			acc := scheduler.Acquire()
+			if acc == nil {
+				b.Fatal("Acquire() returned nil")
+			}
+			scheduler.Release(acc)
+		}
+	})
+}
+
+func newBenchmarkStore(total int, maxConcurrency int64) *Store {
+	accounts := make([]*Account, 0, total)
+	for i := 0; i < total; i++ {
+		tier := HealthTierHealthy
+		score := 100.0 - float64(i%11)
+		limit := maxConcurrency
+
+		switch {
+		case i%17 == 0:
+			tier = HealthTierWarm
+			score = 84
+			limit = maxConcurrency / 2
+			if limit < 1 {
+				limit = 1
+			}
+		case i%29 == 0:
+			tier = HealthTierRisky
+			score = 58
+			limit = 1
+		}
+
+		accounts = append(accounts, &Account{
+			DBID:                    int64(i + 1),
+			AccessToken:             "token",
+			Status:                  StatusReady,
+			HealthTier:              tier,
+			SchedulerScore:          score,
+			DynamicConcurrencyLimit: limit,
+		})
+	}
+
+	return &Store{
+		accounts:       accounts,
+		maxConcurrency: maxConcurrency,
+	}
+}
+
+func TestFastSchedulerRelease(t *testing.T) {
+	acc := newFastSchedulerTestAccount(1, HealthTierHealthy, 100, 2)
+	atomic.StoreInt64(&acc.ActiveRequests, 1)
+
+	scheduler := NewFastScheduler(2)
+	scheduler.Release(acc)
+
+	if got := atomic.LoadInt64(&acc.ActiveRequests); got != 0 {
+		t.Fatalf("ActiveRequests after Release() = %d, want 0", got)
+	}
+}

--- a/auth/store.go
+++ b/auth/store.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"math"
 	"math/rand"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -644,6 +645,28 @@ type Store struct {
 	proxyPool        []string // 已启用的代理 URL 列表
 	proxyPoolEnabled bool     // 代理池是否开启
 	proxyRoundRobin  uint64   // 轮询计数器
+
+	// Fast scheduler POC（默认关闭，通过环境变量启用）
+	fastScheduler        atomic.Pointer[FastScheduler]
+	fastSchedulerEnabled atomic.Bool
+}
+
+func fastSchedulerEnabledFromEnv() bool {
+	for _, key := range []string{"FAST_SCHEDULER_ENABLED", "CODEX_FAST_SCHEDULER"} {
+		if truthyEnv(os.Getenv(key)) {
+			return true
+		}
+	}
+	return false
+}
+
+func truthyEnv(v string) bool {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "1", "true", "yes", "on", "enable", "enabled":
+		return true
+	default:
+		return false
+	}
 }
 
 // NewStore 创建账号管理器
@@ -669,6 +692,11 @@ func NewStore(db *database.DB, tc *cache.TokenCache, settings *database.SystemSe
 	s.autoCleanUnauthorized.Store(settings.AutoCleanUnauthorized)
 	s.autoCleanRateLimited.Store(settings.AutoCleanRateLimited)
 	s.autoCleanFullUsage.Store(settings.AutoCleanFullUsage)
+	s.fastSchedulerEnabled.Store(fastSchedulerEnabledFromEnv())
+	if s.fastSchedulerEnabled.Load() {
+		s.fastScheduler.Store(NewFastScheduler(int64(settings.MaxConcurrency)))
+		log.Printf("Fast scheduler POC 已启用（请求热路径将优先走本地内存调度器）")
+	}
 
 	// 加载代理池
 	if settings.ProxyPoolEnabled {
@@ -685,6 +713,79 @@ func NewStore(db *database.DB, tc *cache.TokenCache, settings *database.SystemSe
 	}
 
 	return s
+}
+
+func (s *Store) getFastScheduler() *FastScheduler {
+	if s == nil || !s.fastSchedulerEnabled.Load() {
+		return nil
+	}
+	return s.fastScheduler.Load()
+}
+
+func (s *Store) rebuildFastScheduler() {
+	if s == nil || !s.fastSchedulerEnabled.Load() {
+		return
+	}
+	s.fastScheduler.Store(s.BuildFastScheduler())
+}
+
+func (s *Store) recomputeAllAccountSchedulerState() {
+	if s == nil {
+		return
+	}
+	baseLimit := atomic.LoadInt64(&s.maxConcurrency)
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, acc := range s.accounts {
+		if acc == nil {
+			continue
+		}
+		acc.mu.Lock()
+		acc.recomputeSchedulerLocked(baseLimit)
+		acc.mu.Unlock()
+	}
+}
+
+func (s *Store) fastSchedulerUpdate(acc *Account) {
+	if s == nil || acc == nil {
+		return
+	}
+	scheduler := s.getFastScheduler()
+	if scheduler == nil {
+		return
+	}
+	scheduler.Update(acc)
+}
+
+func (s *Store) fastSchedulerRemove(dbID int64) {
+	if s == nil || dbID == 0 {
+		return
+	}
+	scheduler := s.getFastScheduler()
+	if scheduler == nil {
+		return
+	}
+	scheduler.Remove(dbID)
+}
+
+func (s *Store) SetFastSchedulerEnabled(enabled bool) {
+	if s == nil {
+		return
+	}
+	s.fastSchedulerEnabled.Store(enabled)
+	if enabled {
+		s.recomputeAllAccountSchedulerState()
+		s.rebuildFastScheduler()
+		return
+	}
+	s.fastScheduler.Store(nil)
+}
+
+func (s *Store) FastSchedulerEnabled() bool {
+	if s == nil {
+		return false
+	}
+	return s.fastSchedulerEnabled.Load()
 }
 
 // GetProxyURL 获取全局代理地址
@@ -792,6 +893,7 @@ func (s *Store) Init(ctx context.Context) error {
 
 	// 2. 并行刷新所有账号的 AT
 	s.parallelRefreshAll(ctx)
+	s.rebuildFastScheduler()
 
 	successCount := 0
 	for _, acc := range s.accounts {
@@ -950,6 +1052,10 @@ func (s *Store) CleanByRuntimeStatus(ctx context.Context, targetStatus string) i
 
 // Next 获取下一个可用账号（健康优先 + 低负载择优 + warm 公平调度）
 func (s *Store) Next() *Account {
+	if scheduler := s.getFastScheduler(); scheduler != nil {
+		return scheduler.Acquire()
+	}
+
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
@@ -1041,12 +1147,18 @@ func (s *Store) Release(acc *Account) {
 	if acc == nil {
 		return
 	}
+	if scheduler := s.getFastScheduler(); scheduler != nil {
+		scheduler.Release(acc)
+		return
+	}
 	atomic.AddInt64(&acc.ActiveRequests, -1)
 }
 
 // SetMaxConcurrency 动态更新每账号并发上限
 func (s *Store) SetMaxConcurrency(n int) {
 	atomic.StoreInt64(&s.maxConcurrency, int64(n))
+	s.recomputeAllAccountSchedulerState()
+	s.rebuildFastScheduler()
 }
 
 // GetMaxConcurrency 获取当前每账号并发上限
@@ -1079,9 +1191,16 @@ func (s *Store) GetTestConcurrency() int {
 
 // AddAccount 热加载新账号到内存池（前端添加后即刻生效）
 func (s *Store) AddAccount(acc *Account) {
+	if acc == nil {
+		return
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	acc.mu.Lock()
+	acc.recomputeSchedulerLocked(atomic.LoadInt64(&s.maxConcurrency))
+	acc.mu.Unlock()
 	s.accounts = append(s.accounts, acc)
+	s.fastSchedulerUpdate(acc)
 }
 
 // RemoveAccount 从内存池移除账号
@@ -1092,6 +1211,7 @@ func (s *Store) RemoveAccount(dbID int64) {
 	for i, acc := range s.accounts {
 		if acc.DBID == dbID {
 			s.accounts = append(s.accounts[:i], s.accounts[i+1:]...)
+			s.fastSchedulerRemove(dbID)
 			return
 		}
 	}
@@ -1145,6 +1265,7 @@ func (s *Store) MarkCooldown(acc *Account, duration time.Duration, reason string
 
 	until := now.Add(duration)
 	acc.SetCooldownUntil(until, reason)
+	s.fastSchedulerUpdate(acc)
 
 	if s.db == nil {
 		return
@@ -1175,6 +1296,7 @@ func (s *Store) ClearCooldown(acc *Account) {
 	}
 	acc.recomputeSchedulerLocked(atomic.LoadInt64(&s.maxConcurrency))
 	acc.mu.Unlock()
+	s.fastSchedulerUpdate(acc)
 
 	if s.db == nil {
 		return
@@ -1194,8 +1316,6 @@ func (s *Store) ReportRequestSuccess(acc *Account, latency time.Duration) {
 	}
 
 	acc.mu.Lock()
-	defer acc.mu.Unlock()
-
 	acc.recordLatencyLocked(latency)
 	acc.recordResultLocked(true)
 	acc.LastSuccessAt = time.Now()
@@ -1205,6 +1325,8 @@ func (s *Store) ReportRequestSuccess(acc *Account, latency time.Duration) {
 		acc.HealthTier = HealthTierHealthy
 	}
 	acc.recomputeSchedulerLocked(atomic.LoadInt64(&s.maxConcurrency))
+	acc.mu.Unlock()
+	s.fastSchedulerUpdate(acc)
 }
 
 // ReportRequestFailure 记录一次失败请求，用于动态调度评分
@@ -1215,8 +1337,6 @@ func (s *Store) ReportRequestFailure(acc *Account, kind string, latency time.Dur
 
 	now := time.Now()
 	acc.mu.Lock()
-	defer acc.mu.Unlock()
-
 	acc.recordLatencyLocked(latency)
 	acc.recordResultLocked(false)
 	acc.LastFailureAt = now
@@ -1254,6 +1374,8 @@ func (s *Store) ReportRequestFailure(acc *Account, kind string, latency time.Dur
 	}
 
 	acc.recomputeSchedulerLocked(atomic.LoadInt64(&s.maxConcurrency))
+	acc.mu.Unlock()
+	s.fastSchedulerUpdate(acc)
 }
 
 // PersistUsageSnapshot 持久化账号 7d 用量快照
@@ -1614,6 +1736,7 @@ func (s *Store) refreshAccount(ctx context.Context, acc *Account) error {
 		}
 		acc.recomputeSchedulerLocked(atomic.LoadInt64(&s.maxConcurrency))
 		acc.mu.Unlock()
+		s.fastSchedulerUpdate(acc)
 		if expiredCooldown {
 			_ = s.db.ClearCooldown(ctx, dbID)
 		}
@@ -1643,6 +1766,7 @@ func (s *Store) refreshAccount(ctx context.Context, acc *Account) error {
 			}
 			acc.recomputeSchedulerLocked(atomic.LoadInt64(&s.maxConcurrency))
 			acc.mu.Unlock()
+			s.fastSchedulerUpdate(acc)
 			if expiredCooldown {
 				_ = s.db.ClearCooldown(ctx, dbID)
 			}
@@ -1660,6 +1784,7 @@ func (s *Store) refreshAccount(ctx context.Context, acc *Account) error {
 			acc.Status = StatusError
 			acc.ErrorMsg = err.Error()
 			acc.mu.Unlock()
+			s.fastSchedulerUpdate(acc)
 
 			_ = s.db.SetError(ctx, dbID, err.Error())
 		}
@@ -1688,6 +1813,7 @@ func (s *Store) refreshAccount(ctx context.Context, acc *Account) error {
 	}
 	acc.recomputeSchedulerLocked(atomic.LoadInt64(&s.maxConcurrency))
 	acc.mu.Unlock()
+	s.fastSchedulerUpdate(acc)
 
 	// 5. 写入 Redis 缓存
 	ttl := time.Until(td.ExpiresAt) - 5*time.Minute


### PR DESCRIPTION
# 并发改进

**auth: 增加可选的内存快速调度器，优化账号选择热路径**

参考：
- https://github.com/arron196/cliproxyapi

> 该分支为纯 vibe，请作者自行辨别和取舍。

## 概述

这个 PR 给账号选择路径增加了一个可选的内存快速调度器。

现有 `Store.Next()` 在账号池较大时，热路径选择成本会明显上升。  
这个 PR 引入 `FastScheduler`，复用账号上已经缓存好的状态：

- `HealthTier`
- `SchedulerScore`
- `DynamicConcurrencyLimit`

开启时：

- `Store.Next()` 走 `FastScheduler.Acquire()`
- `Store.Release()` 走 `FastScheduler.Release()`

关闭时：

- 保持原有路径，不改变现有行为

---

## 目的

主要想解决大号池、高并发场景下，账号选择本身成为瓶颈的问题。

实现思路是：

- 把调度状态保存在本地内存里
- 热路径尽量只做轻量检查
- 在账号状态变化时增量更新调度器

这样可以减少每次请求在选择账号时的扫描和计算开销。

---

## 包含内容

- 新增 `auth/fast_scheduler.go`
- 在 `auth/store.go` 中接入可选 fast scheduler
- 增加对应测试和 benchmark

---

## Benchmark

本地测试结果：

- `BenchmarkStoreNext1000`: ~`265765 ns/op`
- `BenchmarkFastSchedulerAcquire1000`: ~`256.5 ns/op`
- `BenchmarkStoreNext2813`: ~`872390 ns/op`
- `BenchmarkFastSchedulerAcquire2813`: ~`279.3 ns/op`

在大账号池下，热路径开销下降比较明显。
