### PR TITLE
fix(oauth): fall back to system proxy when OAuth session has no proxy_url

### DIFF
--- a/admin/oauth.go
+++ b/admin/oauth.go
@@ -224,6 +224,9 @@ func (h *Handler) ExchangeOAuthCode(c *gin.Context) {
 	if trimmed := strings.TrimSpace(req.ProxyURL); trimmed != "" {
 		proxyURL = trimmed
 	}
+	if proxyURL == "" {
+		proxyURL = h.store.GetProxyURL()
+	}
 
 	// Resin 临时身份用于 OAuth 兑换（新账号尚无 DBID）
 	resinTempID := "oauth-" + req.SessionID
@@ -391,8 +394,12 @@ func (h *Handler) OAuthCallback(c *gin.Context) {
 	sess.CallbackAt = time.Now()
 
 	// 执行 code exchange（Resin 临时身份）
+	proxyURL := sess.ProxyURL
+	if proxyURL == "" {
+		proxyURL = h.store.GetProxyURL()
+	}
 	resinTempID := "oauth-" + sessionID
-	tokenResp, accountInfo, err := doOAuthCodeExchange(c.Request.Context(), code, sess.CodeVerifier, sess.RedirectURI, sess.ProxyURL, resinTempID)
+	tokenResp, accountInfo, err := doOAuthCodeExchange(c.Request.Context(), code, sess.CodeVerifier, sess.RedirectURI, proxyURL, resinTempID)
 	if err != nil {
 		sess.ExchangeResult = &oauthExchangeResult{
 			Success: false,
@@ -429,7 +436,7 @@ func (h *Handler) OAuthCallback(c *gin.Context) {
 	ctx, cancel := context.WithTimeout(c.Request.Context(), 30*time.Second)
 	defer cancel()
 
-	id, err := h.db.InsertAccount(ctx, name, tokenResp.RefreshToken, sess.ProxyURL)
+	id, err := h.db.InsertAccount(ctx, name, tokenResp.RefreshToken, proxyURL)
 	if err != nil {
 		sess.ExchangeResult = &oauthExchangeResult{
 			Success: false,
@@ -453,7 +460,7 @@ func (h *Handler) OAuthCallback(c *gin.Context) {
 		go proxy.InheritLease(resinTempID, fmt.Sprintf("%d", id))
 	}
 
-	newAcc := accountFromCredentialSeed(id, sess.ProxyURL, seed)
+	newAcc := accountFromCredentialSeed(id, proxyURL, seed)
 	h.store.AddAccount(newAcc)
 
 	email := ""


### PR DESCRIPTION
## Summary
- When adding accounts via OAuth flow, if no `proxy_url` is provided in either the `generate-auth-url` step or the `exchange-code` step, the request to `auth.openai.com` goes **direct** — which fails from geo-restricted regions with 403, wrapped by codex2api as 502.
- This PR adds a fallback to `h.store.GetProxyURL()` (the system default proxy) in both `ExchangeOAuthCode` and `OAuthCallback` handlers.

## Root cause
The `exchange-code` endpoint in `admin/oauth.go` uses `sess.ProxyURL` (set during `generate-auth-url`) merged with `req.ProxyURL` (from the request body). When both are empty, `auth.BuildHTTPClient("")` creates a direct HTTP client with no proxy, and the call to `https://auth.openai.com/oauth/token` fails from regions where OpenAI blocks direct access.

## Fix
Three lines added across two handlers:
1. `ExchangeOAuthCode`: after merging session + request proxy_url, if still empty, load `h.store.GetProxyURL()`
2. `OAuthCallback`: same fallback, and unified all `sess.ProxyURL` references to use the resolved `proxyURL` variable

## Verification
- Before fix: `exchange-code` returns 502 in under 70ms with an HTML error body (direct call → geo-blocked → 403)
- After fix: `exchange-code` returns a proper JSON error with upstream response body, confirming the proxy is used for the OAuth token exchange

## Tested on
- codex2api v2.1.5 (SQLite deployment) behind a proxy pool in a geo-restricted region

🤖 Generated with [Claude Code](https://claude.com/claude-code)