### PR TITLE
perf: 复用已缓存请求体，减少热路径重复读取 

### DIFF
--- a/api/middleware.go
+++ b/api/middleware.go
@@ -181,6 +181,12 @@ func randInt() int {
 // BodyCacheMiddleware caches the request body for multiple reads
 func BodyCacheMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
+		if body := GetRawBody(c); body != nil {
+			c.Request.Body = io.NopCloser(bytes.NewReader(body))
+			c.Next()
+			return
+		}
+
 		if c.Request.Body != nil && c.Request.Body != http.NoBody {
 			body, err := io.ReadAll(c.Request.Body)
 			if err != nil {

--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -614,6 +614,24 @@ func rawRequestBodyFromContext(c *gin.Context) ([]byte, bool) {
 	}
 }
 
+func readRawRequestBody(c *gin.Context) ([]byte, error) {
+	if body, ok := rawRequestBodyFromContext(c); ok {
+		return body, nil
+	}
+	body, err := io.ReadAll(c.Request.Body)
+	if err != nil {
+		return nil, err
+	}
+	setRawRequestBody(c, body)
+	return body, nil
+}
+
+func setRawRequestBody(c *gin.Context, body []byte) {
+	if c != nil {
+		c.Set("raw_body", body)
+	}
+}
+
 func requestBodyHasCompactionInput(body []byte) bool {
 	input := gjson.GetBytes(body, "input")
 	return gjsonResultHasCompactionInput(input)
@@ -1338,7 +1356,7 @@ func firstGJSONInt(body []byte, paths ...string) int64 {
 // Responses 处理 /v1/responses 请求（原生透传，增强输入验证）
 func (h *Handler) Responses(c *gin.Context) {
 	// 1. 读取请求体
-	rawBody, err := io.ReadAll(c.Request.Body)
+	rawBody, err := readRawRequestBody(c)
 	if err != nil {
 		api.SendError(c, api.NewAPIError(api.ErrCodeInvalidRequest, "Failed to read request body", api.ErrorTypeInvalidRequest))
 		return
@@ -1346,7 +1364,7 @@ func (h *Handler) Responses(c *gin.Context) {
 
 	supportedModels := h.supportedModelIDs(c.Request.Context())
 	rawBody, requestModel, mappedModel, mappingApplied := h.applyConfiguredModelMappingToBody(rawBody, supportedModels)
-	c.Set("raw_body", rawBody)
+	setRawRequestBody(c, rawBody)
 
 	// Validate request
 	validator := api.NewValidator(rawBody)
@@ -2232,7 +2250,7 @@ func (h *Handler) Responses(c *gin.Context) {
 // ResponsesCompact 处理 /v1/responses/compact 请求（非流式压缩接口，透传到上游 /responses/compact）
 func (h *Handler) ResponsesCompact(c *gin.Context) {
 	// 1. 读取请求体
-	rawBody, err := io.ReadAll(c.Request.Body)
+	rawBody, err := readRawRequestBody(c)
 	if err != nil {
 		api.SendError(c, api.NewAPIError(api.ErrCodeInvalidRequest, "Failed to read request body", api.ErrorTypeInvalidRequest))
 		return
@@ -2240,7 +2258,7 @@ func (h *Handler) ResponsesCompact(c *gin.Context) {
 
 	supportedModels := h.supportedModelIDs(c.Request.Context())
 	rawBody, requestModel, mappedModel, mappingApplied := h.applyConfiguredModelMappingToBody(rawBody, supportedModels)
-	c.Set("raw_body", rawBody)
+	setRawRequestBody(c, rawBody)
 
 	// Validate request
 	validator := api.NewValidator(rawBody)
@@ -2646,7 +2664,7 @@ func (h *Handler) ResponsesCompact(c *gin.Context) {
 
 func (h *Handler) ChatCompletions(c *gin.Context) {
 	// 1. 读取请求体
-	rawBody, err := io.ReadAll(c.Request.Body)
+	rawBody, err := readRawRequestBody(c)
 	if err != nil {
 		api.SendError(c, api.NewAPIError(api.ErrCodeInvalidRequest, "Failed to read request body", api.ErrorTypeInvalidRequest))
 		return

--- a/proxy/handler_anthropic.go
+++ b/proxy/handler_anthropic.go
@@ -65,7 +65,7 @@ func mapHTTPStatusToAnthropicError(statusCode int) string {
 // Messages 处理 /v1/messages 请求（Anthropic Messages API → Codex Responses）
 func (h *Handler) Messages(c *gin.Context) {
 	// 1. 读取请求体
-	rawBody, err := io.ReadAll(c.Request.Body)
+	rawBody, err := readRawRequestBody(c)
 	if err != nil {
 		sendAnthropicError(c, http.StatusBadRequest, "invalid_request_error", "Failed to read request body")
 		return

--- a/proxy/images.go
+++ b/proxy/images.go
@@ -709,7 +709,7 @@ func multipartFileToDataURL(fileHeader *multipart.FileHeader) (string, error) {
 }
 
 func (h *Handler) ImagesGenerations(c *gin.Context) {
-	rawBody, err := io.ReadAll(c.Request.Body)
+	rawBody, err := readRawRequestBody(c)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"message": "Invalid request: " + err.Error(), "type": "invalid_request_error"}})
 		return
@@ -911,7 +911,7 @@ func buildImagesEditToolFromForm(c *gin.Context, imageModel, maskDataURL string)
 }
 
 func (h *Handler) imagesEditsFromJSON(c *gin.Context) {
-	rawBody, err := io.ReadAll(c.Request.Body)
+	rawBody, err := readRawRequestBody(c)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"message": "Invalid request: " + err.Error(), "type": "invalid_request_error"}})
 		return

--- a/security/middleware.go
+++ b/security/middleware.go
@@ -58,7 +58,8 @@ func RateLimitMiddleware(requests int, window time.Duration) gin.HandlerFunc {
 // RequestSizeLimiter limits request body size
 func RequestSizeLimiter(maxSize int64) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		// Read the request body
+		// Read the request body once, enforce the configured size limit, and cache it
+		// for downstream handlers that need raw JSON without re-reading c.Request.Body.
 		body, err := io.ReadAll(io.LimitReader(c.Request.Body, maxSize+1))
 		if err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{
@@ -85,7 +86,8 @@ func RequestSizeLimiter(maxSize int64) gin.HandlerFunc {
 			return
 		}
 
-		// Replace the body so it can be read again
+		c.Set("raw_body", body)
+		// Replace the body so code paths using Gin binding/GetRawData can still read it.
 		c.Request.Body = io.NopCloser(bytes.NewReader(body))
 		c.Next()
 	}

--- a/security/middleware_test.go
+++ b/security/middleware_test.go
@@ -79,6 +79,17 @@ func TestRequestSizeLimiter(t *testing.T) {
 	r.Use(RequestSizeLimiter(100))
 	r.POST("/test", func(c *gin.Context) {
 		body, _ := c.GetRawData()
+		cached, exists := c.Get("raw_body")
+		if !exists {
+			t.Fatal("raw_body was not cached")
+		}
+		cachedBody, ok := cached.([]byte)
+		if !ok {
+			t.Fatalf("raw_body type = %T, want []byte", cached)
+		}
+		if string(cachedBody) != string(body) {
+			t.Fatalf("cached body = %q, want %q", string(cachedBody), string(body))
+		}
 		c.String(200, "Received %d bytes", len(body))
 	})
 
@@ -97,6 +108,37 @@ func TestRequestSizeLimiter(t *testing.T) {
 	r.ServeHTTP(w, req)
 	if w.Code != 413 {
 		t.Errorf("Large request: expected 413, got %d", w.Code)
+	}
+}
+
+func TestRequestSizeLimiterAllowsEmptyBody(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(RequestSizeLimiter(100))
+	r.POST("/test", func(c *gin.Context) {
+		body, _ := c.GetRawData()
+		if len(body) != 0 {
+			t.Fatalf("body length = %d, want 0", len(body))
+		}
+		cached, exists := c.Get("raw_body")
+		if !exists {
+			t.Fatal("raw_body was not cached for empty body")
+		}
+		cachedBody, ok := cached.([]byte)
+		if !ok {
+			t.Fatalf("raw_body type = %T, want []byte", cached)
+		}
+		if len(cachedBody) != 0 {
+			t.Fatalf("cached body length = %d, want 0", len(cachedBody))
+		}
+		c.String(200, "OK")
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/test", strings.NewReader(""))
+	r.ServeHTTP(w, req)
+	if w.Code != 200 {
+		t.Fatalf("status = %d, want 200", w.Code)
 	}
 }
 


### PR DESCRIPTION
## 背景                                                                                                                                            
                                                                                                                                                     
  当前 JSON 请求热路径中，请求体可能被完整读取和复制多次：                                                                                           
                                                                                                                                                     
  1. `RequestSizeLimiter` 读取一次，用于限制请求体大小。                                                                                             
  2. `BodyCacheMiddleware` 再读取一次，用于设置 `raw_body`。                                                                                         
  3. 具体 proxy handler 再读取一次，用于解析、校验和转发。                                                                                           
                                                                                                                                                     
  这会导致同一个请求体在全局中间件和 handler 中最多被完整读取 3 次。对于大请求体或高并发请求，会增加重复 byte slice 分配、memcpy 和 GC 压力。        
                                                                                                                                                     
  ## 修改内容                                                                                                                                        
                                                                                                                                                     
  本 PR 将请求体读取层合并为单次读取 + 后续复用：                                                                                                    
                                                                                                                                                     
  - `RequestSizeLimiter` 在读取并校验请求体大小后，直接缓存 `raw_body`。                                                                             
  - `BodyCacheMiddleware` 如果发现 `raw_body` 已存在，则直接复用，不再重复 `io.ReadAll`。                                                            
  - proxy handler 改为通过 `readRawRequestBody(c)` 获取请求体，优先复用 `raw_body`。                                                                 
  - 对模型映射后修改过的请求体，继续更新 `raw_body`，保持后续 prompt filter / usage compact 检测等逻辑读取最新 body。                                
  - 保留 `c.Request.Body = io.NopCloser(bytes.NewReader(body))`，确保 `ShouldBindJSON` / `GetRawData` 等旧路径仍兼容。                               
  - 增强 `RequestSizeLimiter` 测试，验证 `raw_body` 缓存和空 body 兼容性。                                                                           
                                                                                                                                                     
  ## 优化前后对比                                                                                                                                    
                                                                                                                                                     
  优化前：                                                                                                                                           
                                                                                                                                                     
  ```text                                                                                                                                            
  RequestSizeLimiter 读取 body 一次                                                                                                                  
  BodyCacheMiddleware 再读取 body 一次                                                                                                               
  proxy handler 再读取 body 一次                                                                                                                     
                                                                                                                                                     
  优化后：                                                                                                                                           
                                                                                                                                                     
  RequestSizeLimiter 读取 body 一次并缓存 raw_body                                                                                                   
  BodyCacheMiddleware 复用 raw_body                                                                                                                  
  proxy handler 复用 raw_body                                                                                                                        
                                                                                                                                                     
  预期收益                                                                                                                                           
                                                                                                                                                     
  以请求体大小为 N 估算：                                                                                                                            
                                                                                                                                                     
  - 优化前：热路径中可能产生约 3N 的请求体 byte slice 相关分配。                                                                                     
  - 优化后：主要保留约 1N 的请求体 byte slice，并由后续逻辑复用。                                                                                    
                                                                                                                                                     
  理论上可减少约 2/3 的请求体重复 buffer 分配，降低大请求和高并发场景下的内存峰值、memcpy 成本与 GC 压力。                                           
                                                                                                                                                     
  受益路径包括：                                                                                                                                     
                                                                                                                                                     
  - /v1/responses                                                                                                                                    
  - /v1/responses/compact                                                                                                                            
  - /v1/chat/completions                                                                                                                             
  - /v1/messages                                                                                                                                     
  - /v1/images/generations                                                                                                                           
  - /v1/images/edits JSON 路径                                                                                                                       
                                                                                                                                                     
  兼容性                                                                                                                                             
                                                                                                                                                     
  保持以下行为不变：                                                                                                                                 
                                                                                                                                                     
  - 请求体大小限制仍由 RequestSizeLimiter 控制。                                                                                                     
  - 超限仍返回 413。                                                                                                                                 
  - 读取失败仍返回 400。                                                                                                                             
  - ShouldBindJSON / GetRawData 仍可读取恢复后的 body。                                                                                              
  - BodyCacheMiddleware 单独使用时仍保留 fallback 读取逻辑。                                                                                         
  - handler 内模型映射后仍会更新 raw_body。                                                                                                          
                                                                                                                                                     
  测试                                                                                                                                               
                                                                                                                                                     
  已执行并通过：                                                                                                                                     
                                                                                                                                                     
  go test ./security ./api ./proxy                                                                                                                   
  go test ./...                         

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized request body processing to improve efficiency and reduce duplicate reads across operations
  * Enhanced validation middleware to consistently manage request bodies during processing

* **Tests**
  * Added test coverage for request body handling and validation scenarios, including empty body cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->