### PR TITLE
feat: abbreviate multi-level email domains

### DIFF
--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -4,3 +4,19 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export function formatCompactEmail(email?: string | null, fallback = '-'): string {
+  const value = email?.trim() ?? ''
+  if (!value) return fallback
+
+  const parts = value.split('@')
+  if (parts.length !== 2 || !parts[0] || !parts[1]) return value
+
+  const [localPart, domainPart] = parts
+  const labels = domainPart.split('.').filter(Boolean)
+  if (labels.length < 2) return value
+  if (labels.length < 3) return value
+
+  const hiddenLevels = labels.length - 2
+  return `${localPart}@${'*'.repeat(hiddenLevels)}.${labels.slice(-2).join('.')}`
+}

--- a/frontend/src/pages/Accounts.tsx
+++ b/frontend/src/pages/Accounts.tsx
@@ -12,6 +12,7 @@ import { useConfirmDialog } from '../hooks/useConfirmDialog'
 import { useToast } from '../hooks/useToast'
 import type { AccountRow, AddAccountRequest, AddATAccountRequest } from '../types'
 import { getErrorMessage } from '../utils/error'
+import { formatCompactEmail } from '../lib/utils'
 import { formatRelativeTime, formatBeijingTime } from '../utils/time'
 import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
@@ -1098,7 +1099,7 @@ export default function Accounts() {
                         </TableCell>
                         <TableCell className="text-[14px] font-mono text-muted-foreground">{account.id}</TableCell>
                         <TableCell className="text-[14px] text-muted-foreground">
-                          {account.email || '-'}
+                          {formatCompactEmail(account.email)}
                           {account.at_only && (
                             <span className="ml-1.5 inline-flex items-center rounded-md bg-amber-50 px-1.5 py-0.5 text-[10px] font-medium text-amber-700 ring-1 ring-inset ring-amber-600/20 dark:bg-amber-950 dark:text-amber-400 dark:ring-amber-400/20">
                               AT

--- a/frontend/src/pages/SchedulerBoard.tsx
+++ b/frontend/src/pages/SchedulerBoard.tsx
@@ -9,6 +9,7 @@ import StateShell from '../components/StateShell'
 import { useDataLoader } from '../hooks/useDataLoader'
 import StatusBadge from '../components/StatusBadge'
 import type { AccountRow, OpsOverviewResponse } from '../types'
+import { formatCompactEmail } from '../lib/utils'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
@@ -257,7 +258,7 @@ export default function SchedulerBoard() {
                         <div className="flex items-start justify-between gap-3">
                           <div className="min-w-0">
                             <div className="truncate text-[14px] font-semibold text-foreground">
-                              {account.email || `ID ${account.id}`}
+                              {account.email ? formatCompactEmail(account.email) : `ID ${account.id}`}
                             </div>
                             <div className="mt-1 text-[12px] text-muted-foreground">
                               {t('scheduler.score')} {Math.round(getDispatchScore(account))} · {t('scheduler.concurrency')} {account.dynamic_concurrency_limit ?? '-'} · {t('scheduler.plan')} {account.plan_type || '-'}

--- a/frontend/src/pages/Usage.tsx
+++ b/frontend/src/pages/Usage.tsx
@@ -11,6 +11,7 @@ import { useDataLoader } from '../hooks/useDataLoader'
 import { useConfirmDialog } from '../hooks/useConfirmDialog'
 import { useToast } from '../hooks/useToast'
 import type { APIKeyRow, UsageLog, UsageStats } from '../types'
+import { formatCompactEmail } from '../lib/utils'
 import { formatBeijingTime } from '../utils/time'
 import { Card, CardContent } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
@@ -552,7 +553,7 @@ export default function Usage() {
                           </div>
                         </TableCell>
                         <TableCell className="text-[14px] text-muted-foreground">
-                          {log.account_email || '-'}
+                          {formatCompactEmail(log.account_email)}
                         </TableCell>
                         <TableCell className="text-[14px] text-muted-foreground">
                           <span className="block max-w-[180px] truncate whitespace-nowrap" title={formatUsageAPIKeyLabel(log.api_key_name, log.api_key_masked) || t('usage.unknownApiKey')}>


### PR DESCRIPTION
## 背景

部分账号邮箱包含很长的多级子域名，直接展示会导致账号列表、调度看板和 Usage 表格可读性较差。

## 本次修改

- 新增前端统一邮箱缩略函数 `formatCompactEmail`
- 多级域名邮箱展示时保留本地名和最后两级域名
- 每省略一级子域名，使用一个 `*` 表示
- 账号列表页使用缩略展示
- 调度看板卡片使用缩略展示
- Usage 表格邮箱列使用缩略展示

## 展示规则

- `liamanderson@agenticai-eqrw.neuralnetworks-eaik.transformers-rfxb.finetuning-ynkg.rag-thx6.vectordatabase-pvo2.embeddings-mr8w.xxxx.com`
  显示为
  `liamanderson@*******.xxxx.com`
- `emmaharrison@promptengineering-zvn5.xxxx.com`
  显示为
  `emmaharrison@*.xxxx.com`
- 域名层级不足三级时保持原样
- 空值返回 `-`
- 非法邮箱格式原样返回，避免误处理

## 保持不变

- 后端接口返回结构不变
- 搜索逻辑不变
- 账号页仍按完整 `account.email` / `account.name` 进行本地搜索
- Usage 页仍按完整邮箱参数进行服务端筛选
- 详情、编辑、测试连接、删除确认、OAuth 成功提示等场景仍显示完整邮箱

## 验证

- `npm run typecheck`
- `npm run build`

## 影响范围

- 前端展示层
- 不涉及数据库、后端接口和搜索链路变更
