### PR TITLE
fix: expose cached token details in OpenAI-compatible usage

### DIFF
--- a/proxy/translator.go
+++ b/proxy/translator.go
@@ -1150,14 +1150,38 @@ func schemaDeclaresArray(schema map[string]interface{}) bool {
 // ==================== 响应翻译: Codex SSE → OpenAI SSE ====================
 
 // UsageInfo token 使用统计
+type TokenDetails struct {
+	CachedTokens int `json:"cached_tokens,omitempty"`
+}
+
 type UsageInfo struct {
-	PromptTokens     int `json:"prompt_tokens"`
-	CompletionTokens int `json:"completion_tokens"`
-	TotalTokens      int `json:"total_tokens"`
-	InputTokens      int `json:"input_tokens,omitempty"`
-	OutputTokens     int `json:"output_tokens,omitempty"`
-	ReasoningTokens  int `json:"reasoning_tokens,omitempty"`
-	CachedTokens     int `json:"cached_tokens,omitempty"`
+	PromptTokens            int           `json:"prompt_tokens"`
+	CompletionTokens        int           `json:"completion_tokens"`
+	TotalTokens             int           `json:"total_tokens"`
+	InputTokens             int           `json:"input_tokens,omitempty"`
+	OutputTokens            int           `json:"output_tokens,omitempty"`
+	ReasoningTokens         int           `json:"reasoning_tokens,omitempty"`
+	CachedTokens            int           `json:"cached_tokens,omitempty"`
+	PromptTokensDetails     *TokenDetails `json:"prompt_tokens_details,omitempty"`
+	InputTokensDetails      *TokenDetails `json:"input_tokens_details,omitempty"`
+}
+
+func newUsageInfo(inputTokens, outputTokens, reasoningTokens, cachedTokens int) *UsageInfo {
+	usage := &UsageInfo{
+		PromptTokens:     inputTokens,
+		CompletionTokens: outputTokens,
+		TotalTokens:      inputTokens + outputTokens,
+		InputTokens:      inputTokens,
+		OutputTokens:     outputTokens,
+		ReasoningTokens:  reasoningTokens,
+		CachedTokens:     cachedTokens,
+	}
+	if cachedTokens > 0 {
+		details := &TokenDetails{CachedTokens: cachedTokens}
+		usage.PromptTokensDetails = details
+		usage.InputTokensDetails = details
+	}
+	return usage
 }
 
 // newContentChunk 构建文本内容流式块
@@ -1492,15 +1516,7 @@ func extractUsageFromResult(usage gjson.Result) *UsageInfo {
 	outputTokens := int(usage.Get("output_tokens").Int())
 	reasoningTokens := int(usage.Get("output_tokens_details.reasoning_tokens").Int())
 	cachedTokens := int(usage.Get("input_tokens_details.cached_tokens").Int())
-	return &UsageInfo{
-		PromptTokens:     inputTokens,
-		CompletionTokens: outputTokens,
-		TotalTokens:      inputTokens + outputTokens,
-		InputTokens:      inputTokens,
-		OutputTokens:     outputTokens,
-		ReasoningTokens:  reasoningTokens,
-		CachedTokens:     cachedTokens,
-	}
+	return newUsageInfo(inputTokens, outputTokens, reasoningTokens, cachedTokens)
 }
 
 // ExtractToolCallsFromOutput 从 response.completed 事件的 output 数组中提取 function_call 项


### PR DESCRIPTION
## Summary

This PR exposes cached token usage in OpenAI-compatible responses using standard token detail fields.

Previously, converted OpenAI-compatible usage included a top-level `cached_tokens` field, but some downstream gateways only parse cached tokens from:

- `usage.prompt_tokens_details.cached_tokens`
- `usage.input_tokens_details.cached_tokens`

As a result, downstream systems could miss prompt cache hits and bill cached tokens as regular prompt tokens.

## Changes

- Add `TokenDetails` with `cached_tokens`
- Populate both:
  - `prompt_tokens_details.cached_tokens`
  - `input_tokens_details.cached_tokens`
- Keep existing top-level `cached_tokens` for backward compatibility
- Centralize usage construction in `newUsageInfo`

## Validation

Verified with NewAPI as downstream gateway:

- Before: downstream `cache_tokens = 0`
- After: downstream `cache_tokens = 51200`

codex2api internal `usage_logs.cached_tokens` continues to record cache hits correctly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced token usage reporting to include detailed cached token metrics in API responses. Users can now track prompt and input cached tokens separately for improved cost analysis and monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->