### PR TITLE
fix: adjust account table scrolling

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -940,6 +940,11 @@
     max-height: min(680px, calc(100vh - 280px));
   }
 
+  .account-table-shell-fit-content [data-slot="table-container"] {
+    max-height: none;
+    overflow-y: visible;
+  }
+
   .data-table-shell [data-slot="table-head"],
   .data-table-shell thead th {
     position: sticky;

--- a/frontend/src/pages/Accounts.tsx
+++ b/frontend/src/pages/Accounts.tsx
@@ -3470,7 +3470,11 @@ export default function Accounts() {
                 ) : null}
 
                 {shouldRenderDesktopTable ? (
-                  <div className="data-table-shell hidden lg:block">
+                  <div
+                    className={`data-table-shell hidden lg:block ${
+                      sortedAccounts.length <= pageSize ? "account-table-shell-fit-content" : ""
+                    }`}
+                  >
                   <Table>
                     <TableHeader>
                       <TableRow>


### PR DESCRIPTION
正文：

  ## 变更内容

  - 修复账号管理列表表格在分页场景下的滚动条显示逻辑
  - 当筛选后的记录数超过当前分页大小时，保留表格内部滚动条
  - 当记录数未超过当前分页大小时，取消不必要的表格内部纵向滚动，避免底部仍有空白却出现滚动条

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed accounts table layout to properly display content when the number of results is smaller than the page size, improving overall visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->