### PR TITLE
修复 Claude 模型映射展示与 reasoning 参数兼容

### DIFF
--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,5 +1,5 @@
 import type { ChangeEvent, ReactNode } from 'react'
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { api, resetAdminAuthState, setAdminKey } from '../api'
 import { formatBeijingTime, getTimezone, setTimezone } from '../utils/time'
@@ -38,31 +38,60 @@ const DEFAULT_MODEL_MAPPING: Record<string, string> = {
   'claude-opus-4-5-20251101': 'gpt-5.3-codex',
 }
 
+type ModelMappingEntry = [string, string]
+
+const getDefaultModelMappingEntries = (): ModelMappingEntry[] =>
+  Object.entries(DEFAULT_MODEL_MAPPING) as ModelMappingEntry[]
+
+const parseModelMappingEntries = (value: string): ModelMappingEntry[] => {
+  try {
+    const parsed = JSON.parse(value || '{}')
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return getDefaultModelMappingEntries()
+    }
+
+    const entries = Object.entries(parsed).map(([key, model]) => [
+      key,
+      typeof model === 'string' ? model : String(model ?? ''),
+    ]) as ModelMappingEntry[]
+
+    // 如果数据库中为空，用默认值填充
+    return entries.length > 0 ? entries : getDefaultModelMappingEntries()
+  } catch {
+    return getDefaultModelMappingEntries()
+  }
+}
+
+const serializeModelMappingEntries = (entries: ModelMappingEntry[]) => {
+  const obj: Record<string, string> = {}
+  for (const [key, model] of entries) {
+    const trimmedKey = key.trim()
+    if (trimmedKey) obj[trimmedKey] = model.trim()
+  }
+  return JSON.stringify(obj)
+}
+
 // 模型映射编辑器组件
 function ModelMappingEditor({ value, onChange }: { value: string; onChange: (v: string) => void }) {
   const { t } = useTranslation()
+  const [mappings, setMappings] = useState<ModelMappingEntry[]>(() => parseModelMappingEntries(value))
+  const lastEmittedValueRef = useRef<string | null>(null)
 
-  let mappings: [string, string][] = []
-  try {
-    const parsed = JSON.parse(value || '{}')
-    const entries = Object.entries(parsed) as [string, string][]
-    // 如果数据库中为空，用默认值填充
-    mappings = entries.length > 0 ? entries : Object.entries(DEFAULT_MODEL_MAPPING) as [string, string][]
-  } catch {
-    mappings = Object.entries(DEFAULT_MODEL_MAPPING) as [string, string][]
-  }
+  useEffect(() => {
+    if (value === lastEmittedValueRef.current) return
+    setMappings(parseModelMappingEntries(value))
+  }, [value])
 
-  const updateMappings = (entries: [string, string][]) => {
-    const obj: Record<string, string> = {}
-    for (const [k, v] of entries) {
-      if (k.trim()) obj[k.trim()] = v.trim()
-    }
-    onChange(JSON.stringify(obj))
+  const updateMappings = (entries: ModelMappingEntry[]) => {
+    setMappings(entries)
+    const serialized = serializeModelMappingEntries(entries)
+    lastEmittedValueRef.current = serialized
+    onChange(serialized)
   }
 
   const handleChange = (index: number, field: 0 | 1, val: string) => {
     const next = [...mappings]
-    next[index] = [...next[index]] as [string, string]
+    next[index] = [...next[index]] as ModelMappingEntry
     next[index][field] = val
     updateMappings(next)
   }
@@ -98,6 +127,7 @@ function ModelMappingEditor({ value, onChange }: { value: string; onChange: (v: 
             onChange={(e: ChangeEvent<HTMLInputElement>) => handleChange(i, 1, e.target.value)}
           />
           <button
+            type="button"
             onClick={() => handleRemove(i)}
             className="flex items-center justify-center size-9 rounded-lg text-muted-foreground hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-500/10 transition-colors"
           >
@@ -105,7 +135,7 @@ function ModelMappingEditor({ value, onChange }: { value: string; onChange: (v: 
           </button>
         </div>
       ))}
-      <Button variant="outline" size="sm" onClick={handleAdd}>
+      <Button type="button" variant="outline" size="sm" onClick={handleAdd}>
         + {t('settings2.addMapping')}
       </Button>
     </div>

--- a/frontend/src/pages/Usage.tsx
+++ b/frontend/src/pages/Usage.tsx
@@ -35,7 +35,7 @@ function formatTokens(value?: number | null): string {
 }
 
 // Claude 模型 → Codex 模型映射（与后端 defaultAnthropicModelMap 一致）
-const CLAUDE_MODEL_MAP: Record<string, string> = {
+const DEFAULT_CLAUDE_MODEL_MAP: Record<string, string> = {
   'claude-opus-4-6': 'gpt-5.4',
   'claude-opus-4-6-20250610': 'gpt-5.4',
   'claude-haiku-4-5-20251001': 'gpt-5.4-mini',
@@ -51,8 +51,29 @@ const CLAUDE_MODEL_MAP: Record<string, string> = {
   'claude-opus-4': 'gpt-5.4',
 }
 
-function getCodexModel(model: string): string {
-  return CLAUDE_MODEL_MAP[model] || 'gpt-5.4'
+function parseClaudeModelMap(value: string): Record<string, string> {
+  try {
+    const parsed = JSON.parse(value || '{}')
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return DEFAULT_CLAUDE_MODEL_MAP
+    }
+
+    const customMap: Record<string, string> = {}
+    for (const [key, mappedModel] of Object.entries(parsed)) {
+      const trimmedKey = key.trim()
+      const trimmedModel = typeof mappedModel === 'string' ? mappedModel.trim() : ''
+      if (trimmedKey && trimmedModel) {
+        customMap[trimmedKey] = trimmedModel
+      }
+    }
+    return { ...DEFAULT_CLAUDE_MODEL_MAP, ...customMap }
+  } catch {
+    return DEFAULT_CLAUDE_MODEL_MAP
+  }
+}
+
+function getCodexModel(model: string, modelMap: Record<string, string>): string {
+  return modelMap[model] || ''
 }
 
 function getStatusBadgeClassName(statusCode: number): string {
@@ -184,6 +205,7 @@ export default function Usage() {
   const [filterStream, setFilterStream] = useState<'' | 'true' | 'false'>('')
   const [apiKeys, setAPIKeys] = useState<APIKeyRow[]>([])
   const [modelOptions, setModelOptions] = useState<string[]>([])
+  const [claudeModelMap, setClaudeModelMap] = useState<Record<string, string>>(DEFAULT_CLAUDE_MODEL_MAP)
   const [apiKeyLoadFailed, setAPIKeyLoadFailed] = useState(false)
   const showFastFilter = false
   const pageSizeOptions = [10, 20, 50, 100]
@@ -254,6 +276,22 @@ export default function Usage() {
   useEffect(() => {
     void loadAPIKeys()
   }, [loadAPIKeys])
+
+  useEffect(() => {
+    let active = true
+    const loadModelMapping = async () => {
+      try {
+        const settings = await api.getSettings()
+        if (active) setClaudeModelMap(parseClaudeModelMap(settings.model_mapping))
+      } catch {
+        if (active) setClaudeModelMap(DEFAULT_CLAUDE_MODEL_MAP)
+      }
+    }
+    void loadModelMapping()
+    return () => {
+      active = false
+    }
+  }, [])
 
   useEffect(() => {
     let active = true
@@ -598,6 +636,7 @@ export default function Usage() {
                   </TableHeader>
                   <TableBody>
                     {logs.map((log: UsageLog) => {
+                      const mappedModel = log.model?.startsWith('claude') ? getCodexModel(log.model, claudeModelMap) : ''
                       return (
                       <TableRow key={log.id}>
                         <TableCell>
@@ -613,9 +652,9 @@ export default function Usage() {
                             <Badge variant="outline" className={usageTableBadgeClass}>
                               {log.model || '-'}
                             </Badge>
-                            {log.model && log.model.startsWith('claude') && (
+                            {mappedModel && (
                               <Badge variant="outline" className="text-[11px] font-medium border-transparent bg-blue-500/10 text-blue-600 dark:bg-blue-500/20 dark:text-blue-400">
-                                → {getCodexModel(log.model)}
+                                → {mappedModel}
                               </Badge>
                             )}
                             {log.reasoning_effort && (

--- a/proxy/anthropic.go
+++ b/proxy/anthropic.go
@@ -13,23 +13,28 @@ import (
 
 // anthropicRequest 表示 Anthropic Messages API 请求
 type anthropicRequest struct {
-	Model       string             `json:"model"`
-	MaxTokens   int                `json:"max_tokens"`
-	System      json.RawMessage    `json:"system,omitempty"`
-	Messages    []anthropicMessage `json:"messages"`
-	Tools       []anthropicTool    `json:"tools,omitempty"`
-	Stream      bool               `json:"stream,omitempty"`
-	Temperature *float64           `json:"temperature,omitempty"`
-	TopP        *float64           `json:"top_p,omitempty"`
-	StopSeqs    []string           `json:"stop_sequences,omitempty"`
-	Thinking    *anthropicThinking `json:"thinking,omitempty"`
-	ToolChoice  json.RawMessage    `json:"tool_choice,omitempty"`
-	Metadata    json.RawMessage    `json:"metadata,omitempty"`
+	Model        string                 `json:"model"`
+	MaxTokens    int                    `json:"max_tokens"`
+	System       json.RawMessage        `json:"system,omitempty"`
+	Messages     []anthropicMessage     `json:"messages"`
+	Tools        []anthropicTool        `json:"tools,omitempty"`
+	Stream       bool                   `json:"stream,omitempty"`
+	Temperature  *float64               `json:"temperature,omitempty"`
+	TopP         *float64               `json:"top_p,omitempty"`
+	StopSeqs     []string               `json:"stop_sequences,omitempty"`
+	Thinking     *anthropicThinking     `json:"thinking,omitempty"`
+	OutputConfig *anthropicOutputConfig `json:"output_config,omitempty"`
+	ToolChoice   json.RawMessage        `json:"tool_choice,omitempty"`
+	Metadata     json.RawMessage        `json:"metadata,omitempty"`
 }
 
 type anthropicThinking struct {
 	Type         string `json:"type"`
 	BudgetTokens int    `json:"budget_tokens,omitempty"`
+}
+
+type anthropicOutputConfig struct {
+	Effort string `json:"effort,omitempty"`
 }
 
 type anthropicMessage struct {
@@ -129,6 +134,8 @@ var defaultAnthropicModelMap = map[string]string{
 // resolveAnthropicModel 将 Anthropic 模型名解析为 Codex 模型名
 // 优先使用数据库中的动态映射，回退到默认映射
 func resolveAnthropicModel(model string, dynamicMappingJSON string, supportedModels []string) string {
+	model = strings.TrimSpace(model)
+
 	// 1. 尝试动态映射（从系统设置）
 	if dynamicMappingJSON != "" && dynamicMappingJSON != "{}" {
 		var dynamicMap map[string]string
@@ -220,10 +227,10 @@ func TranslateAnthropicToCodexWithModels(rawJSON []byte, modelMappingJSON string
 
 	// 注意：不设置 max_output_tokens，上游 Codex 不支持该字段
 
-	// reasoning effort（仅设置 effort，不设置 summary）
-	effort := resolveReasoningEffort(req.Thinking)
-	if effort != "" && effort != "high" {
-		out["reasoning"] = map[string]any{"effort": effort}
+	// reasoning effort: align Claude Code /v1/messages with the Responses reasoning shape.
+	out["reasoning"] = map[string]any{
+		"effort":  resolveReasoningEffort(req.OutputConfig),
+		"summary": "auto",
 	}
 
 	// tools
@@ -410,24 +417,14 @@ func extractToolResultText(b anthropicContentBlock) string {
 	return string(b.Content)
 }
 
-// resolveReasoningEffort 从 thinking 配置推断 reasoning effort
-func resolveReasoningEffort(thinking *anthropicThinking) string {
-	if thinking == nil || thinking.Type != "enabled" {
-		return "high" // 默认
+// resolveReasoningEffort maps Claude output_config.effort to Responses reasoning.effort.
+// Claude thinking.type/budget_tokens only indicates that thinking mode exists; it
+// does not control effort on this OpenAI/Codex compatibility path.
+func resolveReasoningEffort(outputConfig *anthropicOutputConfig) string {
+	if outputConfig != nil && strings.TrimSpace(outputConfig.Effort) != "" {
+		return normalizeReasoningEffort(outputConfig.Effort)
 	}
-	budget := thinking.BudgetTokens
-	switch {
-	case budget <= 0:
-		return "high"
-	case budget < 2048:
-		return "low"
-	case budget < 8192:
-		return "medium"
-	case budget < 20000:
-		return "high"
-	default:
-		return "xhigh"
-	}
+	return "high"
 }
 
 // convertAnthropicTools 将 Anthropic 工具格式转为 Codex 格式

--- a/proxy/anthropic_test.go
+++ b/proxy/anthropic_test.go
@@ -1,0 +1,81 @@
+package proxy
+
+import (
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestTranslateAnthropicToCodex_OutputConfigEffortTakesPrecedence(t *testing.T) {
+	raw := []byte(`{
+		"model":"claude-sonnet-4-5",
+		"messages":[{"role":"user","content":"hello"}],
+		"thinking":{"type":"enabled","budget_tokens":512},
+		"output_config":{"effort":"max"}
+	}`)
+
+	got, _, err := TranslateAnthropicToCodexWithModels(raw, "", []string{"gpt-5.4", "gpt-5.4-mini"})
+	if err != nil {
+		t.Fatalf("TranslateAnthropicToCodexWithModels returned error: %v", err)
+	}
+
+	if effort := gjson.GetBytes(got, "reasoning.effort").String(); effort != "xhigh" {
+		t.Fatalf("reasoning.effort = %q, want xhigh; body=%s", effort, got)
+	}
+	if summary := gjson.GetBytes(got, "reasoning.summary").String(); summary != "auto" {
+		t.Fatalf("reasoning.summary = %q, want auto; body=%s", summary, got)
+	}
+}
+
+func TestTranslateAnthropicToCodex_OutputConfigHighIsExplicit(t *testing.T) {
+	raw := []byte(`{
+		"model":"claude-sonnet-4-5",
+		"messages":[{"role":"user","content":"hello"}],
+		"output_config":{"effort":"high"}
+	}`)
+
+	got, _, err := TranslateAnthropicToCodexWithModels(raw, "", []string{"gpt-5.4"})
+	if err != nil {
+		t.Fatalf("TranslateAnthropicToCodexWithModels returned error: %v", err)
+	}
+
+	if effort := gjson.GetBytes(got, "reasoning.effort").String(); effort != "high" {
+		t.Fatalf("reasoning.effort = %q, want high; body=%s", effort, got)
+	}
+}
+
+func TestTranslateAnthropicToCodex_DefaultsReasoningHighWithSummary(t *testing.T) {
+	raw := []byte(`{
+		"model":"claude-sonnet-4-5",
+		"messages":[{"role":"user","content":"hello"}]
+	}`)
+
+	got, _, err := TranslateAnthropicToCodexWithModels(raw, "", []string{"gpt-5.4"})
+	if err != nil {
+		t.Fatalf("TranslateAnthropicToCodexWithModels returned error: %v", err)
+	}
+
+	if effort := gjson.GetBytes(got, "reasoning.effort").String(); effort != "high" {
+		t.Fatalf("reasoning.effort = %q, want high; body=%s", effort, got)
+	}
+	if summary := gjson.GetBytes(got, "reasoning.summary").String(); summary != "auto" {
+		t.Fatalf("reasoning.summary = %q, want auto; body=%s", summary, got)
+	}
+}
+
+func TestTranslateAnthropicToCodex_ThinkingBudgetDoesNotControlEffort(t *testing.T) {
+	raw := []byte(`{
+		"model":"claude-sonnet-4-5",
+		"messages":[{"role":"user","content":"hello"}],
+		"thinking":{"type":"enabled","budget_tokens":4096}
+	}`)
+
+	got, _, err := TranslateAnthropicToCodexWithModels(raw, "", []string{"gpt-5.4"})
+	if err != nil {
+		t.Fatalf("TranslateAnthropicToCodexWithModels returned error: %v", err)
+	}
+
+	if effort := gjson.GetBytes(got, "reasoning.effort").String(); effort != "high" {
+		t.Fatalf("reasoning.effort = %q, want high; body=%s", effort, got)
+	}
+}

--- a/proxy/translator.go
+++ b/proxy/translator.go
@@ -679,12 +679,7 @@ func PrepareResponsesBody(rawBody []byte) ([]byte, string) {
 	}
 	if reasoning, ok := body["reasoning"].(map[string]any); ok {
 		if effort, ok := reasoning["effort"].(string); ok && effort != "" {
-			switch strings.ToLower(effort) {
-			case "low", "medium", "high", "xhigh":
-				// 合法值，保留
-			default:
-				reasoning["effort"] = "high"
-			}
+			reasoning["effort"] = normalizeReasoningEffort(effort)
 		}
 	}
 
@@ -788,12 +783,15 @@ func PrepareCompactResponsesBody(rawBody []byte) ([]byte, string) {
 
 // normalizeReasoningEffort 将 reasoning_effort 钳位到上游支持的值
 func normalizeReasoningEffort(effort string) string {
+	effort = strings.ToLower(strings.TrimSpace(effort))
 	if effort == "" {
 		return ""
 	}
-	switch strings.ToLower(effort) {
+	switch effort {
 	case "low", "medium", "high", "xhigh":
 		return effort
+	case "max":
+		return "xhigh"
 	default:
 		return "high"
 	}

--- a/proxy/translator_test.go
+++ b/proxy/translator_test.go
@@ -71,6 +71,23 @@ func TestTranslateRequest_PreservesSupportedServiceTier(t *testing.T) {
 	}
 }
 
+func TestTranslateRequest_NormalizesReasoningEffortAliases(t *testing.T) {
+	raw := []byte(`{
+		"model":"gpt-5.4",
+		"messages":[{"role":"user","content":"hello"}],
+		"reasoning_effort":"MAX"
+	}`)
+
+	got, err := TranslateRequest(raw)
+	if err != nil {
+		t.Fatalf("TranslateRequest returned error: %v", err)
+	}
+
+	if effort := gjson.GetBytes(got, "reasoning.effort").String(); effort != "xhigh" {
+		t.Fatalf("reasoning.effort mismatch: got %q want %q", effort, "xhigh")
+	}
+}
+
 func TestTranslateRequest_FillsMissingArrayItemsInToolSchema(t *testing.T) {
 	raw := []byte(`{
 		"model":"gpt-5.4",
@@ -160,6 +177,20 @@ func TestPrepareResponsesBody_DefaultsIncludeForResponses(t *testing.T) {
 	}
 	if instructions := gjson.GetBytes(got, "instructions").String(); !strings.Contains(instructions, codexImageGenerationBridgeMarker) {
 		t.Fatalf("expected bridge instructions, got %q", instructions)
+	}
+}
+
+func TestPrepareResponsesBody_NormalizesNestedReasoningEffortAliases(t *testing.T) {
+	raw := []byte(`{
+		"model":"gpt-5.4",
+		"input":"test",
+		"reasoning":{"effort":"MAX"}
+	}`)
+
+	got, _ := PrepareResponsesBody(raw)
+
+	if effort := gjson.GetBytes(got, "reasoning.effort").String(); effort != "xhigh" {
+		t.Fatalf("reasoning.effort mismatch: got %q want %q; body=%s", effort, "xhigh", got)
 	}
 }
 


### PR DESCRIPTION
  - 修复系统设置里的「添加映射」按钮：
    - 点击后会新增可编辑的空白映射行
    - 空 key 不会被写入最终保存的 JSON 配置

  - 修复 Usage 页面模型映射展示：
    - 改为读取已保存的 `model_mapping`
    - 支持展示自定义 Claude → Codex 映射关系
    - 不再对未知 Claude 模型硬编码猜测为 `gpt-5.4`

  - 调整 Claude `/v1/messages` reasoning 转换逻辑：
    - 支持 `output_config.effort`
    - `max` 映射为 `xhigh`
    - 默认显式发送 `reasoning.effort=high`
    - 补充 `reasoning.summary=auto`
    - 不再通过 `thinking.budget_tokens` 推导 effort

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Model mappings now dynamically load from settings for customizable configuration
  * Added support for "max" as a reasoning effort intensity level

* **Tests**
  * Added comprehensive test coverage for reasoning effort normalization and model mapping handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->