### PR TITLE
feat: handle premium 5h rate limit state

### DIFF
--- a/admin/test_connection.go
+++ b/admin/test_connection.go
@@ -80,24 +80,19 @@ func (h *Handler) TestConnection(c *gin.Context) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		if usagePct, ok := proxy.ParseCodexUsageHeaders(resp, account); ok {
-			h.store.PersistUsageSnapshot(account, usagePct)
-		}
+		proxy.SyncCodexUsageState(h.store, account, resp)
+		errBody, _ := io.ReadAll(resp.Body)
 		switch resp.StatusCode {
 		case http.StatusUnauthorized:
 			h.store.MarkCooldown(account, 24*time.Hour, "unauthorized")
 		case http.StatusTooManyRequests:
-			h.store.MarkCooldown(account, 5*time.Minute, "rate_limited")
+			proxy.Apply429Cooldown(h.store, account, errBody, resp)
 		}
-		errBody, _ := io.ReadAll(resp.Body)
 		sendTestEvent(c, testEvent{Type: "error", Error: fmt.Sprintf("上游返回 %d: %s", resp.StatusCode, truncate(string(errBody), 500))})
 		return
 	}
 
-	usagePct, hasUsage := proxy.ParseCodexUsageHeaders(resp, account)
-	if hasUsage {
-		h.store.PersistUsageSnapshot(account, usagePct)
-	}
+	usageState := proxy.SyncCodexUsageState(h.store, account, resp)
 
 	// 解析 SSE 流
 	hasContent := false
@@ -113,9 +108,11 @@ func (h *Handler) TestConnection(c *gin.Context) {
 			}
 		case "response.completed":
 			// 测试成功即重置冷却状态，用量限制由调度器自行判断
-			h.store.ClearCooldown(account)
+			if !usageState.Premium5hRateLimited && (!usageState.HasUsage7d || usageState.UsagePct7d < 100) {
+				h.store.ClearCooldown(account)
+			}
 			// 如果上游未返回用量头，清除旧的用量缓存，避免显示过期数据
