### PR TITLE
feat: 支持 API 密钥 Token 上限单位选择

### DIFF
--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1803,7 +1803,19 @@
       "cost5h": "Cost limit (5h)",
       "cost7d": "Cost limit (7d)",
       "tokens5h": "Token limit (5h)",
-      "tokens7d": "Token limit (7d)"
+      "tokens7d": "Token limit (7d)",
+      "tokenUnits": {
+        "token": "Tokens",
+        "k": "K Tokens",
+        "m": "M Tokens",
+        "b": "B Tokens"
+      },
+      "tokenUnitShort": {
+        "token": "Tokens",
+        "k": "K",
+        "m": "M",
+        "b": "B"
+      }
     },
     "allowedGroupsLabel": "Allowed Account Groups",
     "allowedGroupsPlaceholder": "Choose allowed groups",

--- a/frontend/src/locales/zh.json
+++ b/frontend/src/locales/zh.json
@@ -1803,7 +1803,19 @@
       "cost5h": "5h 成本上限",
       "cost7d": "7d 成本上限",
       "tokens5h": "5h Token 上限",
-      "tokens7d": "7d Token 上限"
+      "tokens7d": "7d Token 上限",
+      "tokenUnits": {
+        "token": "Token",
+        "k": "K Token",
+        "m": "M Token",
+        "b": "B Token"
+      },
+      "tokenUnitShort": {
+        "token": "Token",
+        "k": "K",
+        "m": "M",
+        "b": "B"
+      }
     },
     "allowedGroupsLabel": "允许账号分组",
     "allowedGroupsPlaceholder": "选择允许调用的分组",

