### PR TITLE
修复 Claude Code 工具参数清洗过宽导致 Read/Write 出错

### DIFF
--- a/proxy/anthropic.go
+++ b/proxy/anthropic.go
@@ -416,7 +416,7 @@ func appendAssistantBlocks(input []any, blocks []anthropicContentBlock) []any {
 			}
 			args := "{}"
 			if len(b.Input) > 0 {
-				if cleaned := sanitizeToolInputJSON(string(b.Input)); cleaned != "" {
+				if cleaned := sanitizeToolInputJSON(b.Name, string(b.Input)); cleaned != "" {
 					args = cleaned
 				}
 			}
@@ -860,7 +860,7 @@ func (t *anthropicStreamTranslator) closeCurrentBlock() []anthropicStreamEvent {
 
 	var events []anthropicStreamEvent
 	if t.currentBlockType == "tool_use" && t.currentToolInputBuffer.Len() > 0 {
-		cleaned := sanitizeToolInputJSON(t.currentToolInputBuffer.String())
+		cleaned := sanitizeToolInputJSON(t.currentToolUseName, t.currentToolInputBuffer.String())
 		if cleaned != "" {
 			events = append(events, anthropicStreamEvent{
 				Type:  "content_block_delta",
@@ -881,32 +881,24 @@ func (t *anthropicStreamTranslator) closeCurrentBlock() []anthropicStreamEvent {
 	return events
 }
 
-// sanitizeToolInputJSON 清洗工具调用 arguments JSON：
-// 仅删除顶层值为空字符串("")或 null 的字段。
-// 不动空对象 {} / 空数组 []（部分工具语义上允许这两者）。
-// 上游 gpt-5.5 偶尔会给 Read 工具加 "pages":""，导致 claudecode 看到的入参
-// 带上无效空字段，模型在后续轮次里反复纠结"工具层带入了空 pages"。在代理
-// 层统一清掉，比让客户端去兼容更简单。
-func sanitizeToolInputJSON(raw string) string {
+// sanitizeToolInputJSON 清洗工具调用 arguments JSON。
+// 只处理 Claude Code Read 工具已知兼容问题：上游 gpt-5.5 偶尔会给
+// Read 工具加 "pages":""，导致 claudecode 看到无效空字段。
+// 其他工具的空字符串和 null 参数可能有合法语义，不能泛化删除。
+func sanitizeToolInputJSON(toolName string, raw string) string {
 	raw = strings.TrimSpace(raw)
-	if raw == "" {
+	if toolName != "Read" || raw == "" {
 		return raw
 	}
 	var obj map[string]json.RawMessage
 	if err := json.Unmarshal([]byte(raw), &obj); err != nil {
 		return raw
 	}
-	changed := false
-	for k, v := range obj {
-		s := strings.TrimSpace(string(v))
-		if s == `""` || s == "null" {
-			delete(obj, k)
-			changed = true
-		}
-	}
-	if !changed {
+	pages, ok := obj["pages"]
+	if !ok || strings.TrimSpace(string(pages)) != `""` {
 		return raw
 	}
+	delete(obj, "pages")
 	out, err := json.Marshal(obj)
 	if err != nil {
 		return raw
@@ -1112,7 +1104,7 @@ func buildAnthropicResponseFromCompleted(completedData []byte, model string) *an
 			callID := fromCodexCallID(item.Get("call_id").String())
 			name := item.Get("name").String()
 			args := item.Get("arguments").String()
-			if cleaned := sanitizeToolInputJSON(args); cleaned != "" {
+			if cleaned := sanitizeToolInputJSON(name, args); cleaned != "" {
 				args = cleaned
 			} else {
 				args = "{}"

--- a/proxy/anthropic_test.go
+++ b/proxy/anthropic_test.go
@@ -207,63 +207,167 @@ func TestTranslateAnthropicToCodexDoesNotCanonicalizeDisabledModelAlias(t *testi
 
 func TestSanitizeToolInputJSON(t *testing.T) {
 	tests := []struct {
-		name string
-		in   string
-		want string
+		name     string
+		toolName string
+		in       string
+		want     string
 	}{
 		{
-			name: "drops empty string optional field",
-			in:   `{"file_path":"/etc/hosts","pages":""}`,
-			want: `{"file_path":"/etc/hosts"}`,
+			name:     "read drops empty pages",
+			toolName: "Read",
+			in:       `{"file_path":"/etc/hosts","pages":""}`,
+			want:     `{"file_path":"/etc/hosts"}`,
 		},
 		{
-			name: "drops null field",
-			in:   `{"file_path":"/etc/hosts","limit":null}`,
-			want: `{"file_path":"/etc/hosts"}`,
+			name:     "read preserves null fields other than pages",
+			toolName: "Read",
+			in:       `{"file_path":"/etc/hosts","limit":null}`,
+			want:     `{"file_path":"/etc/hosts","limit":null}`,
 		},
 		{
-			name: "drops multiple empties",
-			in:   `{"file_path":"/x","pages":"","limit":null,"offset":0}`,
-			want: `{"file_path":"/x","offset":0}`,
+			name:     "read only drops empty pages",
+			toolName: "Read",
+			in:       `{"file_path":"/x","pages":"","limit":null,"offset":0}`,
+			want:     `{"file_path":"/x","limit":null,"offset":0}`,
 		},
 		{
-			name: "preserves empty object",
-			in:   `{"options":{}}`,
-			want: `{"options":{}}`,
+			name:     "write preserves empty content",
+			toolName: "Write",
+			in:       `{"file_path":"/tmp/empty.txt","content":""}`,
+			want:     `{"file_path":"/tmp/empty.txt","content":""}`,
 		},
 		{
-			name: "preserves empty array",
-			in:   `{"items":[]}`,
-			want: `{"items":[]}`,
+			name:     "edit preserves empty replacement",
+			toolName: "Edit",
+			in:       `{"file_path":"/tmp/a.txt","old_string":"abc","new_string":""}`,
+			want:     `{"file_path":"/tmp/a.txt","old_string":"abc","new_string":""}`,
 		},
 		{
-			name: "preserves whitespace strings",
-			in:   `{"sep":" "}`,
-			want: `{"sep":" "}`,
+			name:     "custom tool preserves empty string",
+			toolName: "Search",
+			in:       `{"query":""}`,
+			want:     `{"query":""}`,
 		},
 		{
-			name: "no-op when nothing to drop",
-			in:   `{"file_path":"/etc/hosts"}`,
-			want: `{"file_path":"/etc/hosts"}`,
+			name:     "read preserves empty object",
+			toolName: "Read",
+			in:       `{"options":{}}`,
+			want:     `{"options":{}}`,
 		},
 		{
-			name: "invalid JSON returned as-is",
-			in:   `{"file_path":`,
-			want: `{"file_path":`,
+			name:     "read preserves empty array",
+			toolName: "Read",
+			in:       `{"items":[]}`,
+			want:     `{"items":[]}`,
 		},
 		{
-			name: "empty input returned as-is",
-			in:   ``,
-			want: ``,
+			name:     "read preserves whitespace strings",
+			toolName: "Read",
+			in:       `{"sep":" "}`,
+			want:     `{"sep":" "}`,
+		},
+		{
+			name:     "read no-op when pages absent",
+			toolName: "Read",
+			in:       `{"file_path":"/etc/hosts"}`,
+			want:     `{"file_path":"/etc/hosts"}`,
+		},
+		{
+			name:     "invalid JSON returned as-is",
+			toolName: "Read",
+			in:       `{"file_path":`,
+			want:     `{"file_path":`,
+		},
+		{
+			name:     "empty input returned as-is",
+			toolName: "Read",
+			in:       ``,
+			want:     ``,
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := sanitizeToolInputJSON(tc.in)
+			got := sanitizeToolInputJSON(tc.toolName, tc.in)
 			// Compare as JSON to ignore key ordering.
 			if !jsonEqual(t, got, tc.want) {
-				t.Fatalf("sanitizeToolInputJSON(%q) = %q, want equivalent to %q",
-					tc.in, got, tc.want)
+				t.Fatalf("sanitizeToolInputJSON(%q, %q) = %q, want equivalent to %q",
+					tc.toolName, tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTranslateAnthropicToCodexPreservesToolInputByToolName(t *testing.T) {
+	raw := []byte(`{
+		"model":"claude-sonnet-4-5",
+		"messages":[{
+			"role":"assistant",
+			"content":[{
+				"type":"tool_use",
+				"id":"toolu_abc",
+				"name":"Write",
+				"input":{"file_path":"/tmp/empty.txt","content":""}
+			}]
+		}]
+	}`)
+
+	body, _, err := TranslateAnthropicToCodexWithModels(raw, "", []string{"gpt-5.4"})
+	if err != nil {
+		t.Fatalf("TranslateAnthropicToCodexWithModels returned error: %v", err)
+	}
+
+	args := gjson.GetBytes(body, `input.#(type=="function_call").arguments`).String()
+	want := `{"file_path":"/tmp/empty.txt","content":""}`
+	if !jsonEqual(t, args, want) {
+		t.Fatalf("function_call arguments = %q, want equivalent to %q; body=%s", args, want, body)
+	}
+}
+
+func TestBuildAnthropicResponseFromCompletedPreservesToolInputByToolName(t *testing.T) {
+	tests := []struct {
+		name      string
+		toolName  string
+		arguments string
+		wantInput string
+	}{
+		{
+			name:      "read drops empty pages",
+			toolName:  "Read",
+			arguments: `{"file_path":"/etc/hosts","pages":""}`,
+			wantInput: `{"file_path":"/etc/hosts"}`,
+		},
+		{
+			name:      "write preserves empty content",
+			toolName:  "Write",
+			arguments: `{"file_path":"/tmp/empty.txt","content":""}`,
+			wantInput: `{"file_path":"/tmp/empty.txt","content":""}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			completed := []byte(`{
+				"type":"response.completed",
+				"response":{
+					"status":"completed",
+					"output":[{
+						"type":"function_call",
+						"call_id":"call_abc",
+						"name":` + mustJSONString(tc.toolName) + `,
+						"arguments":` + mustJSONString(tc.arguments) + `
+					}]
+				}
+			}`)
+
+			resp := buildAnthropicResponseFromCompleted(completed, "claude-sonnet-4-5")
+			if len(resp.Content) != 1 {
+				t.Fatalf("len(content) = %d, want 1: %+v", len(resp.Content), resp.Content)
+			}
+			if got := resp.Content[0].Name; got != tc.toolName {
+				t.Fatalf("tool name = %q, want %q", got, tc.toolName)
+			}
+			if !jsonEqual(t, string(resp.Content[0].Input), tc.wantInput) {
+				t.Fatalf("tool input = %q, want equivalent to %q", string(resp.Content[0].Input), tc.wantInput)
 			}
 		})
 	}
@@ -290,63 +394,88 @@ func jsonEqual(t *testing.T, a, b string) bool {
 // "pages":"" 拆成多片 SSE 推送：translator 应缓冲到 tool_use 块关闭时再
 // 整段清洗，并以单次 input_json_delta 发出，下游收到的 JSON 不含空 pages。
 func TestAnthropicStreamTranslator_ToolInputBufferedAndCleaned(t *testing.T) {
-	tr := newAnthropicStreamTranslator("claude-sonnet-4-5")
-
-	// response.created
-	tr.translateEvent([]byte(`{"type":"response.created"}`))
-	// output_item.added — 启动 tool_use 块
-	tr.translateEvent([]byte(`{
-		"type":"response.output_item.added",
-		"output_index":0,
-		"item":{"type":"function_call","call_id":"call_abc","name":"Read"}
-	}`))
-
-	// 三片 function_call_arguments.delta，分别是开头/中段/结尾
-	deltas := []string{
-		`{"file_path":"/etc/hosts"`,
-		`,"pages":""`,
-		`}`,
-	}
-	var streamed []anthropicStreamEvent
-	for _, d := range deltas {
-		evt := []byte(`{"type":"response.function_call_arguments.delta","delta":` +
-			mustJSONString(d) + `}`)
-		streamed = append(streamed, tr.translateEvent(evt)...)
-	}
-
-	// delta 阶段不应该泄漏任何 input_json_delta
-	for _, evt := range streamed {
-		if evt.Type == "content_block_delta" {
-			t.Fatalf("expected no content_block_delta during streaming, got %+v", evt)
-		}
+	tests := []struct {
+		name      string
+		toolName  string
+		deltas    []string
+		wantInput string
+	}{
+		{
+			name:     "read drops empty pages",
+			toolName: "Read",
+			deltas: []string{
+				`{"file_path":"/etc/hosts"`,
+				`,"pages":""`,
+				`}`,
+			},
+			wantInput: `{"file_path":"/etc/hosts"}`,
+		},
+		{
+			name:     "write preserves empty content",
+			toolName: "Write",
+			deltas: []string{
+				`{"file_path":"/tmp/empty.txt"`,
+				`,"content":""`,
+				`}`,
+			},
+			wantInput: `{"file_path":"/tmp/empty.txt","content":""}`,
+		},
 	}
 
-	// output_item.done 触发 closeCurrentBlock，整段清洗
-	closing := tr.translateEvent([]byte(`{"type":"response.output_item.done"}`))
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tr := newAnthropicStreamTranslator("claude-sonnet-4-5")
 
-	var sawDelta bool
-	var sawStop bool
-	for _, evt := range closing {
-		if evt.Type == "content_block_delta" {
-			sawDelta = true
-			if evt.Delta == nil || evt.Delta.Type != "input_json_delta" {
-				t.Fatalf("expected input_json_delta, got %+v", evt.Delta)
+			// response.created
+			tr.translateEvent([]byte(`{"type":"response.created"}`))
+			// output_item.added — 启动 tool_use 块
+			tr.translateEvent([]byte(`{
+				"type":"response.output_item.added",
+				"output_index":0,
+				"item":{"type":"function_call","call_id":"call_abc","name":` + mustJSONString(tc.toolName) + `}
+			}`))
+
+			var streamed []anthropicStreamEvent
+			for _, d := range tc.deltas {
+				evt := []byte(`{"type":"response.function_call_arguments.delta","delta":` +
+					mustJSONString(d) + `}`)
+				streamed = append(streamed, tr.translateEvent(evt)...)
 			}
-			want := `{"file_path":"/etc/hosts"}`
-			if !jsonEqual(t, evt.Delta.PartialJSON, want) {
-				t.Fatalf("cleaned tool input = %q, want equivalent to %q",
-					evt.Delta.PartialJSON, want)
+
+			// delta 阶段不应该泄漏任何 input_json_delta
+			for _, evt := range streamed {
+				if evt.Type == "content_block_delta" {
+					t.Fatalf("expected no content_block_delta during streaming, got %+v", evt)
+				}
 			}
-		}
-		if evt.Type == "content_block_stop" {
-			sawStop = true
-		}
-	}
-	if !sawDelta {
-		t.Fatalf("expected one content_block_delta with cleaned input on close")
-	}
-	if !sawStop {
-		t.Fatalf("expected content_block_stop on close")
+
+			// output_item.done 触发 closeCurrentBlock，整段清洗
+			closing := tr.translateEvent([]byte(`{"type":"response.output_item.done"}`))
+
+			var sawDelta bool
+			var sawStop bool
+			for _, evt := range closing {
+				if evt.Type == "content_block_delta" {
+					sawDelta = true
+					if evt.Delta == nil || evt.Delta.Type != "input_json_delta" {
+						t.Fatalf("expected input_json_delta, got %+v", evt.Delta)
+					}
+					if !jsonEqual(t, evt.Delta.PartialJSON, tc.wantInput) {
+						t.Fatalf("cleaned tool input = %q, want equivalent to %q",
+							evt.Delta.PartialJSON, tc.wantInput)
+					}
+				}
+				if evt.Type == "content_block_stop" {
+					sawStop = true
+				}
+			}
+			if !sawDelta {
+				t.Fatalf("expected one content_block_delta with cleaned input on close")
+			}
+			if !sawStop {
+				t.Fatalf("expected content_block_stop on close")
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## 背景

在 Claude Code / Claude CLI 通过 codex2api 请求 gpt-5.5 后端推理时，上游模型有时会在 `Read` 工具调用参数中生成非法的空 `pages` 字段，例如：

```json
{
  "file_path": "/path/to/file",
  "limit": 2000,
  "offset": 0,
  "pages": ""
}
```

其中 `pages:""` 对 Claude Code 的 `Read` 工具不是合法参数，会导致文件读取失败。为规避这个兼容问题，之前代理层在工具参数转换时做了泛化清洗：删除所有顶层值为空字符串 `""` 或 `null` 的字段。

这个旧策略虽然能删除 `Read.pages:""`，但清洗范围过宽，会误删其他工具中具有合法语义的参数，典型场景包括：

- `Write.content:""`：用于写入空文件或清空文件内容，是合法且必要的参数。
- `Edit.new_string:""`：用于将目标文本替换为空字符串，也是合法语义。
- 自定义工具 / MCP 工具中的空字符串或 `null` 参数：代理层无法判断其业务语义，不应统一删除。

因此，本 PR 将 sanitizer 从“泛化删除空值”收窄为“只处理 Claude Code `Read.pages:""` 这一类已知兼容问题”，避免代理层破坏其他工具参数语义。

## 修改前

旧实现只接收原始 JSON 参数，不知道当前工具名称：

```go
func sanitizeToolInputJSON(raw string) string {
    raw = strings.TrimSpace(raw)
    if raw == "" {
        return raw
    }
    var obj map[string]json.RawMessage
    if err := json.Unmarshal([]byte(raw), &obj); err != nil {
        return raw
    }
    changed := false
    for k, v := range obj {
        s := strings.TrimSpace(string(v))
        if s == `""` || s == "null" {
            delete(obj, k)
            changed = true
        }
    }
    if !changed {
        return raw
    }
    out, err := json.Marshal(obj)
    if err != nil {
        return raw
    }
    return string(out)
}
```

旧行为示例：

```json
{"file_path":"/tmp/empty.txt","content":""}
```

会被错误清洗为：

```json
{"file_path":"/tmp/empty.txt"}
```

这会导致 `Write` 工具缺少必需的 `content` 参数。

类似地：

```json
{"file_path":"/tmp/a.txt","old_string":"abc","new_string":""}
```

可能被错误清洗为：

```json
{"file_path":"/tmp/a.txt","old_string":"abc"}
```

从而破坏 `Edit` 将内容替换为空字符串的合法语义。

## 修改后

新实现增加工具名参数，仅当工具名为 `Read` 且顶层字段 `pages` 的 JSON 值为 `""` 时删除该字段：

```go
func sanitizeToolInputJSON(toolName string, raw string) string {
    raw = strings.TrimSpace(raw)
    if toolName != "Read" || raw == "" {
        return raw
    }
    var obj map[string]json.RawMessage
    if err := json.Unmarshal([]byte(raw), &obj); err != nil {
        return raw
    }
    pages, ok := obj["pages"]
    if !ok || strings.TrimSpace(string(pages)) != `""` {
        return raw
    }
    delete(obj, "pages")
    out, err := json.Marshal(obj)
    if err != nil {
        return raw
    }
    return string(out)
}
```

现在只有以下类型输入会被清洗：

```json
{"file_path":"/tmp/demo.py","limit":2000,"offset":0,"pages":""}
```

清洗后：

```json
{"file_path":"/tmp/demo.py","limit":2000,"offset":0}
```

以下合法参数会被完整保留：

```json
{"file_path":"/tmp/empty.txt","content":""}
```

```json
{"file_path":"/tmp/a.txt","old_string":"abc","new_string":""}
```

```json
{"query":""}
```

```json
{"file_path":"/etc/hosts","limit":null}
```

## 修改范围

本 PR 更新了三条工具参数转换路径，确保 sanitizer 都能拿到工具名并按工具类型处理：

1. 历史 assistant `tool_use` 转 Codex `function_call.arguments`
2. streaming tool input 缓冲完成后的清洗路径
3. completed response 转 Anthropic `tool_use.input`

同时新增/更新回归测试，覆盖：

- `Read.pages:""` 删除
- `Read` 其他字段保留，包括 `limit:null`
- `Write.content:""` 保留
- `Edit.new_string:""` 保留
- 非 `Read` 工具空字符串保留
- invalid JSON / empty input 原样返回
- streaming 场景下仍然先缓冲完整参数，在 tool_use 块关闭时统一清洗，再发送单次 `input_json_delta`

## 前后对比分析

### 兼容性

- 修改前：代理层不知道工具名，无法区分 `Read.pages:""` 这种非法参数和其他工具的合法空值参数。
- 修改后：代理层只对明确已知的 Claude Code `Read.pages:""` 兼容问题做特殊处理，其他工具参数保持原样。

### 风险控制

- 修改前：所有工具都可能受泛化 sanitizer 影响，包括未来新增工具和 MCP 自定义工具。
- 修改后：影响范围限定为 `Read` 工具的顶层 `pages:""` 字段，副作用更小。

### 功能语义

- 修改前：`Write.content:""` 和 `Edit.new_string:""` 这类合法空字符串语义可能被破坏。
- 修改后：这些合法参数会被保留，空文件写入、清空内容、替换为空字符串等操作不会再被代理层误删参数。

### Streaming 行为

- 修改前：streaming 路径会缓冲参数后清洗，但使用的是泛化删除逻辑。
- 修改后：streaming 路径仍保持“缓冲完整 JSON 后统一清洗”的安全策略，但清洗规则收窄为只删除 `Read.pages:""`。

## 测试情况

已执行并通过：

```powershell
go test ./proxy -run "TestSanitizeToolInputJSON|TestTranslateAnthropicToCodexPreservesToolInputByToolName|TestAnthropicStreamTranslator_ToolInputBufferedAndCleaned|TestBuildAnthropicResponseFromCompletedPreservesToolInputByToolName" -count=1 -v
```

```text
ok   github.com/codex2api/proxy   0.596s
```

```powershell
go test ./proxy -count=1
```

```text
ok   github.com/codex2api/proxy   4.455s
```

```powershell
go test ./proxy -cover -count=1
```

```text
ok   github.com/codex2api/proxy   6.686s   coverage: 58.0% of statements
```

```powershell
go vet ./proxy
```

通过，无输出。

```powershell
gofmt -l proxy/anthropic.go proxy/anthropic_test.go
```

通过，无输出。

```powershell
git diff --check -- proxy/anthropic.go proxy/anthropic_test.go
```

通过，无 whitespace error。

```powershell
npm --prefix frontend ci
npm --prefix frontend run build
npm --prefix frontend run typecheck
go test ./... -count=1
```

最终全仓库 Go 测试通过：

```text
ok   github.com/codex2api              1.947s
ok   github.com/codex2api/admin        2.515s
ok   github.com/codex2api/api          0.701s
ok   github.com/codex2api/auth         5.105s
ok   github.com/codex2api/cache        0.981s
ok   github.com/codex2api/config       0.381s
ok   github.com/codex2api/database     2.309s
ok   github.com/codex2api/internal/imageproc      0.607s
ok   github.com/codex2api/internal/imagestore     0.691s
ok   github.com/codex2api/internal/signedasset    0.616s
ok   github.com/codex2api/proxy        4.854s
ok   github.com/codex2api/proxy/wsrelay           0.694s
ok   github.com/codex2api/security     0.704s
ok   github.com/codex2api/security/promptfilter   0.711s
```

补充说明：

```powershell
go test ./proxy -race -count=1
```

当前 Windows 环境无法运行，原因是 Go race detector 需要 cgo，设置 `CGO_ENABLED=1` 后本机缺少 GCC：

```text
cgo: C compiler "gcc" not found: exec: "gcc": executable file not found in %PATH%
```

这是本地环境限制，不是本次代码改动导致。

## 修改总结

本 PR 修复了 Claude Code 工具参数清洗过宽的问题：

- 删除 `Read.pages:""`，避免 Claude Code `Read` 工具收到非法空 `pages` 参数。
- 保留 `Write.content:""`，避免空文件写入或清空文件内容失败。
- 保留 `Edit.new_string:""`，避免替换为空字符串的合法语义被破坏。
- 保留其他工具 / MCP 自定义工具中的空字符串和 `null` 参数，降低代理层误判工具参数语义的风险。
- 保持 streaming 路径的完整参数缓冲策略，避免半截 JSON 或未清洗参数提前下发。

整体变更范围集中在工具参数兼容清洗逻辑和对应回归测试，风险较低，测试已覆盖主要回归场景。