-			if !hasUsage {
+			if !usageState.HasUsage7d && !usageState.HasUsage5h {
 				account.ClearUsageCache()
 			}
 			duration := time.Since(start).Milliseconds()
@@ -228,28 +225,23 @@ func (h *Handler) BatchTest(c *gin.Context) {
 				return
 			}
 			defer resp.Body.Close()
-			io.ReadAll(resp.Body) // 消费 body
+			body, _ := io.ReadAll(resp.Body)
 
 			switch resp.StatusCode {
 			case http.StatusOK:
-				usagePct, hasUsage := proxy.ParseCodexUsageHeaders(resp, acc)
-				if hasUsage {
-					h.store.PersistUsageSnapshot(acc, usagePct)
-				}
+				usageState := proxy.SyncCodexUsageState(h.store, acc, resp)
 				// 测试成功即重置冷却状态，用量限制由调度器自行判断
-				h.store.ClearCooldown(acc)
+				if !usageState.Premium5hRateLimited && (!usageState.HasUsage7d || usageState.UsagePct7d < 100) {
+					h.store.ClearCooldown(acc)
+				}
 				atomic.AddInt64(&successCount, 1)
 			case http.StatusUnauthorized:
-				if usagePct, ok := proxy.ParseCodexUsageHeaders(resp, acc); ok {
-					h.store.PersistUsageSnapshot(acc, usagePct)
-				}
+				proxy.SyncCodexUsageState(h.store, acc, resp)
 				h.store.MarkCooldown(acc, 24*time.Hour, "unauthorized")
 				atomic.AddInt64(&bannedCount, 1)
 			case http.StatusTooManyRequests:
-				if usagePct, ok := proxy.ParseCodexUsageHeaders(resp, acc); ok {
-					h.store.PersistUsageSnapshot(acc, usagePct)
-				}
-				h.store.MarkCooldown(acc, 5*time.Minute, "rate_limited")
+				proxy.SyncCodexUsageState(h.store, acc, resp)
+				proxy.Apply429Cooldown(h.store, acc, body, resp)
 				atomic.AddInt64(&rateLimitCount, 1)
 			default:
 				atomic.AddInt64(&failedCount, 1)

--- a/admin/usage_probe.go
+++ b/admin/usage_probe.go
@@ -31,10 +31,7 @@ func (h *Handler) ProbeUsageSnapshot(ctx context.Context, account *auth.Account)
 	}
 	defer resp.Body.Close()
 
-	usagePct, hasUsage := proxy.ParseCodexUsageHeaders(resp, account)
-	if hasUsage {
-		h.store.PersistUsageSnapshot(account, usagePct)
-	}
+	usageState := proxy.SyncCodexUsageState(h.store, account, resp)
 
 	_, _ = io.Copy(io.Discard, resp.Body)
 
@@ -42,7 +39,7 @@ func (h *Handler) ProbeUsageSnapshot(ctx context.Context, account *auth.Account)
 	case http.StatusOK:
 		h.store.ReportRequestSuccess(account, 0)
 		// 只有用量未耗尽时才重置状态
-		if !hasUsage || usagePct < 100 {
+		if !usageState.Premium5hRateLimited && (!usageState.HasUsage7d || usageState.UsagePct7d < 100) {
 			h.store.ClearCooldown(account)
 		}
 		return nil
@@ -52,7 +49,7 @@ func (h *Handler) ProbeUsageSnapshot(ctx context.Context, account *auth.Account)
 		return nil
 	case http.StatusTooManyRequests:
 		h.store.ReportRequestFailure(account, "client", 0)
-		h.store.MarkCooldown(account, 5*time.Minute, "rate_limited")
+		proxy.Apply429Cooldown(h.store, account, nil, resp)
 		return nil
 	default:
 		if resp.StatusCode >= 500 {

--- a/auth/fast_scheduler.go
+++ b/auth/fast_scheduler.go
@@ -179,38 +179,54 @@ func (s *FastScheduler) AcquireExcluding(exclude map[int64]bool) *Account {
 
 	now := time.Now()
 
-	s.mu.RLock()
-	baseLimit := s.baseLimit
-	for tierIdx, tier := range fastSchedulerTierOrder {
-		bucket := s.buckets[tier]
-		if len(bucket) == 0 {
-			continue
-		}
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
-		// 阶段 1：优先在验证过的账号（桶前部 provenBound 个）中 round-robin
-		provenBound := s.provenBounds[tierIdx]
-		if provenBound > 0 {
-			if acc := s.scanRange(bucket, 0, provenBound, &s.provenCurs[tierIdx], baseLimit, now, exclude); acc != nil {
-				s.mu.RUnlock()
+	baseLimit := s.baseLimit
+	for {
+		changed := false
+		for tierIdx, tier := range fastSchedulerTierOrder {
+			bucket := s.buckets[tier]
+			if len(bucket) == 0 {
+				continue
+			}
+
+			// 阶段 1：优先在验证过的账号（桶前部 provenBound 个）中 round-robin
+			provenBound := s.provenBounds[tierIdx]
+			if provenBound > 0 {
+				acc, stale := s.scanRangeLocked(tier, 0, provenBound, &s.provenCurs[tierIdx], baseLimit, now, exclude)
+				if acc != nil {
+					return acc
+				}
+				if stale {
+					changed = true
+					break
+				}
+			}
+
+			// 阶段 2：回退到全量 round-robin
+			acc, stale := s.scanRangeLocked(tier, 0, len(bucket), &s.cursors[tierIdx], baseLimit, now, exclude)
+			if acc != nil {
 				return acc
 			}
+			if stale {
+				changed = true
+				break
+			}
 		}
-
-		// 阶段 2：回退到全量 round-robin
-		if acc := s.scanRange(bucket, 0, len(bucket), &s.cursors[tierIdx], baseLimit, now, exclude); acc != nil {
-			s.mu.RUnlock()
-			return acc
+		if !changed {
+			return nil
 		}
 	}
-	s.mu.RUnlock()
-	return nil
 }
 
-// scanRange 在 bucket[start:end) 范围内 round-robin 扫描可用账号
-func (s *FastScheduler) scanRange(bucket []fastSchedulerEntry, rangeStart, rangeEnd int, cursor *atomic.Uint64, baseLimit int64, now time.Time, exclude map[int64]bool) *Account {
+// scanRangeLocked 在 bucket[start:end) 范围内 round-robin 扫描可用账号。
+// 返回 stale=true 表示桶内缓存已过期，调用方应重新开始扫描。
+func (s *FastScheduler) scanRangeLocked(expectedTier AccountHealthTier, rangeStart, rangeEnd int, cursor *atomic.Uint64, baseLimit int64, now time.Time, exclude map[int64]bool) (*Account, bool) {
+	bucket := s.buckets[expectedTier]
 	rangeLen := rangeEnd - rangeStart
 	if rangeLen <= 0 {
-		return nil
+		return nil, false
 	}
 	start := int(cursor.Add(1)-1) % rangeLen
 	for offset := 0; offset < rangeLen; offset++ {
@@ -221,16 +237,23 @@ func (s *FastScheduler) scanRange(bucket []fastSchedulerEntry, rangeStart, range
 		if exclude != nil && exclude[entry.dbID] {
 			continue
 		}
-		_, _, limit, _, available := entry.acc.fastSchedulerSnapshot(baseLimit, now)
+		tier, _, limit, _, available := entry.acc.fastSchedulerSnapshot(baseLimit, now)
+		if tier != expectedTier {
+			s.removeLocked(entry.dbID)
+			if available && limit > 0 {
+				s.insertLocked(entry.acc, now)
+			}
+			return nil, true
+		}
 		if !available || limit <= 0 {
 			continue
 		}
 		if !tryAcquireAccount(entry.acc, limit) {
 			continue
 		}
-		return entry.acc
+		return entry.acc, false
 	}
-	return nil
+	return nil, false
 }
 
 func (s *FastScheduler) Release(acc *Account) {
@@ -339,8 +362,12 @@ func (s *FastScheduler) rebuildPositionsLocked(tier AccountHealthTier) {
 }
 
 func (a *Account) fastSchedulerSnapshot(baseLimit int64, now time.Time) (AccountHealthTier, float64, int64, bool, bool) {
-	a.mu.RLock()
-	defer a.mu.RUnlock()
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if isPremium5hPlan(a.PlanType) && a.UsagePercent5hValid {
+		a.recomputeSchedulerLocked(baseLimit)
+	}
 
 	tier := a.healthTierLocked()
 	score := a.DispatchScore
@@ -364,7 +391,7 @@ func (a *Account) fastSchedulerSnapshot(baseLimit int64, now time.Time) (Account
 	}
 
 	available := a.Status != StatusError && tier != HealthTierBanned && a.AccessToken != ""
-	if a.Status == StatusCooldown && now.Before(a.CooldownUtil) {
+	if a.Status == StatusCooldown && now.Before(a.CooldownUtil) && !a.premium5hCooldownSuppressedLocked(now) {
 		available = false
 	}
 	// Free 账号 7d 用量耗尽，不参与调度

--- a/auth/fast_scheduler_test.go
+++ b/auth/fast_scheduler_test.go
@@ -240,6 +240,59 @@ func TestStoreFastSchedulerTracksCooldownTransition(t *testing.T) {
 	store.Release(got)
 }
 
+func TestFastSchedulerPremium5hRateLimitUsesSingleConcurrencyAndRecoversAfterReset(t *testing.T) {
+	acc := &Account{
+		DBID:                1,
+		AccessToken:         "token",
+		PlanType:            "plus",
+		Status:              StatusReady,
+		HealthTier:          HealthTierHealthy,
+		UsagePercent5h:      100,
+		UsagePercent5hValid: true,
+		Reset5hAt:           time.Now().Add(30 * time.Minute),
+	}
+
+	scheduler := NewFastScheduler(4)
+	scheduler.Rebuild([]*Account{acc})
+
+	sizes := scheduler.BucketSizes()
+	if sizes[HealthTierRisky] != 1 {
+		t.Fatalf("risky bucket size = %d, want 1", sizes[HealthTierRisky])
+	}
+
+	first := scheduler.Acquire()
+	if first == nil {
+		t.Fatal("first Acquire() returned nil")
+	}
+
+	second := scheduler.Acquire()
+	if second != nil {
+		t.Fatal("second Acquire() should be nil while premium 5h rate limit is active")
+	}
+
+	acc.mu.Lock()
+	acc.Reset5hAt = time.Now().Add(-time.Minute)
+	acc.mu.Unlock()
+	scheduler.Release(first)
+
+	third := scheduler.Acquire()
+	if third == nil {
+		t.Fatal("third Acquire() returned nil after premium 5h reset expired")
+	}
+	fourth := scheduler.Acquire()
+	if fourth == nil {
+		t.Fatal("fourth Acquire() returned nil, want recovered concurrency after reset")
+	}
+
+	sizes = scheduler.BucketSizes()
+	if sizes[HealthTierHealthy] != 1 || sizes[HealthTierRisky] != 0 {
+		t.Fatalf("unexpected bucket sizes after reset recovery: %#v", sizes)
+	}
+
+	scheduler.Release(third)
+	scheduler.Release(fourth)
+}
+
 func TestFastSchedulerEnabledFromEnv(t *testing.T) {
 	t.Setenv("FAST_SCHEDULER_ENABLED", "")
 	t.Setenv("CODEX_FAST_SCHEDULER", "")

--- a/auth/premium_rate_limit.go
+++ b/auth/premium_rate_limit.go
@@ -1,0 +1,143 @@
+package auth
+
+import (
+	"context"
+	"log"
+	"strings"
+	"sync/atomic"
+	"time"
+)
+
+const premium5hFallbackWindow = 5 * time.Hour
+
+func normalizePlanType(plan string) string {
+	return strings.ToLower(strings.TrimSpace(plan))
+}
+
+func isPremium5hPlan(plan string) bool {
+	switch normalizePlanType(plan) {
+	case "plus", "pro", "team":
+		return true
+	default:
+		return false
+	}
+}
+
+// IsPremium5hPlan 判断当前账号是否属于 premium 5h 限流语义范围。
+func (a *Account) IsPremium5hPlan() bool {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return isPremium5hPlan(a.PlanType)
+}
+
+func (a *Account) premium5hRateLimitedLocked(now time.Time) bool {
+	if !isPremium5hPlan(a.PlanType) {
+		return false
+	}
+	if !a.UsagePercent5hValid || a.UsagePercent5h < 100 {
+		return false
+	}
+	if a.Reset5hAt.IsZero() {
+		return false
+	}
+	return a.Reset5hAt.After(now)
+}
+
+func (a *Account) premium5hRateLimitWindowLocked(now time.Time) (bool, time.Time) {
+	if !a.premium5hRateLimitedLocked(now) {
+		return false, time.Time{}
+	}
+	return true, a.Reset5hAt
+}
+
+func (a *Account) premium5hCooldownSuppressedLocked(now time.Time) bool {
+	if a.Status != StatusCooldown || a.CooldownReason != "rate_limited" {
+		return false
+	}
+	active, _ := a.premium5hRateLimitWindowLocked(now)
+	return active
+}
+
+// IsPremium5hRateLimited 判断账号当前是否处于 premium 5h 限流态。
+func (a *Account) IsPremium5hRateLimited() bool {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.premium5hRateLimitedLocked(time.Now())
+}
+
+// GetUsageSnapshot5h 返回当前 5h 用量快照。
+func (a *Account) GetUsageSnapshot5h() (pct float64, resetAt time.Time, ok bool) {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	if !a.UsagePercent5hValid {
+		return 0, time.Time{}, false
+	}
+	return a.UsagePercent5h, a.Reset5hAt, true
+}
+
+// PersistUsageSnapshot5hOnly 持久化仅包含 5h 数据的用量快照。
+func (s *Store) PersistUsageSnapshot5hOnly(acc *Account) {
+	if acc == nil || s == nil || s.db == nil {
+		return
+	}
+
+	pct5h, reset5hAt, ok := acc.GetUsageSnapshot5h()
+	if !ok {
+		return
+	}
+
+	updatedAt := time.Now()
+	acc.mu.Lock()
+	acc.UsageUpdatedAt = updatedAt
+	acc.mu.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := s.db.UpdateUsageSnapshot5h(ctx, acc.DBID, pct5h, reset5hAt, updatedAt); err != nil {
+		log.Printf("[账号 %d] 持久化 5h 用量快照失败: %v", acc.DBID, err)
+	}
+}
+
+// MarkPremium5hRateLimited 将账号标记为 premium 5h 限流态，并按 resetAt 驱动恢复。
+func (s *Store) MarkPremium5hRateLimited(acc *Account, resetAt time.Time) {
+	if acc == nil || s == nil {
+		return
+	}
+
+	now := time.Now()
+	if resetAt.IsZero() || !resetAt.After(now) {
+		resetAt = now.Add(premium5hFallbackWindow)
+	}
+
+	acc.mu.Lock()
+	acc.UsagePercent5h = 100
+	acc.UsagePercent5hValid = true
+	acc.Reset5hAt = resetAt
+	acc.UsageUpdatedAt = now
+	acc.LastRateLimitedAt = now
+	if acc.Status == StatusCooldown && acc.CooldownReason == "rate_limited" {
+		acc.Status = StatusReady
+		acc.CooldownUtil = time.Time{}
+		acc.CooldownReason = ""
+	}
+	if acc.HealthTier != HealthTierBanned {
+		acc.HealthTier = HealthTierRisky
+	}
+	acc.recomputeSchedulerLocked(atomic.LoadInt64(&s.maxConcurrency))
+	acc.mu.Unlock()
+
+	s.fastSchedulerUpdate(acc)
+
+	if s.db == nil {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := s.db.ClearCooldown(ctx, acc.DBID); err != nil {
+		log.Printf("[账号 %d] 清理 premium 5h 限流冷却状态失败: %v", acc.DBID, err)
+	}
+	if err := s.db.UpdateUsageSnapshot5h(ctx, acc.DBID, 100, resetAt, now); err != nil {
+		log.Printf("[账号 %d] 持久化 premium 5h 限流快照失败: %v", acc.DBID, err)
+	}
+}

--- a/auth/premium_rate_limit_test.go
+++ b/auth/premium_rate_limit_test.go
@@ -1,0 +1,82 @@
+package auth
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func newPremium5hTestAccount(plan string, resetAt time.Time) *Account {
+	return &Account{
+		DBID:                1,
+		AccessToken:         "token",
+		PlanType:            plan,
+		Status:              StatusReady,
+		HealthTier:          HealthTierHealthy,
+		UsagePercent5h:      100,
+		UsagePercent5hValid: true,
+		Reset5hAt:           resetAt,
+		UsageUpdatedAt:      time.Now().Add(-20 * time.Minute),
+	}
+}
+
+func TestPremium5hRateLimitedAccountRemainsSchedulable(t *testing.T) {
+	acc := newPremium5hTestAccount("plus", time.Now().Add(45*time.Minute))
+
+	snapshot := acc.GetSchedulerDebugSnapshot(4)
+	if got := acc.RuntimeStatus(); got != "rate_limited" {
+		t.Fatalf("RuntimeStatus() = %q, want rate_limited", got)
+	}
+	if !acc.IsAvailable() {
+		t.Fatal("IsAvailable() = false, want true for premium 5h rate limited account")
+	}
+	if snapshot.HealthTier != string(HealthTierRisky) {
+		t.Fatalf("HealthTier = %q, want %q", snapshot.HealthTier, HealthTierRisky)
+	}
+	if snapshot.DynamicConcurrencyLimit != 1 {
+		t.Fatalf("DynamicConcurrencyLimit = %d, want 1", snapshot.DynamicConcurrencyLimit)
+	}
+}
+
+func TestPremium5hRateLimitExpiresAndUsageProbeResumes(t *testing.T) {
+	acc := newPremium5hTestAccount("team", time.Now().Add(-time.Minute))
+
+	snapshot := acc.GetSchedulerDebugSnapshot(4)
+	if got := acc.RuntimeStatus(); got != "active" {
+		t.Fatalf("RuntimeStatus() = %q, want active after reset expires", got)
+	}
+	if !acc.IsAvailable() {
+		t.Fatal("IsAvailable() = false, want true after reset expires")
+	}
+	if snapshot.HealthTier != string(HealthTierHealthy) {
+		t.Fatalf("HealthTier = %q, want %q", snapshot.HealthTier, HealthTierHealthy)
+	}
+	if snapshot.DynamicConcurrencyLimit != 4 {
+		t.Fatalf("DynamicConcurrencyLimit = %d, want 4", snapshot.DynamicConcurrencyLimit)
+	}
+	if !acc.NeedsUsageProbe(10 * time.Minute) {
+		t.Fatal("NeedsUsageProbe() = false, want true after reset expires and snapshot becomes stale")
+	}
+}
+
+func TestPremium5hRateLimitedSkipsUsageProbeBeforeReset(t *testing.T) {
+	acc := newPremium5hTestAccount("pro", time.Now().Add(30*time.Minute))
+
+	if acc.NeedsUsageProbe(10 * time.Minute) {
+		t.Fatal("NeedsUsageProbe() = true, want false before premium 5h reset time")
+	}
+}
+
+func TestCleanByRuntimeStatusSkipsPremium5hRateLimitedAccount(t *testing.T) {
+	acc := newPremium5hTestAccount("plus", time.Now().Add(20*time.Minute))
+	store := &Store{
+		accounts: []*Account{acc},
+	}
+
+	if cleaned := store.CleanByRuntimeStatus(context.Background(), "rate_limited"); cleaned != 0 {
+		t.Fatalf("CleanByRuntimeStatus() cleaned = %d, want 0", cleaned)
+	}
+	if store.AccountCount() != 1 {
+		t.Fatalf("AccountCount() = %d, want 1", store.AccountCount())
+	}
+}

--- a/auth/store.go
+++ b/auth/store.go
@@ -339,6 +339,7 @@ func linearDecay(base float64, elapsed, window time.Duration) float64 {
 func (a *Account) schedulerBreakdownLocked() SchedulerBreakdown {
 	now := time.Now()
 	breakdown := SchedulerBreakdown{}
+	premium5hLimited := a.premium5hRateLimitedLocked(now)
 
 	// 线性衰减惩罚：随时间平滑更无突变
 	if !a.LastUnauthorizedAt.IsZero() {
@@ -359,10 +360,12 @@ func (a *Account) schedulerBreakdownLocked() SchedulerBreakdown {
 	}
 
 	breakdown.FailurePenalty = float64(clampInt(a.FailureStreak*6, 0, 24))
-	breakdown.SuccessBonus = float64(clampInt(a.SuccessStreak*2, 0, 12))
+	if !premium5hLimited {
+		breakdown.SuccessBonus = float64(clampInt(a.SuccessStreak*2, 0, 12))
+	}
 
 	// 经过验证的账号（累计请求 > 10 次）优先调度
-	if atomic.LoadInt64(&a.TotalRequests) > 10 {
+	if !premium5hLimited && atomic.LoadInt64(&a.TotalRequests) > 10 {
 		breakdown.ProvenBonus = 20
 	}
 
@@ -484,6 +487,9 @@ func (a *Account) recomputeSchedulerLocked(baseLimit int64) {
 	if a.HealthTier == HealthTierBanned {
 		tier = HealthTierBanned
 	}
+	if a.premium5hRateLimitedLocked(now) && tier != HealthTierBanned {
+		tier = HealthTierRisky
+	}
 
 	baseConcurrencyEffective := a.effectiveBaseConcurrencyLocked(baseLimit)
 	scoreBiasEffective := a.effectiveScoreBiasLocked(now, tier)
@@ -495,6 +501,9 @@ func (a *Account) recomputeSchedulerLocked(baseLimit int64) {
 	a.ScoreBiasEffective = scoreBiasEffective
 	a.BaseConcurrencyEffective = baseConcurrencyEffective
 	a.DynamicConcurrencyLimit = concurrencyLimitForTier(baseConcurrencyEffective, tier)
+	if a.premium5hRateLimitedLocked(now) && a.DynamicConcurrencyLimit > 1 {
+		a.DynamicConcurrencyLimit = 1
+	}
 }
 
 func (a *Account) schedulerSnapshot(baseLimit int64) (AccountHealthTier, float64, float64, int64) {
@@ -523,6 +532,9 @@ func (a *Account) IsAvailable() bool {
 	// Free 账号 7d 用量 >= 100%，视为不可用
 	if a.usageExhaustedLocked() {
 		return false
+	}
+	if a.premium5hRateLimitedLocked(time.Now()) {
+		return a.AccessToken != ""
 	}
 	if a.Status == StatusCooldown && time.Now().Before(a.CooldownUtil) {
 		return false
@@ -604,6 +616,7 @@ func (a *Account) IsBanned() bool {
 func (a *Account) RuntimeStatus() string {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
+	now := time.Now()
 	if a.healthTierLocked() == HealthTierBanned {
 		return "unauthorized"
 	}
@@ -611,11 +624,14 @@ func (a *Account) RuntimeStatus() string {
 	if a.usageExhaustedLocked() {
 		return "usage_exhausted"
 	}
+	if a.premium5hRateLimitedLocked(now) {
+		return "rate_limited"
+	}
 	switch a.Status {
 	case StatusError:
 		return "error"
 	case StatusCooldown:
-		if time.Now().Before(a.CooldownUtil) {
+		if now.Before(a.CooldownUtil) {
 			if a.CooldownReason != "" {
 				return a.CooldownReason
 			}
@@ -797,11 +813,15 @@ func (a *Account) GetSchedulerDebugSnapshot(baseLimit int64) SchedulerDebugSnaps
 func (a *Account) NeedsUsageProbe(maxAge time.Duration) bool {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
+	now := time.Now()
 
 	if a.usageProbeInFlight || a.AccessToken == "" || a.Status == StatusError {
 		return false
 	}
 	if a.Status == StatusCooldown && a.CooldownReason == "unauthorized" {
+		return false
+	}
+	if a.premium5hRateLimitedLocked(now) {
 		return false
 	}
 	if a.Status == StatusCooldown && a.CooldownReason == "rate_limited" {
@@ -1388,6 +1408,18 @@ func (s *Store) loadFromDB(ctx context.Context) error {
 			}
 		}
 		account.mu.Lock()
+		if account.premium5hCooldownSuppressedLocked(time.Now()) {
+			account.Status = StatusReady
+			account.CooldownUtil = time.Time{}
+			account.CooldownReason = ""
+		}
+		account.mu.Unlock()
+		if row.CooldownUntil.Valid && row.CooldownReason == "rate_limited" && account.IsPremium5hRateLimited() && s.db != nil {
+			if err := s.db.ClearCooldown(ctx, row.ID); err != nil {
+				log.Printf("[账号 %d] 清理 premium 5h 冷却状态失败: %v", row.ID, err)
+			}
+		}
+		account.mu.Lock()
 		account.recomputeSchedulerLocked(atomic.LoadInt64(&s.maxConcurrency))
 		account.mu.Unlock()
 
@@ -1470,6 +1502,9 @@ func (s *Store) CleanByRuntimeStatus(ctx context.Context, targetStatus string) i
 
 	for _, acc := range accounts {
 		if acc == nil || acc.RuntimeStatus() != targetStatus {
+			continue
+		}
+		if targetStatus == "rate_limited" && acc.IsPremium5hRateLimited() {
 			continue
 		}
 
@@ -1920,12 +1955,13 @@ func (s *Store) ClearCooldown(acc *Account) {
 	atomic.StoreInt32(&acc.Disabled, 0) // 清除原子禁用标志
 	acc.mu.Lock()
 	wasCooling := acc.Status == StatusCooldown
+	premium5hLimited := acc.premium5hRateLimitedLocked(time.Now())
 	if acc.Status == StatusCooldown {
 		acc.Status = StatusReady
 	}
 	acc.CooldownUtil = time.Time{}
 	acc.CooldownReason = ""
-	if wasCooling {
+	if wasCooling && !premium5hLimited {
 		acc.HealthTier = HealthTierWarm
 	}
 	acc.recomputeSchedulerLocked(atomic.LoadInt64(&s.maxConcurrency))
@@ -2500,8 +2536,10 @@ func (s *Store) refreshAccount(ctx context.Context, acc *Account) error {
 	dbID := acc.DBID
 	cooldownUntil := acc.CooldownUtil
 	cooldownReason := acc.CooldownReason
-	activeCooldown := acc.Status == StatusCooldown && time.Now().Before(acc.CooldownUtil)
-	expiredCooldown := acc.Status == StatusCooldown && !time.Now().Before(acc.CooldownUtil)
+	now := time.Now()
+	premiumCooldownSuppressed := acc.premium5hCooldownSuppressedLocked(now)
+	activeCooldown := acc.Status == StatusCooldown && now.Before(acc.CooldownUtil) && !premiumCooldownSuppressed
+	expiredCooldown := acc.Status == StatusCooldown && !now.Before(acc.CooldownUtil)
 	acc.mu.RUnlock()
 
 	// 1. 尝试从缓存读取 AT

--- a/database/usage_snapshot.go
+++ b/database/usage_snapshot.go
@@ -1,0 +1,15 @@
+package database
+
+import (
+	"context"
+	"time"
+)
+
+// UpdateUsageSnapshot5h 持久化 5h 用量快照（无 7d 数据时使用）
+func (db *DB) UpdateUsageSnapshot5h(ctx context.Context, id int64, pct5h float64, reset5hAt time.Time, updatedAt time.Time) error {
+	return db.UpdateCredentials(ctx, id, map[string]interface{}{
+		"codex_5h_used_percent":  pct5h,
+		"codex_5h_reset_at":      reset5hAt.Format(time.RFC3339),
+		"codex_usage_updated_at": updatedAt.Format(time.RFC3339),
+	})
+}

--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -51,6 +51,32 @@ type usageLimitDetails struct {
 	resetsInSeconds int64
 }
 
+type CodexUsageSyncResult struct {
+	UsagePct7d           float64
+	HasUsage7d           bool
+	UsagePct5h           float64
+	Reset5hAt            time.Time
+	HasUsage5h           bool
+	Used5hHeaders        bool
+	Persisted5hOnly      bool
+	Premium5hRateLimited bool
+}
+
+type codexRateLimitWindow string
+
+const (
+	codexRateLimitWindowUnknown codexRateLimitWindow = ""
+	codexRateLimitWindowShort   codexRateLimitWindow = "short"
+	codexRateLimitWindow5h      codexRateLimitWindow = "5h"
+	codexRateLimitWindow7d      codexRateLimitWindow = "7d"
+)
+
+type codex429Decision struct {
+	Premium5h bool
+	ResetAt   time.Time
+	Cooldown  time.Duration
+}
+
 const (
 	contextAPIKeyID     = "apiKeyID"
 	contextAPIKeyName   = "apiKeyName"
@@ -518,9 +544,7 @@ func (h *Handler) Responses(c *gin.Context) {
 			if kind := classifyHTTPFailure(resp.StatusCode); kind != "" {
 				h.store.ReportRequestFailure(account, kind, time.Duration(durationMs)*time.Millisecond)
 			}
-			if usagePct, ok := parseCodexUsageHeaders(resp, account); ok {
-				h.store.PersistUsageSnapshot(account, usagePct)
-			}
+			SyncCodexUsageState(h.store, account, resp)
 			errBody, _ := io.ReadAll(resp.Body)
 			resp.Body.Close()
 			h.store.Release(account)
@@ -672,9 +696,7 @@ func (h *Handler) Responses(c *gin.Context) {
 		if shouldTransparentRetryStream(outcome, attempt, maxRetries, wroteAnyBody, c.Request.Context().Err(), writeErr) {
 			log.Printf("上游流在首包前断开，重置连接并重试 (attempt %d/%d, account %d, /v1/responses): %s", attempt+1, maxRetries+1, account.ID(), outcome.failureMessage)
 			recyclePooledClientForAccount(account)
-			if usagePct, ok := parseCodexUsageHeaders(resp, account); ok {
-				h.store.PersistUsageSnapshot(account, usagePct)
-			}
+			SyncCodexUsageState(h.store, account, resp)
 			h.store.ReportRequestFailure(account, outcome.failureKind, time.Duration(totalDuration)*time.Millisecond)
 			resp.Body.Close()
 			h.store.Release(account)
@@ -739,9 +761,7 @@ func (h *Handler) Responses(c *gin.Context) {
 		h.logUsageForRequest(c, logInput)
 
 		resp.Body.Close()
-		if usagePct, ok := parseCodexUsageHeaders(resp, account); ok {
-			h.store.PersistUsageSnapshot(account, usagePct)
-		}
+		SyncCodexUsageState(h.store, account, resp)
 		if outcome.penalize {
 			recyclePooledClientForAccount(account)
 			h.store.ReportRequestFailure(account, outcome.failureKind, time.Duration(totalDuration)*time.Millisecond)
@@ -876,9 +896,7 @@ func (h *Handler) ResponsesCompact(c *gin.Context) {
 			if kind := classifyHTTPFailure(resp.StatusCode); kind != "" {
 				h.store.ReportRequestFailure(account, kind, time.Duration(durationMs)*time.Millisecond)
 			}
-			if usagePct, ok := parseCodexUsageHeaders(resp, account); ok {
-				h.store.PersistUsageSnapshot(account, usagePct)
-			}
+			SyncCodexUsageState(h.store, account, resp)
 			errBody, _ := io.ReadAll(resp.Body)
 			resp.Body.Close()
 			h.store.Release(account)
@@ -910,9 +928,7 @@ func (h *Handler) ResponsesCompact(c *gin.Context) {
 		}
 
 		// 成功：直接透传响应体
-		if usagePct, ok := parseCodexUsageHeaders(resp, account); ok {
-			h.store.PersistUsageSnapshot(account, usagePct)
-		}
+		SyncCodexUsageState(h.store, account, resp)
 
 		respBody, _ := io.ReadAll(resp.Body)
 		resp.Body.Close()
@@ -1089,9 +1105,7 @@ func (h *Handler) ChatCompletions(c *gin.Context) {
 			if kind := classifyHTTPFailure(resp.StatusCode); kind != "" {
 				h.store.ReportRequestFailure(account, kind, time.Duration(durationMs)*time.Millisecond)
 			}
-			if usagePct, ok := parseCodexUsageHeaders(resp, account); ok {
-				h.store.PersistUsageSnapshot(account, usagePct)
-			}
+			SyncCodexUsageState(h.store, account, resp)
 			errBody, _ := io.ReadAll(resp.Body)
 			resp.Body.Close()
 			h.store.Release(account)
@@ -1248,9 +1262,7 @@ func (h *Handler) ChatCompletions(c *gin.Context) {
 		if shouldTransparentRetryStream(outcome, attempt, maxRetries, wroteAnyBody, c.Request.Context().Err(), writeErr) {
 			log.Printf("上游流在首包前断开，重置连接并重试 (attempt %d/%d, account %d, /v1/chat/completions): %s", attempt+1, maxRetries+1, account.ID(), outcome.failureMessage)
 			recyclePooledClientForAccount(account)
-			if usagePct, ok := parseCodexUsageHeaders(resp, account); ok {
-				h.store.PersistUsageSnapshot(account, usagePct)
-			}
+			SyncCodexUsageState(h.store, account, resp)
 			h.store.ReportRequestFailure(account, outcome.failureKind, time.Duration(totalDuration)*time.Millisecond)
 			resp.Body.Close()
 			h.store.Release(account)
@@ -1315,9 +1327,7 @@ func (h *Handler) ChatCompletions(c *gin.Context) {
 		h.logUsageForRequest(c, logInput)
 
 		resp.Body.Close()
-		if usagePct, ok := parseCodexUsageHeaders(resp, account); ok {
-			h.store.PersistUsageSnapshot(account, usagePct)
-		}
+		SyncCodexUsageState(h.store, account, resp)
 		if outcome.penalize {
 			recyclePooledClientForAccount(account)
 			h.store.ReportRequestFailure(account, outcome.failureKind, time.Duration(totalDuration)*time.Millisecond)
@@ -1443,13 +1453,184 @@ func isMissingScopeUnauthorized(body []byte) bool {
 	return strings.Contains(msg, "scope")
 }
 
+func parseRetryAfterResetAt(body []byte, now time.Time) (time.Time, bool) {
+	if len(body) == 0 {
+		return time.Time{}, false
+	}
+
+	if resetsAt := gjson.GetBytes(body, "error.resets_at").Int(); resetsAt > 0 {
+		resetTime := time.Unix(resetsAt, 0)
+		if resetTime.After(now) {
+			return resetTime, true
+		}
+	}
+
+	if secs := gjson.GetBytes(body, "error.resets_in_seconds").Int(); secs > 0 {
+		return now.Add(time.Duration(secs) * time.Second), true
+	}
+
+	return time.Time{}, false
+}
+
+func codexWindowType(windowMinutes float64) codexRateLimitWindow {
+	switch {
+	case windowMinutes >= 1440:
+		return codexRateLimitWindow7d
+	case windowMinutes >= 60:
+		return codexRateLimitWindow5h
+	case windowMinutes > 0:
+		return codexRateLimitWindowShort
+	default:
+		return codexRateLimitWindowUnknown
+	}
+}
+
+type codexWindowUsage struct {
+	usedPct   float64
+	resetSec  float64
+	windowMin float64
+	valid     bool
+}
+
+func parseCodexWindowUsage(usedStr, windowStr, resetStr string) codexWindowUsage {
+	if usedStr == "" {
+		return codexWindowUsage{}
+	}
+	return codexWindowUsage{
+		usedPct:   parseFloat(usedStr),
+		windowMin: parseFloat(windowStr),
+		resetSec:  parseFloat(resetStr),
+		valid:     true,
+	}
+}
+
+func classifyCodex429Window(resp *http.Response, now time.Time) (codexRateLimitWindow, time.Time, bool) {
+	if resp == nil {
+		return codexRateLimitWindowUnknown, time.Time{}, false
+	}
+
+	primary := parseCodexWindowUsage(
+		resp.Header.Get("x-codex-primary-used-percent"),
+		resp.Header.Get("x-codex-primary-window-minutes"),
+		resp.Header.Get("x-codex-primary-reset-after-seconds"),
+	)
+	secondary := parseCodexWindowUsage(
+		resp.Header.Get("x-codex-secondary-used-percent"),
+		resp.Header.Get("x-codex-secondary-window-minutes"),
+		resp.Header.Get("x-codex-secondary-reset-after-seconds"),
+	)
+
+	var exhausted []codexWindowUsage
+	if primary.valid && primary.usedPct >= 100 {
+		exhausted = append(exhausted, primary)
+	}
+	if secondary.valid && secondary.usedPct >= 100 {
+		exhausted = append(exhausted, secondary)
+	}
+	if len(exhausted) == 0 {
+		return codexRateLimitWindowUnknown, time.Time{}, false
+	}
+
+	chosen := exhausted[0]
+	for _, candidate := range exhausted[1:] {
+		if candidate.windowMin > chosen.windowMin {
+			chosen = candidate
+		}
+	}
+
+	var resetAt time.Time
+	if chosen.resetSec > 0 {
+		resetAt = now.Add(time.Duration(chosen.resetSec) * time.Second)
+	}
+	return codexWindowType(chosen.windowMin), resetAt, !resetAt.IsZero()
+}
+
+func responseHasCodex5hHeaders(resp *http.Response) bool {
+	if resp == nil {
+		return false
+	}
+
+	primary := parseCodexWindowUsage(
+		resp.Header.Get("x-codex-primary-used-percent"),
+		resp.Header.Get("x-codex-primary-window-minutes"),
+		resp.Header.Get("x-codex-primary-reset-after-seconds"),
+	)
+	if primary.valid && codexWindowType(primary.windowMin) == codexRateLimitWindow5h {
+		return true
+	}
+
+	secondary := parseCodexWindowUsage(
+		resp.Header.Get("x-codex-secondary-used-percent"),
+		resp.Header.Get("x-codex-secondary-window-minutes"),
+		resp.Header.Get("x-codex-secondary-reset-after-seconds"),
+	)
+	return secondary.valid && codexWindowType(secondary.windowMin) == codexRateLimitWindow5h
+}
+
+func classify429RateLimit(account *auth.Account, body []byte, resp *http.Response, now time.Time) codex429Decision {
+	if account != nil && account.IsPremium5hPlan() {
+		windowType, resetAt, hasWindowReset := classifyCodex429Window(resp, now)
+		exactResetAt, hasExactReset := parseRetryAfterResetAt(body, now)
+
+		switch windowType {
+		case codexRateLimitWindow5h:
+			if hasExactReset {
+				resetAt = exactResetAt
+			} else if !hasWindowReset {
+				resetAt = now.Add(5 * time.Hour)
+			}
+			return codex429Decision{
+				Premium5h: true,
+				ResetAt:   resetAt,
+				Cooldown:  time.Until(resetAt),
+			}
+		case codexRateLimitWindow7d, codexRateLimitWindowShort:
+			// 明确不是 5h 窗口时，保持原有 cooldown 语义。
+		default:
+			if hasExactReset {
+				return codex429Decision{
+					Premium5h: true,
+					ResetAt:   exactResetAt,
+					Cooldown:  time.Until(exactResetAt),
+				}
+			}
+			resetAt = now.Add(5 * time.Hour)
+			return codex429Decision{
+				Premium5h: true,
+				ResetAt:   resetAt,
+				Cooldown:  5 * time.Hour,
+			}
+		}
+	}
+
+	cooldown := compute429Cooldown(account, body, resp)
+	return codex429Decision{Cooldown: cooldown}
+}
+
+// Apply429Cooldown 统一处理 429 对账号状态的影响，premium 5h 场景优先写入显式限流态。
+func Apply429Cooldown(store *auth.Store, account *auth.Account, body []byte, resp *http.Response) codex429Decision {
+	decision := classify429RateLimit(account, body, resp, time.Now())
+	if store == nil || account == nil {
+		return decision
+	}
+	if decision.Premium5h {
+		store.MarkPremium5hRateLimited(account, decision.ResetAt)
+		return decision
+	}
+	store.MarkCooldown(account, decision.Cooldown, "rate_limited")
+	return decision
+}
+
 // applyCooldown 根据上游状态码设置智能冷却
 func (h *Handler) applyCooldown(account *auth.Account, statusCode int, body []byte, resp *http.Response) {
 	switch statusCode {
 	case http.StatusTooManyRequests:
-		cooldown := h.compute429Cooldown(account, body, resp)
-		log.Printf("账号 %d 被限速 (plan=%s)，冷却 %v", account.ID(), account.GetPlanType(), cooldown)
-		h.store.MarkCooldown(account, cooldown, "rate_limited")
+		decision := Apply429Cooldown(h.store, account, body, resp)
+		if decision.Premium5h {
+			log.Printf("账号 %d 触发 premium 5h 限流 (plan=%s)，重置时间 %s", account.ID(), account.GetPlanType(), decision.ResetAt.Format(time.RFC3339))
+			return
+		}
+		log.Printf("账号 %d 被限速 (plan=%s)，冷却 %v", account.ID(), account.GetPlanType(), decision.Cooldown)
 	case http.StatusUnauthorized:
 		// 原子标志瞬间置位，阻止其他并发请求再选到该账号
 		atomic.StoreInt32(&account.Disabled, 1)
@@ -1478,6 +1659,10 @@ func (h *Handler) applyCooldown(account *auth.Account, statusCode int, body []by
 
 // compute429Cooldown 根据计划类型和 Codex 响应精确计算 429 冷却时间
 func (h *Handler) compute429Cooldown(account *auth.Account, body []byte, resp *http.Response) time.Duration {
+	return compute429Cooldown(account, body, resp)
+}
+
+func compute429Cooldown(account *auth.Account, body []byte, resp *http.Response) time.Duration {
 	// 1. 优先使用 Codex 响应体中的精确重置时间
 	if resetDuration := parseRetryAfter(body); resetDuration > 2*time.Minute {
 		// parseRetryAfter 默认返回 2min（无数据），超过 2min 说明解析到了真实的 resets_at/resets_in_seconds
@@ -1497,7 +1682,7 @@ func (h *Handler) compute429Cooldown(account *auth.Account, body []byte, resp *h
 
 	case "team", "teamplus", "pro", "plus", "enterprise":
 		// Team/Pro/Plus 有 5h + 7d 双窗口，需要判断是哪个窗口触发了限制
-		return h.detectTeamCooldownWindow(resp)
+		return detectTeamCooldownWindow(resp)
 
 	default:
 		// 未知套餐，保守默认 5 小时
@@ -1507,6 +1692,10 @@ func (h *Handler) compute429Cooldown(account *auth.Account, body []byte, resp *h
 
 // detectTeamCooldownWindow 通过响应头判断 Team/Pro/Plus 账号是哪个窗口触发的限制
 func (h *Handler) detectTeamCooldownWindow(resp *http.Response) time.Duration {
+	return detectTeamCooldownWindow(resp)
+}
+
+func detectTeamCooldownWindow(resp *http.Response) time.Duration {
 	if resp == nil {
 		return 5 * time.Hour // 保守默认
 	}
@@ -1551,6 +1740,35 @@ func windowMinutesToCooldown(windowMinutes float64) time.Duration {
 	}
 }
 
+// SyncCodexUsageState 解析 Codex 响应头并完成 7d / 5h 快照持久化与 premium 5h 提前限流。
+func SyncCodexUsageState(store *auth.Store, account *auth.Account, resp *http.Response) CodexUsageSyncResult {
+	result := CodexUsageSyncResult{}
+	if account == nil || resp == nil {
+		return result
+	}
+
+	result.Used5hHeaders = responseHasCodex5hHeaders(resp)
+	result.UsagePct7d, result.HasUsage7d = parseCodexUsageHeaders(resp, account)
+	if store != nil {
+		if result.HasUsage7d {
+			store.PersistUsageSnapshot(account, result.UsagePct7d)
+		} else if result.Used5hHeaders {
+			store.PersistUsageSnapshot5hOnly(account)
+			result.Persisted5hOnly = true
+		}
+	}
+
+	result.UsagePct5h, result.Reset5hAt, result.HasUsage5h = account.GetUsageSnapshot5h()
+	if result.Used5hHeaders && account.IsPremium5hPlan() && result.HasUsage5h && result.UsagePct5h >= 100 {
+		if store != nil {
+			store.MarkPremium5hRateLimited(account, result.Reset5hAt)
+		}
+		result.Premium5hRateLimited = true
+	}
+
+	return result
+}
+
 // parseCodexUsageHeaders 从 Codex 响应头解析 5h/7d 用量百分比
 func parseCodexUsageHeaders(resp *http.Response, account *auth.Account) (float64, bool) {
 	if resp == nil {
@@ -1565,30 +1783,11 @@ func parseCodexUsageHeaders(resp *http.Response, account *auth.Account) (float64
 	secondaryWindowStr := resp.Header.Get("x-codex-secondary-window-minutes")
 	secondaryResetStr := resp.Header.Get("x-codex-secondary-reset-after-seconds")
 
-	type windowData struct {
-		usedPct   float64
-		resetSec  float64
-		windowMin float64
-		valid     bool
-	}
-
-	parseWindow := func(usedStr, windowStr, resetStr string) windowData {
-		if usedStr == "" {
-			return windowData{}
-		}
-		return windowData{
-			usedPct:   parseFloat(usedStr),
-			windowMin: parseFloat(windowStr),
-			resetSec:  parseFloat(resetStr),
-			valid:     true,
-		}
-	}
-
-	primary := parseWindow(primaryUsedStr, primaryWindowStr, primaryResetStr)
-	secondary := parseWindow(secondaryUsedStr, secondaryWindowStr, secondaryResetStr)
+	primary := parseCodexWindowUsage(primaryUsedStr, primaryWindowStr, primaryResetStr)
+	secondary := parseCodexWindowUsage(secondaryUsedStr, secondaryWindowStr, secondaryResetStr)
 
 	// 归一化：小窗口 (≤360min) → 5h，大窗口 (>360min) → 7d
-	var w5h, w7d windowData
+	var w5h, w7d codexWindowUsage
 	now := time.Now()
 
 	if primary.valid && secondary.valid {

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -172,6 +172,81 @@ func TestCompute429CooldownPlusPrefersExactResetTime(t *testing.T) {
 	}
 }
 
+func TestApply429CooldownPremiumMarks5hRateLimitFromWindow(t *testing.T) {
+	store := auth.NewStore(nil, nil, &database.SystemSettings{MaxConcurrency: 2, TestConcurrency: 1, TestModel: "gpt-5.4"})
+	account := &auth.Account{DBID: 101, PlanType: "plus"}
+	resp := &http.Response{Header: make(http.Header)}
+	resp.Header.Set("x-codex-primary-used-percent", "100")
+	resp.Header.Set("x-codex-primary-window-minutes", "300")
+	resp.Header.Set("x-codex-primary-reset-after-seconds", "900")
+
+	decision := Apply429Cooldown(store, account, []byte(`{"error":{"type":"usage_limit_reached"}}`), resp)
+
+	if !decision.Premium5h {
+		t.Fatal("expected premium 5h decision")
+	}
+	if !account.IsPremium5hRateLimited() {
+		t.Fatal("expected account to enter premium 5h rate limited state")
+	}
+	pct5h, resetAt, ok := account.GetUsageSnapshot5h()
+	if !ok {
+		t.Fatal("expected 5h snapshot to be set")
+	}
+	if pct5h != 100 {
+		t.Fatalf("usage_percent_5h = %v, want 100", pct5h)
+	}
+	if got := resetAt.Sub(time.Now()); got < 14*time.Minute || got > 16*time.Minute {
+		t.Fatalf("resetAt delta = %v, want about 15m", got)
+	}
+}
+
+func TestApply429CooldownPremiumFallsBackToFiveHoursWithoutExactReset(t *testing.T) {
+	store := auth.NewStore(nil, nil, &database.SystemSettings{MaxConcurrency: 2, TestConcurrency: 1, TestModel: "gpt-5.4"})
+	account := &auth.Account{DBID: 102, PlanType: "pro"}
+
+	decision := Apply429Cooldown(store, account, []byte(`{"error":{"type":"rate_limit_error","message":"Too many requests"}}`), &http.Response{Header: make(http.Header)})
+
+	if !decision.Premium5h {
+		t.Fatal("expected premium 5h fallback decision")
+	}
+	if got := decision.ResetAt.Sub(time.Now()); got < 4*time.Hour+59*time.Minute || got > 5*time.Hour+time.Minute {
+		t.Fatalf("resetAt delta = %v, want about 5h", got)
+	}
+	if !account.IsPremium5hRateLimited() {
+		t.Fatal("expected account to be marked premium 5h rate limited")
+	}
+}
+
+func TestSyncCodexUsageStateTriggersPremium5hLimitWith5hHeadersOnly(t *testing.T) {
+	store := auth.NewStore(nil, nil, &database.SystemSettings{MaxConcurrency: 2, TestConcurrency: 1, TestModel: "gpt-5.4"})
+	account := &auth.Account{DBID: 103, PlanType: "team"}
+	resp := &http.Response{Header: make(http.Header)}
+	resp.Header.Set("x-codex-primary-used-percent", "100")
+	resp.Header.Set("x-codex-primary-window-minutes", "300")
+	resp.Header.Set("x-codex-primary-reset-after-seconds", "600")
+
+	result := SyncCodexUsageState(store, account, resp)
+
+	if !result.Used5hHeaders {
+		t.Fatal("expected 5h headers to be detected")
+	}
+	if result.HasUsage7d {
+		t.Fatal("expected no 7d usage snapshot")
+	}
+	if !result.HasUsage5h {
+		t.Fatal("expected 5h usage snapshot")
+	}
+	if !result.Persisted5hOnly {
+		t.Fatal("expected 5h-only persistence path to be selected")
+	}
+	if !result.Premium5hRateLimited {
+		t.Fatal("expected premium 5h rate limit to trigger")
+	}
+	if !account.IsPremium5hRateLimited() {
+		t.Fatal("expected account to be premium 5h rate limited")
+	}
+}
+
 func TestAuthMiddlewareSetsAPIKeyContext(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/proxy/premium_rate_limit_test.go
+++ b/proxy/premium_rate_limit_test.go
@@ -1,0 +1,108 @@
+package proxy
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/codex2api/auth"
+	"github.com/codex2api/database"
+)
+
+func newProxyPremiumTestStore() *auth.Store {
+	return auth.NewStore(nil, nil, &database.SystemSettings{
+		MaxConcurrency:                   4,
+		TestConcurrency:                  1,
+		TestModel:                        "gpt-5.4",
+		BackgroundRefreshIntervalMinutes: 2,
+		UsageProbeMaxAgeMinutes:          10,
+		RecoveryProbeIntervalMinutes:     30,
+	})
+}
+
+func TestApply429CooldownPremium5hWindowMarksRateLimited(t *testing.T) {
+	store := newProxyPremiumTestStore()
+	acc := &auth.Account{
+		DBID:        1,
+		AccessToken: "token",
+		PlanType:    "plus",
+		Status:      auth.StatusReady,
+	}
+	resp := &http.Response{Header: make(http.Header)}
+	resp.Header.Set("x-codex-primary-used-percent", "100")
+	resp.Header.Set("x-codex-primary-window-minutes", "300")
+	resp.Header.Set("x-codex-primary-reset-after-seconds", "1800")
+
+	decision := Apply429Cooldown(store, acc, nil, resp)
+
+	if !decision.Premium5h {
+		t.Fatal("Apply429Cooldown() should classify premium 5h window as Premium5h")
+	}
+	if !acc.IsPremium5hRateLimited() {
+		t.Fatal("account should enter premium 5h rate_limited state")
+	}
+	if got := acc.RuntimeStatus(); got != "rate_limited" {
+		t.Fatalf("RuntimeStatus() = %q, want %q", got, "rate_limited")
+	}
+	if !acc.IsAvailable() {
+		t.Fatal("IsAvailable() = false, want true while premium 5h limit is active")
+	}
+	if got := acc.GetDynamicConcurrencyLimit(); got != 1 {
+		t.Fatalf("GetDynamicConcurrencyLimit() = %d, want 1", got)
+	}
+}
+
+func TestApply429CooldownPremiumFallsBackTo5hWhenResetUnknown(t *testing.T) {
+	store := newProxyPremiumTestStore()
+	acc := &auth.Account{
+		DBID:        1,
+		AccessToken: "token",
+		PlanType:    "pro",
+		Status:      auth.StatusReady,
+	}
+
+	start := time.Now()
+	decision := Apply429Cooldown(store, acc, []byte(`{"error":{"type":"usage_limit_reached"}}`), nil)
+
+	if !decision.Premium5h {
+		t.Fatal("Apply429Cooldown() should fallback to premium 5h when no reset details are available")
+	}
+	if decision.ResetAt.Before(start.Add(4*time.Hour+59*time.Minute)) || decision.ResetAt.After(start.Add(5*time.Hour+time.Minute)) {
+		t.Fatalf("ResetAt = %v, want about 5h from now", decision.ResetAt)
+	}
+	if !acc.IsPremium5hRateLimited() {
+		t.Fatal("account should enter premium 5h rate_limited state after fallback")
+	}
+}
+
+func TestSyncCodexUsageStatePremium5hOnlyHeadersMarksRateLimited(t *testing.T) {
+	store := newProxyPremiumTestStore()
+	acc := &auth.Account{
+		DBID:        1,
+		AccessToken: "token",
+		PlanType:    "team",
+		Status:      auth.StatusReady,
+	}
+	resp := &http.Response{Header: make(http.Header)}
+	resp.Header.Set("x-codex-primary-used-percent", "100")
+	resp.Header.Set("x-codex-primary-window-minutes", "300")
+	resp.Header.Set("x-codex-primary-reset-after-seconds", "900")
+
+	result := SyncCodexUsageState(store, acc, resp)
+
+	if result.HasUsage7d {
+		t.Fatal("HasUsage7d = true, want false for 5h-only headers")
+	}
+	if !result.HasUsage5h {
+		t.Fatal("HasUsage5h = false, want true")
+	}
+	if !result.Persisted5hOnly {
+		t.Fatal("Persisted5hOnly = false, want true")
+	}
+	if !result.Premium5hRateLimited {
+		t.Fatal("Premium5hRateLimited = false, want true")
+	}
+	if !acc.IsPremium5hRateLimited() {
+		t.Fatal("account should enter premium 5h rate_limited state from headers alone")
+	}
+}


### PR DESCRIPTION
## 概要

本 PR 调整了 `plus` / `pro` / `team` 账号的 5 小时限流处理逻辑。

当 premium 账号出现以下任一情况时：
- 收到 `429`
- 从 Codex 响应头中解析到 5h 窗口已用满

系统会将账号标记为 `rate_limited`，但不会将其移出调度池，而是将并发强制降为 `1`，并按照 `reset_5h_at` 进行恢复。

## 变更内容

- 在 `auth` 中新增 premium 5h 限流状态辅助逻辑
- premium 5h 限流账号仍可参与调度，但动态并发固定为 `1`
- premium 5h 限流恢复改为依赖 `reset_5h_at`，不再依赖固定 cooldown
- 在 5h 重置时间到达前，避免反复进行无意义的探针请求
- 在缺少 7d 用量头时，支持持久化仅包含 5h 的用量快照
- 将统一的 5h 限流处理接入以下流程：
  - 主请求代理流程
  - 用量探针流程
  - 单账号测试流程
  - 批量账号测试流程
- 补充调度器与代理层相关回归测试

## 验证

- `go test ./...`
