### PR TITLE
feat(accounts): 新增 Plus 筛选并对齐 plus 的 429 冷却处理

### DIFF
--- a/frontend/src/pages/Accounts.tsx
+++ b/frontend/src/pages/Accounts.tsx
@@ -34,7 +34,7 @@ export default function Accounts() {
   const [page, setPage] = useState(1)
   const [statusFilter, setStatusFilter] = useState<'all' | 'normal' | 'rate_limited' | 'banned' | 'locked'>('all')
   const [searchQuery, setSearchQuery] = useState('')
-  const [planFilter, setPlanFilter] = useState<'all' | 'pro' | 'team' | 'free'>('all')
+  const [planFilter, setPlanFilter] = useState<'all' | 'pro' | 'plus' | 'team' | 'free'>('all')
   const [sortKey, setSortKey] = useState<'requests' | 'usage' | 'importTime' | null>(null)
   const [sortDir, setSortDir] = useState<'asc' | 'desc'>('desc')
 
@@ -916,7 +916,7 @@ export default function Accounts() {
             />
           </div>
           <div className="flex items-center gap-1 rounded-lg border border-border bg-muted/30 p-0.5">
-            {(['all', 'pro', 'team', 'free'] as const).map((key) => (
+            {(['all', 'pro', 'plus', 'team', 'free'] as const).map((key) => (
               <button
                 key={key}
                 onClick={() => { setPlanFilter(key); setPage(1) }}

--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -1268,8 +1268,8 @@ func (h *Handler) compute429Cooldown(account *auth.Account, body []byte, resp *h
 		// Free 只有 7d 窗口，429 = 额度耗尽，冷却 7 天
 		return 7 * 24 * time.Hour
 
-	case "team", "pro", "enterprise":
-		// Team/Pro 有 5h + 7d 双窗口，需要判断是哪个窗口触发了限制
+	case "team", "teamplus", "pro", "plus", "enterprise":
+		// Team/Pro/Plus 有 5h + 7d 双窗口，需要判断是哪个窗口触发了限制
 		return h.detectTeamCooldownWindow(resp)
 
 	default:
@@ -1278,7 +1278,7 @@ func (h *Handler) compute429Cooldown(account *auth.Account, body []byte, resp *h
 	}
 }
 
-// detectTeamCooldownWindow 通过响应头判断 Team/Pro 账号是哪个窗口触发的限制
+// detectTeamCooldownWindow 通过响应头判断 Team/Pro/Plus 账号是哪个窗口触发的限制
 func (h *Handler) detectTeamCooldownWindow(resp *http.Response) time.Duration {
 	if resp == nil {
 		return 5 * time.Hour // 保守默认

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -7,7 +7,9 @@ import (
 	"net/http/httptest"
 	"path/filepath"
 	"testing"
+	"time"
 
+	"github.com/codex2api/auth"
 	"github.com/codex2api/database"
 	"github.com/gin-gonic/gin"
 )
@@ -133,6 +135,40 @@ func TestSendFinalUpstreamError_Non429StatusPassthrough(t *testing.T) {
 	// 非 429 直接透传原状态码
 	if recorder.Code != http.StatusInternalServerError {
 		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusInternalServerError)
+	}
+}
+
+func TestCompute429CooldownPlusUsesWindowHeaders(t *testing.T) {
+	handler := &Handler{}
+	account := &auth.Account{PlanType: "plus"}
+	resp := &http.Response{
+		Header: make(http.Header),
+	}
+	resp.Header.Set("x-codex-primary-used-percent", "100")
+	resp.Header.Set("x-codex-primary-window-minutes", "300")
+	resp.Header.Set("x-codex-secondary-used-percent", "20")
+	resp.Header.Set("x-codex-secondary-window-minutes", "10080")
+
+	got := handler.compute429Cooldown(account, []byte(`{"error":{"type":"usage_limit_reached"}}`), resp)
+	want := 5 * time.Hour
+	if got != want {
+		t.Fatalf("cooldown = %v, want %v", got, want)
+	}
+}
+
+func TestCompute429CooldownPlusPrefersExactResetTime(t *testing.T) {
+	handler := &Handler{}
+	account := &auth.Account{PlanType: "plus"}
+	resp := &http.Response{
+		Header: make(http.Header),
+	}
+	resp.Header.Set("x-codex-primary-used-percent", "100")
+	resp.Header.Set("x-codex-primary-window-minutes", "10080")
+
+	got := handler.compute429Cooldown(account, []byte(`{"error":{"type":"usage_limit_reached","resets_in_seconds":1800}}`), resp)
+	want := 30 * time.Minute
+	if got != want {
+		t.Fatalf("cooldown = %v, want %v", got, want)
 	}
 }
 


### PR DESCRIPTION
## 变更说明

本次 PR 包含两部分改动：

- 账号管理页新增 `Plus` 套餐筛选标签，筛选顺序调整为：`全部 / Pro / Plus / Team / Free`
- 修复 `plus` 账号触发 429 时的冷却判定逻辑，使其与 `Pro / Team` 等类型保持一致

## 具体变更

- 扩展账号页 `planFilter` 类型，支持 `plus`
- 在账号管理页套餐筛选栏中新增 `Plus` 标签
- `Plus` 标签严格匹配 `plan_type === "plus"`
- `teamplus` 不纳入 `Plus` 标签，仍只会出现在“全部”中
- 保持现有筛选行为不变，切换标签时仍会重置到第 1 页
- 调整 `plus` 的 429 冷却逻辑，在无精确 `resets_at` / `resets_in_seconds` 时，改为按窗口响应头推断冷却时长
- 保留现有优先级：如果上游返回精确重置时间，仍优先使用精确值
- 补充 `plus` 冷却逻辑相关单元测试

## 验证

- [x] `npm run build` 通过
- [x] `go test ./proxy/...` 通过
- [ ] `npm run typecheck` 通过

已知基线问题：

- `npm run typecheck` 当前失败，报错位于 `frontend/src/pages/ApiReference.tsx:949`
- 原因是同一 JSX 元素存在重复属性
- 该问题为仓库现有问题，不是本次改动引入

## 影响范围

- 账号管理页套餐筛选 UI
- `plus` 账号的 429 冷却策略
- 不影响数据库结构
- 不影响账号接口返回字段
