### PR TITLE
fix: wire manual account refresh

### DIFF
--- a/admin/handler.go
+++ b/admin/handler.go
@@ -29,6 +29,7 @@ type Handler struct {
 	cache          cache.TokenCache
 	db             *database.DB
 	rateLimiter    *proxy.RateLimiter
+	refreshAccount func(context.Context, int64) error
 	cpuSampler     *cpuSampler
 	startedAt      time.Time
 	pgMaxConns     int
@@ -51,7 +52,7 @@ type chartCacheEntry struct {
 
 // NewHandler 创建管理后台处理器
 func NewHandler(store *auth.Store, db *database.DB, tc cache.TokenCache, rl *proxy.RateLimiter, adminSecretEnv string) *Handler {
-	return &Handler{
+	handler := &Handler{
 		store:          store,
 		cache:          tc,
 		db:             db,
@@ -65,6 +66,8 @@ func NewHandler(store *auth.Store, db *database.DB, tc cache.TokenCache, rl *pro
 		adminSecretEnv: adminSecretEnv,
 		chartCacheData: make(map[string]*chartCacheEntry),
 	}
+	handler.refreshAccount = handler.refreshSingleAccount
+	return handler
 }
 
 // SetPoolSizes 设置连接池大小跟踪值（由 main.go 在启动时调用）
@@ -706,10 +709,30 @@ func (h *Handler) RefreshAccount(c *gin.Context) {
 		return
 	}
 
-	// 查找运行时账号并触发刷新
-	_ = id // TODO: 实现通过 ID 查找运行时 Account 并触发刷新
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 30*time.Second)
+	defer cancel()
 
-	writeMessage(c, http.StatusOK, "刷新请求已发送")
+	refreshFn := h.refreshAccount
+	if refreshFn == nil {
+		refreshFn = h.refreshSingleAccount
+	}
+	if err := refreshFn(ctx, id); err != nil {
+		if strings.Contains(err.Error(), "不存在") {
+			writeError(c, http.StatusNotFound, err.Error())
+			return
+		}
+		writeError(c, http.StatusInternalServerError, "刷新失败: "+err.Error())
+		return
+	}
+
+	writeMessage(c, http.StatusOK, "账号刷新成功")
+}
+
+func (h *Handler) refreshSingleAccount(ctx context.Context, id int64) error {
+	if h == nil || h.store == nil {
+		return fmt.Errorf("账号池未初始化")
+	}
+	return h.store.RefreshSingle(ctx, id)
 }
 
 // ==================== Health ====================

--- a/admin/handler_test.go
+++ b/admin/handler_test.go
@@ -1,0 +1,139 @@
+package admin
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestRefreshAccountRejectsInvalidID(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	handler := &Handler{
+		refreshAccount: func(context.Context, int64) error {
+			t.Fatal("refresh should not be called for invalid id")
+			return nil
+		},
+	}
+
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Params = gin.Params{{Key: "id", Value: "bad-id"}}
+	ctx.Request = httptest.NewRequest(http.MethodPost, "/api/admin/accounts/bad-id/refresh", nil)
+
+	handler.RefreshAccount(ctx)
+
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusBadRequest)
+	}
+
+	var payload map[string]string
+	if err := json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got := payload["error"]; got != "无效的账号 ID" {
+		t.Fatalf("error = %q, want %q", got, "无效的账号 ID")
+	}
+}
+
+func TestRefreshAccountRunsSingleRefresh(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	var called bool
+	var gotID int64
+	handler := &Handler{
+		refreshAccount: func(_ context.Context, id int64) error {
+			called = true
+			gotID = id
+			return nil
+		},
+	}
+
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Params = gin.Params{{Key: "id", Value: "42"}}
+	ctx.Request = httptest.NewRequest(http.MethodPost, "/api/admin/accounts/42/refresh", nil)
+
+	handler.RefreshAccount(ctx)
+
+	if !called {
+		t.Fatal("expected refresh to be called")
+	}
+	if gotID != 42 {
+		t.Fatalf("refresh id = %d, want %d", gotID, 42)
+	}
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusOK)
+	}
+
+	var payload map[string]string
+	if err := json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got := payload["message"]; got != "账号刷新成功" {
+		t.Fatalf("message = %q, want %q", got, "账号刷新成功")
+	}
+}
+
+func TestRefreshAccountReturnsNotFoundForMissingAccount(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	handler := &Handler{
+		refreshAccount: func(context.Context, int64) error {
+			return errors.New("账号 7 不存在")
+		},
+	}
+
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Params = gin.Params{{Key: "id", Value: "7"}}
+	ctx.Request = httptest.NewRequest(http.MethodPost, "/api/admin/accounts/7/refresh", nil)
+
+	handler.RefreshAccount(ctx)
+
+	if recorder.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusNotFound)
+	}
+
+	var payload map[string]string
+	if err := json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got := payload["error"]; got != "账号 7 不存在" {
+		t.Fatalf("error = %q, want %q", got, "账号 7 不存在")
+	}
+}
+
+func TestRefreshAccountReturnsRefreshFailure(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	handler := &Handler{
+		refreshAccount: func(context.Context, int64) error {
+			return errors.New("upstream unavailable")
+		},
+	}
+
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Params = gin.Params{{Key: "id", Value: "9"}}
+	ctx.Request = httptest.NewRequest(http.MethodPost, "/api/admin/accounts/9/refresh", nil)
+
+	handler.RefreshAccount(ctx)
+
+	if recorder.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusInternalServerError)
+	}
+
+	var payload map[string]string
+	if err := json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got := payload["error"]; got != "刷新失败: upstream unavailable" {
+		t.Fatalf("error = %q, want %q", got, "刷新失败: upstream unavailable")
+	}
+}

--- a/frontend/src/pages/Accounts.tsx
+++ b/frontend/src/pages/Accounts.tsx
@@ -320,8 +320,8 @@ export default function Accounts() {
   const handleRefresh = async (account: AccountRow) => {
     setRefreshingIds((prev) => new Set(prev).add(account.id))
     try {
-      await api.refreshAccount(account.id)
-      showToast(t('accounts.refreshRequested'))
+      const result = await api.refreshAccount(account.id)
+      showToast(result.message || t('accounts.refreshRequested'))
       void reloadSilently()
     } catch (error) {
       showToast(t('accounts.refreshFailed', { error: getErrorMessage(error) }), 'error')


### PR DESCRIPTION
## Summary
- make the admin account refresh endpoint execute the real single-account refresh path instead of returning a placeholder success message
- return real 404 / refresh failure responses so the UI can reflect what actually happened
- update the accounts page toast to show the backend message after a manual refresh succeeds
- add focused handler tests covering invalid ids, missing accounts, refresh failures, and the success path

## Verification
- `git diff --check origin/main..HEAD`
- frontend sanity check confirming the accounts page now uses the backend refresh message
- full Go test run not executed in this environment because the `go` toolchain is not installed here