### PR TITLE
fix: support socks5 proxies in runtime HTTP clients

### DIFF
--- a/admin/handler.go
+++ b/admin/handler.go
@@ -8,8 +8,8 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"net/http"
-	neturl "net/url"
 	"strconv"
 	"strings"
 	"sync"
@@ -1657,12 +1657,12 @@ func (h *Handler) TestProxy(c *gin.Context) {
 
 	// 创建使用指定代理的 HTTP client
 	transport := &http.Transport{}
-	proxyURL, err := parseProxyURL(req.URL)
-	if err != nil {
+	baseDialer := &net.Dialer{Timeout: 10 * time.Second, KeepAlive: 30 * time.Second}
+	transport.DialContext = baseDialer.DialContext
+	if err := auth.ConfigureTransportProxy(transport, req.URL, baseDialer); err != nil {
 		c.JSON(http.StatusOK, gin.H{"success": false, "error": fmt.Sprintf("代理 URL 格式错误: %v", err)})
 		return
 	}
-	transport.Proxy = http.ProxyURL(proxyURL)
 	client := &http.Client{Transport: transport, Timeout: 15 * time.Second}
 
 	apiLang := req.Lang
@@ -1713,7 +1713,3 @@ func (h *Handler) TestProxy(c *gin.Context) {
 	})
 }
 
-// parseProxyURL 解析代理 URL
-func parseProxyURL(rawURL string) (*neturl.URL, error) {
-	return neturl.Parse(rawURL)
-}

--- a/auth/proxy_transport.go
+++ b/auth/proxy_transport.go
@@ -1,0 +1,77 @@
+package auth
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	xproxy "golang.org/x/net/proxy"
+)
+
+type contextDialer interface {
+	DialContext(ctx context.Context, network, address string) (net.Conn, error)
+}
+
+// ConfigureTransportProxy applies HTTP(S) or SOCKS5 proxy settings to a transport.
+func ConfigureTransportProxy(transport *http.Transport, rawProxyURL string, baseDialer *net.Dialer) error {
+	if transport == nil || strings.TrimSpace(rawProxyURL) == "" {
+		return nil
+	}
+	if baseDialer == nil {
+		baseDialer = &net.Dialer{Timeout: 10 * time.Second, KeepAlive: 30 * time.Second}
+	}
+
+	u, err := url.Parse(rawProxyURL)
+	if err != nil {
+		return fmt.Errorf("parse proxy url: %w", err)
+	}
+
+	switch strings.ToLower(strings.TrimSpace(u.Scheme)) {
+	case "http", "https":
+		transport.Proxy = http.ProxyURL(u)
+		transport.DialContext = baseDialer.DialContext
+		return nil
+	case "socks5", "socks5h":
+		var auth *xproxy.Auth
+		if u.User != nil {
+			password, _ := u.User.Password()
+			auth = &xproxy.Auth{User: u.User.Username(), Password: password}
+		}
+
+		dialer, err := xproxy.SOCKS5("tcp", u.Host, auth, baseDialer)
+		if err != nil {
+			return fmt.Errorf("build socks5 dialer: %w", err)
+		}
+		if cd, ok := dialer.(contextDialer); ok {
+			transport.DialContext = cd.DialContext
+			transport.Proxy = nil
+			return nil
+		}
+
+		transport.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+			type result struct {
+				conn net.Conn
+				err  error
+			}
+			done := make(chan result, 1)
+			go func() {
+				conn, err := dialer.Dial(network, address)
+				done <- result{conn: conn, err: err}
+			}()
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case out := <-done:
+				return out.conn, out.err
+			}
+		}
+		transport.Proxy = nil
+		return nil
+	default:
+		return fmt.Errorf("unsupported proxy scheme: %s", u.Scheme)
+	}
+}

