### PR TITLE
feat: 增加 API Key 并发数限制

### DIFF
--- a/admin/handler.go
+++ b/admin/handler.go
@@ -4609,14 +4609,15 @@ func sanitizeAPIKeyLimits(in database.APIKeyLimits) database.APIKeyLimits {
 		return out
 	}
 	out := database.APIKeyLimits{
-		ModelAllow:   clean(in.ModelAllow),
-		ModelDeny:    clean(in.ModelDeny),
-		RPM:          maxInt(in.RPM, 0),
-		RPD:          maxInt(in.RPD, 0),
-		CostLimit5h:  maxFloat(in.CostLimit5h, 0),
-		CostLimit7d:  maxFloat(in.CostLimit7d, 0),
-		TokenLimit5h: maxInt64(in.TokenLimit5h, 0),
-		TokenLimit7d: maxInt64(in.TokenLimit7d, 0),
+		ModelAllow:     clean(in.ModelAllow),
+		ModelDeny:      clean(in.ModelDeny),
+		RPM:            maxInt(in.RPM, 0),
+		RPD:            maxInt(in.RPD, 0),
+		MaxConcurrency: maxInt(in.MaxConcurrency, 0),
+		CostLimit5h:    maxFloat(in.CostLimit5h, 0),
+		CostLimit7d:    maxFloat(in.CostLimit7d, 0),
+		TokenLimit5h:   maxInt64(in.TokenLimit5h, 0),
+		TokenLimit7d:   maxInt64(in.TokenLimit7d, 0),
 	}
 	return out
 }

