### PR TITLE
 fix: usage log 写入失败时回队列重试 

### DIFF
--- a/database/postgres.go
+++ b/database/postgres.go
@@ -125,6 +125,10 @@ func (a *AccountRow) GetCredentialStringSlice(key string) []string {
 	return stringSliceFromValue(value)
 }
 
+type sqlExecer interface {
+	ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error)
+}
+
 // DB PostgreSQL 数据库操作
 type DB struct {
 	conn   *sql.DB
@@ -2050,21 +2054,55 @@ func (db *DB) flushLogs() {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second) // 增加超时时间
 	defer cancel()
 
+	var err error
 	// 使用批处理插入优化性能
 	if db.driver == "postgres" {
-		err := db.batchInsertLogs(ctx, batch)
-		if err != nil {
-			log.Printf("批量写入日志失败: %v", err)
-		}
+		err = db.batchInsertLogs(ctx, batch)
+	} else {
+		err = db.insertSQLiteUsageLogBatch(ctx, batch)
+	}
+	if err != nil {
+		log.Printf("批量写入日志失败，已重新放回缓冲区等待重试: %v", err)
+		db.requeueUsageLogBatch(batch)
 		return
+	}
+
+	if len(batch) > 10 {
+		log.Printf("批量写入 %d 条使用日志", len(batch))
+	}
+}
+
+func (db *DB) requeueUsageLogBatch(batch []usageLogEntry) {
+	if len(batch) == 0 {
+		return
+	}
+	db.logMu.Lock()
+	defer db.logMu.Unlock()
+
+	if len(db.logBuf) == 0 {
+		requeued := make([]usageLogEntry, len(batch), len(batch)+db.GetUsageLogBatchSize())
+		copy(requeued, batch)
+		db.logBuf = requeued
+		return
+	}
+
+	requeued := make([]usageLogEntry, 0, len(batch)+len(db.logBuf))
+	requeued = append(requeued, batch...)
+	requeued = append(requeued, db.logBuf...)
+	db.logBuf = requeued
+}
+
+func (db *DB) insertSQLiteUsageLogBatch(ctx context.Context, batch []usageLogEntry) error {
+	if len(batch) == 0 {
+		return nil
 	}
 
 	// SQLite 使用事务插入
 	tx, err := db.conn.BeginTx(ctx, nil)
 	if err != nil {
-		log.Printf("批量写入日志失败（开始事务）: %v", err)
-		return
+		return fmt.Errorf("开始事务: %w", err)
 	}
+	defer tx.Rollback()
 
 	stmt, err := tx.PrepareContext(ctx,
 		`INSERT INTO usage_logs (account_id, client_ip, endpoint, model, effective_model, prompt_tokens, completion_tokens, total_tokens, status_code, duration_ms,
@@ -2074,9 +2112,7 @@ func (db *DB) flushLogs() {
 			  is_retry_attempt, attempt_index, upstream_error_kind, error_message, via_websocket)
 			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40)`)
 	if err != nil {
-		tx.Rollback()
-		log.Printf("批量写入日志失败（准备语句）: %v", err)
-		return
+		return fmt.Errorf("准备语句: %w", err)
 	}
 	defer stmt.Close()
 
@@ -2086,23 +2122,17 @@ func (db *DB) flushLogs() {
 			e.RequestedServiceTier, e.ActualServiceTier, e.BillingServiceTier,
 			e.APIKeyID, e.APIKeyName, e.APIKeyMasked, e.ImageCount, e.ImageWidth, e.ImageHeight, e.ImageBytes, e.ImageFormat, e.ImageSize, e.AccountBilled, e.UserBilled,
 			e.IsRetryAttempt, e.AttemptIndex, e.UpstreamErrorKind, e.ErrorMessage, e.ViaWebsocket); err != nil {
-			tx.Rollback()
-			log.Printf("批量写入日志失败（执行）: %v", err)
-			return
+			return fmt.Errorf("执行插入: %w", err)
 		}
 	}
 