--- a/frontend/src/pages/APIKeys.tsx
+++ b/frontend/src/pages/APIKeys.tsx
@@ -17,7 +17,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
-import { Select } from "@/components/ui/select";
+import { Select, type SelectOption } from "@/components/ui/select";
 import {
   Table,
   TableBody,
@@ -42,6 +42,7 @@ import {
 } from "lucide-react";
 
 type ExpireMode = "never" | "7" | "30" | "90" | "custom";
+type TokenLimitUnit = "token" | "k" | "m" | "b";
 
 interface CreateKeyFormState {
   name: string;
@@ -71,8 +72,19 @@ interface LimitsFormState {
   costLimit5h: string;
   costLimit7d: string;
   tokenLimit5h: string;
+  tokenLimit5hUnit: TokenLimitUnit;
   tokenLimit7d: string;
+  tokenLimit7dUnit: TokenLimitUnit;
 }
+
+const TOKEN_LIMIT_UNIT_MULTIPLIERS: Record<TokenLimitUnit, number> = {
+  token: 1,
+  k: 1_000,
+  m: 1_000_000,
+  b: 1_000_000_000,
+};
+
+const TOKEN_LIMIT_UNIT_ORDER: TokenLimitUnit[] = ["b", "m", "k", "token"];
 
 const emptyLimitsForm: LimitsFormState = {
   modelAllow: [],
@@ -83,7 +95,9 @@ const emptyLimitsForm: LimitsFormState = {
   costLimit5h: "",
   costLimit7d: "",
   tokenLimit5h: "",
+  tokenLimit5hUnit: "token",
   tokenLimit7d: "",
+  tokenLimit7dUnit: "token",
 };
 
 const initialCreateForm: CreateKeyFormState = {
@@ -971,6 +985,8 @@ function buildExpirationPayload(
 
 function limitsFromAPIKey(limits: APIKeyLimits | undefined): LimitsFormState {
   if (!limits) return emptyLimitsForm;
+  const token5h = formatTokenLimitForForm(limits.token_limit_5h);
+  const token7d = formatTokenLimitForForm(limits.token_limit_7d);
   return {
     modelAllow: Array.isArray(limits.model_allow) ? limits.model_allow : [],
     modelDeny: Array.isArray(limits.model_deny) ? limits.model_deny : [],
@@ -988,15 +1004,38 @@ function limitsFromAPIKey(limits: APIKeyLimits | undefined): LimitsFormState {
       limits.cost_limit_7d && limits.cost_limit_7d > 0
         ? String(limits.cost_limit_7d)
         : "",
-    tokenLimit5h:
-      limits.token_limit_5h && limits.token_limit_5h > 0
-        ? String(limits.token_limit_5h)
-        : "",
-    tokenLimit7d:
-      limits.token_limit_7d && limits.token_limit_7d > 0
-        ? String(limits.token_limit_7d)
-        : "",
+    tokenLimit5h: token5h.value,
+    tokenLimit5hUnit: token5h.unit,
+    tokenLimit7d: token7d.value,
+    tokenLimit7dUnit: token7d.unit,
   };
+}
+
+function formatTokenLimitForForm(value?: number): {
+  value: string;
+  unit: TokenLimitUnit;
+} {
+  if (!value || value <= 0 || !Number.isFinite(value)) {
+    return { value: "", unit: "token" };
+  }
+  const integerValue = Math.trunc(value);
+  const unit =
+    TOKEN_LIMIT_UNIT_ORDER.find(
+      (candidate) => integerValue % TOKEN_LIMIT_UNIT_MULTIPLIERS[candidate] === 0,
+    ) ?? "token";
+  return {
+    value: String(integerValue / TOKEN_LIMIT_UNIT_MULTIPLIERS[unit]),
+    unit,
+  };
+}
+
+function parseTokenLimit(value: string, unit: TokenLimitUnit): number {
+  const trimmed = value.trim();
+  if (!trimmed) return 0;
+  const amount = Number(trimmed);
+  if (!Number.isFinite(amount) || amount <= 0) return 0;
+  const tokens = amount * TOKEN_LIMIT_UNIT_MULTIPLIERS[unit];
+  return Number.isInteger(tokens) && tokens > 0 ? tokens : 0;
 }
 
 // limitsFormToPayload 把表单值转为后端期望的 APIKeyLimits。
@@ -1019,8 +1058,8 @@ function limitsFormToPayload(form: LimitsFormState): APIKeyLimits {
     max_concurrency: intNum(form.maxConcurrency),
     cost_limit_5h: num(form.costLimit5h),
     cost_limit_7d: num(form.costLimit7d),
-    token_limit_5h: intNum(form.tokenLimit5h),
-    token_limit_7d: intNum(form.tokenLimit7d),
+    token_limit_5h: parseTokenLimit(form.tokenLimit5h, form.tokenLimit5hUnit),
+    token_limit_7d: parseTokenLimit(form.tokenLimit7d, form.tokenLimit7dUnit),
   };
 }
 
@@ -1213,6 +1252,15 @@ function LimitsEditor({
     value.tokenLimit5h !== "" ||
     value.tokenLimit7d !== "";
   const [open, setOpen] = useState(hasAny);
+  const tokenUnitOptions = useMemo(
+    () =>
+      (["token", "k", "m", "b"] as TokenLimitUnit[]).map((unit) => ({
+        label: t(`apiKeys.limits.tokenUnits.${unit}`),
+        triggerLabel: t(`apiKeys.limits.tokenUnitShort.${unit}`),
+        value: unit,
+      })),
+    [t],
+  );
 
   const patch = (next: Partial<LimitsFormState>) =>
     onChange({ ...value, ...next });
@@ -1302,21 +1350,67 @@ function LimitsEditor({
               suffix="$"
               step="0.01"
             />
-            <LimitNumberField
+            <TokenLimitField
               label={t("apiKeys.limits.tokens5h")}
               value={value.tokenLimit5h}
-              onChange={(tokenLimit5h) => patch({ tokenLimit5h })}
-              suffix="tk"
+              unit={value.tokenLimit5hUnit}
+              unitOptions={tokenUnitOptions}
+              onValueChange={(tokenLimit5h) => patch({ tokenLimit5h })}
+              onUnitChange={(tokenLimit5hUnit) => patch({ tokenLimit5hUnit })}
             />
-            <LimitNumberField
+            <TokenLimitField
               label={t("apiKeys.limits.tokens7d")}
               value={value.tokenLimit7d}
-              onChange={(tokenLimit7d) => patch({ tokenLimit7d })}
-              suffix="tk"
+              unit={value.tokenLimit7dUnit}
+              unitOptions={tokenUnitOptions}
+              onValueChange={(tokenLimit7d) => patch({ tokenLimit7d })}
+              onUnitChange={(tokenLimit7dUnit) => patch({ tokenLimit7dUnit })}
             />
           </div>
         </div>
       )}
+    </div>
+  );
+}
+
+function TokenLimitField({
+  label,
+  value,
+  unit,
+  unitOptions,
+  onValueChange,
+  onUnitChange,
+}: {
+  label: string;
+  value: string;
+  unit: TokenLimitUnit;
+  unitOptions: SelectOption[];
+  onValueChange: (next: string) => void;
+  onUnitChange: (next: TokenLimitUnit) => void;
+}) {
+  return (
+    <div className="space-y-1">
+      <label className="text-[11px] font-medium text-muted-foreground">
+        {label}
+      </label>
+      <div className="grid grid-cols-[minmax(0,1fr)_112px] gap-2">
+        <Input
+          type="number"
+          min="0"
+          step="0.01"
+          inputMode="decimal"
+          value={value}
+          onChange={(e) => onValueChange(e.target.value)}
+          placeholder="0"
+          className="text-xs"
+        />
+        <Select
+          value={unit}
+          onValueChange={(next) => onUnitChange(next as TokenLimitUnit)}
+          options={unitOptions}
+          compact
+        />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
  ## 摘要                                                                                                               
                                                                                                                        
  - 在 API 密钥高级限制中，为 5h / 7d Token 上限增加单位选择器                                                          
  - 支持 `Token` / `K` / `M` / `B` 单位，方便运维按常用量级维护                                                         
  - 保存时自动换算为后端原有的原始 token 数，不改变后端接口                                                             
  - 编辑已有密钥时，自动将原始 token 数回显为更易读的单位                                                               
  - 补充中英文界面文案                                                                                                  
                                                                                                                        
  ## 验证                                                                                                               
                                                                                                                        
  - `npm --prefix frontend run typecheck`                                                                               
  - `npm --prefix frontend run build`          

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API key token limits now support unit selection (Tokens, K, M, B) for both 5-hour and 7-day windows.
  * Token amounts can be displayed with full or abbreviated unit labels.
  * Added localization support for English and Chinese interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->