### PR TITLE
fix:  修复 5h usage auto-pause freshness 判断错误，拆分 5h/7d 用量更新时间

### DIFF
--- a/admin/handler.go
+++ b/admin/handler.go
@@ -566,6 +566,7 @@ type accountResponse struct {
 	CreatedAt                string                     `json:"created_at"`
 	UpdatedAt                string                     `json:"updated_at"`
 	CodexUsageUpdatedAt      string                     `json:"codex_usage_updated_at,omitempty"`
+	Codex5HUsageUpdatedAt    string                     `json:"codex_5h_usage_updated_at,omitempty"`
 	ActiveRequests           int64                      `json:"active_requests"`
 	TotalRequests            int64                      `json:"total_requests"`
 	LastUsedAt               string                     `json:"last_used_at"`
@@ -715,6 +716,7 @@ func (h *Handler) ListAccounts(c *gin.Context) {
 			CreatedAt:                row.CreatedAt.Format(time.RFC3339),
 			UpdatedAt:                row.UpdatedAt.Format(time.RFC3339),
 			CodexUsageUpdatedAt:      row.GetCredential("codex_usage_updated_at"),
+			Codex5HUsageUpdatedAt:    row.GetCredential("codex_5h_usage_updated_at"),
 		}
 		resp.AutoPause5hThreshold = accountQuotaAutoPauseThreshold(row, "auto_pause_5h_threshold")
 		resp.AutoPause7dThreshold = accountQuotaAutoPauseThreshold(row, "auto_pause_7d_threshold")
@@ -2099,42 +2101,44 @@ func fetchOpenAIResponsesModelIDs(ctx context.Context, baseURL, apiKey, proxyURL
 
 // importToken 导入时的统一 token 载体
 type importToken struct {
-	refreshToken        string
-	sessionToken        string
-	accessToken         string // AT-only 兼容路径
-	name                string
-	email               string
-	idToken             string
-	accountID           string
-	chatgptAccountID    string // sub2api 等导出格式中的 ChatGPT 账号唯一标识，用于精确去重
-	planType            string
-	expiresAt           string
-	codex7DUsedPercent  string
-	codex7DResetAt      string
-	codex5HUsedPercent  string
-	codex5HResetAt      string
-	codexUsageUpdatedAt string
+	refreshToken          string
+	sessionToken          string
+	accessToken           string // AT-only 兼容路径
+	name                  string
+	email                 string
+	idToken               string
+	accountID             string
+	chatgptAccountID      string // sub2api 等导出格式中的 ChatGPT 账号唯一标识，用于精确去重
+	planType              string
+	expiresAt             string
+	codex7DUsedPercent    string
+	codex7DResetAt        string
+	codex5HUsedPercent    string
+	codex5HResetAt        string
+	codex5HUsageUpdatedAt string
+	codexUsageUpdatedAt   string
 }
 
 // jsonAccountEntry CLIProxyAPI 凭证 JSON 条目
 type jsonAccountEntry struct {
-	RefreshToken        string                 `json:"refresh_token"`
-	SessionToken        string                 `json:"session_token"`
-	SessionTokenCamel   string                 `json:"sessionToken"`
-	AccessToken         string                 `json:"access_token"`
-	IDToken             string                 `json:"id_token"`
-	AccountID           string                 `json:"account_id"`
-	ChatGPTAccountID    string                 `json:"chatgpt_account_id"`
-	Email               string                 `json:"email"`
-	Name                string                 `json:"name"`
-	PlanType            string                 `json:"plan_type"`
-	Codex7DUsedPercent  importJSONScalarString `json:"codex_7d_used_percent"`
-	Codex7DResetAt      string                 `json:"codex_7d_reset_at"`
-	Codex5HUsedPercent  importJSONScalarString `json:"codex_5h_used_percent"`
-	Codex5HResetAt      string                 `json:"codex_5h_reset_at"`
-	CodexUsageUpdatedAt string                 `json:"codex_usage_updated_at"`
-	Expired             importJSONScalarString `json:"expired"`
-	ExpiresAt           importJSONScalarString `json:"expires_at"`
+	RefreshToken          string                 `json:"refresh_token"`
+	SessionToken          string                 `json:"session_token"`
+	SessionTokenCamel     string                 `json:"sessionToken"`
+	AccessToken           string                 `json:"access_token"`
+	IDToken               string                 `json:"id_token"`
+	AccountID             string                 `json:"account_id"`
+	ChatGPTAccountID      string                 `json:"chatgpt_account_id"`
+	Email                 string                 `json:"email"`
+	Name                  string                 `json:"name"`
+	PlanType              string                 `json:"plan_type"`
+	Codex7DUsedPercent    importJSONScalarString `json:"codex_7d_used_percent"`
+	Codex7DResetAt        string                 `json:"codex_7d_reset_at"`
+	Codex5HUsedPercent    importJSONScalarString `json:"codex_5h_used_percent"`
+	Codex5HResetAt        string                 `json:"codex_5h_reset_at"`
+	Codex5HUsageUpdatedAt string                 `json:"codex_5h_usage_updated_at"`
+	CodexUsageUpdatedAt   string                 `json:"codex_usage_updated_at"`
+	Expired               importJSONScalarString `json:"expired"`
+	ExpiresAt             importJSONScalarString `json:"expires_at"`
 }
 
 type sub2apiImportPayload struct {
@@ -2147,22 +2151,23 @@ type sub2apiAccountEntry struct {
 }
 
 type sub2apiAccountCredentials struct {
-	RefreshToken        string                 `json:"refresh_token"`
-	SessionToken        string                 `json:"session_token"`
-	SessionTokenCamel   string                 `json:"sessionToken"`
-	AccessToken         string                 `json:"access_token"`
-	IDToken             string                 `json:"id_token"`
-	AccountID           string                 `json:"account_id"`
-	ChatGPTAccountID    string                 `json:"chatgpt_account_id"`
-	Email               string                 `json:"email"`
-	PlanType            string                 `json:"plan_type"`
-	Codex7DUsedPercent  importJSONScalarString `json:"codex_7d_used_percent"`
-	Codex7DResetAt      string                 `json:"codex_7d_reset_at"`
-	Codex5HUsedPercent  importJSONScalarString `json:"codex_5h_used_percent"`
-	Codex5HResetAt      string                 `json:"codex_5h_reset_at"`
-	CodexUsageUpdatedAt string                 `json:"codex_usage_updated_at"`
-	ExpiresAt           importJSONScalarString `json:"expires_at"`
-	Expired             importJSONScalarString `json:"expired"`
+	RefreshToken          string                 `json:"refresh_token"`
+	SessionToken          string                 `json:"session_token"`
+	SessionTokenCamel     string                 `json:"sessionToken"`
+	AccessToken           string                 `json:"access_token"`
+	IDToken               string                 `json:"id_token"`
+	AccountID             string                 `json:"account_id"`
+	ChatGPTAccountID      string                 `json:"chatgpt_account_id"`
+	Email                 string                 `json:"email"`
+	PlanType              string                 `json:"plan_type"`
+	Codex7DUsedPercent    importJSONScalarString `json:"codex_7d_used_percent"`
+	Codex7DResetAt        string                 `json:"codex_7d_reset_at"`
+	Codex5HUsedPercent    importJSONScalarString `json:"codex_5h_used_percent"`
+	Codex5HResetAt        string                 `json:"codex_5h_reset_at"`
+	Codex5HUsageUpdatedAt string                 `json:"codex_5h_usage_updated_at"`
+	CodexUsageUpdatedAt   string                 `json:"codex_usage_updated_at"`
+	ExpiresAt             importJSONScalarString `json:"expires_at"`
+	Expired               importJSONScalarString `json:"expired"`
 }
 
 type importJSONScalarString string
@@ -2243,21 +2248,22 @@ func jsonAccountEntriesToTokens(entries []jsonAccountEntry) []importToken {
 
 		if rt != "" || st != "" || at != "" {
 			tokens = append(tokens, importToken{
-				refreshToken:        rt,
-				sessionToken:        st,
-				accessToken:         at,
-				name:                name,
-				email:               email,
-				idToken:             strings.TrimSpace(entry.IDToken),
-				accountID:           strings.TrimSpace(entry.AccountID),
-				chatgptAccountID:    strings.TrimSpace(entry.ChatGPTAccountID),
-				planType:            strings.TrimSpace(entry.PlanType),
-				expiresAt:           firstNonEmpty(entry.ExpiresAt.String(), entry.Expired.String()),
-				codex7DUsedPercent:  strings.TrimSpace(entry.Codex7DUsedPercent.String()),
-				codex7DResetAt:      strings.TrimSpace(entry.Codex7DResetAt),
-				codex5HUsedPercent:  strings.TrimSpace(entry.Codex5HUsedPercent.String()),
-				codex5HResetAt:      strings.TrimSpace(entry.Codex5HResetAt),
-				codexUsageUpdatedAt: strings.TrimSpace(entry.CodexUsageUpdatedAt),
+				refreshToken:          rt,
+				sessionToken:          st,
+				accessToken:           at,
+				name:                  name,
+				email:                 email,
+				idToken:               strings.TrimSpace(entry.IDToken),
+				accountID:             strings.TrimSpace(entry.AccountID),
+				chatgptAccountID:      strings.TrimSpace(entry.ChatGPTAccountID),
+				planType:              strings.TrimSpace(entry.PlanType),
+				expiresAt:             firstNonEmpty(entry.ExpiresAt.String(), entry.Expired.String()),
+				codex7DUsedPercent:    strings.TrimSpace(entry.Codex7DUsedPercent.String()),
+				codex7DResetAt:        strings.TrimSpace(entry.Codex7DResetAt),
+				codex5HUsedPercent:    strings.TrimSpace(entry.Codex5HUsedPercent.String()),
+				codex5HResetAt:        strings.TrimSpace(entry.Codex5HResetAt),
+				codex5HUsageUpdatedAt: strings.TrimSpace(entry.Codex5HUsageUpdatedAt),
+				codexUsageUpdatedAt:   strings.TrimSpace(entry.CodexUsageUpdatedAt),
 			})
 		}
 	}
@@ -2284,21 +2290,22 @@ func parseSub2APIJSONImportTokens(data []byte) []importToken {
 
 		if rt != "" || st != "" || at != "" {
 			tokens = append(tokens, importToken{
-				refreshToken:        rt,
-				sessionToken:        st,
-				accessToken:         at,
-				name:                name,
-				email:               email,
-				idToken:             strings.TrimSpace(account.Credentials.IDToken),
-				accountID:           strings.TrimSpace(account.Credentials.AccountID),
-				chatgptAccountID:    strings.TrimSpace(account.Credentials.ChatGPTAccountID),
-				planType:            strings.TrimSpace(account.Credentials.PlanType),
-				expiresAt:           firstNonEmpty(account.Credentials.ExpiresAt.String(), account.Credentials.Expired.String()),
-				codex7DUsedPercent:  strings.TrimSpace(account.Credentials.Codex7DUsedPercent.String()),
-				codex7DResetAt:      strings.TrimSpace(account.Credentials.Codex7DResetAt),
-				codex5HUsedPercent:  strings.TrimSpace(account.Credentials.Codex5HUsedPercent.String()),
-				codex5HResetAt:      strings.TrimSpace(account.Credentials.Codex5HResetAt),
-				codexUsageUpdatedAt: strings.TrimSpace(account.Credentials.CodexUsageUpdatedAt),
+				refreshToken:          rt,
+				sessionToken:          st,
+				accessToken:           at,
+				name:                  name,
+				email:                 email,
+				idToken:               strings.TrimSpace(account.Credentials.IDToken),
+				accountID:             strings.TrimSpace(account.Credentials.AccountID),
+				chatgptAccountID:      strings.TrimSpace(account.Credentials.ChatGPTAccountID),
+				planType:              strings.TrimSpace(account.Credentials.PlanType),
+				expiresAt:             firstNonEmpty(account.Credentials.ExpiresAt.String(), account.Credentials.Expired.String()),
+				codex7DUsedPercent:    strings.TrimSpace(account.Credentials.Codex7DUsedPercent.String()),
+				codex7DResetAt:        strings.TrimSpace(account.Credentials.Codex7DResetAt),
+				codex5HUsedPercent:    strings.TrimSpace(account.Credentials.Codex5HUsedPercent.String()),
+				codex5HResetAt:        strings.TrimSpace(account.Credentials.Codex5HResetAt),
+				codex5HUsageUpdatedAt: strings.TrimSpace(account.Credentials.Codex5HUsageUpdatedAt),
+				codexUsageUpdatedAt:   strings.TrimSpace(account.Credentials.CodexUsageUpdatedAt),
 			})
 		}
 	}
@@ -2822,18 +2829,19 @@ func (h *Handler) importAccountsCommon(c *gin.Context, tokens []importToken, pro
 				h.db.InsertAccountEventAsync(id, "added", "import_at")
 
 				seed := normalizeTokenCredentialSeed(tokenCredentialSeed{
-					sessionToken:        tok.sessionToken,
-					accessToken:         tok.accessToken,
-					idToken:             tok.idToken,
-					accountID:           importStoredAccountID(tok, conflictingChatGPTIDs),
-					email:               tok.email,
-					planType:            tok.planType,
-					expiresAtRaw:        tok.expiresAt,
-					codex7DUsedPercent:  tok.codex7DUsedPercent,
-					codex7DResetAt:      tok.codex7DResetAt,
-					codex5HUsedPercent:  tok.codex5HUsedPercent,
-					codex5HResetAt:      tok.codex5HResetAt,
-					codexUsageUpdatedAt: tok.codexUsageUpdatedAt,
+					sessionToken:          tok.sessionToken,
+					accessToken:           tok.accessToken,
+					idToken:               tok.idToken,
+					accountID:             importStoredAccountID(tok, conflictingChatGPTIDs),
+					email:                 tok.email,
+					planType:              tok.planType,
+					expiresAtRaw:          tok.expiresAt,
+					codex7DUsedPercent:    tok.codex7DUsedPercent,
+					codex7DResetAt:        tok.codex7DResetAt,
+					codex5HUsedPercent:    tok.codex5HUsedPercent,
+					codex5HResetAt:        tok.codex5HResetAt,
+					codex5HUsageUpdatedAt: tok.codex5HUsageUpdatedAt,
+					codexUsageUpdatedAt:   tok.codexUsageUpdatedAt,
 				})
 				newAcc := accountFromCredentialSeed(id, proxyURL, seed)
 				if len(tokenCredentialMap(seed)) > 0 {
@@ -2859,18 +2867,19 @@ func (h *Handler) importAccountsCommon(c *gin.Context, tokens []importToken, pro
 					id, err = h.db.InsertAccount(insertCtx, name, tok.refreshToken, proxyURL)
 				} else {
 					seed := normalizeTokenCredentialSeed(tokenCredentialSeed{
-						sessionToken:        tok.sessionToken,
-						accessToken:         tok.accessToken,
-						idToken:             tok.idToken,
-						accountID:           importStoredAccountID(tok, conflictingChatGPTIDs),
-						email:               tok.email,
-						planType:            tok.planType,
-						expiresAtRaw:        tok.expiresAt,
-						codex7DUsedPercent:  tok.codex7DUsedPercent,
-						codex7DResetAt:      tok.codex7DResetAt,
-						codex5HUsedPercent:  tok.codex5HUsedPercent,
-						codex5HResetAt:      tok.codex5HResetAt,
-						codexUsageUpdatedAt: tok.codexUsageUpdatedAt,
+						sessionToken:          tok.sessionToken,
+						accessToken:           tok.accessToken,
+						idToken:               tok.idToken,
+						accountID:             importStoredAccountID(tok, conflictingChatGPTIDs),
+						email:                 tok.email,
+						planType:              tok.planType,
+						expiresAtRaw:          tok.expiresAt,
+						codex7DUsedPercent:    tok.codex7DUsedPercent,
+						codex7DResetAt:        tok.codex7DResetAt,
+						codex5HUsedPercent:    tok.codex5HUsedPercent,
+						codex5HResetAt:        tok.codex5HResetAt,
+						codex5HUsageUpdatedAt: tok.codex5HUsageUpdatedAt,
+						codexUsageUpdatedAt:   tok.codexUsageUpdatedAt,
 					})
 					id, err = h.db.InsertAccountWithCredentials(insertCtx, name, tokenCredentialMap(seed), proxyURL)
 				}
@@ -2888,19 +2897,20 @@ func (h *Handler) importAccountsCommon(c *gin.Context, tokens []importToken, pro
 				h.db.InsertAccountEventAsync(id, "added", "import")
 
 				seed := normalizeTokenCredentialSeed(tokenCredentialSeed{
-					refreshToken:        tok.refreshToken,
-					sessionToken:        tok.sessionToken,
-					accessToken:         tok.accessToken,
-					idToken:             tok.idToken,
-					accountID:           importStoredAccountID(tok, conflictingChatGPTIDs),
-					email:               tok.email,
-					planType:            tok.planType,
-					expiresAtRaw:        tok.expiresAt,
-					codex7DUsedPercent:  tok.codex7DUsedPercent,
-					codex7DResetAt:      tok.codex7DResetAt,
-					codex5HUsedPercent:  tok.codex5HUsedPercent,
-					codex5HResetAt:      tok.codex5HResetAt,
-					codexUsageUpdatedAt: tok.codexUsageUpdatedAt,
+					refreshToken:          tok.refreshToken,
+					sessionToken:          tok.sessionToken,
+					accessToken:           tok.accessToken,
+					idToken:               tok.idToken,
+					accountID:             importStoredAccountID(tok, conflictingChatGPTIDs),
+					email:                 tok.email,
+					planType:              tok.planType,
+					expiresAtRaw:          tok.expiresAt,
+					codex7DUsedPercent:    tok.codex7DUsedPercent,
+					codex7DResetAt:        tok.codex7DResetAt,
+					codex5HUsedPercent:    tok.codex5HUsedPercent,
+					codex5HResetAt:        tok.codex5HResetAt,
+					codex5HUsageUpdatedAt: tok.codex5HUsageUpdatedAt,
+					codexUsageUpdatedAt:   tok.codexUsageUpdatedAt,
 				})
 				if len(tokenCredentialMap(seed)) > 0 {
 					credCtx, credCancel := context.WithTimeout(context.Background(), 3*time.Second)
@@ -4750,161 +4760,161 @@ func (h *Handler) DeleteAPIKey(c *gin.Context) {
 // ==================== Settings ====================
 
 type settingsResponse struct {
-	SiteName                           string `json:"site_name"`
-	SiteLogo                           string `json:"site_logo"`
-	BackgroundImage                    string `json:"background_image"`
-	BackgroundOpacity                  int    `json:"background_opacity"`
-	BackgroundBlur                     int    `json:"background_blur"`
-	BackgroundGlassOpacity             int    `json:"background_glass_opacity"`
-	BackgroundGlassBlur                int    `json:"background_glass_blur"`
-	MaxConcurrency                     int    `json:"max_concurrency"`
-	GlobalRPM                          int    `json:"global_rpm"`
-	TestModel                          string `json:"test_model"`
-	TestConcurrency                    int    `json:"test_concurrency"`
-	BackgroundRefreshIntervalMinutes   int    `json:"background_refresh_interval_minutes"`
-	UsageProbeMaxAgeMinutes            int    `json:"usage_probe_max_age_minutes"`
-	UsageProbeConcurrency              int    `json:"usage_probe_concurrency"`
-	UsageProbeResponsesFallbackEnabled bool   `json:"usage_probe_responses_fallback_enabled"`
-	RecoveryProbeIntervalMinutes       int    `json:"recovery_probe_interval_minutes"`
-	LazyMode                           bool   `json:"lazy_mode"`
-	ProxyURL                           string `json:"proxy_url"`
-	PgMaxConns                         int    `json:"pg_max_conns"`
-	RedisPoolSize                      int    `json:"redis_pool_size"`
-	AutoCleanUnauthorized              bool   `json:"auto_clean_unauthorized"`
-	AutoCleanRateLimited               bool   `json:"auto_clean_rate_limited"`
-	AdminSecret                        string `json:"admin_secret"`
-	AdminAuthSource                    string `json:"admin_auth_source"`
-	AutoCleanFullUsage                 bool   `json:"auto_clean_full_usage"`
-	AutoCleanError                     bool   `json:"auto_clean_error"`
-	AutoCleanExpired                   bool   `json:"auto_clean_expired"`
-	ProxyPoolEnabled                   bool   `json:"proxy_pool_enabled"`
-	FastSchedulerEnabled               bool   `json:"fast_scheduler_enabled"`
-	CodexForceWebsocket                bool   `json:"codex_force_websocket"`
-	CodexWSKeepaliveEnabled            bool   `json:"codex_ws_keepalive_enabled"`
-	CodexWSKeepaliveIntervalSec        int    `json:"codex_ws_keepalive_interval_sec"`
-	CodexWSHideUpstreamErrors          bool   `json:"codex_ws_hide_upstream_errors"`
-	CodexWSSilentRetryEnabled          bool   `json:"codex_ws_silent_retry_enabled"`
-	CodexWSSilentMaxRetries            int    `json:"codex_ws_silent_max_retries"`
-	SchedulerMode                      string `json:"scheduler_mode"`
-	AffinityMode                       string `json:"affinity_mode"`
-	MaxRetries                         int    `json:"max_retries"`
-	MaxRateLimitRetries                int    `json:"max_rate_limit_retries"`
-	AllowRemoteMigration               bool   `json:"allow_remote_migration"`
-	DatabaseDriver                     string `json:"database_driver"`
-	DatabaseLabel                      string `json:"database_label"`
-	CacheDriver                        string `json:"cache_driver"`
-	CacheLabel                         string `json:"cache_label"`
-	ExpiredCleaned                     int    `json:"expired_cleaned,omitempty"`
-	ModelMapping                       string `json:"model_mapping"`
-	CodexModelMapping                  string `json:"codex_model_mapping"`
-	ReasoningEffortModels              string `json:"reasoning_effort_models"`
-	ResinURL                           string `json:"resin_url"`
-	ResinPlatformName                  string `json:"resin_platform_name"`
-	PromptFilterEnabled                bool   `json:"prompt_filter_enabled"`
-	PromptFilterMode                   string `json:"prompt_filter_mode"`
-	PromptFilterThreshold              int    `json:"prompt_filter_threshold"`
-	PromptFilterStrictThreshold        int    `json:"prompt_filter_strict_threshold"`
-	PromptFilterLogMatches             bool   `json:"prompt_filter_log_matches"`
-	PromptFilterMaxTextLength          int    `json:"prompt_filter_max_text_length"`
-	PromptFilterSensitiveWords         string `json:"prompt_filter_sensitive_words"`
-	PromptFilterCustomPatterns         string `json:"prompt_filter_custom_patterns"`
-	PromptFilterDisabledPatterns       string `json:"prompt_filter_disabled_patterns"`
-	ClientCompatMode                   string `json:"client_compat_mode"`
-	CodexMinCLIVersion                 string `json:"codex_min_cli_version"`
-	UsageLogMode                       string `json:"usage_log_mode"`
-	UsageLogBatchSize                  int    `json:"usage_log_batch_size"`
-	UsageLogFlushIntervalSeconds       int    `json:"usage_log_flush_interval_seconds"`
-	StreamFlushPolicy                  string `json:"stream_flush_policy"`
-	StreamFlushIntervalMS              int    `json:"stream_flush_interval_ms"`
-	FirstTokenMode                     string `json:"first_token_mode"`
-	FirstTokenTimeoutSeconds           int    `json:"first_token_timeout_seconds"`
-	BillingTierPolicy                  string `json:"billing_tier_policy"`
-	ShowFullUsageNumbers               bool   `json:"show_full_usage_numbers"`
-	ImageStorageBackend                string `json:"image_storage_backend"`
-	ImageS3Endpoint                    string `json:"image_s3_endpoint"`
-	ImageS3Region                      string `json:"image_s3_region"`
-	ImageS3Bucket                      string `json:"image_s3_bucket"`
-	ImageS3AccessKey                   string `json:"image_s3_access_key"`
-	ImageS3SecretKey                   string `json:"image_s3_secret_key"`
-	ImageS3Prefix                      string `json:"image_s3_prefix"`
-	ImageS3ForcePathStyle              bool   `json:"image_s3_force_path_style"`
+	SiteName                           string  `json:"site_name"`
+	SiteLogo                           string  `json:"site_logo"`
+	BackgroundImage                    string  `json:"background_image"`
+	BackgroundOpacity                  int     `json:"background_opacity"`
+	BackgroundBlur                     int     `json:"background_blur"`
+	BackgroundGlassOpacity             int     `json:"background_glass_opacity"`
+	BackgroundGlassBlur                int     `json:"background_glass_blur"`
+	MaxConcurrency                     int     `json:"max_concurrency"`
+	GlobalRPM                          int     `json:"global_rpm"`
+	TestModel                          string  `json:"test_model"`
+	TestConcurrency                    int     `json:"test_concurrency"`
+	BackgroundRefreshIntervalMinutes   int     `json:"background_refresh_interval_minutes"`
+	UsageProbeMaxAgeMinutes            int     `json:"usage_probe_max_age_minutes"`
+	UsageProbeConcurrency              int     `json:"usage_probe_concurrency"`
+	UsageProbeResponsesFallbackEnabled bool    `json:"usage_probe_responses_fallback_enabled"`
+	RecoveryProbeIntervalMinutes       int     `json:"recovery_probe_interval_minutes"`
+	LazyMode                           bool    `json:"lazy_mode"`
+	ProxyURL                           string  `json:"proxy_url"`
+	PgMaxConns                         int     `json:"pg_max_conns"`
+	RedisPoolSize                      int     `json:"redis_pool_size"`
+	AutoCleanUnauthorized              bool    `json:"auto_clean_unauthorized"`
+	AutoCleanRateLimited               bool    `json:"auto_clean_rate_limited"`
+	AdminSecret                        string  `json:"admin_secret"`
+	AdminAuthSource                    string  `json:"admin_auth_source"`
+	AutoCleanFullUsage                 bool    `json:"auto_clean_full_usage"`
+	AutoCleanError                     bool    `json:"auto_clean_error"`
+	AutoCleanExpired                   bool    `json:"auto_clean_expired"`
+	ProxyPoolEnabled                   bool    `json:"proxy_pool_enabled"`
+	FastSchedulerEnabled               bool    `json:"fast_scheduler_enabled"`
+	CodexForceWebsocket                bool    `json:"codex_force_websocket"`
+	CodexWSKeepaliveEnabled            bool    `json:"codex_ws_keepalive_enabled"`
+	CodexWSKeepaliveIntervalSec        int     `json:"codex_ws_keepalive_interval_sec"`
+	CodexWSHideUpstreamErrors          bool    `json:"codex_ws_hide_upstream_errors"`
+	CodexWSSilentRetryEnabled          bool    `json:"codex_ws_silent_retry_enabled"`
+	CodexWSSilentMaxRetries            int     `json:"codex_ws_silent_max_retries"`
+	SchedulerMode                      string  `json:"scheduler_mode"`
+	AffinityMode                       string  `json:"affinity_mode"`
+	MaxRetries                         int     `json:"max_retries"`
+	MaxRateLimitRetries                int     `json:"max_rate_limit_retries"`
+	AllowRemoteMigration               bool    `json:"allow_remote_migration"`
+	DatabaseDriver                     string  `json:"database_driver"`
+	DatabaseLabel                      string  `json:"database_label"`
+	CacheDriver                        string  `json:"cache_driver"`
+	CacheLabel                         string  `json:"cache_label"`
+	ExpiredCleaned                     int     `json:"expired_cleaned,omitempty"`
+	ModelMapping                       string  `json:"model_mapping"`
+	CodexModelMapping                  string  `json:"codex_model_mapping"`
+	ReasoningEffortModels              string  `json:"reasoning_effort_models"`
+	ResinURL                           string  `json:"resin_url"`
+	ResinPlatformName                  string  `json:"resin_platform_name"`
+	PromptFilterEnabled                bool    `json:"prompt_filter_enabled"`
+	PromptFilterMode                   string  `json:"prompt_filter_mode"`
+	PromptFilterThreshold              int     `json:"prompt_filter_threshold"`
+	PromptFilterStrictThreshold        int     `json:"prompt_filter_strict_threshold"`
+	PromptFilterLogMatches             bool    `json:"prompt_filter_log_matches"`
+	PromptFilterMaxTextLength          int     `json:"prompt_filter_max_text_length"`
+	PromptFilterSensitiveWords         string  `json:"prompt_filter_sensitive_words"`
+	PromptFilterCustomPatterns         string  `json:"prompt_filter_custom_patterns"`
+	PromptFilterDisabledPatterns       string  `json:"prompt_filter_disabled_patterns"`
+	ClientCompatMode                   string  `json:"client_compat_mode"`
+	CodexMinCLIVersion                 string  `json:"codex_min_cli_version"`
+	UsageLogMode                       string  `json:"usage_log_mode"`
+	UsageLogBatchSize                  int     `json:"usage_log_batch_size"`
+	UsageLogFlushIntervalSeconds       int     `json:"usage_log_flush_interval_seconds"`
+	StreamFlushPolicy                  string  `json:"stream_flush_policy"`
+	StreamFlushIntervalMS              int     `json:"stream_flush_interval_ms"`
+	FirstTokenMode                     string  `json:"first_token_mode"`
+	FirstTokenTimeoutSeconds           int     `json:"first_token_timeout_seconds"`
+	BillingTierPolicy                  string  `json:"billing_tier_policy"`
+	ShowFullUsageNumbers               bool    `json:"show_full_usage_numbers"`
+	ImageStorageBackend                string  `json:"image_storage_backend"`
+	ImageS3Endpoint                    string  `json:"image_s3_endpoint"`
+	ImageS3Region                      string  `json:"image_s3_region"`
+	ImageS3Bucket                      string  `json:"image_s3_bucket"`
+	ImageS3AccessKey                   string  `json:"image_s3_access_key"`
+	ImageS3SecretKey                   string  `json:"image_s3_secret_key"`
+	ImageS3Prefix                      string  `json:"image_s3_prefix"`
+	ImageS3ForcePathStyle              bool    `json:"image_s3_force_path_style"`
 	AutoPause5hThreshold               float64 `json:"auto_pause_5h_threshold"`
 	AutoPause7dThreshold               float64 `json:"auto_pause_7d_threshold"`
 }
 
 type updateSettingsReq struct {
-	SiteName                           *string `json:"site_name"`
-	SiteLogo                           *string `json:"site_logo"`
-	BackgroundImage                    *string `json:"background_image"`
-	BackgroundOpacity                  *int    `json:"background_opacity"`
-	BackgroundBlur                     *int    `json:"background_blur"`
-	BackgroundGlassOpacity             *int    `json:"background_glass_opacity"`
-	BackgroundGlassBlur                *int    `json:"background_glass_blur"`
-	MaxConcurrency                     *int    `json:"max_concurrency"`
-	GlobalRPM                          *int    `json:"global_rpm"`
-	TestModel                          *string `json:"test_model"`
-	TestConcurrency                    *int    `json:"test_concurrency"`
-	BackgroundRefreshIntervalMinutes   *int    `json:"background_refresh_interval_minutes"`
-	UsageProbeMaxAgeMinutes            *int    `json:"usage_probe_max_age_minutes"`
-	UsageProbeConcurrency              *int    `json:"usage_probe_concurrency"`
-	UsageProbeResponsesFallbackEnabled *bool   `json:"usage_probe_responses_fallback_enabled"`
-	RecoveryProbeIntervalMinutes       *int    `json:"recovery_probe_interval_minutes"`
-	LazyMode                           *bool   `json:"lazy_mode"`
-	ProxyURL                           *string `json:"proxy_url"`
-	PgMaxConns                         *int    `json:"pg_max_conns"`
-	RedisPoolSize                      *int    `json:"redis_pool_size"`
-	AutoCleanUnauthorized              *bool   `json:"auto_clean_unauthorized"`
-	AutoCleanRateLimited               *bool   `json:"auto_clean_rate_limited"`
-	AdminSecret                        *string `json:"admin_secret"`
-	AutoCleanFullUsage                 *bool   `json:"auto_clean_full_usage"`
-	AutoCleanError                     *bool   `json:"auto_clean_error"`
-	AutoCleanExpired                   *bool   `json:"auto_clean_expired"`
-	ProxyPoolEnabled                   *bool   `json:"proxy_pool_enabled"`
-	FastSchedulerEnabled               *bool   `json:"fast_scheduler_enabled"`
-	CodexForceWebsocket                *bool   `json:"codex_force_websocket"`
-	CodexWSKeepaliveEnabled            *bool   `json:"codex_ws_keepalive_enabled"`
-	CodexWSKeepaliveIntervalSec        *int    `json:"codex_ws_keepalive_interval_sec"`
-	CodexWSHideUpstreamErrors          *bool   `json:"codex_ws_hide_upstream_errors"`
-	CodexWSSilentRetryEnabled          *bool   `json:"codex_ws_silent_retry_enabled"`
-	CodexWSSilentMaxRetries            *int    `json:"codex_ws_silent_max_retries"`
-	SchedulerMode                      *string `json:"scheduler_mode"`
-	AffinityMode                       *string `json:"affinity_mode"`
-	MaxRetries                         *int    `json:"max_retries"`
-	MaxRateLimitRetries                *int    `json:"max_rate_limit_retries"`
-	AllowRemoteMigration               *bool   `json:"allow_remote_migration"`
-	ModelMapping                       *string `json:"model_mapping"`
-	CodexModelMapping                  *string `json:"codex_model_mapping"`
-	ReasoningEffortModels              *string `json:"reasoning_effort_models"`
-	ResinURL                           *string `json:"resin_url"`
-	ResinPlatformName                  *string `json:"resin_platform_name"`
-	PromptFilterEnabled                *bool   `json:"prompt_filter_enabled"`
-	PromptFilterMode                   *string `json:"prompt_filter_mode"`
-	PromptFilterThreshold              *int    `json:"prompt_filter_threshold"`
-	PromptFilterStrictThreshold        *int    `json:"prompt_filter_strict_threshold"`
-	PromptFilterLogMatches             *bool   `json:"prompt_filter_log_matches"`
-	PromptFilterMaxTextLength          *int    `json:"prompt_filter_max_text_length"`
-	PromptFilterSensitiveWords         *string `json:"prompt_filter_sensitive_words"`
-	PromptFilterCustomPatterns         *string `json:"prompt_filter_custom_patterns"`
-	PromptFilterDisabledPatterns       *string `json:"prompt_filter_disabled_patterns"`
-	ClientCompatMode                   *string `json:"client_compat_mode"`
-	CodexMinCLIVersion                 *string `json:"codex_min_cli_version"`
-	UsageLogMode                       *string `json:"usage_log_mode"`
-	UsageLogBatchSize                  *int    `json:"usage_log_batch_size"`
-	UsageLogFlushIntervalSeconds       *int    `json:"usage_log_flush_interval_seconds"`
-	StreamFlushPolicy                  *string `json:"stream_flush_policy"`
-	StreamFlushIntervalMS              *int    `json:"stream_flush_interval_ms"`
-	FirstTokenMode                     *string `json:"first_token_mode"`
-	FirstTokenTimeoutSeconds           *int    `json:"first_token_timeout_seconds"`
-	BillingTierPolicy                  *string `json:"billing_tier_policy"`
-	ShowFullUsageNumbers               *bool   `json:"show_full_usage_numbers"`
-	ImageStorageBackend                *string `json:"image_storage_backend"`
-	ImageS3Endpoint                    *string `json:"image_s3_endpoint"`
-	ImageS3Region                      *string `json:"image_s3_region"`
-	ImageS3Bucket                      *string `json:"image_s3_bucket"`
-	ImageS3AccessKey                   *string `json:"image_s3_access_key"`
-	ImageS3SecretKey                   *string `json:"image_s3_secret_key"`
-	ImageS3Prefix                      *string `json:"image_s3_prefix"`
-	ImageS3ForcePathStyle              *bool   `json:"image_s3_force_path_style"`
+	SiteName                           *string  `json:"site_name"`
+	SiteLogo                           *string  `json:"site_logo"`
+	BackgroundImage                    *string  `json:"background_image"`
+	BackgroundOpacity                  *int     `json:"background_opacity"`
+	BackgroundBlur                     *int     `json:"background_blur"`
+	BackgroundGlassOpacity             *int     `json:"background_glass_opacity"`
+	BackgroundGlassBlur                *int     `json:"background_glass_blur"`
+	MaxConcurrency                     *int     `json:"max_concurrency"`
+	GlobalRPM                          *int     `json:"global_rpm"`
+	TestModel                          *string  `json:"test_model"`
+	TestConcurrency                    *int     `json:"test_concurrency"`
+	BackgroundRefreshIntervalMinutes   *int     `json:"background_refresh_interval_minutes"`
+	UsageProbeMaxAgeMinutes            *int     `json:"usage_probe_max_age_minutes"`
+	UsageProbeConcurrency              *int     `json:"usage_probe_concurrency"`
+	UsageProbeResponsesFallbackEnabled *bool    `json:"usage_probe_responses_fallback_enabled"`
+	RecoveryProbeIntervalMinutes       *int     `json:"recovery_probe_interval_minutes"`
+	LazyMode                           *bool    `json:"lazy_mode"`
+	ProxyURL                           *string  `json:"proxy_url"`
+	PgMaxConns                         *int     `json:"pg_max_conns"`
+	RedisPoolSize                      *int     `json:"redis_pool_size"`
+	AutoCleanUnauthorized              *bool    `json:"auto_clean_unauthorized"`
+	AutoCleanRateLimited               *bool    `json:"auto_clean_rate_limited"`
+	AdminSecret                        *string  `json:"admin_secret"`
+	AutoCleanFullUsage                 *bool    `json:"auto_clean_full_usage"`
+	AutoCleanError                     *bool    `json:"auto_clean_error"`
+	AutoCleanExpired                   *bool    `json:"auto_clean_expired"`
+	ProxyPoolEnabled                   *bool    `json:"proxy_pool_enabled"`
+	FastSchedulerEnabled               *bool    `json:"fast_scheduler_enabled"`
+	CodexForceWebsocket                *bool    `json:"codex_force_websocket"`
+	CodexWSKeepaliveEnabled            *bool    `json:"codex_ws_keepalive_enabled"`
+	CodexWSKeepaliveIntervalSec        *int     `json:"codex_ws_keepalive_interval_sec"`
+	CodexWSHideUpstreamErrors          *bool    `json:"codex_ws_hide_upstream_errors"`
+	CodexWSSilentRetryEnabled          *bool    `json:"codex_ws_silent_retry_enabled"`
+	CodexWSSilentMaxRetries            *int     `json:"codex_ws_silent_max_retries"`
+	SchedulerMode                      *string  `json:"scheduler_mode"`
+	AffinityMode                       *string  `json:"affinity_mode"`
+	MaxRetries                         *int     `json:"max_retries"`
+	MaxRateLimitRetries                *int     `json:"max_rate_limit_retries"`
+	AllowRemoteMigration               *bool    `json:"allow_remote_migration"`
+	ModelMapping                       *string  `json:"model_mapping"`
+	CodexModelMapping                  *string  `json:"codex_model_mapping"`
+	ReasoningEffortModels              *string  `json:"reasoning_effort_models"`
+	ResinURL                           *string  `json:"resin_url"`
+	ResinPlatformName                  *string  `json:"resin_platform_name"`
+	PromptFilterEnabled                *bool    `json:"prompt_filter_enabled"`
+	PromptFilterMode                   *string  `json:"prompt_filter_mode"`
+	PromptFilterThreshold              *int     `json:"prompt_filter_threshold"`
+	PromptFilterStrictThreshold        *int     `json:"prompt_filter_strict_threshold"`
+	PromptFilterLogMatches             *bool    `json:"prompt_filter_log_matches"`
+	PromptFilterMaxTextLength          *int     `json:"prompt_filter_max_text_length"`
+	PromptFilterSensitiveWords         *string  `json:"prompt_filter_sensitive_words"`
+	PromptFilterCustomPatterns         *string  `json:"prompt_filter_custom_patterns"`
+	PromptFilterDisabledPatterns       *string  `json:"prompt_filter_disabled_patterns"`
+	ClientCompatMode                   *string  `json:"client_compat_mode"`
+	CodexMinCLIVersion                 *string  `json:"codex_min_cli_version"`
+	UsageLogMode                       *string  `json:"usage_log_mode"`
+	UsageLogBatchSize                  *int     `json:"usage_log_batch_size"`
+	UsageLogFlushIntervalSeconds       *int     `json:"usage_log_flush_interval_seconds"`
+	StreamFlushPolicy                  *string  `json:"stream_flush_policy"`
+	StreamFlushIntervalMS              *int     `json:"stream_flush_interval_ms"`
+	FirstTokenMode                     *string  `json:"first_token_mode"`
+	FirstTokenTimeoutSeconds           *int     `json:"first_token_timeout_seconds"`
+	BillingTierPolicy                  *string  `json:"billing_tier_policy"`
+	ShowFullUsageNumbers               *bool    `json:"show_full_usage_numbers"`
+	ImageStorageBackend                *string  `json:"image_storage_backend"`
+	ImageS3Endpoint                    *string  `json:"image_s3_endpoint"`
+	ImageS3Region                      *string  `json:"image_s3_region"`
+	ImageS3Bucket                      *string  `json:"image_s3_bucket"`
+	ImageS3AccessKey                   *string  `json:"image_s3_access_key"`
+	ImageS3SecretKey                   *string  `json:"image_s3_secret_key"`
+	ImageS3Prefix                      *string  `json:"image_s3_prefix"`
+	ImageS3ForcePathStyle              *bool    `json:"image_s3_force_path_style"`
 	AutoPause5hThreshold               *float64 `json:"auto_pause_5h_threshold"`
 	AutoPause7dThreshold               *float64 `json:"auto_pause_7d_threshold"`
 }
@@ -6264,20 +6274,21 @@ func (h *Handler) TestImageStorageConnection(c *gin.Context) {
 // ==================== 导出 & 迁移 ====================
 
 type cpaExportEntry struct {
-	Type                string `json:"type"`
-	Email               string `json:"email"`
-	PlanType            string `json:"plan_type,omitempty"`
-	Codex7DUsedPercent  string `json:"codex_7d_used_percent,omitempty"`
-	Codex7DResetAt      string `json:"codex_7d_reset_at,omitempty"`
-	Codex5HUsedPercent  string `json:"codex_5h_used_percent,omitempty"`
-	Codex5HResetAt      string `json:"codex_5h_reset_at,omitempty"`
-	CodexUsageUpdatedAt string `json:"codex_usage_updated_at,omitempty"`
-	Expired             string `json:"expired"`
-	IDToken             string `json:"id_token"`
-	AccountID           string `json:"account_id"`
-	AccessToken         string `json:"access_token"`
-	LastRefresh         string `json:"last_refresh"`
-	RefreshToken        string `json:"refresh_token"`
+	Type                  string `json:"type"`
+	Email                 string `json:"email"`
+	PlanType              string `json:"plan_type,omitempty"`
+	Codex7DUsedPercent    string `json:"codex_7d_used_percent,omitempty"`
+	Codex7DResetAt        string `json:"codex_7d_reset_at,omitempty"`
+	Codex5HUsedPercent    string `json:"codex_5h_used_percent,omitempty"`
+	Codex5HResetAt        string `json:"codex_5h_reset_at,omitempty"`
+	Codex5HUsageUpdatedAt string `json:"codex_5h_usage_updated_at,omitempty"`
+	CodexUsageUpdatedAt   string `json:"codex_usage_updated_at,omitempty"`
+	Expired               string `json:"expired"`
+	IDToken               string `json:"id_token"`
+	AccountID             string `json:"account_id"`
+	AccessToken           string `json:"access_token"`
+	LastRefresh           string `json:"last_refresh"`
+	RefreshToken          string `json:"refresh_token"`
 }
 
 type accountAuthJSONTokens struct {
@@ -6426,20 +6437,21 @@ func (h *Handler) ExportAccounts(c *gin.Context) {
 			accountID = row.GetCredential("account_id")
 		}
 		entries = append(entries, cpaExportEntry{
-			Type:                "codex",
-			Email:               row.GetCredential("email"),
-			PlanType:            row.GetCredential("plan_type"),
-			Codex7DUsedPercent:  row.GetCredential("codex_7d_used_percent"),
-			Codex7DResetAt:      row.GetCredential("codex_7d_reset_at"),
-			Codex5HUsedPercent:  row.GetCredential("codex_5h_used_percent"),
-			Codex5HResetAt:      row.GetCredential("codex_5h_reset_at"),
-			CodexUsageUpdatedAt: row.GetCredential("codex_usage_updated_at"),
-			Expired:             row.GetCredential("expires_at"),
-			IDToken:             row.GetCredential("id_token"),
-			AccountID:           accountID,
-			AccessToken:         at,
-			LastRefresh:         row.UpdatedAt.Format(time.RFC3339),
-			RefreshToken:        rt,
+			Type:                  "codex",
+			Email:                 row.GetCredential("email"),
+			PlanType:              row.GetCredential("plan_type"),
+			Codex7DUsedPercent:    row.GetCredential("codex_7d_used_percent"),
+			Codex7DResetAt:        row.GetCredential("codex_7d_reset_at"),
+			Codex5HUsedPercent:    row.GetCredential("codex_5h_used_percent"),
+			Codex5HResetAt:        row.GetCredential("codex_5h_reset_at"),
+			Codex5HUsageUpdatedAt: row.GetCredential("codex_5h_usage_updated_at"),
+			CodexUsageUpdatedAt:   row.GetCredential("codex_usage_updated_at"),
+			Expired:               row.GetCredential("expires_at"),
+			IDToken:               row.GetCredential("id_token"),
+			AccountID:             accountID,
+			AccessToken:           at,
+			LastRefresh:           row.UpdatedAt.Format(time.RFC3339),
+			RefreshToken:          rt,
 		})
 	}
 
@@ -6527,19 +6539,20 @@ func (h *Handler) MigrateAccounts(c *gin.Context) {
 			name = "migrate"
 		}
 		tokens = append(tokens, importToken{
-			refreshToken:        rt,
-			accessToken:         at,
-			name:                name,
-			email:               strings.TrimSpace(entry.Email),
-			idToken:             strings.TrimSpace(entry.IDToken),
-			accountID:           strings.TrimSpace(entry.AccountID),
-			planType:            strings.TrimSpace(entry.PlanType),
-			expiresAt:           strings.TrimSpace(entry.Expired),
-			codex7DUsedPercent:  strings.TrimSpace(entry.Codex7DUsedPercent),
-			codex7DResetAt:      strings.TrimSpace(entry.Codex7DResetAt),
-			codex5HUsedPercent:  strings.TrimSpace(entry.Codex5HUsedPercent),
-			codex5HResetAt:      strings.TrimSpace(entry.Codex5HResetAt),
-			codexUsageUpdatedAt: strings.TrimSpace(entry.CodexUsageUpdatedAt),
+			refreshToken:          rt,
+			accessToken:           at,
+			name:                  name,
+			email:                 strings.TrimSpace(entry.Email),
+			idToken:               strings.TrimSpace(entry.IDToken),
+			accountID:             strings.TrimSpace(entry.AccountID),
+			planType:              strings.TrimSpace(entry.PlanType),
+			expiresAt:             strings.TrimSpace(entry.Expired),
+			codex7DUsedPercent:    strings.TrimSpace(entry.Codex7DUsedPercent),
+			codex7DResetAt:        strings.TrimSpace(entry.Codex7DResetAt),
+			codex5HUsedPercent:    strings.TrimSpace(entry.Codex5HUsedPercent),
+			codex5HResetAt:        strings.TrimSpace(entry.Codex5HResetAt),
+			codex5HUsageUpdatedAt: strings.TrimSpace(entry.Codex5HUsageUpdatedAt),
+			codexUsageUpdatedAt:   strings.TrimSpace(entry.CodexUsageUpdatedAt),
 		})
 	}
 

--- a/admin/import_json_test.go
+++ b/admin/import_json_test.go
@@ -192,6 +192,7 @@ func TestParseImportJSONTokensPreservesCPAFields(t *testing.T) {
 		"codex_7d_reset_at": "2026-05-15T20:33:11+08:00",
 		"codex_5h_used_percent": 0,
 		"codex_5h_reset_at": "2026-05-11T11:39:07+08:00",
+		"codex_5h_usage_updated_at": "2026-05-11T10:39:07+08:00",
 		"codex_usage_updated_at": "2026-05-11T11:39:07+08:00",
 		"expired": "2026-04-25T12:00:00Z",
 		"id_token": "id-cpa",
@@ -224,6 +225,9 @@ func TestParseImportJSONTokensPreservesCPAFields(t *testing.T) {
 	if token.codex5HUsedPercent != "0" || token.codex5HResetAt != "2026-05-11T11:39:07+08:00" {
 		t.Fatalf("5h usage = %q/%q, want 0/reset", token.codex5HUsedPercent, token.codex5HResetAt)
 	}
+	if token.codex5HUsageUpdatedAt != "2026-05-11T10:39:07+08:00" {
+		t.Fatalf("5h usageUpdatedAt = %q, want timestamp", token.codex5HUsageUpdatedAt)
+	}
 	if token.codexUsageUpdatedAt != "2026-05-11T11:39:07+08:00" {
 		t.Fatalf("usageUpdatedAt = %q, want timestamp", token.codexUsageUpdatedAt)
 	}
@@ -234,12 +238,13 @@ func TestParseImportJSONTokensPreservesCPAFields(t *testing.T) {
 
 func TestAccountFromCredentialSeedRestoresUsageSnapshots(t *testing.T) {
 	account := accountFromCredentialSeed(42, "", tokenCredentialSeed{
-		planType:            "free",
-		codex7DUsedPercent:  "3",
-		codex7DResetAt:      "2026-05-15T20:33:11+08:00",
-		codex5HUsedPercent:  "0",
-		codex5HResetAt:      "2026-05-11T11:39:07+08:00",
-		codexUsageUpdatedAt: "2026-05-11T11:39:07+08:00",
+		planType:              "free",
+		codex7DUsedPercent:    "3",
+		codex7DResetAt:        "2026-05-15T20:33:11+08:00",
+		codex5HUsedPercent:    "0",
+		codex5HResetAt:        "2026-05-11T11:39:07+08:00",
+		codex5HUsageUpdatedAt: "2026-05-11T10:39:07+08:00",
+		codexUsageUpdatedAt:   "2026-05-11T11:39:07+08:00",
 	})
 
 	if got := account.GetPlanType(); got != "free" {
@@ -256,8 +261,27 @@ func TestAccountFromCredentialSeedRestoresUsageSnapshots(t *testing.T) {
 	if !ok || pct5h != 0 {
 		t.Fatalf("5h usage = %v/%t, want 0/true", pct5h, ok)
 	}
-	if account.GetReset5hAt().IsZero() {
-		t.Fatal("Reset5hAt is zero")
+	if account.GetUsageUpdatedAt5h().IsZero() {
+		t.Fatal("UsageUpdatedAt5h is zero")
+	}
+	if account.GetUsageUpdatedAt5h().Equal(account.GetUsageUpdatedAt()) {
+		t.Fatalf("UsageUpdatedAt5h = %s, want separate 5h timestamp from 7d", account.GetUsageUpdatedAt5h())
+	}
+}
+
+func TestAccountFromCredentialSeedDoesNotReuse7dFreshnessForMissing5hTimestamp(t *testing.T) {
+	account := accountFromCredentialSeed(42, "", tokenCredentialSeed{
+		codex7DUsedPercent:  "3",
+		codex5HUsedPercent:  "95",
+		codex5HResetAt:      time.Now().Add(time.Hour).Format(time.RFC3339),
+		codexUsageUpdatedAt: time.Now().Format(time.RFC3339),
+	})
+
+	if account.GetUsageUpdatedAt().IsZero() {
+		t.Fatal("UsageUpdatedAt is zero")
+	}
+	if !account.GetUsageUpdatedAt5h().IsZero() {
+		t.Fatalf("UsageUpdatedAt5h = %s, want zero when codex_5h_usage_updated_at is missing", account.GetUsageUpdatedAt5h())
 	}
 }
 

--- a/admin/sub2api_import.go
+++ b/admin/sub2api_import.go
@@ -54,13 +54,13 @@ type sub2apiDataPayload struct {
 
 // sub2api 分页 list 返回的账号状态条目
 type sub2apiListAccount struct {
-	ID               int64      `json:"id"`
-	Name             string     `json:"name"`
-	Platform         string     `json:"platform"`
-	Status           string     `json:"status"`
-	ErrorMessage     string     `json:"error_message"`
-	RateLimitedAt    *time.Time `json:"rate_limited_at"`
-	RateLimitResetAt *time.Time `json:"rate_limit_reset_at"`
+	ID               int64                  `json:"id"`
+	Name             string                 `json:"name"`
+	Platform         string                 `json:"platform"`
+	Status           string                 `json:"status"`
+	ErrorMessage     string                 `json:"error_message"`
+	RateLimitedAt    *time.Time             `json:"rate_limited_at"`
+	RateLimitResetAt *time.Time             `json:"rate_limit_reset_at"`
 	Credentials      map[string]interface{} `json:"credentials"`
 }
 
@@ -308,21 +308,22 @@ func sub2apiAccountToImportToken(a sub2apiAccountInternal) (importToken, bool) {
 		return importToken{}, false
 	}
 	tok := importToken{
-		refreshToken:        rt,
-		sessionToken:        st,
-		accessToken:         at,
-		name:                a.Name,
-		email:               a.Email,
-		idToken:             stringFromMap(c, "id_token"),
-		accountID:           stringFromMap(c, "account_id"),
-		chatgptAccountID:    a.ChatGPTAccountID,
-		planType:            a.PlanType,
-		expiresAt:           stringFromMap(c, "expires_at"),
-		codex7DUsedPercent:  stringFromMap(c, "codex_7d_used_percent"),
-		codex7DResetAt:      stringFromMap(c, "codex_7d_reset_at"),
-		codex5HUsedPercent:  stringFromMap(c, "codex_5h_used_percent"),
-		codex5HResetAt:      stringFromMap(c, "codex_5h_reset_at"),
-		codexUsageUpdatedAt: stringFromMap(c, "codex_usage_updated_at"),
+		refreshToken:          rt,
+		sessionToken:          st,
+		accessToken:           at,
+		name:                  a.Name,
+		email:                 a.Email,
+		idToken:               stringFromMap(c, "id_token"),
+		accountID:             stringFromMap(c, "account_id"),
+		chatgptAccountID:      a.ChatGPTAccountID,
+		planType:              a.PlanType,
+		expiresAt:             stringFromMap(c, "expires_at"),
+		codex7DUsedPercent:    stringFromMap(c, "codex_7d_used_percent"),
+		codex7DResetAt:        stringFromMap(c, "codex_7d_reset_at"),
+		codex5HUsedPercent:    stringFromMap(c, "codex_5h_used_percent"),
+		codex5HResetAt:        stringFromMap(c, "codex_5h_reset_at"),
+		codex5HUsageUpdatedAt: stringFromMap(c, "codex_5h_usage_updated_at"),
+		codexUsageUpdatedAt:   stringFromMap(c, "codex_usage_updated_at"),
 	}
 	if tok.name == "" {
 		tok.name = tok.email

--- a/admin/token_credentials.go
+++ b/admin/token_credentials.go
@@ -24,6 +24,7 @@ type tokenCredentialSeed struct {
 	codex7DResetAt        string
 	codex5HUsedPercent    string
 	codex5HResetAt        string
+	codex5HUsageUpdatedAt string
 	codexUsageUpdatedAt   string
 }
 
@@ -40,6 +41,7 @@ func normalizeTokenCredentialSeed(seed tokenCredentialSeed) tokenCredentialSeed 
 	seed.codex7DResetAt = strings.TrimSpace(seed.codex7DResetAt)
 	seed.codex5HUsedPercent = strings.TrimSpace(seed.codex5HUsedPercent)
 	seed.codex5HResetAt = strings.TrimSpace(seed.codex5HResetAt)
+	seed.codex5HUsageUpdatedAt = strings.TrimSpace(seed.codex5HUsageUpdatedAt)
 	seed.codexUsageUpdatedAt = strings.TrimSpace(seed.codexUsageUpdatedAt)
 
 	if info := accountInfoFromTokens(seed.idToken, seed.accessToken); info != nil {
@@ -139,6 +141,9 @@ func tokenCredentialMap(seed tokenCredentialSeed) map[string]interface{} {
 	if seed.codex5HResetAt != "" {
 		credentials["codex_5h_reset_at"] = seed.codex5HResetAt
 	}
+	if seed.codex5HUsageUpdatedAt != "" {
+		credentials["codex_5h_usage_updated_at"] = seed.codex5HUsageUpdatedAt
+	}
 	if seed.codexUsageUpdatedAt != "" {
 		credentials["codex_usage_updated_at"] = seed.codexUsageUpdatedAt
 	}
@@ -168,7 +173,7 @@ func accountFromCredentialSeed(id int64, proxyURL string, seed tokenCredentialSe
 		}
 	}
 	if pct, ok := parseSeedUsagePercent(seed.codex5HUsedPercent); ok {
-		account.SetUsageSnapshot5h(pct, parseSeedRFC3339(seed.codex5HResetAt))
+		account.SetUsageSnapshot5hAt(pct, parseSeedRFC3339(seed.codex5HResetAt), parseSeedRFC3339(seed.codex5HUsageUpdatedAt))
 	}
 	return account
 }

--- a/auth/premium_rate_limit.go
+++ b/auth/premium_rate_limit.go
@@ -109,7 +109,7 @@ func (s *Store) PersistUsageSnapshot5hOnly(acc *Account) {
 
 	updatedAt := time.Now()
 	acc.mu.Lock()
-	acc.UsageUpdatedAt = updatedAt
+	acc.UsageUpdatedAt5h = updatedAt
 	acc.mu.Unlock()
 
 	s.fastSchedulerUpdate(acc)
@@ -140,7 +140,7 @@ func (s *Store) MarkPremium5hRateLimited(acc *Account, resetAt time.Time) {
 	acc.UsagePercent5h = 100
 	acc.UsagePercent5hValid = true
 	acc.Reset5hAt = resetAt
-	acc.UsageUpdatedAt = now
+	acc.UsageUpdatedAt5h = now
 	acc.LastRateLimitedAt = now
 	acc.Status = StatusCooldown
 	acc.CooldownUtil = resetAt

--- a/auth/quota_auto_pause_test.go
+++ b/auth/quota_auto_pause_test.go
@@ -40,6 +40,28 @@ func TestQuotaAutoPause5hThresholdFencesAccount(t *testing.T) {
 	}
 }
 
+func TestQuotaAutoPause5hThresholdRefreshesMissing5hBeforeFencing(t *testing.T) {
+	acc := newQuotaAutoPauseTestAccount()
+	acc.AutoPause5hThreshold = 0.95
+	acc.UsagePercent7d = 12
+	acc.UsagePercent7dValid = true
+	acc.UsageUpdatedAt = time.Now()
+	setAutoPauseThresholds(acc)
+
+	if !acc.NeedsUsageProbe(10 * time.Minute) {
+		t.Fatal("NeedsUsageProbe() = false, want true when 7d is fresh but 5h snapshot is missing")
+	}
+
+	acc.SetUsageSnapshot5h(95, time.Now().Add(time.Hour))
+
+	if acc.IsAvailable() {
+		t.Fatal("IsAvailable() = true, want false after refreshed 5h usage reaches the threshold")
+	}
+	if got := acc.RuntimeStatus(); got != "quota_paused" {
+		t.Fatalf("RuntimeStatus() = %q, want quota_paused after refreshed 5h usage reaches the threshold", got)
+	}
+}
+
 func TestQuotaAutoPauseIgnoresBelowThresholdAndDisabledWindow(t *testing.T) {
 	acc := newQuotaAutoPauseTestAccount()
 	acc.AutoPause5hThreshold = 0.95

--- a/auth/store.go
+++ b/auth/store.go
@@ -71,7 +71,8 @@ type Account struct {
 	UsagePercent5h        float64   // 5h 窗口使用率 0-100+
 	UsagePercent5hValid   bool
 	Reset5hAt             time.Time // 5h 窗口重置时间
-	UsageUpdatedAt        time.Time
+	UsageUpdatedAt        time.Time // 7d 用量快照刷新时间
+	UsageUpdatedAt5h      time.Time // 5h 用量快照刷新时间
 	usageProbeInFlight    bool
 	recoveryProbeInFlight bool
 	AutoPause5hThreshold  float64 // 0..1, 0 = disabled
@@ -1175,11 +1176,17 @@ func (a *Account) usagePercentForScheduling() float64 {
 
 // SetUsageSnapshot5h 更新 5h 用量快照
 func (a *Account) SetUsageSnapshot5h(pct float64, resetAt time.Time) {
+	a.SetUsageSnapshot5hAt(pct, resetAt, time.Now())
+}
+
+// SetUsageSnapshot5hAt 更新 5h 用量快照及刷新时间
+func (a *Account) SetUsageSnapshot5hAt(pct float64, resetAt time.Time, updatedAt time.Time) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	a.UsagePercent5h = pct
 	a.UsagePercent5hValid = true
 	a.Reset5hAt = resetAt
+	a.UsageUpdatedAt5h = updatedAt
 }
 
 // GetUsagePercent5h 获取 5h 用量百分比
@@ -1200,6 +1207,7 @@ func (a *Account) ClearUsageCache() {
 	a.UsagePercent5hValid = false
 	a.Reset5hAt = time.Time{}
 	a.UsageUpdatedAt = time.Time{}
+	a.UsageUpdatedAt5h = time.Time{}
 }
 
 // SetReset7dAt 设置 7d 窗口重置时间
@@ -1221,6 +1229,20 @@ func (a *Account) GetReset7dAt() time.Time {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
 	return a.Reset7dAt
+}
+
+// GetUsageUpdatedAt 获取 7d 用量快照刷新时间
+func (a *Account) GetUsageUpdatedAt() time.Time {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.UsageUpdatedAt
+}
+
+// GetUsageUpdatedAt5h 获取 5h 用量快照刷新时间
+func (a *Account) GetUsageUpdatedAt5h() time.Time {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.UsageUpdatedAt5h
 }
 
 // GetPlanType 获取账号套餐类型
@@ -1522,10 +1544,18 @@ func (a *Account) NeedsUsageProbe(maxAge time.Duration) bool {
 	if a.Status == StatusCooldown && a.CooldownReason == "rate_limited" && (a.CooldownUtil.IsZero() || now.Before(a.CooldownUtil)) {
 		return false // 429 冷却期间不探活，避免加重限流
 	}
-	if !a.UsagePercent7dValid || a.UsageUpdatedAt.IsZero() {
+	if !a.UsagePercent7dValid || a.UsageUpdatedAt.IsZero() || now.Sub(a.UsageUpdatedAt) > maxAge {
 		return true
 	}
-	return time.Since(a.UsageUpdatedAt) > maxAge
+	if a.effectiveAutoPause5h > 0 && !a.AutoPause5hDisabled {
+		if !a.UsagePercent5hValid || a.UsageUpdatedAt5h.IsZero() {
+			return true
+		}
+		if a.Reset5hAt.IsZero() || a.Reset5hAt.After(now) {
+			return now.Sub(a.UsageUpdatedAt5h) > maxAge
+		}
+	}
+	return false
 }
 
 // TryBeginUsageProbe 尝试开始一次用量探针
@@ -1672,8 +1702,8 @@ type Store struct {
 	sessionMu             sync.RWMutex
 	sessionBindings       map[string]sessionAffinity
 
-	globalAutoPause5hThreshold float64 // protected by mu
-	globalAutoPause7dThreshold float64 // protected by mu
+	globalAutoPause5hThreshold float64  // protected by mu
+	globalAutoPause7dThreshold float64  // protected by mu
 	groupAutoPauseThresholds   sync.Map // int64 -> [2]float64 {5h, 7d}
 }
 
@@ -2800,7 +2830,15 @@ func (s *Store) buildAccountFromRow(ctx context.Context, row *database.AccountRo
 					resetAt = t
 				}
 			}
-			account.SetUsageSnapshot5h(parsed, resetAt)
+			updatedAt := time.Time{}
+			if usageUpdatedAt5h := row.GetCredential("codex_5h_usage_updated_at"); usageUpdatedAt5h != "" {
+				if parsedTime, err := time.Parse(time.RFC3339, usageUpdatedAt5h); err == nil {
+					updatedAt = parsedTime
+				} else {
+					log.Printf("[账号 %d] 解析 codex_5h_usage_updated_at 失败: %v", row.ID, err)
+				}
+			}
+			account.SetUsageSnapshot5hAt(parsed, resetAt, updatedAt)
 		}
 	}
 	if threshold, ok := row.GetCredentialFloat64("auto_pause_5h_threshold"); ok {
@@ -4608,7 +4646,7 @@ func (s *Store) PersistUsageSnapshot(acc *Account, pct7d float64) {
 		reset7dAt := acc.GetReset7dAt()
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 		defer cancel()
-		if err := s.db.UpdateUsageSnapshotFull(ctx, acc.DBID, pct7d, reset7dAt, pct5h, reset5hAt, now); err != nil {
+		if err := s.db.UpdateUsageSnapshotFull(ctx, acc.DBID, pct7d, reset7dAt, pct5h, reset5hAt, now, acc.GetUsageUpdatedAt5h()); err != nil {
 			log.Printf("[账号 %d] 持久化用量快照失败: %v", acc.DBID, err)
 		}
 		return

--- a/auth/store_scheduler_test.go
+++ b/auth/store_scheduler_test.go
@@ -251,6 +251,63 @@ func TestNeedsUsageProbeAllowsReadyAccount(t *testing.T) {
 	}
 }
 
+func TestNeedsUsageProbeRequires5hSnapshotWhen5hAutoPauseEnabled(t *testing.T) {
+	acc := &Account{
+		AccessToken:          "token",
+		Status:               StatusReady,
+		UsagePercent7d:       12,
+		UsagePercent7dValid:  true,
+		UsageUpdatedAt:       time.Now(),
+		AutoPause5hThreshold: 0.95,
+	}
+	acc.recomputeEffectiveAutoPause(nil)
+
+	if !acc.NeedsUsageProbe(10 * time.Minute) {
+		t.Fatal("NeedsUsageProbe() = false, want true when 5h auto-pause is enabled but 5h snapshot is missing")
+	}
+}
+
+func TestPersistUsageSnapshotKeeps5hProbeRequiredWhen5hSnapshotMissing(t *testing.T) {
+	store := NewStore(nil, nil, &database.SystemSettings{MaxConcurrency: 2, TestConcurrency: 1, TestModel: "gpt-5.4"})
+	acc := &Account{
+		DBID:                 1,
+		AccessToken:          "token",
+		Status:               StatusReady,
+		AutoPause5hThreshold: 0.95,
+		AutoPause7dThreshold: 0.95,
+		UsagePercent5hValid:  false,
+		UsagePercent7dValid:  false,
+	}
+	acc.recomputeEffectiveAutoPause(store)
+
+	store.PersistUsageSnapshot(acc, 20)
+
+	if !acc.NeedsUsageProbe(10 * time.Minute) {
+		t.Fatal("NeedsUsageProbe() = false, want true after 7d-only persistence when 5h snapshot is still missing")
+	}
+}
+
+func TestPersistUsageSnapshot5hOnlyDoesNotRefreshStale7dSnapshot(t *testing.T) {
+	store := NewStore(nil, nil, &database.SystemSettings{MaxConcurrency: 2, TestConcurrency: 1, TestModel: "gpt-5.4"})
+	acc := &Account{
+		DBID:                1,
+		AccessToken:         "token",
+		Status:              StatusReady,
+		UsagePercent7d:      40,
+		UsagePercent7dValid: true,
+		UsageUpdatedAt:      time.Now().Add(-20 * time.Minute),
+		UsagePercent5h:      25,
+		UsagePercent5hValid: true,
+		Reset5hAt:           time.Now().Add(time.Hour),
+	}
+
+	store.PersistUsageSnapshot5hOnly(acc)
+
+	if !acc.NeedsUsageProbe(10 * time.Minute) {
+		t.Fatal("NeedsUsageProbe() = false, want true because 5h-only persistence must not refresh stale 7d freshness")
+	}
+}
+
 func TestTriggerUsageProbeAsyncRunsInLazyMode(t *testing.T) {
 	store := NewStore(nil, nil, &database.SystemSettings{MaxConcurrency: 2, TestConcurrency: 1, TestModel: "gpt-5.4"})
 	store.SetLazyMode(true)

--- a/database/postgres.go
+++ b/database/postgres.go
@@ -4348,13 +4348,14 @@ func (db *DB) UpdateUsageSnapshot(ctx context.Context, id int64, pct7d float64, 
 }
 
 // UpdateUsageSnapshotFull 持久化完整用量快照（5h + 7d + 重置时间）
-func (db *DB) UpdateUsageSnapshotFull(ctx context.Context, id int64, pct7d float64, reset7dAt time.Time, pct5h float64, reset5hAt time.Time, updatedAt time.Time) error {
+func (db *DB) UpdateUsageSnapshotFull(ctx context.Context, id int64, pct7d float64, reset7dAt time.Time, pct5h float64, reset5hAt time.Time, updatedAt7d time.Time, updatedAt5h time.Time) error {
 	fields := map[string]interface{}{
-		"codex_7d_used_percent":  pct7d,
-		"codex_7d_reset_at":      reset7dAt.Format(time.RFC3339),
-		"codex_5h_used_percent":  pct5h,
-		"codex_5h_reset_at":      reset5hAt.Format(time.RFC3339),
-		"codex_usage_updated_at": updatedAt.Format(time.RFC3339),
+		"codex_7d_used_percent":     pct7d,
+		"codex_7d_reset_at":         reset7dAt.Format(time.RFC3339),
+		"codex_5h_used_percent":     pct5h,
+		"codex_5h_reset_at":         reset5hAt.Format(time.RFC3339),
+		"codex_usage_updated_at":    updatedAt7d.Format(time.RFC3339),
+		"codex_5h_usage_updated_at": updatedAt5h.Format(time.RFC3339),
 	}
 	return db.UpdateCredentials(ctx, id, fields)
 }

--- a/database/usage_snapshot.go
+++ b/database/usage_snapshot.go
@@ -8,8 +8,8 @@ import (
 // UpdateUsageSnapshot5h 持久化 5h 用量快照（无 7d 数据时使用）
 func (db *DB) UpdateUsageSnapshot5h(ctx context.Context, id int64, pct5h float64, reset5hAt time.Time, updatedAt time.Time) error {
 	return db.UpdateCredentials(ctx, id, map[string]interface{}{
-		"codex_5h_used_percent":  pct5h,
-		"codex_5h_reset_at":      reset5hAt.Format(time.RFC3339),
-		"codex_usage_updated_at": updatedAt.Format(time.RFC3339),
+		"codex_5h_used_percent":     pct5h,
+		"codex_5h_reset_at":         reset5hAt.Format(time.RFC3339),
+		"codex_5h_usage_updated_at": updatedAt.Format(time.RFC3339),
 	})
 }

--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -3804,7 +3804,7 @@ func parseCodexUsageHeaders(resp *http.Response, account *auth.Account) (float64
 	// 写入 5h
 	if w5h.valid {
 		resetAt := now.Add(time.Duration(w5h.resetSec) * time.Second)
-		account.SetUsageSnapshot5h(w5h.usedPct, resetAt)
+		account.SetUsageSnapshot5hAt(w5h.usedPct, resetAt, now)
 	}
 
 	// 写入 7d

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -1946,6 +1946,38 @@ func TestSyncCodexUsageStateTriggersPremium5hLimitWith5hHeadersOnly(t *testing.T
 	}
 }
 
+func TestSyncCodexUsageState5hOnlyDoesNotRefreshStale7dProbeFreshness(t *testing.T) {
+	store := auth.NewStore(nil, nil, &database.SystemSettings{MaxConcurrency: 2, TestConcurrency: 1, TestModel: "gpt-5.4"})
+	account := &auth.Account{
+		DBID:                104,
+		AccessToken:         "at",
+		PlanType:            "plus",
+		Status:              auth.StatusReady,
+		UsagePercent7d:      40,
+		UsagePercent7dValid: true,
+		UsageUpdatedAt:      time.Now().Add(-20 * time.Minute),
+	}
+	resp := &http.Response{Header: make(http.Header)}
+	resp.Header.Set("x-codex-primary-used-percent", "83")
+	resp.Header.Set("x-codex-primary-window-minutes", "300")
+	resp.Header.Set("x-codex-primary-reset-after-seconds", "600")
+
+	result := SyncCodexUsageState(store, account, resp)
+
+	if !result.Used5hHeaders || !result.HasUsage5h {
+		t.Fatalf("usage sync result = %#v, want 5h headers to populate a 5h snapshot", result)
+	}
+	if result.HasUsage7d {
+		t.Fatalf("usage sync result = %#v, want no 7d snapshot from 5h-only headers", result)
+	}
+	if !result.Persisted5hOnly {
+		t.Fatalf("usage sync result = %#v, want 5h-only persistence path", result)
+	}
+	if !account.NeedsUsageProbe(10 * time.Minute) {
+		t.Fatal("NeedsUsageProbe() = false, want true because 5h-only header sync must not refresh stale 7d freshness")
+	}
+}
+
 func TestSyncCodexUsageStateMarks7dUsageLimited(t *testing.T) {
 	ctx := context.Background()
 	dbPath := filepath.Join(t.TempDir(), "codex2api.db")

--- a/proxy/usage_wham.go
+++ b/proxy/usage_wham.go
@@ -135,7 +135,7 @@ func ApplyWhamUsage(store *auth.Store, account *auth.Account, usage *WhamUsage) 
 
 	if w5h != nil {
 		resetAt := whamWindowResetAt(w5h, now)
-		account.SetUsageSnapshot5h(w5h.UsedPercent, resetAt)
+		account.SetUsageSnapshot5hAt(w5h.UsedPercent, resetAt, now)
 		result.UsagePct5h = w5h.UsedPercent
 		result.Reset5hAt = resetAt
 		result.HasUsage5h = true

--- a/proxy/usage_wham_test.go
+++ b/proxy/usage_wham_test.go
@@ -134,6 +134,38 @@ func TestApplyWhamUsage_PersistsPlanAnd5h7d(t *testing.T) {
 	}
 }
 
+func TestApplyWhamUsage5hOnlyDoesNotRefreshStale7dProbeFreshness(t *testing.T) {
+	store := auth.NewStore(nil, nil, &database.SystemSettings{MaxConcurrency: 2, TestConcurrency: 1, TestModel: "gpt-5.4"})
+	account := &auth.Account{
+		DBID:                2,
+		AccessToken:         "at",
+		PlanType:            "plus",
+		Status:              auth.StatusReady,
+		UsagePercent7d:      40,
+		UsagePercent7dValid: true,
+		UsageUpdatedAt:      time.Now().Add(-20 * time.Minute),
+	}
+
+	now := time.Now()
+	usage := &WhamUsage{PlanType: "plus"}
+	usage.RateLimit.PrimaryWindow = &WhamUsageWindow{UsedPercent: 83, LimitWindowSeconds: 18000, ResetAt: now.Add(2 * time.Hour).Unix()}
+
+	result := ApplyWhamUsage(store, account, usage)
+
+	if !result.Used5hHeaders || !result.HasUsage5h {
+		t.Fatalf("ApplyWhamUsage result = %+v, want 5h-only usage snapshot", result)
+	}
+	if result.HasUsage7d {
+		t.Fatalf("ApplyWhamUsage result = %+v, want no 7d snapshot from 5h-only usage", result)
+	}
+	if !result.Persisted5hOnly {
+		t.Fatalf("ApplyWhamUsage result = %+v, want 5h-only persistence path", result)
+	}
+	if !account.NeedsUsageProbe(10 * time.Minute) {
+		t.Fatal("NeedsUsageProbe() = false, want true because 5h-only WHAM sync must not refresh stale 7d freshness")
+	}
+}
+
 // 复现 issue #168：free 账号的 wham 响应里 primary_window 实际承载的是 7d 数据
 // （limit_window_seconds=604800），secondary_window=null。代码必须按
 // limit_window_seconds 而不是字段位置来分类，否则 7d 数据会被错误写入 5h 槽位。


### PR DESCRIPTION
## 背景

账号管理支持基于 Codex usage 的自动暂停能力，例如：

- 5h usage 达到指定阈值后暂停调度；
- 7d usage 达到指定阈值后暂停调度。

实际使用中发现：

- 当 7d auto-pause 阈值配置为 95% 时，可以按预期暂停；
- 但当 5h auto-pause 阈值配置为 95% 时，账号可能不会在 95% 附近停止，而是继续被调度直到 100% 或触发上游限流。

排查后确认，根因是 5h 和 7d usage snapshot 共用了同一个 freshness 时间戳：

```text
UsageUpdatedAt
codex_usage_updated_at
```

这会导致：

```text
7d usage 很新
=> NeedsUsageProbe() 认为 usage 整体都很新
=> 即使 5h usage 缺失或过期，也不会触发 probe
=> 5h auto-pause 不能及时生效
```

## 修改前行为

修改前，5h 和 7d 用量 freshness 共享同一个时间戳：

```go
UsageUpdatedAt time.Time
```

DB 中对应：

```text
codex_usage_updated_at
```

典型错误场景：

```text
账号配置：
5h auto-pause threshold = 95%

运行态：
7d usage = 12%
7d freshness = fresh
5h usage = missing 或 stale

修改前：
NeedsUsageProbe() 只看到 UsageUpdatedAt 很新
=> 返回 false
=> 不刷新 usage
=> 5h 即使已经达到 95%，系统也不知道
=> 账号继续被调度直到 100% 或上游限流
```

同时，5h-only 更新路径也可能污染 7d freshness：

```text
只有 5h usage 被刷新
=> 共享 UsageUpdatedAt 被更新
=> 7d usage 可能被误判为 fresh
```

## 修改后行为

本 PR 将 5h 和 7d usage freshness 拆分为两个独立字段。

内存结构：

```go
UsageUpdatedAt   time.Time // 7d 用量快照刷新时间
UsageUpdatedAt5h time.Time // 5h 用量快照刷新时间
```

DB credentials：

```text
codex_usage_updated_at     // 7d freshness
codex_5h_usage_updated_at  // 5h freshness
```

修改后，`NeedsUsageProbe(maxAge)` 会按窗口分别判断：

```text
如果 7d usage 缺失或过期：
    需要 probe

如果 5h auto-pause 启用：
    如果 5h usage 缺失：
        需要 probe
    如果 5h freshness 缺失：
        需要 probe
    如果 5h freshness 过期且 5h 窗口仍有效：
        需要 probe
```

因此核心场景变为：

```text
账号配置：
5h auto-pause threshold = 95%

运行态：
7d usage fresh
5h usage missing/stale

修改后：
NeedsUsageProbe() 会发现 5h freshness 不满足
=> 返回 true
=> 主动刷新 usage
=> 拿到 5h=95% 后进入 quota_paused
=> 账号停止调度
```

## 主要修改内容

### 1. 拆分 5h / 7d freshness

修改文件：

```text
auth/store.go
```

新增：

```go
UsageUpdatedAt5h time.Time
```

新增/调整方法：

```go
SetUsageSnapshot5hAt(...)
GetUsageUpdatedAt()
GetUsageUpdatedAt5h()
```

`ClearUsageCache()` 现在会同时清理：

```text
7d usage
7d freshness
5h usage
5h freshness
```

### 2. 修复 `NeedsUsageProbe()` 判断逻辑

修改文件：

```text
auth/store.go
```

修改后，probe freshness 不再只依赖 7d timestamp，而是分别判断：

- 7d usage freshness；
- 5h usage freshness；
- 5h auto-pause 是否启用；
- 5h snapshot 是否缺失；
- 5h updatedAt 是否缺失或过期。

这样可以防止：

```text
7d fresh 掩盖 5h stale/missing
```

### 3. 调整 DB persistence 语义

修改文件：

```text
database/postgres.go
database/usage_snapshot.go
```

现在持久化语义如下：

#### 7d-only update

只写：

```text
codex_7d_used_percent
codex_usage_updated_at
```

不写：

```text
codex_5h_usage_updated_at
```

#### 5h-only update

只写：

```text
codex_5h_used_percent
codex_5h_reset_at
codex_5h_usage_updated_at
```

不写：

```text
codex_usage_updated_at
```

#### full update

同时写：

```text
codex_7d_used_percent
codex_7d_reset_at
codex_usage_updated_at

codex_5h_used_percent
codex_5h_reset_at
codex_5h_usage_updated_at
```

这样避免了 5h 和 7d freshness 互相污染。

### 4. 修复 5h-only usage sync 路径

修改文件：

```text
proxy/handler.go
proxy/usage_wham.go
auth/premium_rate_limit.go
```

以下路径现在只刷新 5h freshness，不刷新 7d freshness：

- Codex response headers 只返回 5h usage；
- WHAM `/backend-api/wham/usage` 只返回 5h usage；
- premium 5h rate-limit；
- `PersistUsageSnapshot5hOnly()`。

### 5. 修复 restore / import / export / migration 链路

修改文件：

```text
admin/handler.go
admin/sub2api_import.go
admin/token_credentials.go
auth/store.go
```

新增支持字段：

```text
codex_5h_usage_updated_at
```

覆盖范围包括：

- admin account response；
- JSON import；
- CPA import；
- sub2api import；
- remote migration；
- credential seed restore；
- DB account restore。

对于历史数据，如果存在：

```text
codex_5h_used_percent
codex_5h_reset_at
```

但不存在：

```text
codex_5h_usage_updated_at
```

则不会复用：

```text
codex_usage_updated_at
```

而是将 5h freshness 视为缺失，后续触发 probe 来刷新真实 5h 状态。

## 修改前后对比

| 对比项 | 修改前 | 修改后 |
|---|---|---|
| 5h / 7d freshness | 共用 `UsageUpdatedAt` | 拆分为 `UsageUpdatedAt` 和 `UsageUpdatedAt5h` |
| DB freshness 字段 | 共用 `codex_usage_updated_at` | 新增 `codex_5h_usage_updated_at` |
| 5h auto-pause | 可能被 7d fresh 短路 | 5h 独立判断 freshness |
| 7d-only update | 可能间接影响 5h 判断 | 不会刷新 5h freshness |
| 5h-only update | 可能污染 7d freshness | 不会刷新 7d freshness |
| 历史数据 restore | 可能复用错误 freshness | 缺失 5h timestamp 时重新 probe |
| 导入导出 | 无独立 5h timestamp | 保留独立 5h timestamp |
| 回归测试 | 缺少直接覆盖 | 新增多路径测试覆盖 |

## 收益

### 1. 修复 5h auto-pause 不及时生效的问题

修改后，当配置：

```text
5h auto-pause threshold = 95%
```

如果 5h usage 缺失或过期，即使 7d usage 是 fresh，系统也会主动 probe。

probe 到 5h usage 达到 95% 后，账号会进入：

```text
quota_paused
```

并停止调度。

### 2. 降低账号被过度使用的风险

修改前，5h usage 可能已经超过阈值，但系统没有刷新到最新状态，导致账号继续调度。

修改后，5h freshness 独立判断，可以更及时暂停账号，降低：

- 继续调度到 100%；
- 触发上游硬限流；
- 产生额外 429；
- 账号健康状态恶化；

等风险。

### 3. usage 状态模型更准确

修改后，5h 和 7d 不再共用 freshness，语义更清晰：

```text
7d fresh 只代表 7d fresh
5h fresh 只代表 5h fresh
```

这降低了后续维护和排查 usage 问题的复杂度。

### 4. 防止 5h / 7d freshness 相互污染

修改后：

```text
7d-only 更新不会伪造 5h freshness
5h-only 更新不会污染 7d freshness
```

调度和 probe 判断会更可靠。

### 5. 历史数据兼容更安全

对于旧数据中缺少 `codex_5h_usage_updated_at` 的账号，系统不会错误复用 7d timestamp，而是会重新 probe。

这可以避免旧数据继续携带原有 bug。

### 6. 提升导入导出一致性

新增 `codex_5h_usage_updated_at` 后，账号导入、导出、迁移时可以保留完整的 5h usage freshness，避免迁移后误判。

## 测试覆盖

本 PR 新增/调整了以下测试文件：

```text
auth/quota_auto_pause_test.go
auth/store_scheduler_test.go
proxy/handler_test.go
proxy/usage_wham_test.go
admin/import_json_test.go
```

覆盖场景包括：

1. 7d fresh 但 5h missing 时，5h auto-pause 启用后必须触发 probe；
2. 5h usage 达到 95% 后账号进入 `quota_paused`；
3. 7d-only persist 不会伪造 5h freshness；
4. 5h-only persist 不会刷新 7d freshness；
5. Codex response headers 只有 5h usage 时，不会刷新 7d freshness；
6. WHAM 只有 5h usage 时，不会刷新 7d freshness；
7. restore/import 缺失 `codex_5h_usage_updated_at` 时，不会复用 7d timestamp。

## 验证结果

已运行：

```sh
go test ./auth/... ./proxy/... ./admin/... ./database/...
```

测试结果：

```text
ok  	github.com/codex2api/auth	(cached)
ok  	github.com/codex2api/proxy	(cached)
ok  	github.com/codex2api/proxy/wsrelay	(cached)
ok  	github.com/codex2api/admin	2.715s
ok  	github.com/codex2api/database	(cached)
```

退出码：

```text
0
```

同时执行：

```sh
git diff --check
```

未发现实际 whitespace error，仅有 Windows Git 的 LF/CRLF 提示。

## 影响范围

本次修改涉及以下文件：

```text
admin/handler.go
admin/import_json_test.go
admin/sub2api_import.go
admin/token_credentials.go
auth/premium_rate_limit.go
auth/quota_auto_pause_test.go
auth/store.go
auth/store_scheduler_test.go
database/postgres.go
database/usage_snapshot.go
proxy/handler.go
proxy/handler_test.go
proxy/usage_wham.go
proxy/usage_wham_test.go
```

不包含与本次修复无关的文件，例如：

```text
frontend/pnpm-lock.yaml
```

## 兼容性说明

- 现有 `codex_usage_updated_at` 保留，继续表示 7d usage freshness。
- 新增 `codex_5h_usage_updated_at`，用于 5h usage freshness。
- 历史账号如果没有 `codex_5h_usage_updated_at`，会被视为 5h freshness 缺失，并在需要时重新 probe。
- 不改变已有 7d auto-pause 行为。
- 不改变已有 premium 5h 100% rate-limit 行为，只修正其 freshness 归属。

## 最终结论

本 PR 修复了 5h auto-pause 在 7d usage fresh 时无法及时 probe 的问题。

修改后，5h 和 7d usage freshness 独立维护，5h auto-pause 能够基于真实的 5h freshness 及时触发 probe，并在达到配置阈值时进入 `quota_paused`，从而避免账号继续被调度到 100% 或触发上游硬限流。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced usage metadata tracking with separate management of 5-hour and 7-day timestamp windows.
  * Account import and export workflows now preserve complete usage update timestamps.

* **Bug Fixes**
  * Usage availability checks now independently evaluate 5-hour and 7-day freshness for improved accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->