+	if err := db.applyAPIKeyQuotaUsageWithExec(ctx, tx, batch); err != nil {
+		return fmt.Errorf("更新 API Key 额度用量: %w", err)
+	}
 	if err := tx.Commit(); err != nil {
-		log.Printf("批量写入日志失败（提交）: %v", err)
-		return
+		return fmt.Errorf("提交事务: %w", err)
 	}
-	if err := db.applyAPIKeyQuotaUsage(ctx, batch); err != nil {
-		log.Printf("更新 API Key 额度用量失败: %v", err)
-	}
-
-	if len(batch) > 10 {
-		log.Printf("批量写入 %d 条使用日志", len(batch))
-	}
+	return nil
 }
 
 // batchInsertLogs 使用 PostgreSQL 的批量插入优化
@@ -2111,6 +2141,12 @@ func (db *DB) batchInsertLogs(ctx context.Context, batch []usageLogEntry) error 
 	if len(batch) == 0 {
 		return nil
 	}
+
+	tx, err := db.conn.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("开始事务: %w", err)
+	}
+	defer tx.Rollback()
 
 	const maxRowsPerBatch = 1600
 
@@ -2122,18 +2158,21 @@ func (db *DB) batchInsertLogs(ctx context.Context, batch []usageLogEntry) error 
 		}
 		subBatch := batch[start:end]
 
-		if err := db.batchInsertLogsChunk(ctx, subBatch); err != nil {
+		if err := db.batchInsertLogsChunk(ctx, tx, subBatch); err != nil {
 			return err
 		}
-		if err := db.applyAPIKeyQuotaUsage(ctx, subBatch); err != nil {
-			return err
-		}
+	}
+	if err := db.applyAPIKeyQuotaUsageWithExec(ctx, tx, batch); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("提交事务: %w", err)
 	}
 	return nil
 }
 
 // batchInsertLogsChunk 插入单批日志（内部辅助函数）
