### PR TITLE
fix: normalize plaintext compaction input

### DIFF
--- a/proxy/translator.go
+++ b/proxy/translator.go
@@ -748,6 +748,7 @@ func PrepareResponsesBody(rawBody []byte) ([]byte, string) {
 			body["input"] = append(cachedItems, currentInput...)
 		}
 	}
+	normalizePlaintextCompactionItems(body)
 
 	// 保存展开后的 input 原始 JSON（用于响应缓存链路）
 	var expandedInputRaw string
@@ -774,6 +775,49 @@ func PrepareResponsesBody(rawBody []byte) ([]byte, string) {
 		return rawBody, expandedInputRaw
 	}
 	return result, expandedInputRaw
+}
+
+func normalizePlaintextCompactionItems(body map[string]any) {
+	input, ok := body["input"].([]any)
+	if !ok || len(input) == 0 {
+		return
+	}
+
+	changed := false
+	normalized := make([]any, 0, len(input))
+	for _, item := range input {
+		itemMap, ok := item.(map[string]any)
+		if !ok || firstNonEmptyAnyString(itemMap["type"]) != "compaction" {
+			normalized = append(normalized, item)
+			continue
+		}
+		if firstNonEmptyAnyString(itemMap["encrypted_content"]) != "" {
+			normalized = append(normalized, item)
+			continue
+		}
+
+		summary := firstNonEmptyAnyString(itemMap["summary"])
+		if summary == "" {
+			summary = firstNonEmptyAnyString(itemMap["text"])
+		}
+		if summary == "" {
+			changed = true
+			continue
+		}
+
+		normalized = append(normalized, map[string]any{
+			"type": "message",
+			"role": "assistant",
+			"content": []any{
+				map[string]any{"type": "output_text", "text": summary},
+			},
+		})
+		changed = true
+	}
+
+	if changed {
+		body["input"] = normalized
+	}
 }
 
 // PrepareCompactResponsesBody 将 /responses/compact 请求转换为上游可接受的格式。

--- a/proxy/translator_test.go
+++ b/proxy/translator_test.go
@@ -470,6 +470,57 @@ func TestPrepareCompactResponsesBody_RemovesClientSuppliedInclude(t *testing.T) 
 	}
 }
 
+func TestPrepareResponsesBody_ConvertsPlaintextCompactionToAssistantMessage(t *testing.T) {
+	raw := []byte(`{
+		"model":"gpt-5.4",
+		"input":[
+			{"type":"message","role":"user","content":"hello"},
+			{"type":"compaction","summary":"previous context was compacted"}
+		]
+	}`)
+
+	got, expandedInputRaw := PrepareResponsesBody(raw)
+
+	input := gjson.GetBytes(got, "input")
+	if gotType := input.Get("1.type").String(); gotType == "compaction" {
+		t.Fatalf("plaintext compaction item should not be sent upstream, got %s", input.Raw)
+	}
+	if gotRole := input.Get("1.role").String(); gotRole != "assistant" {
+		t.Fatalf("converted compaction role = %q, want assistant; input=%s", gotRole, input.Raw)
+	}
+	if gotText := input.Get("1.content.0.text").String(); gotText != "previous context was compacted" {
+		t.Fatalf("converted compaction text = %q, want summary; input=%s", gotText, input.Raw)
+	}
+
+	expanded := gjson.Parse(expandedInputRaw)
+	if gotType := expanded.Get("1.type").String(); gotType == "compaction" {
+		t.Fatalf("expanded input cache should not retain plaintext compaction, got %s", expanded.Raw)
+	}
+}
+
+func TestPrepareCompactResponsesBody_ConvertsPlaintextCompactionToAssistantMessage(t *testing.T) {
+	raw := []byte(`{
+		"model":"gpt-5.4",
+		"input":[
+			{"type":"message","role":"user","content":"hello"},
+			{"type":"compaction","summary":"previous context was compacted"}
+		]
+	}`)
+
+	got, _ := PrepareCompactResponsesBody(raw)
+
+	input := gjson.GetBytes(got, "input")
+	if gotType := input.Get("1.type").String(); gotType == "compaction" {
+		t.Fatalf("plaintext compaction item should not be sent to compact upstream, got %s", input.Raw)
+	}
+	if gotRole := input.Get("1.role").String(); gotRole != "assistant" {
+		t.Fatalf("converted compaction role = %q, want assistant; input=%s", gotRole, input.Raw)
+	}
+	if gotText := input.Get("1.content.0.text").String(); gotText != "previous context was compacted" {
+		t.Fatalf("converted compaction text = %q, want summary; input=%s", gotText, input.Raw)
+	}
+}
+
 // ==================== Function Calling 测试 ====================
 
 func TestConvertMessagesToInput_ToolRole(t *testing.T) {


### PR DESCRIPTION
解决压缩上下文时的报错问题：{"error":{"code":"invalid_parameter","message":"Invalid input type 'compaction' at index 22","type":"invalid_request_error","details":
{"field":"input.22.type","message":"Invalid input type 'compaction' at index 22","code":"invalid_input_type"}}}

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of plaintext content items in responses by normalizing their format into consistent assistant messages.

* **Tests**
  * Added test coverage to validate proper transformation and formatting of plaintext content in response processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->