--- a/database/postgres.go
+++ b/database/postgres.go
@@ -915,23 +915,25 @@ type APIKeyRow struct {
 // - ModelAllow / ModelDeny: 模型白/黑名单。同时配置时白名单生效,黑名单忽略。
 // - RPM: 每分钟请求数 (滑动 60s 窗口)。
 // - RPD: 每天请求数 (滑动 24h 窗口)。
+// - MaxConcurrency: 同一 API Key 在当前实例内允许的最大并发请求数。
 // - CostLimit5h / CostLimit7d: 美元成本上限,滑动 5h / 7d 窗口,与账号侧窗口语义一致。
 // - TokenLimit5h / TokenLimit7d: token 上限,滑动 5h / 7d 窗口。
 type APIKeyLimits struct {
-	ModelAllow   []string `json:"model_allow,omitempty"`
-	ModelDeny    []string `json:"model_deny,omitempty"`
-	RPM          int      `json:"rpm,omitempty"`
-	RPD          int      `json:"rpd,omitempty"`
-	CostLimit5h  float64  `json:"cost_limit_5h,omitempty"`
-	CostLimit7d  float64  `json:"cost_limit_7d,omitempty"`
-	TokenLimit5h int64    `json:"token_limit_5h,omitempty"`
-	TokenLimit7d int64    `json:"token_limit_7d,omitempty"`
+	ModelAllow     []string `json:"model_allow,omitempty"`
+	ModelDeny      []string `json:"model_deny,omitempty"`
+	RPM            int      `json:"rpm,omitempty"`
+	RPD            int      `json:"rpd,omitempty"`
+	MaxConcurrency int      `json:"max_concurrency,omitempty"`
+	CostLimit5h    float64  `json:"cost_limit_5h,omitempty"`
+	CostLimit7d    float64  `json:"cost_limit_7d,omitempty"`
+	TokenLimit5h   int64    `json:"token_limit_5h,omitempty"`
+	TokenLimit7d   int64    `json:"token_limit_7d,omitempty"`
 }
 
 // IsZero 判断是否为空 limits(全部字段都未配置)
 func (l APIKeyLimits) IsZero() bool {
 	return len(l.ModelAllow) == 0 && len(l.ModelDeny) == 0 &&
-		l.RPM == 0 && l.RPD == 0 &&
+		l.RPM == 0 && l.RPD == 0 && l.MaxConcurrency == 0 &&
 		l.CostLimit5h == 0 && l.CostLimit7d == 0 &&
 		l.TokenLimit5h == 0 && l.TokenLimit7d == 0
 }

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1784,6 +1784,8 @@
       "rpmSuffix": "/min",
       "rpd": "Requests per day",
       "rpdSuffix": "/day",
+      "maxConcurrency": "Max concurrency",
+      "concurrencySuffix": "inflight",
       "cost5h": "Cost limit (5h)",
       "cost7d": "Cost limit (7d)",
       "tokens5h": "Token limit (5h)",

--- a/frontend/src/locales/zh.json
+++ b/frontend/src/locales/zh.json
@@ -1784,6 +1784,8 @@
       "rpmSuffix": "/min",
       "rpd": "每天请求",
       "rpdSuffix": "/day",
+      "maxConcurrency": "最大并发数",
+      "concurrencySuffix": "并发",
       "cost5h": "5h 成本上限",
       "cost7d": "7d 成本上限",
       "tokens5h": "5h Token 上限",

--- a/frontend/src/pages/APIKeys.tsx
+++ b/frontend/src/pages/APIKeys.tsx
@@ -67,6 +67,7 @@ interface LimitsFormState {
   modelDeny: string[];
   rpm: string;
   rpd: string;
+  maxConcurrency: string;
   costLimit5h: string;
   costLimit7d: string;
   tokenLimit5h: string;
@@ -78,6 +79,7 @@ const emptyLimitsForm: LimitsFormState = {
   modelDeny: [],
   rpm: "",
   rpd: "",
+  maxConcurrency: "",
   costLimit5h: "",
   costLimit7d: "",
   tokenLimit5h: "",
@@ -974,6 +976,10 @@ function limitsFromAPIKey(limits: APIKeyLimits | undefined): LimitsFormState {
     modelDeny: Array.isArray(limits.model_deny) ? limits.model_deny : [],
     rpm: limits.rpm && limits.rpm > 0 ? String(limits.rpm) : "",
     rpd: limits.rpd && limits.rpd > 0 ? String(limits.rpd) : "",
+    maxConcurrency:
+      limits.max_concurrency && limits.max_concurrency > 0
+        ? String(limits.max_concurrency)
+        : "",
     costLimit5h:
       limits.cost_limit_5h && limits.cost_limit_5h > 0
         ? String(limits.cost_limit_5h)
@@ -1001,15 +1007,20 @@ function limitsFormToPayload(form: LimitsFormState): APIKeyLimits {
     const n = Number(s.trim());
     return Number.isFinite(n) && n > 0 ? n : 0;
   };
+  const intNum = (s: string) => {
+    const n = Number(s.trim());
+    return Number.isInteger(n) && n > 0 ? n : 0;
+  };
   return {
     model_allow: form.modelAllow.map((m) => m.trim()).filter(Boolean),
     model_deny: form.modelDeny.map((m) => m.trim()).filter(Boolean),
-    rpm: num(form.rpm),
-    rpd: num(form.rpd),
+    rpm: intNum(form.rpm),
+    rpd: intNum(form.rpd),
+    max_concurrency: intNum(form.maxConcurrency),
     cost_limit_5h: num(form.costLimit5h),
     cost_limit_7d: num(form.costLimit7d),
-    token_limit_5h: num(form.tokenLimit5h),
-    token_limit_7d: num(form.tokenLimit7d),
+    token_limit_5h: intNum(form.tokenLimit5h),
+    token_limit_7d: intNum(form.tokenLimit7d),
   };
 }
 
@@ -1196,6 +1207,7 @@ function LimitsEditor({
     value.modelDeny.length > 0 ||
     value.rpm !== "" ||
     value.rpd !== "" ||
+    value.maxConcurrency !== "" ||
     value.costLimit5h !== "" ||
     value.costLimit7d !== "" ||
     value.tokenLimit5h !== "" ||
@@ -1269,6 +1281,12 @@ function LimitsEditor({
               value={value.rpd}
               onChange={(rpd) => patch({ rpd })}
               suffix={t("apiKeys.limits.rpdSuffix")}
+            />
+            <LimitNumberField
+              label={t("apiKeys.limits.maxConcurrency")}
+              value={value.maxConcurrency}
+              onChange={(maxConcurrency) => patch({ maxConcurrency })}
+              suffix={t("apiKeys.limits.concurrencySuffix")}
             />
             <LimitNumberField
               label={t("apiKeys.limits.cost5h")}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -968,6 +968,7 @@ export interface APIKeyLimits {
   model_deny?: string[]
   rpm?: number
   rpd?: number
+  max_concurrency?: number
   cost_limit_5h?: number
   cost_limit_7d?: number
   token_limit_5h?: number

--- a/proxy/apikey_concurrency.go
+++ b/proxy/apikey_concurrency.go
@@ -1,0 +1,111 @@
+package proxy
+
+import (
+	"fmt"
+	"net/http"
+	"sync"
+	"sync/atomic"
+
+	"github.com/codex2api/api"
+	"github.com/gin-gonic/gin"
+)
+
+// apiKeyConcurrencyLimiter tracks per-API-key inflight proxy requests in this
+// process only. A request occupies one slot after API Key limits pass and keeps
+// it until the handler returns, covering account scheduling, upstream retries,
+// streaming, and WebSocket turn processing time.
+type apiKeyConcurrencyLimiter struct {
+	mu       sync.Mutex
+	counters map[int64]*apiKeyConcurrencyCounter
+}
+
+type apiKeyConcurrencyCounter struct {
+	inflight int64
+}
+
+func newAPIKeyConcurrencyLimiter() *apiKeyConcurrencyLimiter {
+	return &apiKeyConcurrencyLimiter{counters: make(map[int64]*apiKeyConcurrencyCounter)}
+}
+
+func (l *apiKeyConcurrencyLimiter) acquire(apiKeyID int64, limit int) (func(), int64, bool) {
+	if l == nil || apiKeyID <= 0 || limit <= 0 {
+		return nil, 0, true
+	}
+	counter := l.counter(apiKeyID)
+	limit64 := int64(limit)
+	for {
+		current := atomic.LoadInt64(&counter.inflight)
+		if current >= limit64 {
+			return nil, current, false
+		}
+		if atomic.CompareAndSwapInt64(&counter.inflight, current, current+1) {
+			released := atomic.Bool{}
+			return func() {
+				if released.CompareAndSwap(false, true) {
+					l.release(counter)
+				}
+			}, current + 1, true
+		}
+	}
+}
+
+func (l *apiKeyConcurrencyLimiter) counter(apiKeyID int64) *apiKeyConcurrencyCounter {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	counter := l.counters[apiKeyID]
+	if counter == nil {
+		counter = &apiKeyConcurrencyCounter{}
+		l.counters[apiKeyID] = counter
+	}
+	return counter
+}
+
+func (l *apiKeyConcurrencyLimiter) release(counter *apiKeyConcurrencyCounter) {
+	if l == nil || counter == nil {
+		return
+	}
+	if current := atomic.AddInt64(&counter.inflight, -1); current < 0 {
+		atomic.StoreInt64(&counter.inflight, 0)
+	}
+}
+
+func (h *Handler) apiKeyConcurrencyLimiter() *apiKeyConcurrencyLimiter {
+	if h == nil {
+		return nil
+	}
+	h.apiKeyGateMu.Lock()
+	defer h.apiKeyGateMu.Unlock()
+	if h.apiKeyGate == nil {
+		h.apiKeyGate = newAPIKeyConcurrencyLimiter()
+	}
+	return h.apiKeyGate
+}
+
+func (h *Handler) acquireAPIKeyConcurrency(c *gin.Context) (func(), bool) {
+	row := apiKeyRowFromContext(c)
+	if row == nil || row.ID <= 0 || row.Limits.MaxConcurrency <= 0 {
+		return nil, true
+	}
+	limiter := h.apiKeyConcurrencyLimiter()
+	release, current, ok := limiter.acquire(row.ID, row.Limits.MaxConcurrency)
+	if ok {
+		return release, true
+	}
+	msg := fmt.Sprintf("API key concurrency limit exceeded: %d inflight requests (max %d)", current, row.Limits.MaxConcurrency)
+	api.SendErrorWithStatus(c, api.NewAPIError(api.ErrCodeRateLimitReached, msg, api.ErrorTypeRateLimit), http.StatusTooManyRequests)
+	return nil, false
+}
+
+func (h *Handler) acquireAPIKeyConcurrencyForWebSocket(c *gin.Context) (func(), *api.APIError, bool) {
+	row := apiKeyRowFromContext(c)
+	if row == nil || row.ID <= 0 || row.Limits.MaxConcurrency <= 0 {
+		return nil, nil, true
+	}
+	limiter := h.apiKeyConcurrencyLimiter()
+	release, current, ok := limiter.acquire(row.ID, row.Limits.MaxConcurrency)
+	if ok {
+		return release, nil, true
+	}
+	msg := fmt.Sprintf("API key concurrency limit exceeded: %d inflight requests (max %d)", current, row.Limits.MaxConcurrency)
+	return nil, api.NewAPIError(api.ErrCodeRateLimitReached, msg, api.ErrorTypeRateLimit), false
+}

--- a/proxy/apikey_concurrency_test.go
+++ b/proxy/apikey_concurrency_test.go
@@ -1,0 +1,132 @@
+package proxy
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/codex2api/database"
+	"github.com/gin-gonic/gin"
+)
+
+func TestAPIKeyConcurrencyLimiterAcquireRelease(t *testing.T) {
+	limiter := newAPIKeyConcurrencyLimiter()
+
+	release1, current, ok := limiter.acquire(42, 2)
+	if !ok || current != 1 || release1 == nil {
+		t.Fatalf("first acquire = (%v, %d), want ok current=1", ok, current)
+	}
+	release2, current, ok := limiter.acquire(42, 2)
+	if !ok || current != 2 || release2 == nil {
+		t.Fatalf("second acquire = (%v, %d), want ok current=2", ok, current)
+	}
+	if release3, current, ok := limiter.acquire(42, 2); ok || release3 != nil || current != 2 {
+		t.Fatalf("third acquire = (ok=%v, current=%d, releaseNil=%v), want rejected current=2", ok, current, release3 == nil)
+	}
+
+	release1()
+	release1()
+	release3, current, ok := limiter.acquire(42, 2)
+	if !ok || current != 2 || release3 == nil {
+		t.Fatalf("acquire after release = (%v, %d), want ok current=2", ok, current)
+	}
+
+	release2()
+	release3()
+	limiter.mu.Lock()
+	counter := limiter.counters[42]
+	limiter.mu.Unlock()
+	if counter == nil {
+		t.Fatal("counter was removed; keeping it avoids orphan-counter acquire races")
+	}
+	if got := atomic.LoadInt64(&counter.inflight); got != 0 {
+		t.Fatalf("inflight after all releases = %d, want 0", got)
+	}
+}
+
+func TestAPIKeyConcurrencyLimiterBypassesUnlimited(t *testing.T) {
+	limiter := newAPIKeyConcurrencyLimiter()
+	for i := 0; i < 3; i++ {
+		release, current, ok := limiter.acquire(42, 0)
+		if !ok || release != nil || current != 0 {
+			t.Fatalf("unlimited acquire = (ok=%v, current=%d, releaseNil=%v), want bypass", ok, current, release == nil)
+		}
+	}
+}
+
+func TestAcquireAPIKeyConcurrencyRejectsWhenFull(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	handler := &Handler{}
+	row := &database.APIKeyRow{
+		ID: 7,
+		Limits: database.APIKeyLimits{
+			MaxConcurrency: 1,
+		},
+	}
+
+	firstCtx, firstRecorder := testAPIKeyConcurrencyContext(row)
+	firstRelease, ok := handler.acquireAPIKeyConcurrency(firstCtx)
+	if !ok || firstRelease == nil {
+		t.Fatalf("first acquire ok=%v releaseNil=%v, want acquired", ok, firstRelease == nil)
+	}
+	if firstRecorder.Code != http.StatusOK {
+		t.Fatalf("first recorder status = %d, want untouched 200", firstRecorder.Code)
+	}
+
+	secondCtx, secondRecorder := testAPIKeyConcurrencyContext(row)
+	secondRelease, ok := handler.acquireAPIKeyConcurrency(secondCtx)
+	if ok || secondRelease != nil {
+		t.Fatalf("second acquire ok=%v releaseNil=%v, want rejected", ok, secondRelease == nil)
+	}
+	if secondRecorder.Code != http.StatusTooManyRequests {
+		t.Fatalf("second recorder status = %d, want 429", secondRecorder.Code)
+	}
+	if !strings.Contains(secondRecorder.Body.String(), "API key concurrency limit exceeded") {
+		t.Fatalf("second response body = %q, want concurrency error", secondRecorder.Body.String())
+	}
+
+	firstRelease()
+	thirdCtx, thirdRecorder := testAPIKeyConcurrencyContext(row)
+	thirdRelease, ok := handler.acquireAPIKeyConcurrency(thirdCtx)
+	if !ok || thirdRelease == nil {
+		t.Fatalf("third acquire ok=%v releaseNil=%v, want acquired after release", ok, thirdRelease == nil)
+	}
+	thirdRelease()
+	if thirdRecorder.Code != http.StatusOK {
+		t.Fatalf("third recorder status = %d, want untouched 200", thirdRecorder.Code)
+	}
+}
+
+func TestAcquireAPIKeyConcurrencyUsesPerHandlerLimiter(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	row := &database.APIKeyRow{ID: 7, Limits: database.APIKeyLimits{MaxConcurrency: 1}}
+
+	firstHandler := &Handler{}
+	firstCtx, _ := testAPIKeyConcurrencyContext(row)
+	firstRelease, ok := firstHandler.acquireAPIKeyConcurrency(firstCtx)
+	if !ok || firstRelease == nil {
+		t.Fatalf("first handler acquire ok=%v releaseNil=%v, want acquired", ok, firstRelease == nil)
+	}
+	defer firstRelease()
+
+	secondHandler := &Handler{}
+	secondCtx, secondRecorder := testAPIKeyConcurrencyContext(row)
+	secondRelease, ok := secondHandler.acquireAPIKeyConcurrency(secondCtx)
+	if !ok || secondRelease == nil {
+		t.Fatalf("second handler acquire ok=%v releaseNil=%v, want independent limiter", ok, secondRelease == nil)
+	}
+	secondRelease()
+	if secondRecorder.Code != http.StatusOK {
+		t.Fatalf("second handler recorder status = %d, want untouched 200", secondRecorder.Code)
+	}
+}
+
+func testAPIKeyConcurrencyContext(row *database.APIKeyRow) (*gin.Context, *httptest.ResponseRecorder) {
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	ctx.Set(contextAPIKeyRow, row)
+	return ctx, recorder
+}

--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -29,12 +30,14 @@ import (
 
 // Handler API 路由处理器
 type Handler struct {
-	store      *auth.Store
-	configKeys map[string]bool // 配置文件中的静态 key
-	db         *database.DB
-	cfg        *config.Config       // 全局配置
-	deviceCfg  *DeviceProfileConfig // 设备指纹配置
-	cache      cache.TokenCache     // Redis/Memory 运行态缓存
+	store        *auth.Store
+	configKeys   map[string]bool // 配置文件中的静态 key
+	db           *database.DB
+	cfg          *config.Config       // 全局配置
+	deviceCfg    *DeviceProfileConfig // 设备指纹配置
+	cache        cache.TokenCache     // Redis/Memory 运行态缓存
+	apiKeyGateMu sync.Mutex
+	apiKeyGate   *apiKeyConcurrencyLimiter
 }
 
 const (
@@ -351,6 +354,7 @@ func NewHandler(store *auth.Store, db *database.DB, cfg *config.Config, deviceCf
 		db:         db,
 		cfg:        cfg,
 		deviceCfg:  deviceCfg,
+		apiKeyGate: newAPIKeyConcurrencyLimiter(),
 	}
 }
 
@@ -1412,6 +1416,13 @@ func (h *Handler) Responses(c *gin.Context) {
 	if h.enforceAPIKeyLimitsAndReply(c, effectiveModel) {
 		return
 	}
+	releaseAPIKeyConcurrency, ok := h.acquireAPIKeyConcurrency(c)
+	if !ok {
+		return
+	}
+	if releaseAPIKeyConcurrency != nil {
+		defer releaseAPIKeyConcurrency()
+	}
 	accountFilter := accountFilterForResponsesModel(effectiveModel, modelIDInList(effectiveModel, SupportedModelIDs(c.Request.Context(), h.db)))
 	accountFilter = h.withModelCooldownFilter(effectiveModel, accountFilter)
 
@@ -2299,6 +2310,13 @@ func (h *Handler) ResponsesCompact(c *gin.Context) {
 	if h.enforceAPIKeyLimitsAndReply(c, effectiveModel) {
 		return
 	}
+	releaseAPIKeyConcurrency, ok := h.acquireAPIKeyConcurrency(c)
+	if !ok {
+		return
+	}
+	if releaseAPIKeyConcurrency != nil {
+		defer releaseAPIKeyConcurrency()
+	}
 	// compact 同时允许官方 Codex OAuth 账号与中转（OpenAI Responses API）账号：
 	// 中转账号会命中上游自身的 /responses/compact，使仅接入中转的用户也能压缩（issue #174）。
 	accountFilter := accountFilterForResponsesModel(effectiveModel, modelIDInList(effectiveModel, SupportedModelIDs(c.Request.Context(), h.db)))
@@ -2702,6 +2720,13 @@ func (h *Handler) ChatCompletions(c *gin.Context) {
 	logEffectiveModel := usageEffectiveModelForMapping(logModel, effectiveModel, mappingApplied)
 	if h.enforceAPIKeyLimitsAndReply(c, effectiveModel) {
 		return
+	}
+	releaseAPIKeyConcurrency, ok := h.acquireAPIKeyConcurrency(c)
+	if !ok {
+		return
+	}
+	if releaseAPIKeyConcurrency != nil {
+		defer releaseAPIKeyConcurrency()
 	}
 	// /v1/chat/completions 同时允许官方 Codex OAuth 账号与中转（OpenAI Responses API）账号：
 	// 翻译后的请求体本身就是 Responses 形态，中转账号直接以 HTTP 转发（issue #181）。

--- a/proxy/handler_anthropic.go
+++ b/proxy/handler_anthropic.go
@@ -120,6 +120,13 @@ func (h *Handler) Messages(c *gin.Context) {
 	if h.enforceAPIKeyLimitsAndReply(c, effectiveModel) {
 		return
 	}
+	releaseAPIKeyConcurrency, ok := h.acquireAPIKeyConcurrency(c)
+	if !ok {
+		return
+	}
+	if releaseAPIKeyConcurrency != nil {
+		defer releaseAPIKeyConcurrency()
+	}
 	// /v1/messages 同时允许官方 Codex OAuth 账号与中转（OpenAI Responses API）账号：
 	// 翻译后的请求体本身就是 Responses 形态，中转账号直接以 HTTP 转发，
 	// 使仅接入中转的用户也能使用 Claude Code（issue #181）。

--- a/proxy/images.go
+++ b/proxy/images.go
@@ -756,6 +756,13 @@ func (h *Handler) ImagesGenerations(c *gin.Context) {
 	if h.enforceAPIKeyLimitsAndReply(c, imageModel) {
 		return
 	}
+	releaseAPIKeyConcurrency, ok := h.acquireAPIKeyConcurrency(c)
+	if !ok {
+		return
+	}
+	if releaseAPIKeyConcurrency != nil {
+		defer releaseAPIKeyConcurrency()
+	}
 	tool := []byte(`{"type":"image_generation","action":"generate","model":""}`)
 	toolModel, defaultSize := normalizeImageToolModelForPrompt(imageModel, promptForRequest)
 	tool, _ = sjson.SetBytes(tool, "model", toolModel)
@@ -870,6 +877,13 @@ func (h *Handler) imagesEditsFromMultipart(c *gin.Context) {
 	if h.enforceAPIKeyLimitsAndReply(c, imageModel) {
 		return
 	}
+	releaseAPIKeyConcurrency, ok := h.acquireAPIKeyConcurrency(c)
+	if !ok {
+		return
+	}
+	if releaseAPIKeyConcurrency != nil {
+		defer releaseAPIKeyConcurrency()
+	}
 	tool := buildImagesEditToolFromForm(c, imageModel, maskDataURL)
 	responsesBody := buildImagesResponsesRequest(promptForRequest, images, tool)
 	h.forwardImagesRequest(c, "/v1/images/edits", imageModel, requestModel, logEffectiveModel, responsesBody, responseFormat, "image_edit", stream)
@@ -974,6 +988,13 @@ func (h *Handler) imagesEditsFromJSON(c *gin.Context) {
 	}
 	if h.enforceAPIKeyLimitsAndReply(c, imageModel) {
 		return
+	}
+	releaseAPIKeyConcurrency, ok := h.acquireAPIKeyConcurrency(c)
+	if !ok {
+		return
+	}
+	if releaseAPIKeyConcurrency != nil {
+		defer releaseAPIKeyConcurrency()
 	}
 	tool := []byte(`{"type":"image_generation","action":"edit","model":""}`)
 	toolModel, defaultSize := normalizeImageToolModelForPrompt(imageModel, promptForRequest)

--- a/proxy/responses_ws.go
+++ b/proxy/responses_ws.go
@@ -211,6 +211,14 @@ func (h *Handler) forwardResponsesWebSocketTurn(c *gin.Context, conn *websocket.
 		_ = writeResponsesWSError(conn, apiErr)
 		return newResponsesWSCloseError(closeCode, apiErr.Message, apiErr)
 	}
+	releaseAPIKeyConcurrency, concurrencyErr, ok := h.acquireAPIKeyConcurrencyForWebSocket(c)
+	if !ok {
+		_ = writeResponsesWSError(conn, concurrencyErr)
+		return newResponsesWSCloseError(websocket.CloseTryAgainLater, concurrencyErr.Message, concurrencyErr)
+	}
+	if releaseAPIKeyConcurrency != nil {
+		defer releaseAPIKeyConcurrency()
+	}
 
 	accountFilter := accountFilterForModel(effectiveModel)
 	accountFilter = h.withModelCooldownFilter(effectiveModel, accountFilter)


### PR DESCRIPTION
 ## 概述                                                                                                                                                                 
                                                                                                                                                                          
  本 PR 为 API Key 增加单实例并发数控制能力。                                                                                                                             
                                                                                                                                                                          
  主要变更：                                                                                                                                                              
                                                                                                                                                                          
  - 在 API Key `limits` 中新增 `max_concurrency` 字段                                                                                                                     
  - 在代理请求链路中按 API Key 统计当前实例内的 inflight 请求数                                                                                                           
  - 超过并发上限时返回 `429`                                                                                                                                              
  - 支持管理后台创建/编辑 API Key 时配置最大并发数                                                                                                                        
  - 补充中英文前端文案                                                                                                                                                    
  - 新增并发 limiter 与 handler 行为测试                                                                                                                                  
                                                                                                                                                                          
  ## 实现说明                                                                                                                                                             
                                                                                                                                                                          
  `max_concurrency` 的语义为：                                                                                                                                            
                                                                                                                                                                          
  > 当前进程内，同一个 API Key 同时处理中代理请求数的上限。                                                                                                               
                                                                                                                                                                          
  请求通过 API Key limits 检查后开始占用并发槽，直到 handler 返回时释放。占槽时间包含：                                                                                   
                                                                                                                                                                          
  - 账号调度等待                                                                                                                                                          
  - 上游请求                                                                                                                                                              
  - 上游重试                                                                                                                                                              
  - 流式响应                                                                                                                                                              
  - WebSocket 单次 turn 处理时间                                                                                                                                          
                                                                                                                                                                          
  本 PR 仅实现单实例内存并发控制，不做多实例全局并发控制。                                                                                                                
                                                                                                                                                                          
  ## 覆盖范围                                                                                                                                                             
                                                                                                                                                                          
  已接入以下资源消耗型路由：                                                                                                                                              
                                                                                                                                                                          
  - `/v1/responses`                                                                                                                                                       
  - `/v1/responses/compact`                                                                                                                                               
  - `/v1/chat/completions`                                                                                                                                                
  - `/v1/messages`                                                                                                                                                        
  - `/v1/images/generations`                                                                                                                                              
  - `/v1/images/edits`                                                                                                                                                    
  - `/backend-api/codex/responses`                                                                                                                                        
  - `/backend-api/codex/responses/compact`                                                                                                                                
  - Responses WebSocket turn                                                                                                                                              
                                                                                                                                                                          
  `/v1/models` 等元数据接口不计入并发限制。                                                                                                                               
                                                                                                                                                                          
  ## 验证                                                                                                                                                                 
                                                                                                                                                                          
  已通过以下测试：                                                                                                                                                        
                                                                                                                                                                          
  - `go test ./proxy -run 'TestAPIKeyConcurrency|TestAcquireAPIKeyConcurrency' -count=1`                                                                                  
  - `go test ./proxy ./database ./admin -count=1`                                                                                                                         
  - `cd frontend && pnpm typecheck`                                                                                                                                       
  - `cd frontend && pnpm build`                      