### PR TITLE
fix:  优化 Redis 刷新等待轮询的 timer 分配

### DIFF
--- a/cache/redis.go
+++ b/cache/redis.go
@@ -252,8 +252,17 @@ func (tc *redisTokenCache) ReleaseRefreshLock(ctx context.Context, accountID int
 
 // WaitForRefreshComplete 等待另一个进程完成刷新（轮询锁 + 读取缓存）
 func (tc *redisTokenCache) WaitForRefreshComplete(ctx context.Context, accountID int64, timeout time.Duration) (string, error) {
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
+	if timeout <= 0 {
+		timeout = 30 * time.Second
+	}
+
+	timeoutTimer := time.NewTimer(timeout)
+	defer timeoutTimer.Stop()
+
+	ticker := time.NewTicker(200 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
 		// 检查锁是否还在
 		exists, err := tc.client.Exists(ctx, refreshLockKey(accountID)).Result()
 		if err != nil {
@@ -274,10 +283,11 @@ func (tc *redisTokenCache) WaitForRefreshComplete(ctx context.Context, accountID
 		select {
 		case <-ctx.Done():
 			return "", ctx.Err()
-		case <-time.After(200 * time.Millisecond):
+		case <-timeoutTimer.C:
+			return "", fmt.Errorf("等待刷新超时")
+		case <-ticker.C:
 		}
 	}
-	return "", fmt.Errorf("等待刷新超时")
 }
 
 // ==================== 运行态缓存 ====================


### PR DESCRIPTION
 ## 背景                                                                                                                                            
                                                                                                                                                     
  在 Redis token cache 模式下，当某个账号的 access token 正在被刷新时，其他并发请求会进入 `WaitForRefreshComplete` 等待已有刷新任务完成。            
                                                                                                                                                     
  原实现中，等待逻辑每 200ms 轮询一次 Redis 刷新锁状态：                                                                                             
                                                                                                                                                     
  ```go                                                                                                                                              
  case <-time.After(200 * time.Millisecond):                                                                                                         
                                                                                                                                                     
  time.After 每次调用都会创建一个新的 timer。默认等待超时时间为 30 秒时，单个等待调用在最坏情况下会创建约：                                          
                                                                                                                                                     
  30s / 200ms = 150                                                                                                                                  
                                                                                                                                                     
  个 timer。                                                                                                                                         
                                                                                                                                                     
  在普通低并发场景下影响不明显，但在以下场景中会放大：                                                                                               
                                                                                                                                                     
  - 多请求同时命中同一个过期账号 token                                                                                                               
  - 多实例部署时多个进程竞争同一个刷新锁                                                                                                             
  - 上游 token refresh 变慢                                                                                                                          
  - 账号数量较少但请求并发较高                                                                                                                       
  - Redis cache 模式下发生 refresh contention                                                                                                        
                                                                                                                                                     
  这些情况下，等待者数量增加会导致大量短生命周期 timer 对象创建，从而增加堆分配、runtime timer 管理成本和 GC 压力。                                  
                                                                                                                                                     
  修改内容                                                                                                                                           
                                                                                                                                                     
  本 PR 将 WaitForRefreshComplete 中循环内的 time.After 替换为可复用的 timer/ticker 结构：                                                           
                                                                                                                                                     
  - 使用 time.NewTicker(200 * time.Millisecond) 负责固定间隔轮询。                                                                                   
  - 使用 time.NewTimer(timeout) 负责整体等待超时。                                                                                                   
  - 退出时通过 defer ticker.Stop() 和 defer timeoutTimer.Stop() 释放资源。                                                                           
  - 保留外部 ctx 取消时返回 ctx.Err() 的行为。                                                                                                       
  - 保留等待超时时返回原有错误文案：等待刷新超时。                                                                                                   
  - 增加 timeout <= 0 时默认使用 30s，与内存缓存实现行为保持一致。                                                                                   
                                                                                                                                                     
  修改后，等待逻辑仍然保持 200ms 轮询间隔，业务行为基本不变，但避免了每轮循环都创建新 timer。                                                        
                                                                                                                                                     
  性能收益                                                                                                                                           
                                                                                                                                                     
  以默认配置为例：                                                                                                                                   
                                                                                                                                                     
  - 等待超时：30 秒                                                                                                                                  
  - 轮询间隔：200ms                                                                                                                                  
                                                                                                                                                     
  原实现：                                                                                                                                           
                                                                                                                                                     
  单个等待调用最多约 150 个 timer                                                                                                                    
                                                                                                                                                     
  新实现：                                                                                                                                           
                                                                                                                                                     
  单个等待调用固定 1 个 timeout timer + 1 个 ticker                                                                                                  
                                                                                                                                                     
  因此在等待满 30 秒的情况下，timer 创建数量从约 150 个降低到 2 个，理论上减少约 98% 以上的 timer 相关对象创建。                                     
                                                                                                                                                     
  如果只比较轮询部分，则从每轮一个 time.After 降为单个 Ticker，轮询 timer 创建量约减少 99%。                                                         
                                                                                                                                                     
  该优化主要改善：                                                                                                                                   
                                                                                                                                                     
  - token refresh contention 场景下的临时对象分配                                                                                                    
  - GC 压力                                                                                                                                          
  - runtime timer 管理成本                                                                                                                           
  - 高并发等待时的尾延迟稳定性                                                                                                                       
                                                                                                                                                     
  需要说明的是，本 PR 不改变轮询间隔，因此单个请求的正常等待延迟基本不变，收益主要体现在资源消耗和稳定性上。                                         
                                                                                                                                                     
  行为兼容性                                                                                                                                         
                                                                                                                                                     
  本 PR 尽量保持原有行为：                                                                                                                           
                                                                                                                                                     
  - 外部 context 被取消时，仍返回 ctx.Err()。                                                                                                        
  - 等待超过 timeout 时，仍返回 等待刷新超时。                                                                                                       
  - Redis 查询和 token 读取仍使用传入的 ctx。                                                                                                        
  - 轮询间隔仍为 200ms。                                                                                                                             
  - 调用方无需修改。                                                                                                                                 
                                                                                                                                                     
  额外补充：                                                                                                                                         
                                                                                                                                                     
  - 当传入 timeout <= 0 时，使用默认 30s，与 MemoryTokenCache.WaitForRefreshComplete 的处理方式保持一致。                                            
                                                                                                                                                     
  测试                                                                                                                                               
                                                                                                                                                     
  已执行并通过：                                                                                                                                     
                                                                                                                                                     
  go test ./cache                                                                                                                                    
  go test ./auth ./cache                                                                                                                             
  go test ./security/promptfilter                                                                                                                    
                                                                                                                                                     
  也执行过全量测试：                                                                                                                                 
                                                                                                                                                     
  go test ./...                                                                                                                                      
                                                                                                                                                     
  首次全量测试中，security/promptfilter 因 Windows 本地杀毒软件阻止测试二进制执行而失败：                                                            
                                                                                                                                                     
  fork/exec ... promptfilter.test.exe: Access is denied                                                                                              
                                                                                                                                                     
  关闭杀毒软件后，重新执行：                                                                                                                         
                                                                                                                                                     
  go test ./security/promptfilter                                                                                                                    
                                                                                                                                                     
  已通过。                                                                                                                                           
                                                                                                                                                     
  因此该失败属于本地环境权限问题，不是本次代码修改导致。                                                                                             
                                                                                                                                                     
  变更范围                                                                                                                                           
                                                                                                                                                     
  本 PR 最终只修改一个文件：                                                                                                                         
                                                                                                                                                     
  cache/redis.go          

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced refresh operation timeout handling with improved scheduling mechanisms to ensure operations complete within expected timeframes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->