### PR TITLE
fix: handle missing encrypted reasoning content

### DIFF
--- a/proxy/translator.go
+++ b/proxy/translator.go
@@ -923,6 +923,9 @@ func isInvalidEncryptedContentError(statusCode int, body []byte) bool {
 	if statusCode != http.StatusBadRequest {
 		return false
 	}
+	if isMissingEncryptedContentError(body) {
+		return true
+	}
 	for _, path := range []string{"error.code", "detail.code", "code"} {
 		if strings.EqualFold(strings.TrimSpace(gjson.GetBytes(body, path).String()), "invalid_encrypted_content") {
 			return true
@@ -944,6 +947,16 @@ func isInvalidEncryptedContentError(statusCode int, body []byte) bool {
 		}
 	}
 	return false
+}
+
+func isMissingEncryptedContentError(body []byte) bool {
+	code := strings.TrimSpace(gjson.GetBytes(body, "error.code").String())
+	param := strings.TrimSpace(gjson.GetBytes(body, "error.param").String())
+	if !strings.EqualFold(code, "missing_required_parameter") || !strings.HasSuffix(param, ".encrypted_content") {
+		return false
+	}
+	msg := strings.ToLower(gjson.GetBytes(body, "error.message").String())
+	return strings.Contains(msg, "encrypted_content")
 }
 
 func stripInvalidEncryptedContentFromResponsesBody(body []byte) ([]byte, bool) {
@@ -991,13 +1004,16 @@ func stripInvalidEncryptedContentValue(value any, arrayItem bool) (any, bool, bo
 	case map[string]any:
 		changed := false
 		if strings.TrimSpace(firstNonEmptyAnyString(v["type"])) == "reasoning" {
-			if _, hasEncrypted := v["encrypted_content"]; hasEncrypted {
-				if arrayItem {
-					return nil, true, false
-				}
-				delete(v, "encrypted_content")
-				changed = true
+			if arrayItem {
+				return nil, true, false
 			}
+			if _, hasEncrypted := v["encrypted_content"]; hasEncrypted {
+				delete(v, "encrypted_content")
+			}
+			if len(v) == 1 {
+				return nil, true, false
+			}
+			changed = true
 		} else if _, hasEncrypted := v["encrypted_content"]; hasEncrypted {
 			delete(v, "encrypted_content")
 			changed = true
@@ -1025,6 +1041,51 @@ func responsesInputRaw(body []byte) string {
 		return ""
 	}
 	return input.Raw
+}
+
+func dropBareReasoningInputItems(body map[string]any) bool {
+	input, ok := body["input"]
+	if !ok {
+		return false
+	}
+	cleaned, changed, keep := dropBareReasoningInputValue(input)
+	if !changed {
+		return false
+	}
+	if keep {
+		body["input"] = cleaned
+	} else {
+		delete(body, "input")
+	}
+	return true
+}
+
+func dropBareReasoningInputValue(value any) (any, bool, bool) {
+	switch v := value.(type) {
+	case []any:
+		changed := false
+		out := make([]any, 0, len(v))
+		for _, item := range v {
+			cleaned, itemChanged, keep := dropBareReasoningInputValue(item)
+			if itemChanged {
+				changed = true
+			}
+			if !keep {
+				changed = true
+				continue
+			}
+			out = append(out, cleaned)
+		}
+		return out, changed, true
+	case map[string]any:
+		if strings.TrimSpace(firstNonEmptyAnyString(v["type"])) == "reasoning" &&
+			firstNonEmptyAnyString(v["encrypted_content"]) == "" {
+			return nil, true, false
+		}
+		return v, false, true
+	default:
+		return value, false, true
+	}
 }
 
 func normalizeResponsesInputFileFields(item map[string]any) bool {
@@ -1516,6 +1577,7 @@ func prepareResponsesBodyWithOptions(rawBody []byte, opts responsesBodyPrepareOp
 	normalizeResponsesContentPartTypes(body)
 	normalizeResponsesInputMessageContent(body)
 	normalizeResponsesInputItemIDs(body)
+	dropBareReasoningInputItems(body)
 
 	// 保存展开后的 input 原始 JSON（用于响应缓存链路）
 	var expandedInputRaw string

--- a/proxy/translator.go
+++ b/proxy/translator.go
@@ -1430,6 +1430,41 @@ func normalizeResponsesFunctionTools(body map[string]any) bool {
 	return modified
 }
 
+func normalizeResponsesToolChoice(body map[string]any) bool {
+	rawChoice, ok := body["tool_choice"]
+	if !ok {
+		return false
+	}
+	choice, ok := rawChoice.(map[string]any)
+	if !ok {
+		return false
+	}
+
+	modified := false
+	toolType := strings.TrimSpace(firstNonEmptyAnyString(choice["type"]))
+	function, _ := choice["function"].(map[string]any)
+	name := strings.TrimSpace(firstNonEmptyAnyString(choice["name"]))
+	if toolType == "" && (function != nil || name != "") {
+		choice["type"] = "function"
+		toolType = "function"
+		modified = true
+	}
+	if toolType != "function" {
+		return modified
+	}
+	if name == "" && function != nil {
+		if nestedName := strings.TrimSpace(firstNonEmptyAnyString(function["name"])); nestedName != "" {
+			choice["name"] = nestedName
+			modified = true
+		}
+	}
+	if function != nil {
+		delete(choice, "function")
+		modified = true
+	}
+	return modified
+}
+
 type responsesBodyPrepareOptions struct {
 	forceStoreFalse            bool
 	expandPreviousResponse     bool
@@ -1517,6 +1552,7 @@ func prepareResponsesBodyWithOptions(rawBody []byte, opts responsesBodyPrepareOp
 	}
 	normalizeResponsesStructuredOutputFormat(body)
 	normalizeResponsesFunctionTools(body)
+	normalizeResponsesToolChoice(body)
 	normalizeResponsesWebSearchTools(body)
 
 	// 5. 工具描述补充 + schema 清理 + 上游数量限制
@@ -1644,6 +1680,7 @@ func PrepareOpenAIResponsesBody(rawBody []byte) []byte {
 
 	normalizeResponsesStructuredOutputFormat(body)
 	normalizeResponsesFunctionTools(body)
+	normalizeResponsesToolChoice(body)
 	normalizeResponsesContentPartTypes(body)
 	normalizeResponsesInputMessageContent(body)
 	if shouldInjectOpenAIResponsesImageGenerationTool(body) {

--- a/proxy/translator_test.go
+++ b/proxy/translator_test.go
@@ -1735,6 +1735,18 @@ func TestInvalidEncryptedContentErrorDetection(t *testing.T) {
 	if isInvalidEncryptedContentError(http.StatusInternalServerError, body) {
 		t.Fatalf("non-400 response should not trigger encrypted content fallback")
 	}
+
+	missingBody := []byte(`{
+		"error":{
+			"message":"Missing required parameter: 'input[8].encrypted_content'.",
+			"type":"invalid_request_error",
+			"param":"input[8].encrypted_content",
+			"code":"missing_required_parameter"
+		}
+	}`)
+	if !isInvalidEncryptedContentError(http.StatusBadRequest, missingBody) {
+		t.Fatalf("missing encrypted_content error should trigger encrypted content fallback")
+	}
 }
 
 func TestStripInvalidEncryptedContentFromResponsesBody(t *testing.T) {
@@ -1767,6 +1779,65 @@ func TestStripInvalidEncryptedContentFromResponsesBody(t *testing.T) {
 }
 
 // ==================== Function Calling 测试 ====================
+
+func TestStripInvalidEncryptedContentFromResponsesBodyDropsBareReasoning(t *testing.T) {
+	raw := []byte(`{
+		"model":"gpt-5.4",
+		"input":[
+			{"type":"message","role":"user","content":"hello"},
+			{"type":"reasoning","summary":[{"type":"summary_text","text":"stale"}]},
+			{"type":"reasoning"},
+			{"type":"function_call","call_id":"call_123","name":"lookup","arguments":"{}"}
+		]
+	}`)
+
+	got, changed := stripInvalidEncryptedContentFromResponsesBody(raw)
+	if !changed {
+		t.Fatalf("expected body to be changed")
+	}
+	items := gjson.GetBytes(got, "input").Array()
+	if len(items) != 2 {
+		t.Fatalf("expected bare reasoning items to be removed, got %d items: %s", len(items), got)
+	}
+	if typ := gjson.GetBytes(got, "input.0.type").String(); typ != "message" {
+		t.Fatalf("first input should remain message, got %q; body=%s", typ, got)
+	}
+	if typ := gjson.GetBytes(got, "input.1.type").String(); typ != "function_call" {
+		t.Fatalf("function call should remain, got %q; body=%s", typ, got)
+	}
+}
+
+func TestPrepareResponsesBodyDropsBareReasoningItems(t *testing.T) {
+	raw := []byte(`{
+		"model":"gpt-5.4",
+		"input":[
+			{"type":"message","role":"user","content":"hello"},
+			{"type":"reasoning","summary":[{"type":"summary_text","text":"stale"}]},
+			{"type":"reasoning"},
+			{"type":"reasoning","encrypted_content":"opaque"},
+			{"type":"function_call","call_id":"call_123","name":"lookup","arguments":"{}"}
+		]
+	}`)
+
+	got, expandedInputRaw := PrepareResponsesBody(raw)
+
+	items := gjson.GetBytes(got, "input").Array()
+	if len(items) != 3 {
+		t.Fatalf("expected bare reasoning items to be dropped before upstream, got %d items: %s", len(items), got)
+	}
+	if typ := gjson.GetBytes(got, "input.0.type").String(); typ != "message" {
+		t.Fatalf("first input should remain message, got %q; body=%s", typ, got)
+	}
+	if encrypted := gjson.GetBytes(got, "input.1.encrypted_content").String(); encrypted != "opaque" {
+		t.Fatalf("encrypted reasoning should be preserved, got %q; body=%s", encrypted, got)
+	}
+	if typ := gjson.GetBytes(got, "input.2.type").String(); typ != "function_call" {
+		t.Fatalf("function call should remain, got %q; body=%s", typ, got)
+	}
+	if strings.Contains(expandedInputRaw, `"summary_text"`) {
+		t.Fatalf("expanded input cache should use cleaned input, got %s", expandedInputRaw)
+	}
+}
 
 func TestConvertMessagesToInput_ToolRole(t *testing.T) {
 	raw := []byte(`{

--- a/proxy/translator_test.go
+++ b/proxy/translator_test.go
@@ -1651,6 +1651,75 @@ func TestPrepareResponsesBodyNormalizesChatStyleFunctionTool(t *testing.T) {
 	}
 }
 
+func TestPrepareResponsesBodyNormalizesChatStyleFunctionToolChoice(t *testing.T) {
+	raw := []byte(`{
+		"model":"gpt-5.4",
+		"input":"hello",
+		"tools":[{"type":"function","name":"lookup","parameters":{"type":"object"}}],
+		"tool_choice":{
+			"type":"function",
+			"function":{"name":"lookup"}
+		}
+	}`)
+
+	got, _ := PrepareResponsesBody(raw)
+	choice := gjson.GetBytes(got, "tool_choice")
+	if choice.Get("type").String() != "function" {
+		t.Fatalf("tool_choice.type = %q, want function; body=%s", choice.Get("type").String(), got)
+	}
+	if choice.Get("name").String() != "lookup" {
+		t.Fatalf("tool_choice.name = %q, want lookup; body=%s", choice.Get("name").String(), got)
+	}
+	if choice.Get("function").Exists() {
+		t.Fatalf("tool_choice nested function object should be removed, got %s", got)
+	}
+}
+
+func TestPrepareResponsesBodyInfersFunctionToolChoiceTypeWhenMissing(t *testing.T) {
+	raw := []byte(`{
+		"model":"gpt-5.4",
+		"input":"hello",
+		"tools":[{"type":"function","name":"lookup","parameters":{"type":"object"}}],
+		"tool_choice":{"function":{"name":"lookup"}}
+	}`)
+
+	got, _ := PrepareResponsesBody(raw)
+	choice := gjson.GetBytes(got, "tool_choice")
+	if choice.Get("type").String() != "function" {
+		t.Fatalf("tool_choice.type = %q, want function; body=%s", choice.Get("type").String(), got)
+	}
+	if choice.Get("name").String() != "lookup" {
+		t.Fatalf("tool_choice.name = %q, want lookup; body=%s", choice.Get("name").String(), got)
+	}
+	if choice.Get("function").Exists() {
+		t.Fatalf("tool_choice nested function object should be removed, got %s", got)
+	}
+}
+
+func TestPrepareOpenAIResponsesBodyNormalizesChatStyleFunctionToolChoice(t *testing.T) {
+	raw := []byte(`{
+		"model":"gpt-5.4",
+		"input":"hello",
+		"tools":[{"type":"function","name":"lookup","parameters":{"type":"object"}}],
+		"tool_choice":{
+			"type":"function",
+			"function":{"name":"lookup"}
+		}
+	}`)
+
+	got := PrepareOpenAIResponsesBody(raw)
+	choice := gjson.GetBytes(got, "tool_choice")
+	if choice.Get("type").String() != "function" {
+		t.Fatalf("tool_choice.type = %q, want function; body=%s", choice.Get("type").String(), got)
+	}
+	if choice.Get("name").String() != "lookup" {
+		t.Fatalf("tool_choice.name = %q, want lookup; body=%s", choice.Get("name").String(), got)
+	}
+	if choice.Get("function").Exists() {
+		t.Fatalf("tool_choice nested function object should be removed, got %s", got)
+	}
+}
+
 func TestPrepareResponsesBody_DefaultsNullMessageContent(t *testing.T) {
 	raw := []byte(`{
 		"model":"gpt-5.4",


### PR DESCRIPTION
## Summary
- Treat missing `*.encrypted_content` errors as encrypted reasoning fallback triggers
- Drop bare `type: "reasoning"` input items that do not include `encrypted_content` before forwarding Responses payloads
- Remove stale reasoning input items during encrypted-content fallback retries

## Tests
- `go test ./proxy -run "TestInvalidEncryptedContentErrorDetection|TestStripInvalidEncryptedContentFromResponsesBody|TestPrepareResponsesBodyDropsBareReasoningItems|TestPrepareResponsesBody_StripsInputItemIDsForStoreFalse" -count=1`
- `go test ./proxy -count=1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Better detection of missing encrypted-content parameters to avoid incorrect error handling.
  * Improved sanitization of malformed encrypted content, preventing leftover invalid fields.

* **Improvements**
  * Request preprocessing now removes empty/incomplete "reasoning" inputs to avoid sending invalid items upstream.
  * Normalized tool-selection data so tool choices are interpreted consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->