-func (db *DB) batchInsertLogsChunk(ctx context.Context, batch []usageLogEntry) error {
+func (db *DB) batchInsertLogsChunk(ctx context.Context, execer sqlExecer, batch []usageLogEntry) error {
 	if len(batch) == 0 {
 		return nil
 	}
@@ -2164,12 +2203,19 @@ func (db *DB) batchInsertLogsChunk(ctx context.Context, batch []usageLogEntry) e
 		is_retry_attempt, attempt_index, upstream_error_kind, error_message, via_websocket)
 		VALUES %s`, strings.Join(valueStrings, ","))
 
-	_, err := db.conn.ExecContext(ctx, query, valueArgs...)
+	_, err := execer.ExecContext(ctx, query, valueArgs...)
 	return err
 }
 
 func (db *DB) applyAPIKeyQuotaUsage(ctx context.Context, batch []usageLogEntry) error {
-	if db == nil || len(batch) == 0 {
+	if db == nil {
+		return nil
+	}
+	return db.applyAPIKeyQuotaUsageWithExec(ctx, db.conn, batch)
+}
+
+func (db *DB) applyAPIKeyQuotaUsageWithExec(ctx context.Context, execer sqlExecer, batch []usageLogEntry) error {
+	if db == nil || execer == nil || len(batch) == 0 {
 		return nil
 	}
 	usageByKey := make(map[int64]float64)
@@ -2183,7 +2229,7 @@ func (db *DB) applyAPIKeyQuotaUsage(ctx context.Context, batch []usageLogEntry) 
 		if amount <= 0 {
 			continue
 		}
-		if _, err := db.conn.ExecContext(ctx, `UPDATE api_keys SET quota_used = COALESCE(quota_used, 0) + $1 WHERE id = $2`, amount, id); err != nil {
+		if _, err := execer.ExecContext(ctx, `UPDATE api_keys SET quota_used = COALESCE(quota_used, 0) + $1 WHERE id = $2`, amount, id); err != nil {
 			return err
 		}
 	}

--- a/database/sqlite_test.go
+++ b/database/sqlite_test.go
@@ -1977,3 +1977,87 @@ func TestGetAccountsBilledSinceUsesPerAccountWindows(t *testing.T) {
 		t.Fatalf("account 3 billed = %.2f, want 0", got[3])
 	}
 }
+
+func TestFlushLogsRequeuesBatchWhenSQLiteBeginFails(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "codex2api.db")
+
+	db, err := New("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("New(sqlite) 返回错误: %v", err)
+	}
+	close(db.logStop)
+	db.logWg.Wait()
+
+	ctx := context.Background()
+	for _, endpoint := range []string{"/v1/responses", "/v1/chat/completions"} {
+		if err := db.InsertUsageLog(ctx, &UsageLogInput{
+			Endpoint:    endpoint,
+			Model:       "gpt-5.4",
+			StatusCode:  200,
+			InputTokens: 1000,
+		}); err != nil {
+			t.Fatalf("InsertUsageLog 返回错误: %v", err)
+		}
+	}
+	if err := db.conn.Close(); err != nil {
+		t.Fatalf("关闭 sqlite 连接返回错误: %v", err)
+	}
+
+	db.flushLogs()
+
+	db.logMu.Lock()
+	defer db.logMu.Unlock()
+	if len(db.logBuf) != 2 {
+		t.Fatalf("len(logBuf) = %d, want 2", len(db.logBuf))
+	}
+	if db.logBuf[0].Endpoint != "/v1/responses" || db.logBuf[1].Endpoint != "/v1/chat/completions" {
+		t.Fatalf("requeued endpoints = %q, %q", db.logBuf[0].Endpoint, db.logBuf[1].Endpoint)
+	}
+}
+
+func TestFlushLogsRollsBackAndRequeuesWhenQuotaUpdateFails(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "codex2api.db")
+
+	db, err := New("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("New(sqlite) 返回错误: %v", err)
+	}
+	close(db.logStop)
+	db.logWg.Wait()
+	defer db.conn.Close()
+
+	ctx := context.Background()
+	if _, err := db.conn.ExecContext(ctx, `ALTER TABLE api_keys RENAME TO api_keys_broken`); err != nil {
+		t.Fatalf("rename api_keys 返回错误: %v", err)
+	}
+	if err := db.InsertUsageLog(ctx, &UsageLogInput{
+		APIKeyID:    123,
+		Endpoint:    "/v1/responses",
+		Model:       "gpt-5.4",
+		StatusCode:  200,
+		InputTokens: 1000,
+	}); err != nil {
+		t.Fatalf("InsertUsageLog 返回错误: %v", err)
+	}
+
+	db.flushLogs()
+
+	db.logMu.Lock()
+	if len(db.logBuf) != 1 {
+		db.logMu.Unlock()
+		t.Fatalf("len(logBuf) = %d, want 1", len(db.logBuf))
+	}
+	if db.logBuf[0].APIKeyID != 123 {
+		db.logMu.Unlock()
+		t.Fatalf("requeued APIKeyID = %d, want 123", db.logBuf[0].APIKeyID)
+	}
+	db.logMu.Unlock()
+
+	var count int
+	if err := db.conn.QueryRowContext(ctx, `SELECT COUNT(*) FROM usage_logs`).Scan(&count); err != nil {
+		t.Fatalf("count usage_logs 返回错误: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("usage_logs count = %d, want 0 after rolled-back flush", count)
+	}
+}


### PR DESCRIPTION
 ## 背景                                                                                                                                            
                                                                                                                                                     
  此前 `flushLogs()` 会先从 `db.logBuf` 中取出 batch 并清空缓冲区，然后再执行数据库写入。                                                            
                                                                                                                                                     
  如果后续写入过程中发生 transient DB 错误，例如：                                                                                                   
                                                                                                                                                     
  - 开始事务失败                                                                                                                                     
  - prepare statement 失败                                                                                                                           
  - insert 执行失败                                                                                                                                  
  - commit 失败                                                                                                                                      
  - PostgreSQL 分批写入失败                                                                                                                          
  - API Key quota usage 更新失败                                                                                                                     
                                                                                                                                                     
  这批日志已经从内存缓冲中移除，只会打印错误日志，不会再被重试，导致 usage log 永久丢失。                                                            
                                                                                                                                                     
  这会影响：                                                                                                                                         
                                                                                                                                                     
  - 请求日志完整性                                                                                                                                   
  - 使用量统计                                                                                                                                       
  - 错误分析                                                                                                                                         
  - API Key quota usage 准确性                                                                                                                       
                                                                                                                                                     
  ## 修改内容                                                                                                                                        
                                                                                                                                                     
  本 PR 优化 usage log 批量写入失败处理：                                                                                                            
                                                                                                                                                     
  - `flushLogs()` 写入失败时，将失败 batch 重新放回 `db.logBuf`，等待下一轮 flush 重试。                                                             
  - 新增 `requeueUsageLogBatch`，失败 batch 放回缓冲区前部，尽量保持写入顺序。                                                                       
  - 将 SQLite usage log 批量写入拆分为 `insertSQLiteUsageLogBatch`，统一返回 error，由 `flushLogs()` 统一处理失败回队列。                            
  - PostgreSQL 批量写入改为在事务中执行。                                                                                                            
  - SQLite / PostgreSQL 均将 usage log 插入和 API Key quota usage 更新放入同一事务中。                                                               
  - 新增 `sqlExecer` 接口，使批量 insert 和 quota 更新逻辑可复用 `*sql.DB` 或 `*sql.Tx`。                                                            
  - 增加回归测试覆盖：                                                                                                                               
    - SQLite 开始事务失败时 batch 不丢失并回队列。                                                                                                   
    - quota 更新失败时 usage log 写入 rollback，batch 回队列。                                                                                       
                                                                                                                                                     
  ## 优化前后对比                                                                                                                                    
                                                                                                                                                     
  优化前：                                                                                                                                           
                                                                                                                                                     
  ```text                                                                                                                                            
  db.logBuf -> batch                                                                                                                                 
  db.logBuf 清空                                                                                                                                     
  写 DB 失败                                                                                                                                         
  只打印日志                                                                                                                                         
  batch 永久丢失                                                                                                                                     
                                                                                                                                                     
  优化后：                                                                                                                                           
                                                                                                                                                     
  db.logBuf -> batch                                                                                                                                 
  db.logBuf 清空                                                                                                                                     
  写 DB 失败                                                                                                                                         
  打印日志                                                                                                                                           
  batch 放回 db.logBuf 前部                                                                                                                          
  等待下次 flush 重试                                                                                                                                
                                                                                                                                                     
  数据一致性改进                                                                                                                                     
                                                                                                                                                     
  优化前：                                                                                                                                           
                                                                                                                                                     
  usage_logs 插入成功                                                                                                                                
  quota_used 更新失败                                                                                                                                
  => usage_logs 与 API Key quota 可能不一致                                                                                                          
                                                                                                                                                     
  优化后：                                                                                                                                           
                                                                                                                                                     
  usage_logs 插入 + quota_used 更新在同一事务中                                                                                                      
  任一步失败都会 rollback                                                                                                                            
  batch 回队列等待重试                                                                                                                               
                                                                                                                                                     
  测试                                                                                                                                               
                                                                                                                                                     
  已执行并通过：                                                                                                                                     
                                                                                                                                                     
  go test ./database                                                                                                                                 
  go test ./...                  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error recovery in database operations. Failed write batches are now automatically requeued to prevent data loss and maintain system reliability during unexpected database errors.

* **Refactor**
  * Optimized database transaction handling and query batching processes to enhance overall system consistency and reliability.

* **Tests**
  * Added comprehensive tests for database failure scenarios, validating transaction rollback behavior and ensuring data integrity is maintained after operational failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->