--- a/auth/proxy_transport_test.go
+++ b/auth/proxy_transport_test.go
@@ -1,0 +1,38 @@
+package auth
+
+import (
+	"net"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestConfigureTransportProxyHTTPProxy(t *testing.T) {
+	transport := &http.Transport{}
+	baseDialer := &net.Dialer{Timeout: 10 * time.Second, KeepAlive: 30 * time.Second}
+
+	if err := ConfigureTransportProxy(transport, "http://127.0.0.1:8080", baseDialer); err != nil {
+		t.Fatalf("ConfigureTransportProxy() error = %v", err)
+	}
+	if transport.Proxy == nil {
+		t.Fatal("expected HTTP proxy handler to be configured")
+	}
+	if transport.DialContext == nil {
+		t.Fatal("expected HTTP proxy to preserve the base dialer")
+	}
+}
+
+func TestConfigureTransportProxySOCKS5Proxy(t *testing.T) {
+	transport := &http.Transport{}
+	baseDialer := &net.Dialer{Timeout: 10 * time.Second, KeepAlive: 30 * time.Second}
+
+	if err := ConfigureTransportProxy(transport, "socks5://127.0.0.1:1080", baseDialer); err != nil {
+		t.Fatalf("ConfigureTransportProxy() error = %v", err)
+	}
+	if transport.Proxy != nil {
+		t.Fatal("expected SOCKS5 proxy to bypass transport.Proxy")
+	}
+	if transport.DialContext == nil {
+		t.Fatal("expected SOCKS5 proxy dialer to be installed")
+	}
+}

--- a/auth/token.go
+++ b/auth/token.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -202,9 +203,12 @@ func buildHTTPClient(proxyURL string) *http.Client {
 		IdleConnTimeout:     90 * time.Second,
 		TLSHandshakeTimeout: 10 * time.Second,
 	}
+	baseDialer := &net.Dialer{Timeout: 10 * time.Second, KeepAlive: 30 * time.Second}
+	transport.DialContext = baseDialer.DialContext
 	if proxyURL != "" {
-		if u, err := url.Parse(proxyURL); err == nil {
-			transport.Proxy = http.ProxyURL(u)
+		if err := ConfigureTransportProxy(transport, proxyURL, baseDialer); err != nil {
+			transport.Proxy = nil
+			transport.DialContext = baseDialer.DialContext
 		}
 	}
 

--- a/proxy/executor.go
+++ b/proxy/executor.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net"
 	"net/http"
-	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -73,21 +72,19 @@ func getPooledClient(account *auth.Account, proxyURL string) *http.Client {
 		MaxConnsPerHost:     16,               // 降低单连接池过热概率
 		IdleConnTimeout:     90 * time.Second, // 空闲连接超时
 		TLSHandshakeTimeout: 10 * time.Second, // TLS 握手超时
-		// Keep-Alive
-		DialContext: (&net.Dialer{
-			Timeout:   10 * time.Second,
-			KeepAlive: 30 * time.Second,
-		}).DialContext,
 		// 启用 HTTP/2
 		ForceAttemptHTTP2: true,
 		TLSClientConfig:   &tls.Config{MinVersion: tls.VersionTLS12},
 	}
+	baseDialer := &net.Dialer{
+		Timeout:   10 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}
+	transport.DialContext = baseDialer.DialContext
 
 	// 设置代理
 	if proxyURL != "" {
-		if u, err := url.Parse(proxyURL); err == nil {
-			transport.Proxy = http.ProxyURL(u)
-		}
+		_ = auth.ConfigureTransportProxy(transport, proxyURL, baseDialer)
 	}
 
 	client := &http.Client{


### PR DESCRIPTION
## Summary
This patch makes the project actually support socks5:// proxies in the runtime HTTP client paths that currently only use http.ProxyURL(...).

## What changed
- added a shared transport helper to configure HTTP(S) and SOCKS5 proxies correctly
- updated uth/token.go to use the shared helper for refresh/OAuth client construction
- updated proxy/executor.go to use the same helper for upstream runtime requests
- updated dmin/handler.go proxy testing to validate SOCKS5 proxies correctly
- added focused tests for HTTP proxy vs SOCKS5 proxy transport setup

## Why
The UI and proxy management already accept socks5:// URLs, but the runtime code still treated them like HTTP proxies. In practice this caused OAuth / refresh / proxy-test failures on SOCKS5 setups.

## Validation
- go test ./auth ./proxy ./admin
- verified on a live pilot that SOCKS5 proxy test succeeds and returns an exit IP
- verified that the previous timeout behavior on the proxy path is replaced by real upstream responses
