### PR TITLE
fix: allow compaction responses input #96

### DIFF
--- a/api/validation.go
+++ b/api/validation.go
@@ -654,6 +654,7 @@ func ValidateInput() ValidationRule {
 			"item_reference":          true,
 			"image_generation_call":   true,
 			"web_search_call":         true,
+			"compaction":              true,
 			"file":                    true,
 			"image":                   true,
 		}

--- a/api/validation_test.go
+++ b/api/validation_test.go
@@ -58,6 +58,23 @@ func TestValidateResponsesAPIRequestAllowsCodexToolInputTypes(t *testing.T) {
 	}
 }
 
+func TestValidateResponsesAPIRequestAllowsCompactionInputType(t *testing.T) {
+	result := ValidateResponsesAPIRequest(
+		[]byte(`{
+			"model":"gpt-5.4",
+			"input":[
+				{"type":"message","role":"user","content":"hello"},
+				{"type":"compaction","summary":"previous context was compacted"}
+			]
+		}`),
+		[]string{"gpt-5.4"},
+	)
+
+	if !result.Valid {
+		t.Fatalf("expected compaction input type to be valid, got %#v", result.Errors)
+	}
+}
+
 func TestValidateResponsesAPIRequestRejectsUnknownInputType(t *testing.T) {
 	result := ValidateResponsesAPIRequest(
 		[]byte(`{"model":"gpt-5.4","input":[{"type":"unknown_call","call_id":"call_1"}]}`),

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"net/http"
@@ -118,6 +119,49 @@ func TestRegisterRoutesIncludesCodexDirectResponses(t *testing.T) {
 		if !routes[path] {
 			t.Fatalf("expected POST route %s to be registered; routes=%v", path, routes)
 		}
+	}
+}
+
+func TestResponsesEndpointsAllowCompactionInputType(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	handler := NewHandler(auth.NewStore(nil, nil, nil), nil, nil, nil)
+	body := []byte(`{
+		"model":"gpt-5.4",
+		"input":[
+			{"type":"message","role":"user","content":"hello"},
+			{"type":"compaction","summary":"previous context was compacted"}
+		]
+	}`)
+
+	tests := []struct {
+		name    string
+		path    string
+		handler gin.HandlerFunc
+	}{
+		{name: "responses", path: "/v1/responses", handler: handler.Responses},
+		{name: "responses compact", path: "/v1/responses/compact", handler: handler.ResponsesCompact},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+			req := httptest.NewRequest(http.MethodPost, test.path, bytes.NewReader(body)).WithContext(ctx)
+			req.Header.Set("Content-Type", "application/json")
+			recorder := httptest.NewRecorder()
+			ginCtx, _ := gin.CreateTestContext(recorder)
+			ginCtx.Request = req
+
+			test.handler(ginCtx)
+
+			if recorder.Code == http.StatusBadRequest && strings.Contains(recorder.Body.String(), "invalid_input_type") {
+				t.Fatalf("compaction input type was rejected by local validation: %s", recorder.Body.String())
+			}
+			if recorder.Code != http.StatusServiceUnavailable {
+				t.Fatalf("status = %d, want %d after validation passes; body=%s", recorder.Code, http.StatusServiceUnavailable, recorder.Body.String())
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
#96 

自己本地测试 /compact可以正确运行


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Input validation for the Responses API has been improved to accept "compaction" item types in requests. Requests that previously failed due to invalid input type errors are now properly validated and processed, enabling full support for compaction items in API calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->