### PR TITLE
feat(accounts): 支持导入 Sub2Api JSON 账号文件

### DIFF
--- a/admin/handler.go
+++ b/admin/handler.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"encoding/hex"
@@ -632,6 +633,106 @@ type jsonAccountEntry struct {
 	Email        string `json:"email"`
 }
 
+type sub2apiImportPayload struct {
+	Accounts []sub2apiAccountEntry `json:"accounts"`
+}
+
+type sub2apiAccountEntry struct {
+	Name        string                    `json:"name"`
+	Credentials sub2apiAccountCredentials `json:"credentials"`
+}
+
+type sub2apiAccountCredentials struct {
+	RefreshToken string `json:"refresh_token"`
+	AccessToken  string `json:"access_token"`
+	Email        string `json:"email"`
+}
+
+var utf8BOM = []byte{0xef, 0xbb, 0xbf}
+
+func trimUTF8BOM(data []byte) []byte {
+	return bytes.TrimPrefix(data, utf8BOM)
+}
+
+// parseImportJSONTokens 同时兼容现有扁平 JSON 和 Sub2Api 顶层对象。
+func parseImportJSONTokens(data []byte) ([]importToken, error) {
+	data = trimUTF8BOM(data)
+	if !json.Valid(data) {
+		return nil, fmt.Errorf("invalid import json")
+	}
+
+	if tokens := parseFlatJSONImportTokens(data); len(tokens) > 0 {
+		return tokens, nil
+	}
+
+	if tokens := parseSub2APIJSONImportTokens(data); len(tokens) > 0 {
+		return tokens, nil
+	}
+
+	return nil, nil
+}
+
+func parseFlatJSONImportTokens(data []byte) []importToken {
+	var entries []jsonAccountEntry
+	if err := json.Unmarshal(data, &entries); err == nil {
+		return jsonAccountEntriesToTokens(entries)
+	}
+
+	var single jsonAccountEntry
+	if err := json.Unmarshal(data, &single); err == nil {
+		return jsonAccountEntriesToTokens([]jsonAccountEntry{single})
+	}
+
+	return nil
+}
+
+func jsonAccountEntriesToTokens(entries []jsonAccountEntry) []importToken {
+	tokens := make([]importToken, 0, len(entries))
+	for _, entry := range entries {
+		rt := strings.TrimSpace(entry.RefreshToken)
+		at := strings.TrimSpace(entry.AccessToken)
+		email := strings.TrimSpace(entry.Email)
+
+		if rt != "" {
+			tokens = append(tokens, importToken{refreshToken: rt, name: email})
+			continue
+		}
+		if at != "" {
+			tokens = append(tokens, importToken{accessToken: at, name: email})
+		}
+	}
+	return tokens
+}
+
+func parseSub2APIJSONImportTokens(data []byte) []importToken {
+	var payload sub2apiImportPayload
+	if err := json.Unmarshal(data, &payload); err != nil {
+		return nil
+	}
+
+	tokens := make([]importToken, 0, len(payload.Accounts))
+	for _, account := range payload.Accounts {
+		rt := strings.TrimSpace(account.Credentials.RefreshToken)
+		at := strings.TrimSpace(account.Credentials.AccessToken)
+		name := strings.TrimSpace(account.Name)
+		email := strings.TrimSpace(account.Credentials.Email)
+
+		if name == "" {
+			name = email
+		}
+
+		if rt != "" {
+			tokens = append(tokens, importToken{refreshToken: rt, name: name})
+			continue
+		}
+		if at != "" {
+			tokens = append(tokens, importToken{accessToken: at, name: name})
+		}
+	}
+
+	return tokens
+}
+
 // ImportAccounts 批量导入账号（支持 TXT / JSON）
 func (h *Handler) ImportAccounts(c *gin.Context) {
 	format := c.DefaultPostForm("format", "txt")
@@ -721,32 +822,13 @@ func (h *Handler) importAccountsJSON(c *gin.Context, proxyURL string) {
 			return
 		}
 
-		// 去除 UTF-8 BOM
-		data = []byte(strings.TrimPrefix(string(data), "\xef\xbb\xbf"))
-
-		// 尝试解析为数组，失败则尝试单对象
-		var entries []jsonAccountEntry
-		if err := json.Unmarshal(data, &entries); err != nil {
-			var single jsonAccountEntry
-			if err := json.Unmarshal(data, &single); err != nil {
-				writeError(c, http.StatusBadRequest, fmt.Sprintf("文件 %s 不是有效的 JSON 格式", fh.Filename))
-				return
-			}
-			entries = []jsonAccountEntry{single}
+		tokens, err := parseImportJSONTokens(data)
+		if err != nil {
+			writeError(c, http.StatusBadRequest, fmt.Sprintf("文件 %s 不是有效的 JSON 格式", fh.Filename))
+			return
 		}
 
-		for _, entry := range entries {
-			rt := strings.TrimSpace(entry.RefreshToken)
-			at := strings.TrimSpace(entry.AccessToken)
-			email := strings.TrimSpace(entry.Email)
-
-			if rt != "" {
-				allTokens = append(allTokens, importToken{refreshToken: rt, name: email})
-			} else if at != "" {
-				// 没有 RT 则走 AT 兼容路径
-				allTokens = append(allTokens, importToken{accessToken: at, name: email})
-			}
-		}
+		allTokens = append(allTokens, tokens...)
 	}
 
 	if len(allTokens) == 0 {
@@ -759,7 +841,7 @@ func (h *Handler) importAccountsJSON(c *gin.Context, proxyURL string) {
 
 // importEvent SSE 导入进度事件
 type importEvent struct {
-	Type      string `json:"type"`                // progress | complete
+	Type      string `json:"type"` // progress | complete
 	Current   int    `json:"current"`
 	Total     int    `json:"total"`
 	Success   int    `json:"success"`
@@ -2325,4 +2407,3 @@ func (h *Handler) TestProxy(c *gin.Context) {
 		"location":   location,
 	})
 }
-

--- a/admin/import_json_test.go
+++ b/admin/import_json_test.go
@@ -1,0 +1,207 @@
+package admin
+
+import (
+	"bytes"
+	"encoding/json"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestParseImportJSONTokensSupportsFlatObjectWithBOM(t *testing.T) {
+	data := append([]byte{0xef, 0xbb, 0xbf}, []byte(`{"refresh_token":"rt-flat","email":"flat@example.com"}`)...)
+
+	tokens, err := parseImportJSONTokens(data)
+	if err != nil {
+		t.Fatalf("parseImportJSONTokens returned error: %v", err)
+	}
+
+	if len(tokens) != 1 {
+		t.Fatalf("tokens len = %d, want 1", len(tokens))
+	}
+	if tokens[0].refreshToken != "rt-flat" {
+		t.Fatalf("refreshToken = %q, want %q", tokens[0].refreshToken, "rt-flat")
+	}
+	if tokens[0].name != "flat@example.com" {
+		t.Fatalf("name = %q, want %q", tokens[0].name, "flat@example.com")
+	}
+	if tokens[0].accessToken != "" {
+		t.Fatalf("accessToken = %q, want empty", tokens[0].accessToken)
+	}
+}
+
+func TestParseImportJSONTokensSupportsFlatArray(t *testing.T) {
+	data := []byte(`[
+		{"refresh_token":"rt-1","email":"one@example.com"},
+		{"access_token":"at-2","email":"two@example.com"},
+		{"refresh_token":"","access_token":"","email":"ignored@example.com"}
+	]`)
+
+	tokens, err := parseImportJSONTokens(data)
+	if err != nil {
+		t.Fatalf("parseImportJSONTokens returned error: %v", err)
+	}
+
+	if len(tokens) != 2 {
+		t.Fatalf("tokens len = %d, want 2", len(tokens))
+	}
+	if tokens[0].refreshToken != "rt-1" || tokens[0].name != "one@example.com" {
+		t.Fatalf("first token = %+v, want rt-1 / one@example.com", tokens[0])
+	}
+	if tokens[1].accessToken != "at-2" || tokens[1].name != "two@example.com" {
+		t.Fatalf("second token = %+v, want at-2 / two@example.com", tokens[1])
+	}
+}
+
+func TestParseImportJSONTokensSupportsSub2API(t *testing.T) {
+	data := []byte(`{
+		"exported_at": "2026-04-03T14:49:53Z",
+		"proxies": [
+			{"proxy_key":"http|10.0.1.4|80|user|pass","name":"ignored proxy"}
+		],
+		"accounts": [
+			{
+				"name": "Primary Account",
+				"proxy_key": "http|10.0.1.4|80|user|pass",
+				"credentials": {
+					"refresh_token": "rt-primary",
+					"access_token": "at-primary",
+					"email": "primary@example.com"
+				},
+				"extra": {"ignored": true}
+			},
+			{
+				"credentials": {
+					"access_token": "at-email-fallback",
+					"email": "fallback@example.com"
+				}
+			},
+			{
+				"credentials": {
+					"access_token": "at-default-name"
+				}
+			},
+			{
+				"name": "Ignored Account",
+				"credentials": {}
+			}
+		]
+	}`)
+
+	tokens, err := parseImportJSONTokens(data)
+	if err != nil {
+		t.Fatalf("parseImportJSONTokens returned error: %v", err)
+	}
+
+	if len(tokens) != 3 {
+		t.Fatalf("tokens len = %d, want 3", len(tokens))
+	}
+
+	if tokens[0].refreshToken != "rt-primary" {
+		t.Fatalf("first refreshToken = %q, want %q", tokens[0].refreshToken, "rt-primary")
+	}
+	if tokens[0].accessToken != "" {
+		t.Fatalf("first accessToken = %q, want empty because RT should win", tokens[0].accessToken)
+	}
+	if tokens[0].name != "Primary Account" {
+		t.Fatalf("first name = %q, want %q", tokens[0].name, "Primary Account")
+	}
+
+	if tokens[1].accessToken != "at-email-fallback" || tokens[1].name != "fallback@example.com" {
+		t.Fatalf("second token = %+v, want access token with email fallback", tokens[1])
+	}
+
+	if tokens[2].accessToken != "at-default-name" || tokens[2].name != "" {
+		t.Fatalf("third token = %+v, want access token with empty name for default naming", tokens[2])
+	}
+}
+
+func TestParseImportJSONTokensReturnsNoTokensForValidUnsupportedJSON(t *testing.T) {
+	data := []byte(`{"accounts":[{"credentials":{}}],"proxies":[{"proxy_key":"ignored"}]}`)
+
+	tokens, err := parseImportJSONTokens(data)
+	if err != nil {
+		t.Fatalf("parseImportJSONTokens returned error: %v", err)
+	}
+	if len(tokens) != 0 {
+		t.Fatalf("tokens len = %d, want 0", len(tokens))
+	}
+}
+
+func TestParseImportJSONTokensRejectsInvalidJSON(t *testing.T) {
+	if _, err := parseImportJSONTokens([]byte(`{"accounts":[}`)); err == nil {
+		t.Fatal("expected invalid JSON error, got nil")
+	}
+}
+
+func TestImportAccountsJSONReturnsExistingNoTokenMessageForUnsupportedJSON(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	req := newMultipartJSONRequest(t, "accounts.json", `{"accounts":[{"credentials":{}}]}`)
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Request = req
+
+	handler := &Handler{}
+	handler.importAccountsJSON(ctx, "")
+
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusBadRequest)
+	}
+
+	var payload map[string]string
+	if err := json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got := payload["error"]; got != "JSON 文件中未找到有效的 refresh_token 或 access_token" {
+		t.Fatalf("error = %q, want %q", got, "JSON 文件中未找到有效的 refresh_token 或 access_token")
+	}
+}
+
+func TestImportAccountsJSONRejectsInvalidJSONFile(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	req := newMultipartJSONRequest(t, "broken.json", `{"accounts":[}`)
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Request = req
+
+	handler := &Handler{}
+	handler.importAccountsJSON(ctx, "")
+
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusBadRequest)
+	}
+
+	var payload map[string]string
+	if err := json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got := payload["error"]; got != "文件 broken.json 不是有效的 JSON 格式" {
+		t.Fatalf("error = %q, want %q", got, "文件 broken.json 不是有效的 JSON 格式")
+	}
+}
+
+func newMultipartJSONRequest(t *testing.T, filename string, content string) *http.Request {
+	t.Helper()
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	part, err := writer.CreateFormFile("file", filename)
+	if err != nil {
+		t.Fatalf("CreateFormFile: %v", err)
+	}
+	if _, err := part.Write([]byte(content)); err != nil {
+		t.Fatalf("part.Write: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("writer.Close: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/admin/accounts/import", &body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	return req
+}

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -150,7 +150,7 @@
     "importTxt": "TXT File",
     "importTxtDesc": "One refresh token per line",
     "importJson": "JSON File",
-    "importJsonDesc": "Compatible with CLIProxyAPI credential JSON",
+    "importJsonDesc": "Compatible with CLIProxyAPI and Sub2Api JSON",
     "export": "Export",
     "exporting": "Exporting…",
     "exportTitle": "Select Export Method",

--- a/frontend/src/locales/zh.json
+++ b/frontend/src/locales/zh.json
@@ -150,7 +150,7 @@
     "importTxt": "TXT 文件",
     "importTxtDesc": "每行一个 Refresh Token",
     "importJson": "JSON 文件",
-    "importJsonDesc": "兼容 CLIProxyAPI 凭证 JSON",
+    "importJsonDesc": "兼容 CLIProxyAPI / Sub2Api JSON",
     "export": "导出",
     "exporting": "导出中…",
     "exportTitle": "选择导出方式",


### PR DESCRIPTION
## 变更说明
支持在账号管理中通过现有 `JSON 文件` 入口直接导入 `Sub2Api` 导出的 JSON 文件。

## 本次修改
- 扩展后端 JSON 导入解析逻辑，兼容：
  - 原有扁平 JSON
  - `Sub2Api` 顶层对象格式
- `Sub2Api` 导入时：
  - 优先使用 `credentials.refresh_token`
  - 没有 RT 时使用 `credentials.access_token`
  - 名称优先取 `account.name`，其次取 `credentials.email`
- 忽略代理和其他附加字段，不导入 `proxies`、`proxy_key`、`extra`
- 更新前端导入文案，说明现有 JSON 入口兼容 `CLIProxyAPI / Sub2Api JSON`
- 补充后端单元测试，覆盖扁平 JSON、Sub2Api、多账号、无 token、非法 JSON 等场景

## 验证
- `go test ./admin` 通过
- `go test ./...` 通过
