### PR TITLE
优化 usage_limit_reached 429 下游收口

### DIFF
--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -31,6 +31,13 @@ type Handler struct {
 	dbKeysUntil time.Time
 }
 
+type usageLimitDetails struct {
+	message         string
+	planType        string
+	resetsAt        int64
+	resetsInSeconds int64
+}
+
 // NewHandler 创建处理器
 func NewHandler(store *auth.Store, db *database.DB) *Handler {
 	return &Handler{
@@ -276,6 +283,21 @@ func isRetryableStatus(code int) bool {
 	return code == http.StatusTooManyRequests || code == http.StatusServiceUnavailable || code == http.StatusUnauthorized || code == http.StatusInternalServerError
 }
 
+func parseUsageLimitDetails(body []byte) (usageLimitDetails, bool) {
+	if len(body) == 0 {
+		return usageLimitDetails{}, false
+	}
+	if gjson.GetBytes(body, "error.type").String() != "usage_limit_reached" {
+		return usageLimitDetails{}, false
+	}
+	return usageLimitDetails{
+		message:         gjson.GetBytes(body, "error.message").String(),
+		planType:        gjson.GetBytes(body, "error.plan_type").String(),
+		resetsAt:        gjson.GetBytes(body, "error.resets_at").Int(),
+		resetsInSeconds: gjson.GetBytes(body, "error.resets_in_seconds").Int(),
+	}, true
+}
+
 // Responses 处理 /v1/responses 请求（原生透传，无需协议翻译）
 func (h *Handler) Responses(c *gin.Context) {
 	// 1. 读取请求体
@@ -362,6 +384,10 @@ func (h *Handler) Responses(c *gin.Context) {
 			// 排队等待可用账号（最多 30s）
 			account = h.store.WaitForAvailable(c.Request.Context(), 30*time.Second)
 			if account == nil {
+				if lastStatusCode == http.StatusTooManyRequests && len(lastBody) > 0 {
+					h.sendPoolExhaustedError(c, lastStatusCode, lastBody)
+					return
+				}
 				c.JSON(http.StatusServiceUnavailable, gin.H{
 					"error": gin.H{"message": "无可用账号，请稍后重试", "type": "server_error"},
 				})
@@ -417,7 +443,7 @@ func (h *Handler) Responses(c *gin.Context) {
 				continue
 			}
 
-			h.sendUpstreamError(c, resp.StatusCode, errBody)
+			h.sendPoolExhaustedError(c, resp.StatusCode, errBody)
 			return
 		}
 
@@ -622,7 +648,7 @@ func (h *Handler) Responses(c *gin.Context) {
 			"error": gin.H{"message": "上游请求失败: " + lastErr.Error(), "type": "upstream_error"},
 		})
 	} else if lastStatusCode != 0 {
-		h.sendUpstreamError(c, lastStatusCode, lastBody)
+		h.sendPoolExhaustedError(c, lastStatusCode, lastBody)
 	}
 }
 
@@ -670,6 +696,10 @@ func (h *Handler) ChatCompletions(c *gin.Context) {
 			// 排队等待可用账号（最多 30s）
 			account = h.store.WaitForAvailable(c.Request.Context(), 30*time.Second)
 			if account == nil {
+				if lastStatusCode == http.StatusTooManyRequests && len(lastBody) > 0 {
+					h.sendPoolExhaustedError(c, lastStatusCode, lastBody)
+					return
+				}
 				c.JSON(http.StatusServiceUnavailable, gin.H{
 					"error": gin.H{"message": "无可用账号，请稍后重试", "type": "server_error"},
 				})
@@ -725,7 +755,7 @@ func (h *Handler) ChatCompletions(c *gin.Context) {
 				continue
 			}
 
-			h.sendUpstreamError(c, resp.StatusCode, errBody)
+			h.sendPoolExhaustedError(c, resp.StatusCode, errBody)
 			return
 		}
 
@@ -970,7 +1000,7 @@ func (h *Handler) ChatCompletions(c *gin.Context) {
 			"error": gin.H{"message": "上游请求失败: " + lastErr.Error(), "type": "upstream_error"},
 		})
 	} else if lastStatusCode != 0 {
-		h.sendUpstreamError(c, lastStatusCode, lastBody)
+		h.sendPoolExhaustedError(c, lastStatusCode, lastBody)
 	}
 }
 
@@ -1263,6 +1293,35 @@ func (h *Handler) sendUpstreamError(c *gin.Context, statusCode int, body []byte)
 			"code":    fmt.Sprintf("upstream_%d", statusCode),
 		},
 	})
