### PR TITLE
fix: 修复 WebSocket relay 稳定性问题

### DIFF
--- a/proxy/wsrelay/error_passthrough_test.go
+++ b/proxy/wsrelay/error_passthrough_test.go
@@ -26,6 +26,59 @@ func TestBuildErrorEvent_UpstreamErrorBecomesFailedEvent(t *testing.T) {
 	}
 }
 
+// TestBuildErrorEvent_UpstreamStatusBecomesResponseStatusCode verifies an upstream
+// top-level status is copied to response.status_code even when the preserved
+// upstream error object does not contain status_code itself.
+func TestBuildErrorEvent_UpstreamStatusBecomesResponseStatusCode(t *testing.T) {
+	r := &WsResponse{}
+	upstream := []byte(`{"type":"error","status":429,"error":{"type":"rate_limit_error","message":"too many requests","param":"input"}}`)
+
+	event, isErr := r.buildErrorEvent(upstream)
+	if !isErr {
+		t.Fatal("expected error frame to be detected")
+	}
+	if statusCode := gjson.GetBytes(event, "response.status_code").Int(); statusCode != 429 {
+		t.Fatalf("response.status_code = %d, want 429; event=%s", statusCode, event)
+	}
+	if gjson.GetBytes(event, "response.error.status_code").Exists() {
+		t.Fatalf("response.error should preserve upstream error object without injecting status_code: %s", event)
+	}
+	if msg := gjson.GetBytes(event, "response.error.message").String(); msg != "too many requests" {
+		t.Fatalf("response.error.message = %q, want preserved upstream message", msg)
+	}
+	if typ := gjson.GetBytes(event, "response.error.type").String(); typ != "rate_limit_error" {
+		t.Fatalf("response.error.type = %q, want preserved upstream type", typ)
+	}
+	if param := gjson.GetBytes(event, "response.error.param").String(); param != "input" {
+		t.Fatalf("response.error.param = %q, want preserved upstream param", param)
+	}
+}
+
+// TestBuildErrorEvent_UpstreamStatusCodeBecomesResponseStatusCode verifies an
+// upstream top-level status_code is copied to response.status_code while the
+// original response.error payload remains unchanged.
+func TestBuildErrorEvent_UpstreamStatusCodeBecomesResponseStatusCode(t *testing.T) {
+	r := &WsResponse{}
+	upstream := []byte(`{"type":"error","status_code":503,"error":{"message":"service unavailable","code":"server_error"}}`)
+
+	event, isErr := r.buildErrorEvent(upstream)
+	if !isErr {
+		t.Fatal("expected error frame to be detected")
+	}
+	if statusCode := gjson.GetBytes(event, "response.status_code").Int(); statusCode != 503 {
+		t.Fatalf("response.status_code = %d, want 503; event=%s", statusCode, event)
+	}
+	if gjson.GetBytes(event, "response.error.status_code").Exists() {
+		t.Fatalf("response.error should preserve upstream error object without injecting status_code: %s", event)
+	}
+	if msg := gjson.GetBytes(event, "response.error.message").String(); msg != "service unavailable" {
+		t.Fatalf("response.error.message = %q, want preserved upstream message", msg)
+	}
+	if code := gjson.GetBytes(event, "response.error.code").String(); code != "server_error" {
+		t.Fatalf("response.error.code = %q, want preserved upstream code", code)
+	}
+}
+
 // TestBuildErrorEvent_NonErrorPassthrough 验证非错误帧不被识别为错误。
 func TestBuildErrorEvent_NonErrorPassthrough(t *testing.T) {
 	r := &WsResponse{}

--- a/proxy/wsrelay/executor.go
+++ b/proxy/wsrelay/executor.go
@@ -121,6 +121,7 @@ func (e *Executor) ExecuteRequestViaWebsocket(
 	// 获取或创建连接。无显式会话的请求（stateless 连接 ID）在确定性 cache key
 	// 的槽位池内复用连接，避免持续高 RPM 下逐请求握手触发上游限流。
 	poolSessionID := sessionID
+	effectiveProxy := effectiveProxyURL(account, proxyOverride)
 	var wc *WsConnection
 	var pr *PendingRequest
 	var err2 error
@@ -137,7 +138,7 @@ func (e *Executor) ExecuteRequestViaWebsocket(
 	sendErr := e.sendRequest(wc, wsBody, pr.RequestID)
 	for retries := 0; sendErr != nil && retries < 2; retries++ {
 		wc.session.RemovePendingRequest(pr.RequestID)
-		e.manager.RemoveConnection(account.ID(), wsURL, poolSessionID, proxyOverride)
+		e.manager.RemoveConnection(account.ID(), wsURL, poolSessionID, effectiveProxy)
 
 		// 短暂退避，避免瞬间重连风暴
 		select {
@@ -154,7 +155,7 @@ func (e *Executor) ExecuteRequestViaWebsocket(
 	}
 	if sendErr != nil {
 		wc.session.RemovePendingRequest(pr.RequestID)
-		e.manager.ReleaseConnection(wc)
+		e.manager.RemoveConnection(account.ID(), wsURL, poolSessionID, effectiveProxy)
 		return nil, fmt.Errorf("发送 WebSocket 请求失败: %w", sendErr)
 	}
 
@@ -393,6 +394,9 @@ func (r *WsResponse) buildErrorEvent(payload []byte) ([]byte, bool) {
 		errObj = fmt.Sprintf(`{"message":%q,"code":%d}`, errMsg, status)
 	}
 	event := fmt.Sprintf(`{"type":"response.failed","response":{"status":"failed","error":%s}}`, errObj)
+	if status > 0 {
+		event = fmt.Sprintf(`{"type":"response.failed","response":{"status":"failed","status_code":%d,"error":%s}}`, status, errObj)
+	}
 	return []byte(event), true
 }
 

--- a/proxy/wsrelay/executor_test.go
+++ b/proxy/wsrelay/executor_test.go
@@ -1,14 +1,21 @@
 package wsrelay
 
 import (
+	"bufio"
 	"context"
+	"crypto/sha1"
+	"encoding/base64"
+	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/codex2api/auth"
 	"github.com/codex2api/proxy"
 	"github.com/gorilla/websocket"
 	"github.com/tidwall/gjson"
@@ -223,6 +230,81 @@ func TestWebsocketResponseToHTTPClosesBodyOnContextCancel(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("Body.Read stayed blocked after context cancellation")
+	}
+}
+
+func newClosedTestWebsocketConn(t *testing.T) *websocket.Conn {
+	t.Helper()
+	clientConn, serverConn := net.Pipe()
+	handshakeDone := make(chan struct{})
+	go func() {
+		defer close(handshakeDone)
+		defer serverConn.Close()
+		req, err := http.ReadRequest(bufio.NewReader(serverConn))
+		if err != nil {
+			return
+		}
+		acceptHash := sha1.Sum([]byte(req.Header.Get("Sec-Websocket-Key") + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"))
+		_, _ = fmt.Fprintf(serverConn, "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: %s\r\n\r\n", base64.StdEncoding.EncodeToString(acceptHash[:]))
+	}()
+
+	wsURL, err := url.Parse("ws://example.test/responses")
+	if err != nil {
+		t.Fatalf("parse websocket URL: %v", err)
+	}
+	conn, _, err := websocket.NewClient(clientConn, wsURL, nil, 1024, 1024)
+	if err != nil {
+		t.Fatalf("create test websocket client: %v", err)
+	}
+	<-handshakeDone
+	return conn
+}
+
+func TestExecuteRequestViaWebsocketSendFailureRemovesEffectiveProxyConnection(t *testing.T) {
+	manager := NewManager()
+	t.Cleanup(manager.Stop)
+
+	account := &auth.Account{
+		DBID:        42,
+		AccessToken: "token-123",
+		ProxyURL:    "http://account-proxy.test:8080",
+	}
+	sessionID := "session-1"
+	wsURL, err := buildWebsocketURL(proxy.CodexBaseURL + CodexWsEndpoint)
+	if err != nil {
+		t.Fatalf("buildWebsocketURL: %v", err)
+	}
+	effectiveProxy := effectiveProxyURL(account, "")
+	key := manager.poolKey(account.ID(), wsURL, sessionID, effectiveProxy)
+	session := NewSession(account.ID(), manager)
+	session.SetConnected(true)
+	conn := &WsConnection{
+		conn:    newClosedTestWebsocketConn(t),
+		session: session,
+		URL:     wsURL,
+		PoolKey: key,
+	}
+	conn.SetState(StateConnected)
+	conn.Touch()
+	manager.connections.Store(key, conn)
+	manager.sessions.Store(key, session)
+	manager.probeFunc = func(wc *WsConnection) bool { return true }
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	exec := NewExecutorWithManager(manager)
+	_, err = exec.ExecuteRequestViaWebsocket(ctx, account, []byte(`{"model":"gpt-5.4","input":"hi"}`), sessionID, "", "", nil, http.Header{})
+	if err == nil {
+		t.Fatal("expected final send failure")
+	}
+	if _, ok := manager.connections.Load(key); ok {
+		t.Fatal("expected failed connection keyed by effective account proxy to be removed")
+	}
+	if _, ok := manager.sessions.Load(key); ok {
+		t.Fatal("expected failed session keyed by effective account proxy to be removed")
+	}
+	if conn.IsConnected() {
+		t.Fatal("expected failed connection to be closed")
 	}
 }
 

--- a/proxy/wsrelay/manager.go
+++ b/proxy/wsrelay/manager.go
@@ -169,6 +169,7 @@ type Manager struct {
 	// 清理定时器
 	cleanupTicker *time.Ticker
 	stopCleanup   chan struct{}
+	stopOnce      sync.Once
 
 	// 连接回调
 	onConnected    func(accountID int64, session *Session)
@@ -252,8 +253,10 @@ func (m *Manager) evictExpired() {
 
 // Stop 停止管理器
 func (m *Manager) Stop() {
-	close(m.stopCleanup)
-	m.closeAll()
+	m.stopOnce.Do(func() {
+		close(m.stopCleanup)
+		m.closeAll()
+	})
 }
 
 // closeAll 关闭所有连接

--- a/proxy/wsrelay/manager_test.go
+++ b/proxy/wsrelay/manager_test.go
@@ -3,11 +3,99 @@ package wsrelay
 import (
 	"context"
 	"net/http"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/codex2api/auth"
 )
+
+func TestManagerStopIdempotent(t *testing.T) {
+	manager := NewManager()
+
+	for i := 0; i < 3; i++ {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("Stop call %d panicked: %v", i+1, r)
+				}
+			}()
+			manager.Stop()
+		}()
+	}
+}
+
+func TestManagerStopConcurrent(t *testing.T) {
+	manager := NewManager()
+
+	const callers = 32
+	start := make(chan struct{})
+	panicCh := make(chan any, callers)
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(callers)
+
+	for i := 0; i < callers; i++ {
+		go func() {
+			defer wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					panicCh <- r
+				}
+			}()
+			<-start
+			manager.Stop()
+		}()
+	}
+
+	close(start)
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("concurrent Stop calls timed out")
+	}
+	close(panicCh)
+
+	for r := range panicCh {
+		t.Fatalf("concurrent Stop panicked: %v", r)
+	}
+}
+
+func TestRemoveConnectionUsesEffectiveProxyKey(t *testing.T) {
+	manager := NewManager()
+	t.Cleanup(manager.Stop)
+
+	account := &auth.Account{DBID: 42, ProxyURL: " http://proxy-a.example:8080 "}
+	wsURL := "wss://example.test/responses"
+	sessionKey := "session-1"
+	proxyURL := effectiveProxyURL(account, "")
+	key := manager.poolKey(account.ID(), wsURL, sessionKey, proxyURL)
+
+	session := NewSession(account.ID(), manager)
+	session.SetConnected(true)
+	conn := &WsConnection{session: session, URL: wsURL, PoolKey: key}
+	conn.SetState(StateConnected)
+	conn.Touch()
+	manager.connections.Store(key, conn)
+	manager.sessions.Store(key, session)
+
+	manager.RemoveConnection(account.ID(), wsURL, sessionKey, effectiveProxyURL(account, ""))
+
+	if _, ok := manager.connections.Load(key); ok {
+		t.Fatal("expected connection stored under effective proxy key to be removed")
+	}
+	if _, ok := manager.sessions.Load(key); ok {
+		t.Fatal("expected session stored under effective proxy key to be removed")
+	}
+	if conn.IsConnected() {
+		t.Fatal("expected removed connection to be closed")
+	}
+}
 
 func TestAcquireConnectionReusesIdleConnectedConnection(t *testing.T) {
 	manager := NewManager()

--- a/proxy/wsrelay/session.go
+++ b/proxy/wsrelay/session.go
@@ -2,6 +2,7 @@ package wsrelay
 
 import (
 	"context"
+	"log"
 	"sync"
 	"time"
 
@@ -34,7 +35,7 @@ const (
 	// 复用同一 session 的连接时，等待其空闲的轮询退避参数。
 	AcquireInitialBackoff = 10 * time.Millisecond  // 初始退避
 	AcquireMaxBackoff     = 200 * time.Millisecond // 退避封顶
-	AcquireMaxWait        = 30 * time.Second        // 最大累计等待，超时返回错误
+	AcquireMaxWait        = 30 * time.Second       // 最大累计等待，超时返回错误
 )
 
 // ==================== Pending 请求管理 ====================
@@ -244,7 +245,8 @@ func (s *Session) DeliverStreamChunk(msg *Message) bool {
 			pr.closeMu.Unlock()
 			return true
 		default:
-			// 通道已满，丢弃旧数据
+			// 通道已满，丢弃当前流式数据块并返回 false
+			log.Printf("DeliverStreamChunk stream channel full: account=%d session=%s requestID=%s capacity=%d length=%d; dropping current chunk", s.AccountID, s.ID, msg.RequestID, cap(pr.StreamChan), len(pr.StreamChan))
 			pr.closeMu.Unlock()
 			return false
 		}

--- a/proxy/wsrelay/session_test.go
+++ b/proxy/wsrelay/session_test.go
@@ -1,6 +1,9 @@
 package wsrelay
 
 import (
+	"bytes"
+	"log"
+	"strings"
 	"testing"
 	"time"
 )
@@ -129,5 +132,42 @@ func TestSessionConnectedState(t *testing.T) {
 	session.SetConnected(false)
 	if session.IsConnected() {
 		t.Error("session should not be connected after SetConnected(false)")
+	}
+}
+
+// TestSessionDeliverStreamChunkFullChannelNonBlocking verifies stream backpressure is observable and does not block.
+func TestSessionDeliverStreamChunkFullChannelNonBlocking(t *testing.T) {
+	session := NewSession(12345, nil)
+	session.ID = "test-session"
+	pr := session.AddPendingRequest("upstream-session")
+
+	for i := 0; i < cap(pr.StreamChan); i++ {
+		pr.StreamChan <- NewStreamChunkMessage(pr.RequestID, []byte("existing"))
+	}
+
+	var logBuf bytes.Buffer
+	originalOutput := log.Writer()
+	log.SetOutput(&logBuf)
+	t.Cleanup(func() { log.SetOutput(originalOutput) })
+
+	start := time.Now()
+	delivered := session.DeliverStreamChunk(NewStreamChunkMessage(pr.RequestID, []byte("new")))
+	elapsed := time.Since(start)
+
+	if delivered {
+		t.Fatal("expected DeliverStreamChunk to return false when StreamChan is full")
+	}
+	if elapsed > 50*time.Millisecond {
+		t.Fatalf("DeliverStreamChunk blocked too long with full StreamChan: %v", elapsed)
+	}
+	if got := len(pr.StreamChan); got != cap(pr.StreamChan) {
+		t.Fatalf("expected StreamChan to remain full, len=%d cap=%d", got, cap(pr.StreamChan))
+	}
+
+	logOutput := logBuf.String()
+	for _, want := range []string{"stream channel full", "account=12345", "session=test-session", "requestID=" + pr.RequestID, "capacity=64", "length=64"} {
+		if !strings.Contains(logOutput, want) {
+			t.Fatalf("expected log output to contain %q, got %q", want, logOutput)
+		}
 	}
 }


### PR DESCRIPTION
## 背景

本次 PR2 聚焦 WebSocket relay 路径中的低风险、高收益稳定性问题，主要覆盖以下场景：

- 账号配置了默认代理但请求没有显式 `proxyOverride` 时，连接池清理路径使用的 proxy key 与连接创建路径不一致，导致失败连接可能无法被移除。
- 上游 WebSocket 返回 `type: "error"` 帧时，顶层 `status` / `status_code` 在转换为下游 `response.failed` 事件时可能丢失，影响下游 HTTP 状态码映射。
- `Manager.Stop()` 直接关闭 `stopCleanup` channel，重复调用或并发调用可能触发 `close of closed channel` panic。
- `Session.DeliverStreamChunk` 在 `StreamChan` 满时仅返回 `false`，缺少足够日志，排查流式背压和丢 chunk 问题较困难；同时原注释与实际行为不完全一致。

## 修改前

### 连接池清理

连接创建和复用路径会使用账号有效代理地址构造 pool key：

- 优先使用 `proxyOverride`。
- 否则使用 `account.ProxyURL`。
- 最后统一 trim 空白。

但 `ExecuteRequestViaWebsocket` 的 send retry 清理路径曾直接传入 `proxyOverride`。当 `proxyOverride == ""` 且账号配置了 `account.ProxyURL` 时，删除 key 与存储 key 不一致，坏连接可能残留在连接池中。

另外，最终 send 失败时旧逻辑会移除 pending request 后调用 `ReleaseConnection(wc)`，这只会更新连接活跃时间，并不会关闭或移除已经 send 失败的连接。

### 错误状态码

上游 error frame 可能形如：

```json
{"type":"error","status":429,"error":{"type":"rate_limit_error","message":"too many requests"}}
```

旧转换结果通常只保留：

```json
{"type":"response.failed","response":{"status":"failed","error":{...}}}
```

如果 `error` 对象自身没有 `status_code`，顶层数字状态码会丢失。下游虽然已经支持读取 `response.status_code`，但 relay 转换层没有补齐该字段。

### Manager shutdown

`Manager.Stop()` 直接执行：

```go
close(m.stopCleanup)
m.closeAll()
```

重复调用或并发调用会 panic。

### StreamChan 背压

`DeliverStreamChunk` 采用非阻塞 send。通道满时返回 `false`，但缺少日志；旧注释也容易让人误解为“丢弃旧数据”，实际行为是丢弃当前新 chunk。

## 修改后

### 连接池清理统一 effective proxy key

`ExecuteRequestViaWebsocket` 现在提前计算：

```go
effectiveProxy := effectiveProxyURL(account, proxyOverride)
```

send retry 清理和 send failure 清理均使用该 effective proxy key 调用 `RemoveConnection`，与 `AcquireConnection` / `AcquireReusableConnection` 的存储 key 保持一致。

最终 send 失败时也会移除并关闭坏连接，而不是仅 `ReleaseConnection`。

### `response.failed` 保留上游状态码

`buildErrorEvent` 在上游 error frame 带有顶层 `status` 或 `status_code` 时，会写入：

```json
"response":{"status":"failed","status_code":429,"error":{...}}
```

同时保持 `response.error` 原始对象不变，避免破坏客户端依赖的 upstream error payload。

### `Manager.Stop()` 幂等

`Manager` 新增 `stopOnce sync.Once`，`Stop()` 改为：

```go
m.stopOnce.Do(func() {
    close(m.stopCleanup)
    m.closeAll()
})
```

重复调用和并发调用都会安全返回。

### StreamChan 背压日志

`DeliverStreamChunk` 在流式通道已满时继续保持非阻塞行为，但会记录日志，包含：

- account
- session
- requestID
- capacity
- length

注释也调整为“通道已满，丢弃当前流式数据块并返回 false”，与实际行为一致。

## 前后对比分析

### 兼容性

- 连接池 key 的构造逻辑没有改变，只是删除路径改为使用同一 effective proxy 规则，属于一致性修复。
- `response.failed` 新增 `response.status_code` 字段，保留原有 `response.error` 内容；下游已有 `response.status_code` 读取逻辑，因此这是向后兼容的补充信息。
- `Manager.Stop()` 首次调用行为保持不变，后续重复调用从 panic 变为安全 no-op。
- `StreamChan` 满时仍然不阻塞 WebSocket reader，不改变丢弃当前 chunk 的行为，仅增加可观测性。

### 风险控制

- 生产代码改动集中在 `proxy/wsrelay`，范围较小。
- 对每个行为变更均增加了 focused tests。
- 对并发 shutdown 做了重复压力验证。
- 对 WebSocket relay 包做了单独测试，并对相关 proxy 包及非 root Go 包执行了测试和 vet。

### 行为变化

- send 失败的 WebSocket 连接会被从池中移除并关闭，避免后续复用坏连接。
- 上游 4xx/5xx error frame 转换后的下游事件能更可靠携带状态码。
- 重复/并发 shutdown 不再 panic。
- 流式背压不再静默，只要 `StreamChan` 满就会有日志辅助排查。

## 测试情况

已执行并通过：

```powershell
go test ./proxy/wsrelay -run "TestExecuteRequestViaWebsocketSendFailureRemovesEffectiveProxyConnection|TestBuildErrorEvent_Upstream(Status|StatusCode)BecomesResponseStatusCode|TestSessionDeliverStreamChunkFullChannelNonBlocking|TestManagerStop(Idempotent|Concurrent)|TestRemoveConnectionUsesEffectiveProxyKey" -count=1
```

```powershell
go test ./proxy/wsrelay -count=1
```

```powershell
go test ./proxy ./proxy/wsrelay -count=1
```

```powershell
go test ./admin ./api ./auth ./cache ./config ./database ./internal/imageproc ./internal/imagestore ./internal/signedasset ./proxy ./proxy/wsrelay ./security ./security/promptfilter -count=1
```

```powershell
go vet ./admin ./api ./auth ./cache ./config ./database ./internal/imageproc ./internal/imagestore ./internal/signedasset ./proxy ./proxy/wsrelay ./security ./security/promptfilter
```

```powershell
git diff --check
```

重复稳定性验证已通过：

```powershell
go test ./proxy/wsrelay -run "TestExecuteRequestViaWebsocketSendFailureRemovesEffectiveProxyConnection|TestBuildErrorEvent_Upstream(Status|StatusCode)BecomesResponseStatusCode|TestSessionDeliverStreamChunkFullChannelNonBlocking" -count=50
```

```powershell
go test ./proxy/wsrelay -run TestManagerStopConcurrent -count=100
```

已执行但因环境/构建产物限制失败：

```powershell
go test ./... -count=1
```

失败原因：

```text
main.go:29:12: pattern frontend/dist/*: no matching files found
```

说明：当前 worktree 环境缺少 `frontend/dist/*` 嵌入资源，导致根包 setup failed；非 root Go 包测试均已通过，该问题不是本次 WebSocket relay 修改引入。

`git diff --check` 仅出现 Windows 工作区 LF 将被 CRLF 替换的提示，未发现 whitespace error。

## 修改总结

本次 PR 修复了 WebSocket relay 路径中的 4 类稳定性问题：

- 统一连接池删除路径的 effective proxy key，避免失败连接清理不掉。
- 在 `response.failed` 中保留上游 WebSocket error 状态码，提升下游错误映射准确性。
- 让 `Manager.Stop()` 支持重复和并发调用，避免 shutdown panic。
- 为流式通道背压增加日志，同时保持非阻塞行为。

整体改动集中、兼容性风险低，并已通过 WebSocket relay 聚焦测试、相关包测试、非 root 包测试、vet、diff check 和重复稳定性验证。
