### PR TITLE
fix: 修复请求转发错误处理与成功统计

### DIFF
--- a/proxy/anthropic_test.go
+++ b/proxy/anthropic_test.go
@@ -2,10 +2,45 @@ package proxy
 
 import (
 	"encoding/json"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
+	"github.com/gin-gonic/gin"
 	"github.com/tidwall/gjson"
 )
+
+func TestSendAnthropicStreamErrorEscapesJSON(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+
+	sendAnthropicStreamError(c, "api_error", "bad \"quote\"\\slash\nand control \x01")
+
+	body := recorder.Body.String()
+	if !strings.HasPrefix(body, "event: error\ndata: ") || !strings.HasSuffix(body, "\n\n") {
+		t.Fatalf("unexpected SSE frame: %q", body)
+	}
+	data := strings.TrimSuffix(strings.TrimPrefix(body, "event: error\ndata: "), "\n\n")
+
+	var payload struct {
+		Type  string `json:"type"`
+		Error struct {
+			Type    string `json:"type"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal([]byte(data), &payload); err != nil {
+		t.Fatalf("stream error data is not valid JSON: %v; data=%q", err, data)
+	}
+	if payload.Type != "error" || payload.Error.Type != "api_error" {
+		t.Fatalf("unexpected payload metadata: %+v", payload)
+	}
+	wantMessage := "bad \"quote\"\\slash\nand control \x01"
+	if payload.Error.Message != wantMessage {
+		t.Fatalf("message = %q, want %q", payload.Error.Message, wantMessage)
+	}
+}
 
 func TestTranslateAnthropicToCodex_OutputConfigEffortTakesPrecedence(t *testing.T) {
 	raw := []byte(`{

--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -1510,14 +1510,22 @@ func (h *Handler) Responses(c *gin.Context) {
 			if isStream {
 				ttftGuard = newFirstTokenTimeoutGuard(currentFirstTokenTimeout(), upstreamCancel)
 			}
+			stopTTFTGuard := func() {
+				if ttftGuard != nil {
+					ttftGuard.Stop()
+				}
+			}
+			ttftTimedOut := func() bool {
+				return ttftGuard != nil && ttftGuard.TimedOut()
+			}
 			baseURL, _ := account.OpenAIResponsesCredentials()
 			upstreamEndpoint := auth.OpenAIResponsesEndpoint(baseURL, "/v1/responses")
 			resp, reqErr := ExecuteOpenAIResponsesRequest(upstreamCtx, account, openAIResponsesBody, proxyURL, downstreamHeaders)
 			durationMs := int(time.Since(start).Milliseconds())
 
 			if reqErr != nil {
-				timedOut := ttftGuard.TimedOut()
-				ttftGuard.Stop()
+				timedOut := ttftTimedOut()
+				stopTTFTGuard()
 				if timedOut {
 					reqErr = firstTokenTimeoutError(currentFirstTokenTimeout())
 				}
@@ -1554,11 +1562,11 @@ func (h *Handler) Responses(c *gin.Context) {
 				return
 			}
 			if !isStream {
-				ttftGuard.Stop()
+				stopTTFTGuard()
 			}
 
 			if resp.StatusCode != http.StatusOK {
-				ttftGuard.Stop()
+				stopTTFTGuard()
 				errBody, _ := io.ReadAll(resp.Body)
 				resp.Body.Close()
 
@@ -2359,7 +2367,7 @@ func (h *Handler) ResponsesCompact(c *gin.Context) {
 		if account == nil {
 			account, stickyProxyURL = h.store.WaitForSessionAvailableWithFilter(c.Request.Context(), affinityKey, 30*time.Second, apiKeyID, excludeAccounts, accountFilter)
 			if account == nil {
-				if lastStatusCode == http.StatusTooManyRequests && len(lastBody) > 0 {
+				if (lastStatusCode == http.StatusTooManyRequests || lastStatusCode == http.StatusBadGateway) && len(lastBody) > 0 {
 					h.sendFinalUpstreamError(c, lastStatusCode, lastBody)
 					return
 				}
@@ -2472,11 +2480,52 @@ func (h *Handler) ResponsesCompact(c *gin.Context) {
 				return
 			}
 
+			respBody, readErr := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			if readErr != nil {
+				totalDuration := int(time.Since(start).Milliseconds())
+				kind := classifyTransportFailure(readErr)
+				if kind == "" {
+					kind = "transport"
+				}
+				h.store.ReportRequestFailure(account, kind, time.Duration(totalDuration)*time.Millisecond)
+				h.store.Release(account)
+				h.store.UnbindSessionAffinity(affinityKey, account.ID())
+				excludeAccounts[account.ID()] = true
+
+				shouldRetry := shouldRetryRequestError(readErr, &generalRetries, maxRetries)
+				usageTiers := resolveUsageServiceTiers("", serviceTier)
+				h.logUsageForRequest(c, &database.UsageLogInput{
+					AccountID:            account.ID(),
+					Endpoint:             "/v1/responses/compact",
+					Model:                logModel,
+					EffectiveModel:       logEffectiveModel,
+					StatusCode:           http.StatusBadGateway,
+					DurationMs:           totalDuration,
+					ReasoningEffort:      reasoningEffort,
+					InboundEndpoint:      "/v1/responses/compact",
+					UpstreamEndpoint:     upstreamEndpoint,
+					ServiceTier:          usageTiers.ServiceTier,
+					RequestedServiceTier: usageTiers.RequestedServiceTier,
+					ActualServiceTier:    usageTiers.ActualServiceTier,
+					BillingServiceTier:   usageTiers.BillingServiceTier,
+					IsRetryAttempt:       shouldRetry,
+					AttemptIndex:         attempt + 1,
+					UpstreamErrorKind:    kind,
+					ErrorMessage:         fmt.Sprintf("上游响应读取失败: %v", readErr),
+				})
+				log.Printf("OpenAI Responses compact 上游响应读取失败 (attempt %d): %v", attempt+1, readErr)
+				if shouldRetry {
+					lastStatusCode = http.StatusBadGateway
+					lastBody = []byte(fmt.Sprintf("Failed to read upstream response: %v", readErr))
+					continue
+				}
+				api.SendErrorWithStatus(c, api.NewAPIError(api.ErrCodeUpstreamError, "Failed to read upstream response", api.ErrorTypeUpstream), http.StatusBadGateway)
+				return
+			}
+
 			h.store.ClearModelCooldown(account, effectiveModel)
 			h.store.ReportRequestSuccess(account, time.Duration(durationMs)*time.Millisecond)
-
-			respBody, _ := io.ReadAll(resp.Body)
-			resp.Body.Close()
 
 			promptTokens := int(gjson.GetBytes(respBody, "usage.input_tokens").Int())
 			completionTokens := int(gjson.GetBytes(respBody, "usage.output_tokens").Int())
@@ -2617,11 +2666,53 @@ func (h *Handler) ResponsesCompact(c *gin.Context) {
 		}
 
 		// 成功：直接透传响应体
+		respBody, readErr := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if readErr != nil {
+			totalDuration := int(time.Since(start).Milliseconds())
+			kind := classifyTransportFailure(readErr)
+			if kind == "" {
+				kind = "transport"
+			}
+			h.store.ReportRequestFailure(account, kind, time.Duration(totalDuration)*time.Millisecond)
+			SyncCodexUsageState(h.store, account, resp)
+			h.store.Release(account)
+			h.store.UnbindSessionAffinity(affinityKey, account.ID())
+			excludeAccounts[account.ID()] = true
+
+			shouldRetry := shouldRetryRequestError(readErr, &generalRetries, maxRetries)
+			usageTiers := resolveUsageServiceTiers("", serviceTier)
+			h.logUsageForRequest(c, &database.UsageLogInput{
+				AccountID:            account.ID(),
+				Endpoint:             "/v1/responses/compact",
+				Model:                logModel,
+				EffectiveModel:       logEffectiveModel,
+				StatusCode:           http.StatusBadGateway,
+				DurationMs:           totalDuration,
+				ReasoningEffort:      reasoningEffort,
+				InboundEndpoint:      "/v1/responses/compact",
+				UpstreamEndpoint:     "/v1/responses/compact",
+				ServiceTier:          usageTiers.ServiceTier,
+				RequestedServiceTier: usageTiers.RequestedServiceTier,
+				ActualServiceTier:    usageTiers.ActualServiceTier,
+				BillingServiceTier:   usageTiers.BillingServiceTier,
+				IsRetryAttempt:       shouldRetry,
+				AttemptIndex:         attempt + 1,
+				UpstreamErrorKind:    kind,
+				ErrorMessage:         fmt.Sprintf("上游响应读取失败: %v", readErr),
+			})
+			log.Printf("compact 上游响应读取失败 (attempt %d): %v", attempt+1, readErr)
+			if shouldRetry {
+				lastStatusCode = http.StatusBadGateway
+				lastBody = []byte(fmt.Sprintf("Failed to read upstream response: %v", readErr))
+				continue
+			}
+			api.SendErrorWithStatus(c, api.NewAPIError(api.ErrCodeUpstreamError, "Failed to read upstream response", api.ErrorTypeUpstream), http.StatusBadGateway)
+			return
+		}
+
 		SyncCodexUsageState(h.store, account, resp)
 		h.store.ClearModelCooldown(account, effectiveModel)
-
-		respBody, _ := io.ReadAll(resp.Body)
-		resp.Body.Close()
 
 		// 提取 usage 用于日志
 		promptTokens := int(gjson.GetBytes(respBody, "usage.input_tokens").Int())
@@ -2657,6 +2748,7 @@ func (h *Handler) ResponsesCompact(c *gin.Context) {
 			BillingServiceTier:   usageTiers.BillingServiceTier,
 		})
 
+		h.store.ReportRequestSuccess(account, time.Duration(totalDuration)*time.Millisecond)
 		h.store.Release(account)
 		c.Data(http.StatusOK, "application/json", respBody)
 		return

--- a/proxy/handler_anthropic.go
+++ b/proxy/handler_anthropic.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log"
@@ -32,7 +33,17 @@ func sendAnthropicError(c *gin.Context, statusCode int, errType, message string)
 
 // sendAnthropicStreamError 在流式模式中发送错误事件
 func sendAnthropicStreamError(c *gin.Context, errType, message string) {
-	fmt.Fprintf(c.Writer, "event: error\ndata: {\"type\":\"error\",\"error\":{\"type\":\"%s\",\"message\":\"%s\"}}\n\n", errType, message)
+	payload, err := json.Marshal(gin.H{
+		"type": "error",
+		"error": gin.H{
+			"type":    errType,
+			"message": message,
+		},
+	})
+	if err != nil {
+		payload = []byte(`{"type":"error","error":{"type":"api_error","message":"failed to encode stream error"}}`)
+	}
+	fmt.Fprintf(c.Writer, "event: error\ndata: %s\n\n", payload)
 	if flusher, ok := c.Writer.(http.Flusher); ok {
 		flusher.Flush()
 	}

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -900,6 +900,109 @@ func TestResponsesCompactUsesOpenAIResponsesAPIAccount(t *testing.T) {
 	}
 }
 
+func TestResponsesCompactOpenAIReadErrorRetryReturnsBadGateway(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Length", "128")
+		_, _ = w.Write([]byte(`{"id":"truncated"}`))
+	}))
+	defer upstream.Close()
+
+	store := auth.NewStore(nil, nil, &database.SystemSettings{
+		MaxConcurrency:      1,
+		MaxRetries:          1,
+		MaxRateLimitRetries: 0,
+	})
+	store.AddAccount(&auth.Account{
+		DBID:         1,
+		UpstreamType: auth.UpstreamOpenAIResponses,
+		BaseURL:      upstream.URL,
+		APIKey:       "sk-direct",
+		Models:       []string{"gpt-4.1-direct"},
+		PlanType:     "api",
+		Status:       auth.StatusReady,
+	})
+	handler := NewHandler(store, nil, nil, nil)
+
+	body := []byte(`{"model":"gpt-4.1-direct","input":"hello"}`)
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses/compact", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Request = req
+
+	handler.ResponsesCompact(ctx)
+
+	if recorder.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want %d; body=%s", recorder.Code, http.StatusBadGateway, recorder.Body.String())
+	}
+	if got := gjson.GetBytes(recorder.Body.Bytes(), "error.code").String(); got != "upstream_502" {
+		t.Fatalf("error.code = %q, want upstream_502; body=%s", got, recorder.Body.String())
+	}
+	if got := gjson.GetBytes(recorder.Body.Bytes(), "error.message").String(); !strings.Contains(got, "Failed to read upstream response") {
+		t.Fatalf("error.message = %q, want read failure; body=%s", got, recorder.Body.String())
+	}
+}
+
+func TestResponsesCompactCodexReadErrorRetryReturnsBadGatewayAndSyncsUsage(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	previousResin := resinCfg.Load()
+	t.Cleanup(func() {
+		resinCfg.Store(previousResin)
+	})
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/backend-api/codex/responses/compact") {
+			t.Fatalf("upstream path = %q, want Resin path ending /backend-api/codex/responses/compact", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Length", "128")
+		w.Header().Set("x-codex-primary-used-percent", "100")
+		w.Header().Set("x-codex-primary-window-minutes", "300")
+		w.Header().Set("x-codex-primary-reset-after-seconds", "900")
+		_, _ = w.Write([]byte(`{"id":"truncated"}`))
+	}))
+	defer upstream.Close()
+	SetResinConfig(&ResinConfig{BaseURL: upstream.URL, PlatformName: "test"})
+
+	store := auth.NewStore(nil, nil, &database.SystemSettings{
+		MaxConcurrency:      1,
+		MaxRetries:          1,
+		MaxRateLimitRetries: 0,
+	})
+	account := &auth.Account{
+		DBID:        1,
+		AccessToken: "at-1",
+		Models:      []string{"gpt-5.4"},
+		PlanType:    "team",
+		Status:      auth.StatusReady,
+	}
+	store.AddAccount(account)
+	handler := NewHandler(store, nil, nil, nil)
+
+	body := []byte(`{"model":"gpt-5.4","input":"hello"}`)
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses/compact", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Request = req
+
+	handler.ResponsesCompact(ctx)
+
+	if recorder.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want %d; body=%s", recorder.Code, http.StatusBadGateway, recorder.Body.String())
+	}
+	if got := gjson.GetBytes(recorder.Body.Bytes(), "error.code").String(); got != "upstream_502" {
+		t.Fatalf("error.code = %q, want upstream_502; body=%s", got, recorder.Body.String())
+	}
+	if !account.IsPremium5hRateLimited() {
+		t.Fatal("account should sync Codex usage headers and enter premium 5h rate_limited state")
+	}
+}
+
 // newOpenAIResponsesSSEUpstream 模拟仅支持 OpenAI Responses API 的中转上游，
 // 返回一段最小可用的 Responses SSE 流（issue #181 回归用）。
 func newOpenAIResponsesSSEUpstream(seenPath *string, seenAuth *string, seenBody *[]byte) *httptest.Server {


### PR DESCRIPTION
## 背景

本次 PR 来自请求调度 / 请求转发路径的 CodeReview，聚焦低风险、高收益的稳定性与统计准确性修复。当前代理在 OpenAI Responses、compact、Codex compact、Anthropic stream error 等路径中存在若干边界问题：部分成功状态下的响应体读取失败会被误判为成功，重试耗尽后可能返回误导性的 no-available-account，Codex compact 成功统计缺失，Anthropic 流式错误事件手写 JSON 存在转义风险。

这些问题主要影响：

- 上游返回 HTTP 200 headers 但 body 读取失败时的错误语义；
- compact 请求重试后的最终错误透传；
- Codex usage header 同步准确性；
- 账号健康统计中的成功 / 失败记录；
- Anthropic-compatible SSE 错误事件的 JSON 合法性。

## 修改前

1. OpenAI Responses 非流式路径中，`ttftGuard` 只在流式模式创建，调用点依赖 guard 方法自身的 nil-safe 行为，语义不够直观。

2. OpenAI Responses compact 成功状态下直接忽略 `io.ReadAll(resp.Body)` 错误：
   - HTTP 200 headers 已返回但 body 截断 / 读取失败时，可能继续按成功请求处理；
   - 账号统计可能被记为成功；
   - 如果进入 retry，后续账号耗尽时可能返回 `503 no available account`，掩盖真实的上游读取失败。

3. Codex compact 同样忽略成功状态下的 body 读取错误：
   - body 读取失败可能被误判为成功；
   - retry 后账号耗尽时可能返回误导性的 503；
   - 即使 HTTP 200 response headers 已携带 Codex usage 信息，读取失败分支也可能跳过 usage header 同步。

4. Codex compact 成功路径只释放账号，没有调用 `ReportRequestSuccess`，导致账号健康统计缺少成功样本。

5. Anthropic stream error 使用 `fmt.Fprintf` 手写 JSON：
   - 当错误消息包含双引号、反斜杠、换行或控制字符时，SSE `data:` 中的 JSON 可能不合法。

## 修改后

1. 为 OpenAI Responses `ttftGuard` 调用点增加显式 nil-safe wrapper：
   - `stopTTFTGuard()`；
   - `ttftTimedOut()`。

2. OpenAI Responses compact 成功状态下显式处理 `io.ReadAll` 错误：
   - 记录 `ReportRequestFailure`；
   - 记录 usage log；
   - 释放账号并解绑 session affinity；
   - 当前账号加入排除列表；
   - 可重试时保存最终 502 错误，避免账号耗尽时误返回 503。

3. Codex compact 成功状态下显式处理 `io.ReadAll` 错误：
   - body 读取失败按 `502 Bad Gateway` 处理；
   - 可重试时保存 `lastStatusCode = 502` 与错误 body；
   - 读取失败时仍调用 `SyncCodexUsageState`，确保已到达的 Codex usage headers 不丢失。

4. compact 无账号 fallback 支持回放最后一次 502：
   - 429 仍保留原有逻辑；
   - 新增 502 回放，避免上游读取失败被替换成 no-available-account。

5. Codex compact 成功路径补充：
   - `ReportRequestSuccess(account, duration)`。

6. Anthropic stream error 改用 `json.Marshal` 构造 SSE error payload：
   - 自动处理 JSON escaping；
   - 编码失败时使用固定兜底错误 payload。

7. 新增回归测试：
   - Anthropic stream error JSON escaping；
   - OpenAI Responses compact body read error retry 后返回 502；
   - Codex compact body read error retry 后返回 502，并同步 usage headers。

## 前后对比分析

- 兼容性：
  - 正常成功请求行为保持不变；
  - 正常上游错误状态码处理保持不变；
  - 仅改变之前未正确处理的响应体读取失败和统计遗漏路径。

- 风险控制：
  - 修改集中在错误处理、统计和测试，不改变主调度算法；
  - compact no-account fallback 只新增对最后一次 502 的回放，保留原有 429 逻辑；
  - Codex usage 同步使用既有 `SyncCodexUsageState`，没有引入新的 usage 解析规则。

- 行为变化：
  - HTTP 200 headers 但 body 读取失败时，现在返回 502，而不是误记成功或最终误返回 503；
  - Codex compact 成功请求会进入成功统计；
  - Anthropic stream error 中的特殊字符消息会被正确 JSON 转义。

- 影响范围：
  - OpenAI Responses `/v1/responses` 的 ttft guard 调用点；
  - OpenAI Responses compact `/v1/responses/compact`；
  - Codex compact `/v1/responses/compact`；
  - Anthropic-compatible stream error helper。

## 测试情况

已执行并通过：

```powershell
gofmt -w "proxy/handler.go" "proxy/handler_anthropic.go" "proxy/anthropic_test.go" "proxy/handler_test.go"
```

```powershell
git diff --check
```

结果：无 whitespace error；仅有 Windows 环境下 LF/CRLF 提示。

```powershell
go test ./api ./proxy -count=1
```

结果：

```text
ok  	github.com/codex2api/api	0.430s
ok  	github.com/codex2api/proxy	7.661s
```

补跑非 root 包完整测试：

```powershell
go test ./admin ./api ./auth ./cache ./config ./database ./internal/imageproc ./internal/imagestore ./internal/signedasset ./proxy ./proxy/wsrelay ./security ./security/promptfilter -count=1
```

结果：

```text
ok  	github.com/codex2api/admin	3.177s
ok  	github.com/codex2api/api	0.699s
ok  	github.com/codex2api/auth	4.060s
ok  	github.com/codex2api/cache	1.102s
ok  	github.com/codex2api/config	0.656s
ok  	github.com/codex2api/database	2.828s
ok  	github.com/codex2api/internal/imageproc	0.798s
ok  	github.com/codex2api/internal/imagestore	0.698s
ok  	github.com/codex2api/internal/signedasset	0.632s
ok  	github.com/codex2api/proxy	5.104s
ok  	github.com/codex2api/proxy/wsrelay	0.737s
ok  	github.com/codex2api/security	0.703s
ok  	github.com/codex2api/security/promptfilter	0.724s
```

受环境限制未完全通过：

```powershell
go test ./... -count=1
```

当前 worktree 缺少前端构建产物，根包失败：

```text
main.go:29:12: pattern frontend/dist/*: no matching files found
```

这不是本次 Go 代码修改导致；非 root Go 包已全部通过。

```powershell
go test -race ./proxy -count=1
```

Windows 当前环境缺少 race test 所需 cgo/gcc 工具链：

```text
go: -race requires cgo; enable cgo by setting CGO_ENABLED=1
cgo: C compiler "gcc" not found: exec: "gcc": executable file not found in %PATH%
```

## 修改总结

本次变更修复了请求转发路径中多个低风险但高收益的稳定性问题：

- 避免 compact body 读取失败被误判为成功；
- 避免 read-error retry 后账号耗尽时误返回 503；
- 保证 Codex usage headers 在读取失败场景下仍被同步；
- 补齐 Codex compact 成功统计；
- 保证 Anthropic stream error payload 始终是合法 JSON；
- 增加针对关键边界场景的回归测试。

整体修改范围集中、行为边界清晰，主要提升错误语义、账号健康统计准确性和流式错误响应稳定性。