### PR TITLE
fix(memory): 修复 7 处内存泄漏，解决长时间运行 RAM 持续增长

### DIFF
--- a/auth/refresh_scheduler_integration.go
+++ b/auth/refresh_scheduler_integration.go
@@ -50,10 +50,8 @@ func (s *Store) EnableRefreshScheduler(config RefreshConfig) {
 	}
 	integration.enabled.Store(true)
 
-	// 启动调度器
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	integration.scheduler.Start(ctx)
+	// 启动调度器（生命周期由 scheduler.Stop() 管理，不能在此 defer cancel）
+	integration.scheduler.Start(context.Background())
 
 	// 存储到 store
 	s.refreshScheduler.Store(integration)

--- a/auth/store.go
+++ b/auth/store.go
@@ -1210,14 +1210,18 @@ func (s *Store) Next() *Account {
 
 // WaitForAvailable 等待可用账号（带超时的请求排队）
 func (s *Store) WaitForAvailable(ctx context.Context, timeout time.Duration) *Account {
-	deadline := time.After(timeout)
+	deadline := time.NewTimer(timeout)
+	defer deadline.Stop()
+
 	backoff := 50 * time.Millisecond
+	backoffTimer := time.NewTimer(backoff)
+	defer backoffTimer.Stop()
 
 	for {
 		select {
 		case <-ctx.Done():
 			return nil
-		case <-deadline:
+		case <-deadline.C:
 			return nil
 		default:
 			acc := s.Next()
@@ -1225,14 +1229,15 @@ func (s *Store) WaitForAvailable(ctx context.Context, timeout time.Duration) *Ac
 				return acc
 			}
 			// 等待一下再重试（指数退避，最大 500ms）
+			backoffTimer.Reset(backoff)
 			select {
-			case <-time.After(backoff):
+			case <-backoffTimer.C:
 				if backoff < 500*time.Millisecond {
 					backoff *= 2
 				}
 			case <-ctx.Done():
 				return nil
-			case <-deadline:
+			case <-deadline.C:
 				return nil
 			}
 		}
@@ -1332,6 +1337,10 @@ func (s *Store) RemoveAccount(dbID int64) {
 		if acc.DBID == dbID {
 			s.accounts = append(s.accounts[:i], s.accounts[i+1:]...)
 			s.fastSchedulerRemove(dbID)
+			// 清理 RefreshScheduler 中可能残留的任务
+			if scheduler := s.GetRefreshScheduler(); scheduler != nil {
+				scheduler.CancelTask(dbID)
+			}
 			return
 		}
 	}

--- a/auth/token.go
+++ b/auth/token.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -187,13 +188,51 @@ func parseIDToken(idToken string) *AccountInfo {
 	return info
 }
 
-// authClientPool 认证请求的连接池（按 proxyURL 分组）
-var authClientPool sync.Map
+// authClientPool 认证请求的连接池（按 proxyURL 分组，带 TTL 清理）
+var authClientPool sync.Map // map[string]*authPoolEntry
 
-// buildHTTPClient 构建支持代理的 HTTP 客户端（连接池复用）
+type authPoolEntry struct {
+	client   *http.Client
+	lastUsed atomic.Int64
+}
+
+func (e *authPoolEntry) touch() {
+	e.lastUsed.Store(time.Now().UnixNano())
+}
+
+const (
+	authClientPoolTTL         = 5 * time.Minute
+	authClientPoolCleanupInterval = 60 * time.Second
+)
+
+func init() {
+	go func() {
+		ticker := time.NewTicker(authClientPoolCleanupInterval)
+		defer ticker.Stop()
+		for range ticker.C {
+			evictExpiredAuthClients()
+		}
+	}()
+}
+
+func evictExpiredAuthClients() {
+	cutoff := time.Now().Add(-authClientPoolTTL).UnixNano()
+	authClientPool.Range(func(key, value any) bool {
+		entry := value.(*authPoolEntry)
+		if entry.lastUsed.Load() < cutoff {
+			authClientPool.Delete(key)
+			entry.client.CloseIdleConnections()
+		}
+		return true
+	})
+}
+
+// buildHTTPClient 构建支持代理的 HTTP 客户端（连接池复用，带 TTL 清理）
 func buildHTTPClient(proxyURL string) *http.Client {
 	if v, ok := authClientPool.Load(proxyURL); ok {
-		return v.(*http.Client)
+		entry := v.(*authPoolEntry)
+		entry.touch()
+		return entry.client
 	}
 
 	transport := &http.Transport{
@@ -217,8 +256,13 @@ func buildHTTPClient(proxyURL string) *http.Client {
 		Timeout:   30 * time.Second,
 	}
 
-	if v, loaded := authClientPool.LoadOrStore(proxyURL, client); loaded {
-		return v.(*http.Client)
+	entry := &authPoolEntry{client: client}
+	entry.touch()
+
+	if v, loaded := authClientPool.LoadOrStore(proxyURL, entry); loaded {
+		e := v.(*authPoolEntry)
+		e.touch()
+		return e.client
 	}
 	return client
 }

--- a/cache/memory.go
+++ b/cache/memory.go
@@ -145,6 +145,9 @@ func (tc *MemoryTokenCache) WaitForRefreshComplete(ctx context.Context, accountI
 	}
 
 	deadline := time.Now().Add(timeout)
+	pollTimer := time.NewTimer(200 * time.Millisecond)
+	defer pollTimer.Stop()
+
 	for time.Now().Before(deadline) {
 		tc.mu.Lock()
 		lockUntil, locked := tc.locks[accountID]
@@ -164,10 +167,11 @@ func (tc *MemoryTokenCache) WaitForRefreshComplete(ctx context.Context, accountI
 			return entry.token, nil
 		}
 
+		pollTimer.Reset(200 * time.Millisecond)
 		select {
 		case <-ctx.Done():
 			return "", ctx.Err()
-		case <-time.After(200 * time.Millisecond):
+		case <-pollTimer.C:
 		}
 	}
 

--- a/proxy/ratelimit.go
+++ b/proxy/ratelimit.go
@@ -277,6 +277,7 @@ type LevelLimiter struct {
 	cooldown *cooldownManager // 冷却管理器
 	metrics  LimitMetrics    // 指标
 	enabled  bool            // 是否启用
+	lastAccess atomic.Int64  // 最后访问时间（用于 TTL 清理）
 }
 
 // newLevelLimiter 创建单级别限流器
@@ -287,6 +288,7 @@ func newLevelLimiter(key string, level RateLimitLevel, rpm int) *LevelLimiter {
 		enabled:  rpm > 0,
 		cooldown: newCooldownManager(),
 	}
+	ll.lastAccess.Store(time.Now().UnixNano())
 	if ll.enabled {
 		ll.bucket = newTokenBucket(rpm)
 		ll.metrics.LimitRPM = int64(rpm)
@@ -296,6 +298,7 @@ func newLevelLimiter(key string, level RateLimitLevel, rpm int) *LevelLimiter {
 
 // allow 尝试获取令牌
 func (ll *LevelLimiter) allow() bool {
+	ll.lastAccess.Store(time.Now().UnixNano())
 	ll.mu.Lock()
 	defer ll.mu.Unlock()
 
@@ -328,6 +331,7 @@ func (ll *LevelLimiter) allow() bool {
 
 // allowN 尝试获取N个令牌
 func (ll *LevelLimiter) allowN(n int) bool {
+	ll.lastAccess.Store(time.Now().UnixNano())
 	ll.mu.Lock()
 	defer ll.mu.Unlock()
 
@@ -476,6 +480,9 @@ func NewEnhancedRateLimiter(db *database.DB, globalRPM, accountRPM, modelRPM int
 	if db != nil {
 		go erl.persistenceLoop()
 	}
+
+	// 启动 limiter 清理协程（无论是否有 db 都需要）
+	go erl.limiterEvictionLoop()
 
 	return erl
 }
@@ -686,6 +693,46 @@ func (erl *EnhancedRateLimiter) persistenceLoop() {
 			erl.persistSnapshots()
 		case <-erl.stopCh:
 			return
+		}
+	}
+}
+
+// limiterEvictionLoop 清理长时间未使用的限流器（30 分钟 TTL）
+func (erl *EnhancedRateLimiter) limiterEvictionLoop() {
+	const (
+		evictionTTL      = 30 * time.Minute
+		evictionInterval = 5 * time.Minute
+	)
+
+	ticker := time.NewTicker(evictionInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			erl.evictStaleLimiters(evictionTTL)
+		case <-erl.stopCh:
+			return
+		}
+	}
+}
+
+// evictStaleLimiters 清理超过 TTL 未访问的限流器
+func (erl *EnhancedRateLimiter) evictStaleLimiters(ttl time.Duration) {
+	cutoff := time.Now().Add(-ttl).UnixNano()
+
+	erl.mu.Lock()
+	defer erl.mu.Unlock()
+
+	for key, limiter := range erl.accountLimiters {
+		if limiter.lastAccess.Load() < cutoff {
+			delete(erl.accountLimiters, key)
+		}
+	}
+
+	for key, limiter := range erl.modelLimiters {
+		if limiter.lastAccess.Load() < cutoff {
+			delete(erl.modelLimiters, key)
 		}
 	}
 }

--- a/proxy/response_cache.go
+++ b/proxy/response_cache.go
@@ -74,8 +74,7 @@ func getResponseCache(responseID string) []json.RawMessage {
 	}
 	if time.Since(entry.createdAt) > responseCacheTTL {
 		// 同步删除过期条目，避免goroutine爆炸
-		// 先释放读锁，再获取写锁进行删除
-		respCache.mu.RUnlock()
+		// 读锁已在上方释放，直接获取写锁进行删除
 		respCache.mu.Lock()
 		// 双重检查：确认条目仍然存在且已过期
 		if e, exists := respCache.store[responseID]; exists && time.Since(e.createdAt) > responseCacheTTL {

--- a/proxy/wsrelay/manager.go
+++ b/proxy/wsrelay/manager.go
@@ -330,14 +330,19 @@ func (m *Manager) createConnection(
 		}
 	}
 
-	// 创建会话
+	// 创建会话（先关闭旧 session 避免泄漏）
+	sessionKey := m.poolKey(account.ID(), wsURL)
+	if oldSessionVal, ok := m.sessions.Load(sessionKey); ok {
+		oldSession := oldSessionVal.(*Session)
+		oldSession.Close()
+	}
 	session := NewSession(account.ID(), m)
-	m.sessions.Store(m.poolKey(account.ID(), wsURL), session)
+	m.sessions.Store(sessionKey, session)
 
 	// 拨号连接
 	conn, resp, err := dialer.DialContext(ctx, wsURL, headers)
 	if err != nil {
-		m.sessions.Delete(m.poolKey(account.ID(), wsURL))
+		m.sessions.Delete(sessionKey)
 		session.Close()
 		return nil, fmt.Errorf("websocket handshake failed: %w", err)
 	}


### PR DESCRIPTION
## 问题

项目长时间运行后 RAM 占用持续增长，不会回落。经深入分析定位到 7 个内存/资源泄漏点。

## 修复内容

### CRITICAL（2 项）

| 问题 | 文件 | 修复方式 |
|------|------|----------|
| `getResponseCache` 双重 `RUnlock` 导致 panic | `proxy/response_cache.go` | 删除多余的 `RUnlock()` 调用 |
| `EnableRefreshScheduler` 的 `defer cancel()` 立即取消 context，调度器 3 个 goroutine 全部退出，任务堆积永不执行 | `auth/refresh_scheduler_integration.go` | 直接传 `context.Background()`，生命周期由 `Stop()` 管理 |

### HIGH（2 项）

| 问题 | 文件 | 修复方式 |
|------|------|----------|
| `authClientPool`（sync.Map）按 proxyURL 缓存 HTTP client，永不清理 | `auth/token.go` | 添加 5 分钟 TTL + 60 秒周期清理 goroutine |
| `accountLimiters` / `modelLimiters` 每个新 ID 创建 limiter，永不清理 | `proxy/ratelimit.go` | 添加 `lastAccess` 字段 + 30 分钟 TTL 清理 |

### MEDIUM（3 项）

| 问题 | 文件 | 修复方式 |
|------|------|----------|
| `time.After()` 在轮询循环中每次迭代创建新 timer，触发前不会被 GC | `auth/store.go` + `cache/memory.go` | 改用 `time.NewTimer()` + `Reset()` 复用 |
| wsrelay `createConnection` 覆盖 Session 时未关闭旧 Session，heartbeat timer 泄漏 | `proxy/wsrelay/manager.go` | 存储新 Session 前先 `Close()` 旧 Session |
| 账号删除后 RefreshScheduler 中残留孤儿任务 | `auth/store.go` | `RemoveAccount` 时调用 `CancelTask` 清理 |

## 测试

- `go build ./...` 编译通过
- `go test ./...` 全部通过（9 个包）
- 安全审查无新增漏洞