### PR TITLE
feat(frontend): 增强后台分页器交互体验

### DIFF
--- a/frontend/src/components/Pagination.tsx
+++ b/frontend/src/components/Pagination.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@/components/ui/button'
+import { Select } from '@/components/ui/select'
 import { useTranslation } from 'react-i18next'
 
 interface PaginationProps {
@@ -7,40 +8,122 @@ interface PaginationProps {
   onPageChange: (page: number) => void
   totalItems: number
   pageSize: number
+  onPageSizeChange?: (pageSize: number) => void
+  pageSizeOptions?: number[]
 }
 
-export default function Pagination({ page, totalPages, onPageChange, totalItems, pageSize }: PaginationProps) {
-  const { t } = useTranslation()
-  if (totalPages <= 1) return null
+type PagerItem = number | 'ellipsis-left' | 'ellipsis-right'
 
-  const start = (page - 1) * pageSize + 1
-  const end = Math.min(page * pageSize, totalItems)
+function buildPagerItems(page: number, totalPages: number): PagerItem[] {
+  if (totalPages <= 7) {
+    return Array.from({ length: totalPages }, (_, index) => index + 1)
+  }
+
+  if (page <= 4) {
+    return [1, 2, 3, 4, 5, 'ellipsis-right', totalPages]
+  }
+
+  if (page >= totalPages - 3) {
+    return [1, 'ellipsis-left', totalPages - 4, totalPages - 3, totalPages - 2, totalPages - 1, totalPages]
+  }
+
+  return [1, 'ellipsis-left', page - 1, page, page + 1, 'ellipsis-right', totalPages]
+}
+
+export default function Pagination({
+  page,
+  totalPages,
+  onPageChange,
+  totalItems,
+  pageSize,
+  onPageSizeChange,
+  pageSizeOptions = [],
+}: PaginationProps) {
+  const { t } = useTranslation()
+  if (totalItems <= 0) return null
+
+  const normalizedTotalPages = Math.max(1, totalPages)
+  const currentPage = Math.min(Math.max(page, 1), normalizedTotalPages)
+  const pagerItems = buildPagerItems(currentPage, normalizedTotalPages)
+  const selectOptions = pageSizeOptions.map((size) => ({
+    label: t('common.pageSizeOption', { size }),
+    value: String(size),
+  }))
+
+  const start = (currentPage - 1) * pageSize + 1
+  const end = Math.min(currentPage * pageSize, totalItems)
 
   return (
-    <div className="flex items-center justify-between gap-3 pt-3.5 mt-3.5 border-t border-border">
+    <div className="mt-3.5 flex flex-wrap items-center justify-between gap-3 border-t border-border pt-3.5">
       <span className="text-xs text-muted-foreground">
         {t('common.showingRange', { start, end, total: totalItems })}
       </span>
-      <div className="flex items-center gap-2">
-        <Button
-          variant="outline"
-          size="sm"
-          disabled={page <= 1}
-          onClick={() => onPageChange(page - 1)}
-        >
-          {t('common.prev')}
-        </Button>
-        <span className="text-[13px] font-semibold text-muted-foreground min-w-[60px] text-center">
-          {page} / {totalPages}
-        </span>
-        <Button
-          variant="outline"
-          size="sm"
-          disabled={page >= totalPages}
-          onClick={() => onPageChange(page + 1)}
-        >
-          {t('common.next')}
-        </Button>
+      <div className="flex flex-wrap items-center justify-end gap-2">
+        {onPageSizeChange && selectOptions.length > 0 ? (
+          <div className="flex items-center gap-2">
+            <span className="text-xs font-medium text-muted-foreground">{t('common.pageSize')}</span>
+            <div className="w-[108px]">
+              <Select
+                value={String(pageSize)}
+                onValueChange={(value) => onPageSizeChange(Number(value))}
+                options={selectOptions}
+                compact
+              />
+            </div>
+          </div>
+        ) : null}
+        {normalizedTotalPages > 1 ? (
+          <div className="flex flex-wrap items-center justify-end gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={currentPage <= 1}
+              onClick={() => onPageChange(currentPage - 1)}
+            >
+              {t('common.prev')}
+            </Button>
+            <div className="flex items-center gap-1">
+              {pagerItems.map((item) => {
+                if (typeof item !== 'number') {
+                  return (
+                    <span
+                      key={item}
+                      className="flex h-8 min-w-8 items-center justify-center px-1 text-sm text-muted-foreground"
+                    >
+                      ...
+                    </span>
+                  )
+                }
+
+                const isActive = item === currentPage
+                return (
+                  <Button
+                    key={item}
+                    variant={isActive ? 'default' : 'outline'}
+                    size="sm"
+                    aria-current={isActive ? 'page' : undefined}
+                    className="min-w-8 px-2.5"
+                    onClick={() => onPageChange(item)}
+                  >
+                    {item}
+                  </Button>
+                )
+              })}
+            </div>
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={currentPage >= normalizedTotalPages}
+              onClick={() => onPageChange(currentPage + 1)}
+            >
+              {t('common.next')}
+            </Button>
+          </div>
+        ) : (
+          <span className="min-w-[80px] text-right text-[13px] font-semibold text-muted-foreground">
+            {t('common.pageInfo', { current: currentPage, total: normalizedTotalPages })}
+          </span>
+        )}
       </div>
     </div>
   )

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -31,6 +31,8 @@
     "page": "Page",
     "prev": "Previous",
     "next": "Next",
+    "pageSize": "Rows",
+    "pageSizeOption": "{{size}} / page",
     "selected": "{{count}} selected",
     "pageInfo": "Page {{current}} / {{total}}",
     "showingRange": "Showing {{start}}-{{end}} of {{total}}",

--- a/frontend/src/locales/zh.json
+++ b/frontend/src/locales/zh.json
@@ -31,6 +31,8 @@
     "page": "页",
     "prev": "上一页",
     "next": "下一页",
+    "pageSize": "每页条数",
+    "pageSizeOption": "{{size}} 条/页",
     "selected": "已选 {{count}} 项",
     "pageInfo": "第 {{current}} / {{total}} 页",
     "showingRange": "显示 {{start}}-{{end}} / 共 {{total}} 条",

--- a/frontend/src/pages/Accounts.tsx
+++ b/frontend/src/pages/Accounts.tsx
@@ -30,15 +30,15 @@ import AccountUsageModal from '../components/AccountUsageModal'
 
 export default function Accounts() {
   const { t } = useTranslation()
+  const pageSizeOptions = [10, 20, 50, 100]
   const [showAdd, setShowAdd] = useState(false)
   const [page, setPage] = useState(1)
+  const [pageSize, setPageSize] = useState(20)
   const [statusFilter, setStatusFilter] = useState<'all' | 'normal' | 'rate_limited' | 'banned' | 'locked'>('all')
   const [searchQuery, setSearchQuery] = useState('')
   const [planFilter, setPlanFilter] = useState<'all' | 'pro' | 'plus' | 'team' | 'free'>('all')
   const [sortKey, setSortKey] = useState<'requests' | 'usage' | 'importTime' | null>(null)
   const [sortDir, setSortDir] = useState<'asc' | 'desc'>('desc')
-
-  const PAGE_SIZE = 20
   const [addForm, setAddForm] = useState<AddAccountRequest>({
     refresh_token: '',
     proxy_url: '',
@@ -163,9 +163,16 @@ export default function Accounts() {
     return sortDir === 'asc' ? diff : -diff
   })
 
-  const totalPages = Math.max(1, Math.ceil(sortedAccounts.length / PAGE_SIZE))
-  const pagedAccounts = sortedAccounts.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE)
+  const totalPages = Math.max(1, Math.ceil(sortedAccounts.length / pageSize))
+  const currentPage = Math.min(page, totalPages)
+  const pagedAccounts = sortedAccounts.slice((currentPage - 1) * pageSize, currentPage * pageSize)
   const allPageSelected = pagedAccounts.length > 0 && pagedAccounts.every((a) => selected.has(a.id))
+
+  useEffect(() => {
+    if (page > totalPages) {
+      setPage(totalPages)
+    }
+  }, [page, totalPages])
 
   const toggleSelect = (id: number) => {
     setSelected((prev) => {
@@ -1127,11 +1134,16 @@ export default function Accounts() {
                 </Table>
               </div>
               <Pagination
-                page={page}
+                page={currentPage}
                 totalPages={totalPages}
                 onPageChange={setPage}
-                totalItems={accounts.length}
-                pageSize={PAGE_SIZE}
+                totalItems={sortedAccounts.length}
+                pageSize={pageSize}
+                pageSizeOptions={pageSizeOptions}
+                onPageSizeChange={(nextPageSize) => {
+                  setPageSize(nextPageSize)
+                  setPage(1)
+                }}
               />
             </StateShell>
           </CardContent>

--- a/frontend/src/pages/SchedulerBoard.tsx
+++ b/frontend/src/pages/SchedulerBoard.tsx
@@ -14,12 +14,15 @@ import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import { Select } from '@/components/ui/select'
 
+const DEFAULT_PAGE_SIZE = 12
+const PAGE_SIZE_OPTIONS = [12, 20, 50, 100]
+
 export default function SchedulerBoard() {
   const { t } = useTranslation()
   const [tierFilter, setTierFilter] = useState('all')
   const [sortBy, setSortBy] = useState('risk')
   const [page, setPage] = useState(1)
-  const PAGE_SIZE = 12
+  const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE)
 
   const loadSchedulerData = useCallback(async () => {
     const [overview, accountsResponse] = await Promise.all([
@@ -118,13 +121,25 @@ export default function SchedulerBoard() {
       })
   }, [accounts, tierFilter, sortBy])
 
-  const totalPages = Math.max(1, Math.ceil(spotlightAccounts.length / PAGE_SIZE))
-  const pagedAccounts = spotlightAccounts.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE)
+  const totalPages = Math.max(1, Math.ceil(spotlightAccounts.length / pageSize))
+  const currentPage = Math.min(page, totalPages)
+  const pagedAccounts = spotlightAccounts.slice((currentPage - 1) * pageSize, currentPage * pageSize)
 
   // 筛选/排序变更时重置页码
   useEffect(() => {
     setPage(1)
   }, [tierFilter, sortBy])
+
+  useEffect(() => {
+    if (page > totalPages) {
+      setPage(totalPages)
+    }
+  }, [page, totalPages])
+
+  const handlePageSizeChange = useCallback((nextPageSize: number) => {
+    setPageSize(nextPageSize)
+    setPage(1)
+  }, [])
 
   return (
     <StateShell
@@ -270,17 +285,17 @@ export default function SchedulerBoard() {
                       </div>
                     ))}
                     </div>
-                    {totalPages > 1 && (
-                      <div className="mt-4">
-                        <Pagination
-                          page={page}
-                          totalPages={totalPages}
-                          onPageChange={setPage}
-                          totalItems={spotlightAccounts.length}
-                          pageSize={PAGE_SIZE}
-                        />
-                      </div>
-                    )}
+                    <div className="mt-4">
+                      <Pagination
+                        page={currentPage}
+                        totalPages={totalPages}
+                        onPageChange={setPage}
+                        totalItems={spotlightAccounts.length}
+                        pageSize={pageSize}
+                        pageSizeOptions={PAGE_SIZE_OPTIONS}
+                        onPageSizeChange={handlePageSizeChange}
+                      />
+                    </div>
                   </>
                 ) : (
                   <div className="mt-5 rounded-2xl border border-border bg-white/40 dark:bg-white/5 px-4 py-4 text-sm text-muted-foreground">

--- a/frontend/src/pages/Usage.tsx
+++ b/frontend/src/pages/Usage.tsx
@@ -101,6 +101,7 @@ export default function Usage() {
   const { toast, showToast } = useToast()
   const { confirm, confirmDialog } = useConfirmDialog()
   const [page, setPage] = useState(1)
+  const [pageSize, setPageSize] = useState(20)
   const [clearing, setClearing] = useState(false)
   const [timeRange, setTimeRange] = useState<TimeRangeKey>('1h')
   const [logs, setLogs] = useState<UsageLog[]>([])
@@ -116,7 +117,7 @@ export default function Usage() {
   const [apiKeys, setAPIKeys] = useState<APIKeyRow[]>([])
   const [apiKeyLoadFailed, setAPIKeyLoadFailed] = useState(false)
   const showFastFilter = false
-  const PAGE_SIZE = 20
+  const pageSizeOptions = [10, 20, 50, 100]
   const searchTimer = useRef<ReturnType<typeof setTimeout>>(null)
 
   // 搜索防抖：输入停止 400ms 后触发查询
@@ -153,13 +154,13 @@ export default function Usage() {
     }
   }, [])
 
-  // 服务端分页加载日志（每页仅传输 20 行）
+  // 服务端分页加载日志
   const loadLogs = useCallback(async () => {
     setLogsLoading(true)
     try {
       const { start, end } = getTimeRangeISO(timeRange)
       const res = await api.getUsageLogsPaged({
-        start, end, page, pageSize: PAGE_SIZE,
+        start, end, page, pageSize,
         email: searchEmail || undefined,
         model: filterModel || undefined,
         endpoint: filterEndpoint || undefined,
@@ -174,7 +175,7 @@ export default function Usage() {
     } finally {
       setLogsLoading(false)
     }
-  }, [timeRange, page, searchEmail, filterModel, filterEndpoint, filterApiKeyId, filterFast, filterStream])
+  }, [timeRange, page, pageSize, searchEmail, filterModel, filterEndpoint, filterApiKeyId, filterFast, filterStream])
 
   // 首次加载 + timeRange/page 变更时重新拉取日志
   useEffect(() => {
@@ -193,7 +194,15 @@ export default function Usage() {
   }, [reloadSilently])
 
   const { stats } = data
-  const totalPages = Math.max(1, Math.ceil(logsTotal / PAGE_SIZE))
+  const totalPages = Math.max(1, Math.ceil(logsTotal / pageSize))
+  const currentPage = Math.min(page, totalPages)
+
+  useEffect(() => {
+    if (page > totalPages) {
+      setPage(totalPages)
+    }
+  }, [page, totalPages])
+
   const totalRequests = stats?.total_requests ?? 0
   const totalTokens = stats?.total_tokens ?? 0
   const totalPromptTokens = stats?.total_prompt_tokens ?? 0
@@ -622,11 +631,16 @@ export default function Usage() {
                 </Table>
               </div>
               <Pagination
-                page={page}
+                page={currentPage}
                 totalPages={totalPages}
                 onPageChange={setPage}
                 totalItems={logsTotal}
-                pageSize={PAGE_SIZE}
+                pageSize={pageSize}
+                pageSizeOptions={pageSizeOptions}
+                onPageSizeChange={(nextPageSize) => {
+                  setPageSize(nextPageSize)
+                  setPage(1)
+                }}
               />
             </StateShell>
           </CardContent>


### PR DESCRIPTION
## 变更

- 通用分页组件新增每页条数切换
- 新增页码按钮和省略号，交互参考 element-ui
- 接入账号管理、使用统计、调度面板
- 修正页码越界时的空白页问题
- 补充中英文分页文案

## 默认值

- 账号管理：`10 / 20 / 50 / 100`
- 使用统计：`10 / 20 / 50 / 100`
- 调度面板：`12 / 20 / 50 / 100`

## 验证

- `cd frontend && npm run typecheck`