+}
+
+func (h *Handler) sendPoolExhaustedError(c *gin.Context, statusCode int, body []byte) {
+	if statusCode == http.StatusTooManyRequests {
+		if details, ok := parseUsageLimitDetails(body); ok {
+			if details.resetsInSeconds > 0 {
+				c.Header("Retry-After", fmt.Sprintf("%d", details.resetsInSeconds))
+			}
+
+			message := "账号池额度已耗尽，请稍后重试"
+			if details.message != "" {
+				message = fmt.Sprintf("%s：%s", message, details.message)
+			}
+
+			c.JSON(http.StatusServiceUnavailable, gin.H{
+				"error": gin.H{
+					"message":           message,
+					"type":              "server_error",
+					"code":              "account_pool_usage_limit_reached",
+					"plan_type":         details.planType,
+					"resets_at":         details.resetsAt,
+					"resets_in_seconds": details.resetsInSeconds,
+				},
+			})
+			return
+		}
+	}
+
+	h.sendUpstreamError(c, statusCode, body)
 }
 
 // handleUpstreamError 统一处理上游错误（兼容旧调用）

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -1,0 +1,80 @@
+package proxy
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestSendPoolExhaustedUsageLimitErrorRewrites429(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+
+	handler := &Handler{}
+	body := []byte(`{"error":{"type":"usage_limit_reached","message":"The usage limit has been reached","plan_type":"free","resets_at":1775317531,"resets_in_seconds":602705}}`)
+
+	handler.sendPoolExhaustedError(ctx, http.StatusTooManyRequests, body)
+
+	if recorder.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusServiceUnavailable)
+	}
+	if got := recorder.Header().Get("Retry-After"); got != "602705" {
+		t.Fatalf("Retry-After = %q, want %q", got, "602705")
+	}
+
+	var payload struct {
+		Error struct {
+			Message         string `json:"message"`
+			Type            string `json:"type"`
+			Code            string `json:"code"`
+			PlanType        string `json:"plan_type"`
+			ResetsAt        int64  `json:"resets_at"`
+			ResetsInSeconds int64  `json:"resets_in_seconds"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if payload.Error.Type != "server_error" {
+		t.Fatalf("type = %q, want %q", payload.Error.Type, "server_error")
+	}
+	if payload.Error.Code != "account_pool_usage_limit_reached" {
+		t.Fatalf("code = %q, want %q", payload.Error.Code, "account_pool_usage_limit_reached")
+	}
+	if payload.Error.PlanType != "free" {
+		t.Fatalf("plan_type = %q, want %q", payload.Error.PlanType, "free")
+	}
+	if payload.Error.ResetsAt != 1775317531 {
+		t.Fatalf("resets_at = %d, want %d", payload.Error.ResetsAt, 1775317531)
+	}
+	if payload.Error.ResetsInSeconds != 602705 {
+		t.Fatalf("resets_in_seconds = %d, want %d", payload.Error.ResetsInSeconds, 602705)
+	}
+	if payload.Error.Message == "" {
+		t.Fatal("expected non-empty aggregated error message")
+	}
+}
+
+func TestSendPoolExhaustedErrorFallsBackToUpstreamError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+
+	handler := &Handler{}
+	body := []byte(`{"error":{"type":"rate_limit_error","message":"Too many requests"}}`)
+
+	handler.sendPoolExhaustedError(ctx, http.StatusTooManyRequests, body)
+
+	if recorder.Code != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusTooManyRequests)
+	}
+	if got := recorder.Header().Get("Retry-After"); got != "" {
+		t.Fatalf("Retry-After = %q, want empty", got)
+	}
+}


### PR DESCRIPTION
## 变更说明

修复 `usage_limit_reached` 类型的上游 `429` 在重试耗尽后直接把原始错误透传给下游、导致 Codex 链路被生硬中断的问题。

## 关联问题

- closes #9

## 改动内容

- 新增 `usage_limit_reached` 解析逻辑
- 当账号池因为长期额度耗尽而没有可用账号时，将最终返回改写为聚合的 `503`
- 为这类聚合错误补充 `Retry-After` 响应头，以及 `plan_type / resets_at / resets_in_seconds` 字段
- 保持普通 `429` 和其他上游错误的现有透传行为不变
- 补充代理层单测覆盖

## 验证

- `go test ./proxy -run TestSendPoolExhausted`
- `go test ./proxy`
- `go test ./...`
