### PR TITLE
feat: add MiMo upstream support with Responses/Chat switching

### DIFF
--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -11,6 +11,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"os"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -217,12 +218,31 @@ func accountFilterForModel(model string) auth.AccountFilter {
 	}
 }
 
+// marshalModelMapping 将 map[string]string 转换为 JSON string
+func marshalModelMapping(m map[string]string) string {
+	if m == nil {
+		return ""
+	}
+	b, err := json.Marshal(m)
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+
 func accountFilterForResponsesModel(model string, allowCodexAccounts bool) auth.AccountFilter {
 	model = strings.TrimSpace(model)
 	codexFilter := accountFilterForModel(model)
 	return func(account *auth.Account) bool {
 		if account == nil {
 			return false
+		}
+		// MiMo 账号直接放行
+		if IsMimoAccount(account.UpstreamType, account.BaseURL, account.APIKey) {
+			if model != "" && account.IsModelRateLimited(model) {
+				return false
+			}
+			return true
 		}
 		if account.IsOpenAIResponsesAPI() {
 			return account.SupportsOpenAIResponsesModel(model) && (model == "" || !account.IsModelRateLimited(model))
@@ -611,24 +631,6 @@ func rawRequestBodyFromContext(c *gin.Context) ([]byte, bool) {
 		return []byte(body), true
 	default:
 		return nil, false
-	}
-}
-
-func readRawRequestBody(c *gin.Context) ([]byte, error) {
-	if body, ok := rawRequestBodyFromContext(c); ok {
-		return body, nil
-	}
-	body, err := io.ReadAll(c.Request.Body)
-	if err != nil {
-		return nil, err
-	}
-	setRawRequestBody(c, body)
-	return body, nil
-}
-
-func setRawRequestBody(c *gin.Context, body []byte) {
-	if c != nil {
-		c.Set("raw_body", body)
 	}
 }
 
@@ -1357,7 +1359,7 @@ func firstGJSONInt(body []byte, paths ...string) int64 {
 // Responses 处理 /v1/responses 请求（原生透传，增强输入验证）
 func (h *Handler) Responses(c *gin.Context) {
 	// 1. 读取请求体
-	rawBody, err := readRawRequestBody(c)
+	rawBody, err := io.ReadAll(c.Request.Body)
 	if err != nil {
 		api.SendError(c, api.NewAPIError(api.ErrCodeInvalidRequest, "Failed to read request body", api.ErrorTypeInvalidRequest))
 		return
@@ -1365,7 +1367,7 @@ func (h *Handler) Responses(c *gin.Context) {
 
 	supportedModels := h.supportedModelIDs(c.Request.Context())
 	rawBody, requestModel, mappedModel, mappingApplied := h.applyConfiguredModelMappingToBody(rawBody, supportedModels)
-	setRawRequestBody(c, rawBody)
+	c.Set("raw_body", rawBody)
 
 	// Validate request
 	validator := api.NewValidator(rawBody)
@@ -1499,6 +1501,36 @@ func (h *Handler) Responses(c *gin.Context) {
 
 		// 透传下游请求头用于指纹学习
 		downstreamHeaders := c.Request.Header.Clone()
+
+		// ============================================================
+		// MiMo 上游路由
+		// ============================================================
+		// 方式1: 账号级别配置（推荐）- 支持 base_url 自动检测
+		if IsMimoAccount(account.UpstreamType, account.BaseURL, account.APIKey) {
+			mimoCfg := &MimoUpstreamConfig{
+				BaseURL:      account.BaseURL,
+				APIKey:       account.APIKey,
+				IsTokenPlan:  IsMimoTokenPlanKey(account.APIKey),
+				ModelMapping: marshalModelMapping(account.ModelMapping),
+			}
+			HandleMimoResponsesAPI(c, rawBody, mimoCfg)
+			return
+		}
+
+		// 方式2: 根据模型名称自动检测 + 全局环境变量
+		if IsMimoModel(model) {
+			apiKey := os.Getenv("MIMO_API_KEY")
+			if apiKey != "" {
+				mimoCfg := &MimoUpstreamConfig{
+					BaseURL:     os.Getenv("MIMO_BASE_URL"),
+					APIKey:      apiKey,
+					IsTokenPlan: IsMimoTokenPlanKey(apiKey),
+				}
+				HandleMimoResponsesAPI(c, rawBody, mimoCfg)
+				return
+			}
+		}
+		// ============================================================
 
 		if account.IsOpenAIResponsesAPI() {
 			if lastUpstreamCancel != nil {
@@ -2251,7 +2283,7 @@ func (h *Handler) Responses(c *gin.Context) {
 // ResponsesCompact 处理 /v1/responses/compact 请求（非流式压缩接口，透传到上游 /responses/compact）
 func (h *Handler) ResponsesCompact(c *gin.Context) {
 	// 1. 读取请求体
-	rawBody, err := readRawRequestBody(c)
+	rawBody, err := io.ReadAll(c.Request.Body)
 	if err != nil {
 		api.SendError(c, api.NewAPIError(api.ErrCodeInvalidRequest, "Failed to read request body", api.ErrorTypeInvalidRequest))
 		return
@@ -2259,7 +2291,7 @@ func (h *Handler) ResponsesCompact(c *gin.Context) {
 
 	supportedModels := h.supportedModelIDs(c.Request.Context())
 	rawBody, requestModel, mappedModel, mappingApplied := h.applyConfiguredModelMappingToBody(rawBody, supportedModels)
-	setRawRequestBody(c, rawBody)
+	c.Set("raw_body", rawBody)
 
 	// Validate request
 	validator := api.NewValidator(rawBody)
@@ -2665,7 +2697,7 @@ func (h *Handler) ResponsesCompact(c *gin.Context) {
 
 func (h *Handler) ChatCompletions(c *gin.Context) {
 	// 1. 读取请求体
-	rawBody, err := readRawRequestBody(c)
+	rawBody, err := io.ReadAll(c.Request.Body)
 	if err != nil {
 		api.SendError(c, api.NewAPIError(api.ErrCodeInvalidRequest, "Failed to read request body", api.ErrorTypeInvalidRequest))
 		return
@@ -2816,6 +2848,34 @@ func (h *Handler) ChatCompletions(c *gin.Context) {
 
 		// 透传下游请求头用于指纹学习
 		downstreamHeaders := c.Request.Header.Clone()
+
+		// ============================================================
+		// MiMo Chat Completions 路由
+		// ============================================================
+		if IsMimoAccount(account.UpstreamType, account.BaseURL, account.APIKey) {
+			mimoCfg := &MimoUpstreamConfig{
+				BaseURL:      account.BaseURL,
+				APIKey:       account.APIKey,
+				IsTokenPlan:  IsMimoTokenPlanKey(account.APIKey),
+				ModelMapping: marshalModelMapping(account.ModelMapping),
+			}
+			HandleMimoChatCompletionsAPI(c, rawBody, mimoCfg)
+			return
+		}
+
+		if IsMimoModel(model) {
+			apiKey := os.Getenv("MIMO_API_KEY")
+			if apiKey != "" {
+				mimoCfg := &MimoUpstreamConfig{
+					BaseURL:     os.Getenv("MIMO_BASE_URL"),
+					APIKey:      apiKey,
+					IsTokenPlan: IsMimoTokenPlanKey(apiKey),
+				}
+				HandleMimoChatCompletionsAPI(c, rawBody, mimoCfg)
+				return
+			}
+		}
+		// ============================================================
 
 		upstreamSessionID := IsolateCodexSessionID(apiKeyID, sessionID)
 		if useWebsocket && explicitSessionID == "" {
@@ -3804,7 +3864,7 @@ func parseCodexUsageHeaders(resp *http.Response, account *auth.Account) (float64
 	// 写入 5h
 	if w5h.valid {
 		resetAt := now.Add(time.Duration(w5h.resetSec) * time.Second)
-		account.SetUsageSnapshot5hAt(w5h.usedPct, resetAt, now)
+		account.SetUsageSnapshot5h(w5h.usedPct, resetAt)
 	}
 
 	// 写入 7d

--- a/proxy/mimo_executor.go
+++ b/proxy/mimo_executor.go
@@ -1,0 +1,461 @@
+package proxy
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// ==================== MiMo 上游执行器 ====================
+
+// MimoUpstreamConfig MiMo 上游配置
+type MimoUpstreamConfig struct {
+	BaseURL        string // MiMo API 基础 URL
+	APIKey         string // MiMo API Key
+	IsTokenPlan    bool   // 是否为 Token Plan 账号
+	ModelMapping   string // 账号级别模型映射 JSON
+}
+
+// GenerateMimoResponseID 生成 MiMo 响应 ID
+func GenerateMimoResponseID() string {
+	b := make([]byte, 12)
+	_, _ = rand.Read(b)
+	return "resp_mimo_" + hex.EncodeToString(b)
+}
+
+// HandleMimoResponsesAPI 处理通过 MiMo 上游的 Responses API 请求
+// 流程: Responses API body → Chat Completions body → MiMo upstream → Chat chunks → Responses SSE events
+func HandleMimoResponsesAPI(c *gin.Context, responsesBody []byte, cfg *MimoUpstreamConfig) {
+	isStream := gjson.GetBytes(responsesBody, "stream").Bool()
+
+	// 翻译请求: Responses → Chat Completions
+	chatBody, model, err := ResponsesToMimoChat(responsesBody, cfg.IsTokenPlan)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, map[string]string{
+			"error": fmt.Sprintf("failed to translate request: %v", err),
+		})
+		return
+	}
+
+	// 应用账号级别模型映射
+	model = ApplyAccountModelMapping(model, cfg.ModelMapping)
+	chatBody, _ = sjson.SetBytes(chatBody, "model", model)
+
+	slog.Debug("mimo upstream request",
+		"model", model,
+		"stream", isStream,
+		"isTokenPlan", cfg.IsTokenPlan,
+	)
+
+	// 确定 MiMo API 端点
+	baseURL := cfg.BaseURL
+	if baseURL == "" {
+		baseURL = ResolveMimoBaseURL("", cfg.APIKey)
+	}
+	apiURL := strings.TrimRight(baseURL, "/") + "/v1/chat/completions"
+
+	// 生成响应 ID
+	responseID := GenerateMimoResponseID()
+
+	// 发起上游请求
+	req, err := http.NewRequestWithContext(c.Request.Context(), "POST", apiURL, bytes.NewReader(chatBody))
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, map[string]string{
+			"error": fmt.Sprintf("failed to create request: %v", err),
+		})
+		return
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+cfg.APIKey)
+	req.Header.Set("Accept", "text/event-stream")
+
+	client := &http.Client{
+		Timeout: 0, // 无超时，由 context 控制
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		c.JSON(http.StatusBadGateway, map[string]string{
+			"error": fmt.Sprintf("mimo upstream error: %v", err),
+		})
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		slog.Error("mimo upstream error", "status", resp.StatusCode, "body", string(bodyBytes))
+		
+		// 友好错误处理
+		errMsg := string(bodyBytes)
+		if resp.StatusCode == 400 && strings.Contains(errMsg, "webSearchEnabled is false") {
+			errMsg = "MiMo Web Search 插件未激活。请在 https://platform.xiaomimimo.com/#/console/plugin 激活后，" +
+				"设置环境变量 MIMO_FORCE_WEB_SEARCH=true，或移除请求中的 web_search 工具。" +
+				"原始错误: " + errMsg
+		}
+		
+		c.JSON(resp.StatusCode, map[string]string{
+			"error": errMsg,
+		})
+		return
+	}
+
+	if isStream {
+		handleMimoStreamResponse(c, resp.Body, responseID)
+	} else {
+		handleMimoNonStreamResponse(c, resp.Body, responseID)
+	}
+}
+
+// HandleMimoChatCompletionsAPI 处理通过 MiMo 上游的 Chat Completions API 请求
+// 流程: Chat Completions body → MiMo 格式化 → MiMo upstream → 原样返回
+func HandleMimoChatCompletionsAPI(c *gin.Context, chatBody []byte, cfg *MimoUpstreamConfig) {
+	isStream := gjson.GetBytes(chatBody, "stream").Bool()
+
+	// 翻译请求: 标准 Chat → MiMo Chat
+	mimoBody, model, err := TranslateChatCompletionsToMimo(chatBody)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, map[string]string{
+			"error": fmt.Sprintf("failed to translate request: %v", err),
+		})
+		return
+	}
+
+	// 应用账号级别模型映射
+	model = ApplyAccountModelMapping(model, cfg.ModelMapping)
+	mimoBody, _ = sjson.SetBytes(mimoBody, "model", model)
+
+	slog.Debug("mimo chat completions request",
+		"model", model,
+		"stream", isStream,
+	)
+
+	// 确定 MiMo API 端点
+	baseURL := cfg.BaseURL
+	if baseURL == "" {
+		baseURL = ResolveMimoBaseURL("", cfg.APIKey)
+	}
+	apiURL := strings.TrimRight(baseURL, "/") + "/v1/chat/completions"
+
+	// 发起上游请求
+	req, err := http.NewRequestWithContext(c.Request.Context(), "POST", apiURL, bytes.NewReader(mimoBody))
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, map[string]string{
+			"error": fmt.Sprintf("failed to create request: %v", err),
+		})
+		return
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+cfg.APIKey)
+	if isStream {
+		req.Header.Set("Accept", "text/event-stream")
+	}
+
+	client := &http.Client{Timeout: 0}
+	resp, err := client.Do(req)
+	if err != nil {
+		c.JSON(http.StatusBadGateway, map[string]string{
+			"error": fmt.Sprintf("mimo upstream error: %v", err),
+		})
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		
+		// 友好错误处理
+		errMsg := string(bodyBytes)
+		if resp.StatusCode == 400 && strings.Contains(errMsg, "webSearchEnabled is false") {
+			errMsg = "MiMo Web Search 插件未激活。请在 https://platform.xiaomimimo.com/#/console/plugin 激活后重试。" +
+				"原始错误: " + errMsg
+		}
+		
+		c.JSON(resp.StatusCode, map[string]string{
+			"error": errMsg,
+		})
+		return
+	}
+
+	if isStream {
+		// 流式: 透传 MiMo 的 SSE 流
+		handleMimoPassthroughStream(c, resp.Body)
+	} else {
+		// 非流式: 透传响应
+		c.Header("Content-Type", "application/json")
+		io.Copy(c.Writer, resp.Body)
+	}
+}
+
+// ==================== 流式响应处理 ====================
+
+// handleMimoStreamResponse 处理 MiMo 流式响应，翻译为 Responses SSE 格式
+func handleMimoStreamResponse(c *gin.Context, body io.Reader, responseID string) {
+	c.Header("Content-Type", "text/event-stream")
+	c.Header("Cache-Control", "no-cache")
+	c.Header("Connection", "keep-alive")
+
+	flusher, ok := c.Writer.(http.Flusher)
+	if !ok {
+		// 回退到非流式处理
+		handleMimoNonStreamResponse(c, body, responseID)
+		return
+	}
+
+	// 发送 response.created 事件
+	createdEvent := buildResponsesCreatedEvent(responseID)
+	fmt.Fprintf(c.Writer, "%s\n\n", createdEvent)
+	flusher.Flush()
+
+	scanner := bufio.NewScanner(body)
+	// 增大缓冲区以处理大型 reasoning_content
+	scanner.Buffer(make([]byte, 0, 256*1024), 1024*1024)
+
+	var currentData strings.Builder
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		// 检查 context 取消
+		select {
+		case <-c.Request.Context().Done():
+			return
+		default:
+		}
+
+		if strings.HasPrefix(line, "data: ") {
+			data := strings.TrimPrefix(line, "data: ")
+			if data == "[DONE]" {
+				break
+			}
+			currentData.WriteString(data)
+		} else if line == "" && currentData.Len() > 0 {
+			// 一个完整的 SSE 事件
+			chunk := []byte(currentData.String())
+			currentData.Reset()
+
+			events, err := ChatChunkToResponsesEvent(chunk, responseID)
+			if err != nil {
+				slog.Error("failed to translate chunk", "error", err)
+				continue
+			}
+
+			for _, event := range events {
+				if event != "" {
+					fmt.Fprintf(c.Writer, "%s\n\n", event)
+					flusher.Flush()
+				}
+			}
+		}
+	}
+
+	// 处理最后的数据
+	if currentData.Len() > 0 {
+		chunk := []byte(currentData.String())
+		events, _ := ChatChunkToResponsesEvent(chunk, responseID)
+		for _, event := range events {
+			if event != "" {
+				fmt.Fprintf(c.Writer, "%s\n\n", event)
+				flusher.Flush()
+			}
+		}
+	}
+
+	// 确保发送 completed 事件
+	fmt.Fprintf(c.Writer, "%s\n\n", buildResponsesCompletedEvent(responseID))
+	flusher.Flush()
+}
+
+// handleMimoNonStreamResponse 处理 MiMo 非流式响应，翻译为 Responses 格式
+func handleMimoNonStreamResponse(c *gin.Context, body io.Reader, responseID string) {
+	bodyBytes, err := io.ReadAll(body)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, map[string]string{
+			"error": fmt.Sprintf("failed to read response: %v", err),
+		})
+		return
+	}
+
+	// 翻译为 Responses 格式
+	events, err := ChatChunkToResponsesEvent(bodyBytes, responseID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, map[string]string{
+			"error": fmt.Sprintf("failed to translate response: %v", err),
+		})
+		return
+	}
+
+	// 对于非流式响应，提取 response.completed 事件中的 response 对象
+	for _, event := range events {
+		if strings.Contains(event, "response.completed") {
+			parts := strings.SplitN(event, "data: ", 2)
+			if len(parts) == 2 {
+				c.Header("Content-Type", "application/json")
+				c.String(http.StatusOK, parts[1])
+				return
+			}
+		}
+	}
+
+	// 如果没有找到 completed 事件，返回原始翻译结果
+	if len(events) > 0 {
+		c.Header("Content-Type", "text/event-stream")
+		for _, event := range events {
+			fmt.Fprintf(c.Writer, "%s\n\n", event)
+		}
+		return
+	}
+
+	c.JSON(http.StatusInternalServerError, map[string]string{
+		"error": "empty response from mimo upstream",
+	})
+}
+
+// handleMimoPassthroughStream 透传 MiMo SSE 流（用于 Chat Completions API）
+func handleMimoPassthroughStream(c *gin.Context, body io.Reader) {
+	c.Header("Content-Type", "text/event-stream")
+	c.Header("Cache-Control", "no-cache")
+	c.Header("Connection", "keep-alive")
+
+	flusher, ok := c.Writer.(http.Flusher)
+	if !ok {
+		io.Copy(c.Writer, body)
+		return
+	}
+
+	scanner := bufio.NewScanner(body)
+	scanner.Buffer(make([]byte, 0, 256*1024), 1024*1024)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		fmt.Fprintf(c.Writer, "%s\n", line)
+		if line == "" {
+			flusher.Flush()
+		}
+	}
+}
+
+// ==================== 辅助函数 ====================
+
+func buildResponsesCreatedEvent(responseID string) string {
+	resp := map[string]any{
+		"id":         responseID,
+		"object":     "response",
+		"status":     "in_progress",
+		"model":      "mimo",
+		"output":     []any{},
+	}
+	data, _ := json.Marshal(resp)
+	return "event: response.created\ndata: " + string(data)
+}
+
+// ApplyAccountModelMapping 应用账号级别模型映射
+// mapping 格式: {"gpt-4o": "mimo-v2.5-pro", "o3-mini": "mimo-v2-flash"}
+func ApplyAccountModelMapping(model string, mappingJSON string) string {
+	if mappingJSON == "" || mappingJSON == "{}" {
+		return model
+	}
+
+	var mapping map[string]string
+	if err := json.Unmarshal([]byte(mappingJSON), &mapping); err != nil {
+		return model
+	}
+
+	if mapped, ok := mapping[model]; ok {
+		return mapped
+	}
+
+	return model
+}
+
+// ==================== Codex 工具输出检测 ====================
+
+// checkCodexComplete 检查 Codex 是否完成了任务
+// 通过检测特定的函数调用来判断
+func checkCodexComplete(chunkData []byte) bool {
+	if !gjson.ValidBytes(chunkData) {
+		return false
+	}
+
+	choices := gjson.GetBytes(chunkData, "choices")
+	if !choices.IsArray() {
+		return false
+	}
+
+	complete := false
+	choices.ForEach(func(_, choice gjson.Result) bool {
+		if choice.Get("finish_reason").String() != "" {
+			complete = true
+			return false // 停止遍历
+		}
+		return true
+	})
+
+	return complete
+}
+
+// HandleMimoUpstream 处理 MiMo 上游请求的统一分发
+// 根据请求路径判断是 Responses API 还是 Chat Completions API
+func HandleMimoUpstream(c *gin.Context, reqInfo *RequestContext, cfg *MimoUpstreamConfig) {
+	path := c.Request.URL.Path
+
+	if strings.Contains(path, "/responses") {
+		HandleMimoResponsesAPI(c, reqInfo.Body, cfg)
+	} else if strings.Contains(path, "/chat/completions") {
+		HandleMimoChatCompletionsAPI(c, reqInfo.Body, cfg)
+	} else {
+		// 默认走 Responses API
+		HandleMimoResponsesAPI(c, reqInfo.Body, cfg)
+	}
+}
+
+// RequestContext 请求上下文信息
+type RequestContext struct {
+	Body     []byte
+	Stream   bool
+	Model    string
+	IsCodex  bool
+}
+
+// DetermineUpstreamType 判断请求应该路由到哪个上游
+// 返回 "mimo", "codex", "openai"
+func DetermineUpstreamType(model string, accountUpstreamType string) string {
+	// 优先使用账号配置的上游类型
+	if accountUpstreamType != "" {
+		return strings.ToLower(strings.TrimSpace(accountUpstreamType))
+	}
+
+	// 根据模型名称判断
+	if IsMimoModel(model) {
+		return UpstreamTypeMimo
+	}
+
+	// 默认走 Codex
+	return "codex"
+}
+
+// HandleUpstreamRequest 统一的上游请求处理入口
+func HandleUpstreamRequest(c *gin.Context, reqBody []byte, upstreamType string, cfg *MimoUpstreamConfig) {
+	switch upstreamType {
+	case UpstreamTypeMimo:
+		HandleMimoUpstream(c, &RequestContext{Body: reqBody}, cfg)
+	default:
+		// 默认走原始 Codex 处理
+		c.JSON(http.StatusBadRequest, map[string]string{
+			"error": fmt.Sprintf("unsupported upstream type: %s", upstreamType),
+		})
+	}
+}

--- a/proxy/mimo_executor.go
+++ b/proxy/mimo_executor.go
@@ -8,9 +8,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"log/slog"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/tidwall/gjson"
@@ -30,13 +32,25 @@ type MimoUpstreamConfig struct {
 // GenerateMimoResponseID 生成 MiMo 响应 ID
 func GenerateMimoResponseID() string {
 	b := make([]byte, 12)
-	_, _ = rand.Read(b)
+	n, err := rand.Read(b)
+	if err != nil || n != len(b) {
+		b = []byte(fmt.Sprintf("%d", time.Now().UnixNano()))
+	}
 	return "resp_mimo_" + hex.EncodeToString(b)
+}
+
+// MimoUsageResult 从 MiMo 上游返回的 usage 数据
+type MimoUsageResult struct {
+	InputTokens    int64
+	OutputTokens   int64
+	TotalTokens    int64
+	CachedTokens   int64
+	ReasoningTokens int64
 }
 
 // HandleMimoResponsesAPI 处理通过 MiMo 上游的 Responses API 请求
 // 流程: Responses API body → Chat Completions body → MiMo upstream → Chat chunks → Responses SSE events
-func HandleMimoResponsesAPI(c *gin.Context, responsesBody []byte, cfg *MimoUpstreamConfig) {
+func HandleMimoResponsesAPI(c *gin.Context, responsesBody []byte, cfg *MimoUpstreamConfig) *MimoUsageResult {
 	isStream := gjson.GetBytes(responsesBody, "stream").Bool()
 
 	// 翻译请求: Responses → Chat Completions
@@ -45,12 +59,17 @@ func HandleMimoResponsesAPI(c *gin.Context, responsesBody []byte, cfg *MimoUpstr
 		c.JSON(http.StatusBadRequest, map[string]string{
 			"error": fmt.Sprintf("failed to translate request: %v", err),
 		})
-		return
+		return nil
 	}
 
 	// 应用账号级别模型映射
 	model = ApplyAccountModelMapping(model, cfg.ModelMapping)
 	chatBody, _ = sjson.SetBytes(chatBody, "model", model)
+
+	// 流式请求时要求上游返回 usage 数据（否则 token 统计为 0）
+	if isStream {
+		chatBody, _ = sjson.SetBytes(chatBody, "stream_options", map[string]bool{"include_usage": true})
+	}
 
 	slog.Debug("mimo upstream request",
 		"model", model,
@@ -74,12 +93,13 @@ func HandleMimoResponsesAPI(c *gin.Context, responsesBody []byte, cfg *MimoUpstr
 		c.JSON(http.StatusInternalServerError, map[string]string{
 			"error": fmt.Sprintf("failed to create request: %v", err),
 		})
-		return
+		return nil
 	}
 
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+cfg.APIKey)
 	req.Header.Set("Accept", "text/event-stream")
+	req.Header.Set("User-Agent", "OpenAI/1.0 codex2api")
 
 	client := &http.Client{
 		Timeout: 0, // 无超时，由 context 控制
@@ -90,7 +110,7 @@ func HandleMimoResponsesAPI(c *gin.Context, responsesBody []byte, cfg *MimoUpstr
 		c.JSON(http.StatusBadGateway, map[string]string{
 			"error": fmt.Sprintf("mimo upstream error: %v", err),
 		})
-		return
+		return nil
 	}
 	defer resp.Body.Close()
 
@@ -109,14 +129,13 @@ func HandleMimoResponsesAPI(c *gin.Context, responsesBody []byte, cfg *MimoUpstr
 		c.JSON(resp.StatusCode, map[string]string{
 			"error": errMsg,
 		})
-		return
+		return nil
 	}
 
 	if isStream {
-		handleMimoStreamResponse(c, resp.Body, responseID)
-	} else {
-		handleMimoNonStreamResponse(c, resp.Body, responseID)
+		return handleMimoStreamResponse(c, resp.Body, responseID, model)
 	}
+	return handleMimoNonStreamResponse(c, resp.Body, responseID)
 }
 
 // HandleMimoChatCompletionsAPI 处理通过 MiMo 上游的 Chat Completions API 请求
@@ -160,6 +179,7 @@ func HandleMimoChatCompletionsAPI(c *gin.Context, chatBody []byte, cfg *MimoUpst
 
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+cfg.APIKey)
+	req.Header.Set("User-Agent", "OpenAI/1.0 codex2api")
 	if isStream {
 		req.Header.Set("Accept", "text/event-stream")
 	}
@@ -203,36 +223,137 @@ func HandleMimoChatCompletionsAPI(c *gin.Context, chatBody []byte, cfg *MimoUpst
 // ==================== 流式响应处理 ====================
 
 // handleMimoStreamResponse 处理 MiMo 流式响应，翻译为 Responses SSE 格式
-func handleMimoStreamResponse(c *gin.Context, body io.Reader, responseID string) {
+// 完整实现 OpenAI Responses API SSE 生命周期事件序列
+func handleMimoStreamResponse(c *gin.Context, body io.Reader, responseID string, model string) *MimoUsageResult {
 	c.Header("Content-Type", "text/event-stream")
 	c.Header("Cache-Control", "no-cache")
 	c.Header("Connection", "keep-alive")
 
 	flusher, ok := c.Writer.(http.Flusher)
 	if !ok {
-		// 回退到非流式处理
-		handleMimoNonStreamResponse(c, body, responseID)
-		return
+		return handleMimoNonStreamResponse(c, body, responseID)
 	}
 
-	// 发送 response.created 事件
-	createdEvent := buildResponsesCreatedEvent(responseID)
-	fmt.Fprintf(c.Writer, "%s\n\n", createdEvent)
-	flusher.Flush()
+	// 累积状态
+	state := &MimoStreamState{
+		ResponseID:      responseID,
+		Model:           model,
+		FunctionCallSeq: make(map[int]*MimoStreamFunctionCallState),
+	}
+	reasoningItemOpened := false
+	outputItemOpened := false
 
 	scanner := bufio.NewScanner(body)
-	// 增大缓冲区以处理大型 reasoning_content
 	scanner.Buffer(make([]byte, 0, 256*1024), 1024*1024)
 
 	var currentData strings.Builder
+	var lastUsageData string
+	usageResult := &MimoUsageResult{}
+
+	// emit 辅助函数: 写入 SSE 事件并刷新
+	emit := func(event string) {
+		if event != "" {
+			fmt.Fprintf(c.Writer, "%s\n\n", event)
+			flusher.Flush()
+		}
+	}
+
+	// closeReasoningItem 辅助函数: 关闭打开的 reasoning item
+	closeReasoningItem := func() {
+		if !reasoningItemOpened {
+			return
+		}
+		outputIdx := state.OutputIndex
+		seq := state.NextSeq()
+		// reasoning_summary_text.done
+		emit(buildResponseReasoningTextDoneEvent(state.ReasoningText, responseID, 0, seq))
+		// reasoning_summary_part.done
+		seq = state.NextSeq()
+		emit(buildResponsesReasoningSummaryPartDoneEvent(state.ReasoningText, responseID, outputIdx, seq))
+		// output_item.done (带 encrypted_content)
+		reasoningItemData := map[string]any{
+			"type":              "reasoning",
+			"id":                "rs_" + responseID,
+			"summary":           []map[string]any{{"type": "summary_text", "text": state.ReasoningText}},
+			"encrypted_content": state.ReasoningText,
+			"status":            "completed",
+		}
+		seq = state.NextSeq()
+		emit(buildResponseOutputItemDoneEvent(outputIdx, reasoningItemData, seq))
+		state.OutputIndex++
+		reasoningItemOpened = false
+	}
+
+	// closeOutputItem 辅助函数: 关闭打开的 message output item
+	closeOutputItem := func() {
+		if !outputItemOpened {
+			return
+		}
+		outputIdx := state.OutputIndex
+		seq := state.NextSeq()
+		// output_text.done
+		emit(buildResponseOutputTextDoneEvent(state.OutputText, responseID, seq))
+		// content_part.done
+		outputPartData := map[string]any{
+			"type":        "output_text",
+			"text":        state.OutputText,
+			"annotations": []any{},
+		}
+		seq = state.NextSeq()
+		emit(buildResponseContentPartDoneEvent(outputPartData, outputIdx, 0, seq))
+		// output_item.done
+		outputItemData := map[string]any{
+			"type": "message",
+			"id":   "msg_" + responseID,
+			"role": "assistant",
+			"content": []map[string]any{
+				{"type": "output_text", "text": state.OutputText, "annotations": []any{}},
+			},
+			"status": "completed",
+		}
+		seq = state.NextSeq()
+		emit(buildResponseOutputItemDoneEvent(outputIdx, outputItemData, seq))
+		outputItemOpened = false
+	}
+
+	// closeFunctionCallItem 辅助函数: 关闭指定 index 的 function call item
+	closeFunctionCallItem := func(idx int) {
+		tc, ok := state.FunctionCallSeq[idx]
+		if !ok || !tc.Opened {
+			return
+		}
+		// 对 arguments 做 JSON 校验
+		safeArgs := sanitizeToolCallArgumentsOutput(tc.ArgsBuffer, tc.Name, tc.CallID, state.FinishReason)
+		seq := state.NextSeq()
+		// function_call_arguments.done
+		emit(buildResponsesFunctionCallArgumentsDoneEvent(tc.ItemID, safeArgs, tc.OutputIdx, seq))
+		// output_item.done
+		finalItem := map[string]any{
+			"id":       tc.ItemID,
+			"type":     "function_call",
+			"call_id":  tc.CallID,
+			"name":     tc.Name,
+			"arguments": safeArgs,
+			"status":   "completed",
+		}
+		seq = state.NextSeq()
+		emit(buildResponseOutputItemDoneEvent(tc.OutputIdx, finalItem, seq))
+	}
+
+	// === 1. response.created ===
+	seq := state.NextSeq()
+	emit(buildResponsesCreatedEvent(responseID, model, seq))
+
+	// === 2. response.in_progress ===
+	seq = state.NextSeq()
+	emit(buildResponseInProgressEvent(responseID, model, seq))
 
 	for scanner.Scan() {
 		line := scanner.Text()
 
-		// 检查 context 取消
 		select {
 		case <-c.Request.Context().Done():
-			return
+			return nil
 		default:
 		}
 
@@ -243,20 +364,161 @@ func handleMimoStreamResponse(c *gin.Context, body io.Reader, responseID string)
 			}
 			currentData.WriteString(data)
 		} else if line == "" && currentData.Len() > 0 {
-			// 一个完整的 SSE 事件
 			chunk := []byte(currentData.String())
 			currentData.Reset()
 
-			events, err := ChatChunkToResponsesEvent(chunk, responseID)
-			if err != nil {
-				slog.Error("failed to translate chunk", "error", err)
-				continue
+			// 解析 chunk 提取 finish_reason 和 usage
+			if gjson.ValidBytes(chunk) {
+				choices := gjson.GetBytes(chunk, "choices")
+				if choices.IsArray() {
+					choices.ForEach(func(_, choice gjson.Result) bool {
+						if fr := choice.Get("finish_reason").String(); fr != "" {
+							state.FinishReason = fr
+						}
+						return true
+					})
+				}
+				if usage := gjson.GetBytes(chunk, "usage"); usage.Exists() {
+					lastUsageData = usage.Raw
+					state.Usage = &MimoUsageData{
+						InputTokens:  usage.Get("prompt_tokens").Int(),
+						OutputTokens: usage.Get("completion_tokens").Int(),
+						TotalTokens:  usage.Get("total_tokens").Int(),
+					}
+				}
 			}
 
-			for _, event := range events {
-				if event != "" {
-					fmt.Fprintf(c.Writer, "%s\n\n", event)
-					flusher.Flush()
+			// 检测当前 chunk 的内容类型
+			hasReasoning := false
+			hasContent := false
+			hasToolCalls := false
+			if gjson.ValidBytes(chunk) {
+				choices := gjson.GetBytes(chunk, "choices")
+				if choices.IsArray() {
+					choices.ForEach(func(_, choice gjson.Result) bool {
+						delta := choice.Get("delta")
+						if rc := delta.Get("reasoning_content"); rc.Exists() && rc.String() != "" {
+							hasReasoning = true
+						}
+						if ct := delta.Get("content"); ct.Exists() && ct.String() != "" {
+							hasContent = true
+						}
+						if tc := delta.Get("tool_calls"); tc.IsArray() {
+							hasToolCalls = true
+						}
+						return true
+					})
+				}
+			}
+
+			// === 打开 reasoning item（第一次收到 reasoning 时）===
+			if hasReasoning && !reasoningItemOpened {
+				reasoningItemOpened = true
+				itemID := "rs_" + responseID
+				seq = state.NextSeq()
+				emit(buildResponseOutputItemAddedEvent(responseID, itemID, "reasoning", state.OutputIndex, seq))
+				// reasoning_summary_part.added
+				seq = state.NextSeq()
+				emit(buildResponsesReasoningSummaryPartAddedEvent(responseID, state.OutputIndex, seq))
+			}
+
+			// === 打开 output item（第一次收到 content 时）===
+			if hasContent && !outputItemOpened {
+				// 如果 reasoning item 打开着，先关闭它
+				closeReasoningItem()
+
+				outputItemOpened = true
+				itemID := "msg_" + responseID
+				seq = state.NextSeq()
+				emit(buildResponseOutputItemAddedEvent(responseID, itemID, "message", state.OutputIndex, seq))
+				seq = state.NextSeq()
+				emit(buildResponseContentPartAddedEvent("output_text", state.OutputIndex, 0, seq))
+			}
+
+			// === 处理 tool_calls: 按 mimo2codex 方式流式处理 ===
+			if hasToolCalls {
+				// 先关闭 reasoning（如果有）
+				if reasoningItemOpened {
+					closeReasoningItem()
+				}
+
+				choices := gjson.GetBytes(chunk, "choices")
+				if choices.IsArray() {
+					choices.ForEach(func(_, choice gjson.Result) bool {
+						delta := choice.Get("delta")
+						toolCalls := delta.Get("tool_calls")
+						if !toolCalls.IsArray() {
+							return true
+						}
+						toolCalls.ForEach(func(_, tc gjson.Result) bool {
+							tcIndex := int(tc.Get("index").Int())
+							tcState, exists := state.FunctionCallSeq[tcIndex]
+							if !exists {
+								// 首次发现此 tool call: 发送 output_item.added
+								tcName := tc.Get("function.name").String()
+								tcCallID := tc.Get("id").String()
+								itemID := fmt.Sprintf("fc_%d_%s", tcIndex, responseID)
+								if tcCallID == "" {
+									tcCallID = fmt.Sprintf("call_%s_%d", responseID, tcIndex)
+								}
+								outputIdx := state.OutputIndex
+								state.OutputIndex++
+
+								tcState = &MimoStreamFunctionCallState{
+									ItemID:    itemID,
+									CallID:    tcCallID,
+									Name:      tcName,
+									OutputIdx: outputIdx,
+									Opened:    true,
+								}
+								state.FunctionCallSeq[tcIndex] = tcState
+
+								seq = state.NextSeq()
+								emit(buildResponsesFunctionCallAddedEvent(responseID, itemID, tcCallID, tcName, outputIdx, seq))
+							} else if tc.Get("function.name").String() != "" && tcState.Name == "" {
+								tcState.Name = tc.Get("function.name").String()
+							}
+
+							// 发送 arguments delta
+							argsDelta := tc.Get("function.arguments").String()
+							if argsDelta != "" {
+								tcState.ArgsBuffer += argsDelta
+								seq = state.NextSeq()
+								emit(buildResponsesFunctionCallArgumentsDeltaEvent(tcState.ItemID, argsDelta, tcState.OutputIdx, seq))
+							}
+
+							return true
+						})
+						return true
+					})
+				}
+			}
+
+			// === 翻译并发送 reasoning/content delta 事件 ===
+			if gjson.ValidBytes(chunk) {
+				choices := gjson.GetBytes(chunk, "choices")
+				if choices.IsArray() {
+					choices.ForEach(func(_, choice gjson.Result) bool {
+						delta := choice.Get("delta")
+
+						// reasoning_content delta
+						if rc := delta.Get("reasoning_content"); rc.Exists() && rc.String() != "" {
+							state.ReasoningText += rc.String()
+							state.HasReasoning = true
+							seq = state.NextSeq()
+							emit(buildResponsesReasoningDelta(rc.String(), responseID, seq))
+						}
+
+						// content delta
+						if ct := delta.Get("content"); ct.Exists() && ct.String() != "" {
+							state.OutputText += ct.String()
+							state.HasOutput = true
+							seq = state.NextSeq()
+							emit(buildResponsesTextDelta(ct.String(), responseID, seq))
+						}
+
+						return true
+					})
 				}
 			}
 		}
@@ -265,28 +527,101 @@ func handleMimoStreamResponse(c *gin.Context, body io.Reader, responseID string)
 	// 处理最后的数据
 	if currentData.Len() > 0 {
 		chunk := []byte(currentData.String())
-		events, _ := ChatChunkToResponsesEvent(chunk, responseID)
-		for _, event := range events {
-			if event != "" {
-				fmt.Fprintf(c.Writer, "%s\n\n", event)
-				flusher.Flush()
+		if gjson.ValidBytes(chunk) {
+			choices := gjson.GetBytes(chunk, "choices")
+			if choices.IsArray() {
+				choices.ForEach(func(_, choice gjson.Result) bool {
+					if fr := choice.Get("finish_reason").String(); fr != "" {
+						state.FinishReason = fr
+					}
+					return true
+				})
 			}
 		}
 	}
 
-	// 确保发送 completed 事件
-	fmt.Fprintf(c.Writer, "%s\n\n", buildResponsesCompletedEvent(responseID))
-	flusher.Flush()
+	// === 关闭所有打开的 items ===
+
+	// 关闭所有未关闭的 function call items
+	for idx := 0; ; idx++ {
+		tc, ok := state.FunctionCallSeq[idx]
+		if !ok {
+			break
+		}
+		if tc.Opened {
+			closeFunctionCallItem(idx)
+		}
+	}
+
+	// 关闭 reasoning item（纯 reasoning 响应或 reasoning 后无 content）
+	closeReasoningItem()
+
+	// 关闭 output item
+	closeOutputItem()
+
+	// usage 事件
+	if lastUsageData != "" {
+		usageBytes := []byte(lastUsageData)
+		var usageJSON gjson.Result
+		json.Unmarshal(usageBytes, &usageJSON)
+		seq = state.NextSeq()
+		emit(buildResponsesUsageEvent(usageJSON, responseID, seq))
+
+		// 填充 usageResult（兼容 prompt_tokens 和 input_tokens 两种格式）
+		usageResult.InputTokens = gjson.GetBytes(usageBytes, "prompt_tokens").Int()
+		if usageResult.InputTokens == 0 {
+			usageResult.InputTokens = gjson.GetBytes(usageBytes, "input_tokens").Int()
+		}
+		usageResult.OutputTokens = gjson.GetBytes(usageBytes, "completion_tokens").Int()
+		if usageResult.OutputTokens == 0 {
+			usageResult.OutputTokens = gjson.GetBytes(usageBytes, "output_tokens").Int()
+		}
+		usageResult.TotalTokens = gjson.GetBytes(usageBytes, "total_tokens").Int()
+		if usageResult.TotalTokens == 0 {
+			usageResult.TotalTokens = usageResult.InputTokens + usageResult.OutputTokens
+		}
+		// 提取 cached_tokens 和 reasoning_tokens
+		usageResult.CachedTokens = gjson.GetBytes(usageBytes, "prompt_tokens_details.cached_tokens").Int()
+		usageResult.ReasoningTokens = gjson.GetBytes(usageBytes, "completion_tokens_details.reasoning_tokens").Int()
+		log.Printf("[MIMO-USAGE] input=%d, output=%d, total=%d, cached=%d, reasoning=%d", usageResult.InputTokens, usageResult.OutputTokens, usageResult.TotalTokens, usageResult.CachedTokens, usageResult.ReasoningTokens)
+	} else {
+		log.Printf("[MIMO-USAGE] lastUsageData is EMPTY")
+	}
+
+	// response.completed
+	seq = state.NextSeq()
+	completedEvent := buildResponsesCompletedEventWithDataWithSeq(responseID, model, &state.ReasoningText, &state.OutputText, lastUsageData, seq)
+	emit(completedEvent)
+
+	return usageResult
 }
 
 // handleMimoNonStreamResponse 处理 MiMo 非流式响应，翻译为 Responses 格式
-func handleMimoNonStreamResponse(c *gin.Context, body io.Reader, responseID string) {
+func handleMimoNonStreamResponse(c *gin.Context, body io.Reader, responseID string) *MimoUsageResult {
+	usageResult := &MimoUsageResult{}
+
 	bodyBytes, err := io.ReadAll(body)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, map[string]string{
 			"error": fmt.Sprintf("failed to read response: %v", err),
 		})
-		return
+		return nil
+	}
+
+	// 从原始 body 中提取 usage 数据（兼容两种格式）
+	if usage := gjson.GetBytes(bodyBytes, "usage"); usage.Exists() {
+		usageResult.InputTokens = usage.Get("prompt_tokens").Int()
+		if usageResult.InputTokens == 0 {
+			usageResult.InputTokens = usage.Get("input_tokens").Int()
+		}
+		usageResult.OutputTokens = usage.Get("completion_tokens").Int()
+		if usageResult.OutputTokens == 0 {
+			usageResult.OutputTokens = usage.Get("output_tokens").Int()
+		}
+		usageResult.TotalTokens = usage.Get("total_tokens").Int()
+		if usageResult.TotalTokens == 0 {
+			usageResult.TotalTokens = usageResult.InputTokens + usageResult.OutputTokens
+		}
 	}
 
 	// 翻译为 Responses 格式
@@ -295,7 +630,7 @@ func handleMimoNonStreamResponse(c *gin.Context, body io.Reader, responseID stri
 		c.JSON(http.StatusInternalServerError, map[string]string{
 			"error": fmt.Sprintf("failed to translate response: %v", err),
 		})
-		return
+		return nil
 	}
 
 	// 对于非流式响应，提取 response.completed 事件中的 response 对象
@@ -305,7 +640,7 @@ func handleMimoNonStreamResponse(c *gin.Context, body io.Reader, responseID stri
 			if len(parts) == 2 {
 				c.Header("Content-Type", "application/json")
 				c.String(http.StatusOK, parts[1])
-				return
+				return usageResult
 			}
 		}
 	}
@@ -316,12 +651,13 @@ func handleMimoNonStreamResponse(c *gin.Context, body io.Reader, responseID stri
 		for _, event := range events {
 			fmt.Fprintf(c.Writer, "%s\n\n", event)
 		}
-		return
+		return usageResult
 	}
 
 	c.JSON(http.StatusInternalServerError, map[string]string{
 		"error": "empty response from mimo upstream",
 	})
+	return nil
 }
 
 // handleMimoPassthroughStream 透传 MiMo SSE 流（用于 Chat Completions API）
@@ -350,15 +686,90 @@ func handleMimoPassthroughStream(c *gin.Context, body io.Reader) {
 
 // ==================== 辅助函数 ====================
 
-func buildResponsesCreatedEvent(responseID string) string {
+// buildResponsesCompletedEventWithDataWithSeq 构建带序列号的 response.completed 事件
+func buildResponsesCompletedEventWithDataWithSeq(responseID, model string, reasoningText, outputText *string, usageJSON string, seq int) string {
+	var outputItems []any
+
+	// reasoning item
+	if reasoningText != nil && *reasoningText != "" {
+		outputItems = append(outputItems, map[string]any{
+			"type":              "reasoning",
+			"id":                "rs_" + responseID,
+			"summary":           []map[string]any{{"type": "summary_text", "text": *reasoningText}},
+			"encrypted_content": *reasoningText,
+			"status":            "completed",
+		})
+	}
+
+	// message item
+	if outputText != nil && *outputText != "" {
+		outputItems = append(outputItems, map[string]any{
+			"type": "message",
+			"id":   "msg_" + responseID,
+			"role": "assistant",
+			"content": []map[string]any{
+				{"type": "output_text", "text": *outputText, "annotations": []any{}},
+			},
+			"status": "completed",
+		})
+	}
+
+	if outputItems == nil {
+		outputItems = []any{}
+	}
+
+	resp := map[string]any{
+		"id":               responseID,
+		"object":           "response",
+		"created_at":       0,
+		"status":           "completed",
+		"model":            model,
+		"output":           outputItems,
+		"instructions":     "",
+		"tools":            []any{},
+		"tool_choice":      "auto",
+		"temperature":      nil,
+		"max_output_tokens": nil,
+		"top_p":            nil,
+		"parallel_tool_calls": true,
+	}
+
+	if usageJSON != "" {
+		var usageData map[string]any
+		if err := json.Unmarshal([]byte(usageJSON), &usageData); err == nil {
+			resp["usage"] = convertUsageToResponsesFormat(usageData)
+		}
+	} else {
+		resp["usage"] = map[string]any{
+			"input_tokens":  0,
+			"output_tokens": 0,
+			"total_tokens":  0,
+		}
+	}
+
+	event := map[string]any{
+		"type":            "response.completed",
+		"response":        resp,
+		"sequence_number": seq,
+	}
+	data, _ := json.Marshal(event)
+	return "event: response.completed\ndata: " + string(data)
+}
+
+func buildResponsesCreatedEvent(responseID, model string, seq int) string {
 	resp := map[string]any{
 		"id":         responseID,
 		"object":     "response",
 		"status":     "in_progress",
-		"model":      "mimo",
+		"model":      model,
 		"output":     []any{},
 	}
-	data, _ := json.Marshal(resp)
+	event := map[string]any{
+		"type":            "response.created",
+		"response":        resp,
+		"sequence_number": seq,
+	}
+	data, _ := json.Marshal(event)
 	return "event: response.created\ndata: " + string(data)
 }
 

--- a/proxy/mimo_translator.go
+++ b/proxy/mimo_translator.go
@@ -1,0 +1,924 @@
+package proxy
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// ==================== MiMo 翻译器 ====================
+// 将 OpenAI Responses API 请求翻译为 MiMo Chat Completions API
+// 移植自 mimo2codex/src/translate/reqToChat.ts 和 respToResponses.ts
+
+// MimoChatRequest MiMo Chat Completions 请求格式
+type MimoChatRequest struct {
+	Model               string            `json:"model"`
+	Messages            []MimoChatMessage `json:"messages"`
+	Stream              bool              `json:"stream,omitempty"`
+	StreamOptions       *MimoStreamOpts   `json:"stream_options,omitempty"`
+	Tools               []MimoChatTool    `json:"tools,omitempty"`
+	ToolChoice          any               `json:"tool_choice,omitempty"`
+	ParallelToolCalls   *bool             `json:"parallel_tool_calls,omitempty"`
+	Temperature         *float64          `json:"temperature,omitempty"`
+	TopP                *float64          `json:"top_p,omitempty"`
+	MaxCompletionTokens *int              `json:"max_completion_tokens,omitempty"`
+	Thinking            *MimoThinking     `json:"thinking,omitempty"`
+	ReasoningEffort     string            `json:"reasoning_effort,omitempty"`
+}
+
+type MimoStreamOpts struct {
+	IncludeUsage bool `json:"include_usage"`
+}
+
+type MimoThinking struct {
+	Type string `json:"type"` // "enabled" | "disabled" | "auto"
+}
+
+type MimoChatMessage struct {
+	Role             string           `json:"role"`
+	Content          any              `json:"content"` // string 或 []MimoContentPart
+	ToolCalls        []MimoToolCall   `json:"tool_calls,omitempty"`
+	ToolCallID       string           `json:"tool_call_id,omitempty"`
+	ReasoningContent string           `json:"reasoning_content,omitempty"`
+}
+
+type MimoContentPart struct {
+	Type     string `json:"type"`
+	Text     string `json:"text,omitempty"`
+	ImageURL *struct {
+		URL    string `json:"url"`
+		Detail string `json:"detail,omitempty"`
+	} `json:"image_url,omitempty"`
+}
+
+type MimoToolCall struct {
+	ID       string `json:"id"`
+	Type     string `json:"type"`
+	Function struct {
+		Name      string `json:"name"`
+		Arguments string `json:"arguments"`
+	} `json:"function"`
+}
+
+type MimoChatTool struct {
+	Type     string         `json:"type"`
+	Function *MimoToolFunc  `json:"function,omitempty"`
+}
+
+type MimoToolFunc struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description,omitempty"`
+	Parameters  json.RawMessage `json:"parameters,omitempty"`
+}
+
+// MimoWebSearchTool MiMo 原生 web_search 工具
+type MimoWebSearchTool struct {
+	Type string `json:"type"` // "web_search"
+}
+
+// ==================== Responses → Chat Completions 翻译 ====================
+
+// ResponsesToMimoChat 将 OpenAI Responses API 请求翻译为 MiMo Chat Completions 请求
+func ResponsesToMimoChat(responsesBody []byte, isTokenPlan bool) ([]byte, string, error) {
+	if !gjson.ValidBytes(responsesBody) {
+		return nil, "", fmt.Errorf("invalid JSON body")
+	}
+
+	model := NormalizeMimoModelID(strings.TrimSpace(gjson.GetBytes(responsesBody, "model").String()))
+	if model == "" {
+		model = MimoDefaultModel
+	}
+
+	chat := MimoChatRequest{
+		Model:  model,
+		Stream: gjson.GetBytes(responsesBody, "stream").Bool(),
+	}
+
+	// 流式选项
+	if chat.Stream {
+		chat.StreamOptions = &MimoStreamOpts{IncludeUsage: true}
+	}
+
+	// 翻译 instructions → system message
+	if instructions := gjson.GetBytes(responsesBody, "instructions").String(); instructions != "" {
+		chat.Messages = append(chat.Messages, MimoChatMessage{
+			Role:    "system",
+			Content: instructions,
+		})
+	}
+
+	// 翻译 input → messages
+	input := gjson.GetBytes(responsesBody, "input")
+	if input.Exists() {
+		messages := translateResponsesInputToMessages(input, model)
+		chat.Messages = append(chat.Messages, messages...)
+	}
+
+	// 翻译 tools
+	tools := gjson.GetBytes(responsesBody, "tools")
+	if tools.Exists() {
+		chatTools, hasWebSearch := translateResponsesTools(tools, isTokenPlan)
+		if len(chatTools) > 0 {
+			chat.Tools = chatTools
+		}
+
+		// Token Plan 账号 + 有 web_search + 搜索已启用 = 自动搜索注入
+		if hasWebSearch && isTokenPlan && IsSearchEnabled() {
+			// 提取搜索查询
+			query := ExtractSearchQuery(chat.Messages)
+			if query != "" {
+				slog.Info("auto search triggered", "query", query, "provider", GetSearchProvider())
+
+				// 执行搜索
+				searchResults, err := PerformSearch(query, 5)
+				if err != nil {
+					slog.Warn("auto search failed", "error", err)
+				} else if searchResults != nil && len(searchResults.Results) > 0 {
+					// 注入搜索结果到消息
+					formattedResults := FormatSearchResultsForPrompt(searchResults)
+					chat.Messages = InjectSearchResults(chat.Messages, formattedResults)
+					slog.Info("search results injected", "count", len(searchResults.Results))
+				}
+
+				// 移除 web_search 工具（避免 MiMo 400 错误）
+				chat.Tools = RemoveWebSearchTool(chat.Tools)
+			}
+		}
+	}
+
+	// 翻译 tool_choice
+	if toolChoice := gjson.GetBytes(responsesBody, "tool_choice"); toolChoice.Exists() {
+		chat.ToolChoice = translateToolChoice(toolChoice)
+	}
+
+	// 翻译 parallel_tool_calls
+	if pt := gjson.GetBytes(responsesBody, "parallel_tool_calls"); pt.Exists() {
+		val := pt.Bool()
+		chat.ParallelToolCalls = &val
+	}
+
+	// 翻译 temperature
+	if temp := gjson.GetBytes(responsesBody, "temperature"); temp.Exists() && temp.Type != gjson.Null {
+		val := temp.Float()
+		chat.Temperature = &val
+	}
+
+	// 翻译 max_output_tokens → max_completion_tokens
+	if maxTokens := gjson.GetBytes(responsesBody, "max_output_tokens"); maxTokens.Exists() && maxTokens.Type != gjson.Null {
+		val := int(maxTokens.Int())
+		chat.MaxCompletionTokens = &val
+	}
+
+	// 翻译 reasoning.effort → reasoning_effort
+	if effort := gjson.GetBytes(responsesBody, "reasoning.effort"); effort.Exists() {
+		chat.ReasoningEffort = normalizeReasoningEffort(effort.String())
+	}
+
+	// MiMo 特殊处理: 注入 thinking 默认值
+	normalizeMimoThinking(&chat, model)
+
+	// MiMo 特殊处理: thinking 模式下移除 temperature
+	if MimoThinkingFixesTemperature[model] && chat.Thinking != nil && chat.Thinking.Type == "enabled" {
+		chat.Temperature = nil
+	}
+
+	// MiMo 特殊处理: tool_choice 非 "auto" 时移除
+	if chat.ToolChoice != nil {
+		if tc, ok := chat.ToolChoice.(string); ok && tc != "auto" {
+			chat.ToolChoice = nil
+		}
+	}
+
+	// 清理 reasoning_effort: thinking disabled 时不需要
+	if chat.Thinking != nil && chat.Thinking.Type == "disabled" && chat.ReasoningEffort == "none" {
+		chat.ReasoningEffort = ""
+	}
+
+	result, err := json.Marshal(chat)
+	return result, model, err
+}
+
+// translateResponsesInputToMessages 翻译 Responses input 到 Chat messages
+func translateResponsesInputToMessages(input gjson.Result, model string) []MimoChatMessage {
+	var messages []MimoChatMessage
+
+	if input.Type == gjson.String {
+		// 简单字符串 input → user message
+		messages = append(messages, MimoChatMessage{
+			Role:    "user",
+			Content: input.String(),
+		})
+		return messages
+	}
+
+	if !input.IsArray() {
+		return messages
+	}
+
+	supportsImages := MimoModelSupportsImages(model)
+
+	input.ForEach(func(_, item gjson.Result) bool {
+		msg := translateResponsesInputItem(item, supportsImages)
+		if msg != nil {
+			messages = append(messages, *msg)
+		}
+		return true
+	})
+
+	return messages
+}
+
+// translateResponsesInputItem 翻译单个 Responses input item
+func translateResponsesInputItem(item gjson.Result, supportsImages bool) *MimoChatMessage {
+	itemType := item.Get("type").String()
+
+	switch itemType {
+	case "message":
+		return translateResponsesMessage(item, supportsImages)
+	case "function_call":
+		// function_call items 在 Chat Completions 中是 assistant message 的一部分
+		// 这里返回一个带 tool_calls 的 assistant message
+		return &MimoChatMessage{
+			Role: "assistant",
+			ToolCalls: []MimoToolCall{
+				{
+					ID:   item.Get("call_id").String(),
+					Type: "function",
+					Function: struct {
+						Name      string `json:"name"`
+						Arguments string `json:"arguments"`
+					}{
+						Name:      item.Get("name").String(),
+						Arguments: item.Get("arguments").String(),
+					},
+				},
+			},
+		}
+	case "function_call_output":
+		return &MimoChatMessage{
+			Role:       "tool",
+			ToolCallID: item.Get("call_id").String(),
+			Content:    extractOutputText(item.Get("output")),
+		}
+	case "reasoning":
+		// reasoning item → assistant message with reasoning_content
+		text := extractReasoningText(item)
+		if text != "" {
+			return &MimoChatMessage{
+				Role:             "assistant",
+				ReasoningContent: text,
+			}
+		}
+	}
+
+	return nil
+}
+
+// translateResponsesMessage 翻译 Responses message item
+func translateResponsesMessage(item gjson.Result, supportsImages bool) *MimoChatMessage {
+	role := item.Get("role").String()
+	if role == "developer" {
+		role = "system"
+	}
+
+	content := item.Get("content")
+	if !content.Exists() {
+		return &MimoChatMessage{Role: role, Content: ""}
+	}
+
+	// 处理 content 为字符串的情况
+	if content.Type == gjson.String {
+		return &MimoChatMessage{Role: role, Content: content.String()}
+	}
+
+	// 处理 content 为数组的情况
+	if content.IsArray() {
+		parts := translateContentParts(content, supportsImages)
+		if len(parts) == 0 {
+			return &MimoChatMessage{Role: role, Content: ""}
+		}
+		// 如果只有一個 text part，简化为字符串
+		if len(parts) == 1 && parts[0].Type == "text" {
+			return &MimoChatMessage{Role: role, Content: parts[0].Text}
+		}
+		return &MimoChatMessage{Role: role, Content: parts}
+	}
+
+	return &MimoChatMessage{Role: role, Content: ""}
+}
+
+// translateContentParts 翻译内容部分
+func translateContentParts(content gjson.Result, supportsImages bool) []MimoContentPart {
+	var parts []MimoContentPart
+
+	content.ForEach(func(_, part gjson.Result) bool {
+		partType := part.Get("type").String()
+		switch partType {
+		case "input_text", "output_text":
+			text := part.Get("text").String()
+			if text != "" {
+				parts = append(parts, MimoContentPart{Type: "text", Text: text})
+			}
+		case "input_image":
+			if supportsImages {
+				parts = append(parts, MimoContentPart{
+					Type: "image_url",
+					ImageURL: &struct {
+						URL    string `json:"url"`
+						Detail string `json:"detail,omitempty"`
+					}{
+						URL:    part.Get("image_url").String(),
+						Detail: part.Get("detail").String(),
+					},
+				})
+			}
+			// 不支持图片时静默丢弃
+		}
+		return true
+	})
+
+	return parts
+}
+
+// extractOutputText 提取输出文本
+func extractOutputText(output gjson.Result) string {
+	if output.Type == gjson.String {
+		return output.String()
+	}
+	if output.IsArray() {
+		var texts []string
+		output.ForEach(func(_, part gjson.Result) bool {
+			if part.Get("type").String() == "output_text" || part.Get("type").String() == "input_text" {
+				if text := part.Get("text").String(); text != "" {
+					texts = append(texts, text)
+				}
+			}
+			return true
+		})
+		return strings.Join(texts, "\n")
+	}
+	return output.String()
+}
+
+// extractReasoningText 提取 reasoning 文本
+func extractReasoningText(item gjson.Result) string {
+	// 优先使用 encrypted_content
+	if ec := item.Get("encrypted_content"); ec.Exists() && ec.String() != "" {
+		return ec.String()
+	}
+	// 回退到 summary
+	summary := item.Get("summary")
+	if summary.IsArray() {
+		var texts []string
+		summary.ForEach(func(_, s gjson.Result) bool {
+			if s.Get("type").String() == "summary_text" {
+				texts = append(texts, s.Get("text").String())
+			}
+			return true
+		})
+		return strings.Join(texts, "")
+	}
+	return ""
+}
+
+// translateResponsesTools 翻译 Responses tools 到 Chat tools
+func translateResponsesTools(tools gjson.Result, isTokenPlan bool) ([]MimoChatTool, bool) {
+	var chatTools []MimoChatTool
+	hasWebSearch := false
+
+	tools.ForEach(func(_, tool gjson.Result) bool {
+		toolType := tool.Get("type").String()
+
+		switch toolType {
+		case "function":
+			name := tool.Get("name").String()
+			if name == "" {
+				return true // 跳过无名工具
+			}
+			chatTool := MimoChatTool{
+				Type: "function",
+				Function: &MimoToolFunc{
+					Name:        name,
+					Description: tool.Get("description").String(),
+				},
+			}
+			if params := tool.Get("parameters"); params.Exists() && params.Raw != "" {
+				chatTool.Function.Parameters = json.RawMessage(params.Raw)
+			}
+			chatTools = append(chatTools, chatTool)
+
+		case "local_shell":
+			// Codex 的 local_shell → MiMo 的 shell function
+			chatTools = append(chatTools, MimoChatTool{
+				Type: "function",
+				Function: &MimoToolFunc{
+					Name:        "shell",
+					Description: "Execute a shell command on the local machine. Returns stdout, stderr and exit code.",
+					Parameters: json.RawMessage(`{
+						"type": "object",
+						"properties": {
+							"command": {
+								"type": "array",
+								"items": {"type": "string"},
+								"description": "Argv array, e.g. [\"ls\", \"-la\"]"
+							},
+							"workdir": {
+								"type": "string",
+								"description": "Working directory (optional)"
+							},
+							"timeout_ms": {
+								"type": "number",
+								"description": "Timeout in milliseconds (optional)"
+							}
+						},
+						"required": ["command"]
+					}`),
+				},
+			})
+
+		case "web_search", "web_search_preview":
+			// Token Plan 账号默认没有激活 Web Search 插件
+			// 如果发送 web_search，MiMo 会返回 400: "webSearchEnabled is false"
+			// 用户需要在 https://platform.xiaomimimo.com/#/console/plugin 激活
+			// 这里默认移除以避免 400 错误，但可通过环境变量强制启用
+			forceWebSearch := os.Getenv("MIMO_FORCE_WEB_SEARCH") == "true"
+			if !isTokenPlan || forceWebSearch {
+				hasWebSearch = true
+				chatTools = append(chatTools, MimoChatTool{Type: "web_search"})
+			} else {
+				slog.Debug("web_search skipped for token-plan account (set MIMO_FORCE_WEB_SEARCH=true to override)")
+			}
+
+		case "code_interpreter", "file_search", "image_generation",
+			"computer_use_preview", "computer_use", "tool_search":
+			// 这些工具 MiMo 不支持，静默丢弃
+
+		case "namespace":
+			// 递归处理 namespace 内的工具
+			if nested := tool.Get("tools"); nested.Exists() {
+				nestedTools, _ := translateResponsesTools(nested, isTokenPlan)
+				chatTools = append(chatTools, nestedTools...)
+			}
+
+		case "mcp":
+			// MCP 工具 MiMo 不支持，静默丢弃
+
+		case "custom":
+			// custom tool → function tool
+			name := tool.Get("name").String()
+			if name != "" {
+				chatTools = append(chatTools, MimoChatTool{
+					Type: "function",
+					Function: &MimoToolFunc{
+						Name:        name,
+						Description: tool.Get("description").String(),
+						Parameters:  json.RawMessage(`{"type":"object","properties":{"input":{"type":"string"}},"additionalProperties":true}`),
+					},
+				})
+			}
+		}
+		return true
+	})
+
+	// 去重
+	chatTools = deduplicateChatTools(chatTools)
+
+	return chatTools, hasWebSearch
+}
+
+// deduplicateChatTools 去重工具列表
+func deduplicateChatTools(tools []MimoChatTool) []MimoChatTool {
+	seen := make(map[string]bool)
+	var result []MimoChatTool
+	for _, t := range tools {
+		key := t.Type
+		if t.Function != nil {
+			key = "fn:" + t.Function.Name
+		}
+		if !seen[key] {
+			seen[key] = true
+			result = append(result, t)
+		}
+	}
+	return result
+}
+
+// translateToolChoice 翻译 tool_choice
+func translateToolChoice(tc gjson.Result) any {
+	if tc.Type == gjson.String {
+		return tc.String()
+	}
+	if tc.Get("type").String() == "function" {
+		name := tc.Get("function.name").String()
+		if name == "" {
+			name = tc.Get("name").String()
+		}
+		if name != "" {
+			return map[string]any{
+				"type":     "function",
+				"function": map[string]string{"name": name},
+			}
+		}
+	}
+	return nil
+}
+
+// normalizeMimoThinking 注入 MiMo thinking 默认值
+func normalizeMimoThinking(chat *MimoChatRequest, model string) {
+	if chat.Thinking != nil {
+		return // 已经设置了
+	}
+	// 默认禁用 thinking 的模型不注入
+	if MimoThinkingDefaultDisabled[model] {
+		return
+	}
+	// 其他模型默认启用 thinking
+	chat.Thinking = &MimoThinking{Type: "enabled"}
+}
+
+// ==================== Chat Completions → Responses 翻译 ====================
+
+// ChatChunkToResponsesEvent 将 MiMo Chat Completions 流式 chunk 翻译为 Responses SSE 事件
+// 返回多个 SSE 事件行
+func ChatChunkToResponsesEvent(chunk []byte, responseID string) ([]string, error) {
+	if !gjson.ValidBytes(chunk) {
+		return nil, nil
+	}
+
+	var events []string
+
+	chunkType := gjson.GetBytes(chunk, "object").String()
+	if chunkType == "chat.completion.chunk" {
+		events = translateChatStreamChunk(chunk, responseID)
+	} else if chunkType == "chat.completion" {
+		// 非流式响应
+		events = translateChatCompletion(chunk, responseID)
+	}
+
+	return events, nil
+}
+
+// translateChatStreamChunk 翻译流式 chunk
+func translateChatStreamChunk(chunk []byte, responseID string) []string {
+	var events []string
+
+	choices := gjson.GetBytes(chunk, "choices")
+	if !choices.IsArray() {
+		// 可能是 usage-only chunk
+		if usage := gjson.GetBytes(chunk, "usage"); usage.Exists() {
+			events = append(events, buildResponsesUsageEvent(usage, responseID))
+		}
+		return events
+	}
+
+	choices.ForEach(func(_, choice gjson.Result) bool {
+		delta := choice.Get("delta")
+		finishReason := choice.Get("finish_reason").String()
+
+		// reasoning_content → reasoning event
+		if rc := delta.Get("reasoning_content"); rc.Exists() && rc.String() != "" {
+			events = append(events, buildResponsesReasoningDelta(rc.String(), responseID))
+		}
+
+		// content → output_text delta
+		if content := delta.Get("content"); content.Exists() && content.String() != "" {
+			events = append(events, buildResponsesTextDelta(content.String(), responseID))
+		}
+
+		// tool_calls → function_call events
+		if toolCalls := delta.Get("tool_calls"); toolCalls.IsArray() {
+			toolCalls.ForEach(func(_, tc gjson.Result) bool {
+				events = append(events, buildResponsesFunctionCallDelta(tc, responseID))
+				return true
+			})
+		}
+
+		// finish_reason → completed event
+		if finishReason == "stop" || finishReason == "tool_calls" {
+			events = append(events, buildResponsesCompletedEvent(responseID))
+		}
+
+		return true
+	})
+
+	// usage event (通常在最后一个 chunk)
+	if usage := gjson.GetBytes(chunk, "usage"); usage.Exists() {
+		events = append(events, buildResponsesUsageEvent(usage, responseID))
+	}
+
+	return events
+}
+
+// translateChatCompletion 翻译非流式响应
+func translateChatCompletion(completion []byte, responseID string) []string {
+	var events []string
+
+	// 构建完整的 Responses 对象
+	resp := map[string]any{
+		"id":         responseID,
+		"object":     "response",
+		"created_at": gjson.GetBytes(completion, "created").Int(),
+		"status":     "completed",
+		"model":      gjson.GetBytes(completion, "model").String(),
+		"output":     []any{},
+		"usage":      nil,
+	}
+
+	// 翻译 choices
+	choices := gjson.GetBytes(completion, "choices")
+	if choices.IsArray() && choices.Get("0").Exists() {
+		choice := choices.Get("0")
+		message := choice.Get("message")
+
+		var outputItems []any
+
+		// reasoning_content → reasoning item
+		if rc := message.Get("reasoning_content"); rc.Exists() && rc.String() != "" {
+			outputItems = append(outputItems, map[string]any{
+				"type":   "reasoning",
+				"id":     "rs_" + responseID,
+				"summary": []map[string]any{
+					{"type": "summary_text", "text": rc.String()},
+				},
+				"encrypted_content": rc.String(),
+				"status":            "completed",
+			})
+		}
+
+		// content → message item
+		if content := message.Get("content"); content.Exists() && content.String() != "" {
+			outputItems = append(outputItems, map[string]any{
+				"type":   "message",
+				"id":     "msg_" + responseID,
+				"role":   "assistant",
+				"content": []map[string]any{
+					{"type": "output_text", "text": content.String()},
+				},
+				"status": "completed",
+			})
+		}
+
+		// tool_calls → function_call items
+		if toolCalls := message.Get("tool_calls"); toolCalls.IsArray() {
+			toolCalls.ForEach(func(_, tc gjson.Result) bool {
+				outputItems = append(outputItems, map[string]any{
+					"type":     "function_call",
+					"id":       "fc_" + tc.Get("id").String(),
+					"call_id":  tc.Get("id").String(),
+					"name":     tc.Get("function.name").String(),
+					"arguments": tc.Get("function.arguments").String(),
+					"status":   "completed",
+				})
+				return true
+			})
+		}
+
+		resp["output"] = outputItems
+	}
+
+	// usage
+	if usage := gjson.GetBytes(completion, "usage"); usage.Exists() {
+		resp["usage"] = map[string]any{
+			"input_tokens":  usage.Get("prompt_tokens").Int(),
+			"output_tokens": usage.Get("completion_tokens").Int(),
+			"total_tokens":  usage.Get("total_tokens").Int(),
+		}
+	}
+
+	data, _ := json.Marshal(resp)
+	events = append(events, "event: response.completed\ndata: "+string(data))
+
+	return events
+}
+
+// ==================== SSE 事件构建函数 ====================
+
+func buildResponsesTextDelta(text, responseID string) string {
+	event := map[string]any{
+		"type":         "response.output_text.delta",
+		"item_id":      "msg_" + responseID,
+		"output_index": 0,
+		"content_index": 0,
+		"delta":        text,
+	}
+	data, _ := json.Marshal(event)
+	return "event: response.output_text.delta\ndata: " + string(data)
+}
+
+func buildResponsesReasoningDelta(text, responseID string) string {
+	event := map[string]any{
+		"type":            "response.reasoning_summary_text.delta",
+		"item_id":         "rs_" + responseID,
+		"output_index":    0,
+		"summary_index":   0,
+		"delta":           text,
+	}
+	data, _ := json.Marshal(event)
+	return "event: response.reasoning_summary_text.delta\ndata: " + string(data)
+}
+
+func buildResponsesFunctionCallDelta(tc gjson.Result, responseID string) string {
+	name := tc.Get("function.name").String()
+	args := tc.Get("function.arguments").String()
+	callID := tc.Get("id").String()
+
+	var events []string
+
+	if name != "" {
+		// function_call arguments.start
+		startEvent := map[string]any{
+			"type":        "response.function_call_arguments.done",
+			"item_id":     "fc_" + callID,
+			"output_index": 0,
+			"name":        name,
+			"call_id":     callID,
+			"arguments":   args,
+		}
+		data, _ := json.Marshal(startEvent)
+		events = append(events, "event: response.function_call_arguments.done\ndata: "+string(data))
+	}
+
+	if len(events) > 0 {
+		return events[0]
+	}
+	return ""
+}
+
+func buildResponsesUsageEvent(usage gjson.Result, responseID string) string {
+	event := map[string]any{
+		"type": "response.usage",
+		"usage": map[string]any{
+			"input_tokens":  usage.Get("prompt_tokens").Int(),
+			"output_tokens": usage.Get("completion_tokens").Int(),
+			"total_tokens":  usage.Get("total_tokens").Int(),
+		},
+	}
+	data, _ := json.Marshal(event)
+	return "event: response.usage\ndata: " + string(data)
+}
+
+func buildResponsesCompletedEvent(responseID string) string {
+	event := map[string]any{
+		"type":    "response.completed",
+		"response": map[string]any{
+			"id":     responseID,
+			"status": "completed",
+		},
+	}
+	data, _ := json.Marshal(event)
+	return "event: response.completed\ndata: " + string(data)
+}
+
+// ==================== Chat Completions API 请求处理 ====================
+
+// TranslateChatCompletionsToMimo 将标准 Chat Completions 请求翻译为 MiMo 格式
+func TranslateChatCompletionsToMimo(chatBody []byte) ([]byte, string, error) {
+	if !gjson.ValidBytes(chatBody) {
+		return nil, "", fmt.Errorf("invalid JSON body")
+	}
+
+	model := NormalizeMimoModelID(strings.TrimSpace(gjson.GetBytes(chatBody, "model").String()))
+	if model == "" {
+		model = MimoDefaultModel
+	}
+
+	// 直接使用原始 body，只做必要的修改
+	body := chatBody
+
+	// 设置正确的模型
+	var err error
+	body, err = sjson.SetBytes(body, "model", model)
+	if err != nil {
+		return nil, "", err
+	}
+
+	// 注入 thinking 默认值
+	if !gjson.GetBytes(body, "thinking").Exists() && !MimoThinkingDefaultDisabled[model] {
+		body, _ = sjson.SetBytes(body, "thinking", map[string]string{"type": "enabled"})
+	}
+
+	// thinking 模式下移除 temperature
+	if MimoThinkingFixesTemperature[model] {
+		thinkingType := gjson.GetBytes(body, "thinking.type").String()
+		if thinkingType == "enabled" {
+			body, _ = sjson.DeleteBytes(body, "temperature")
+		}
+	}
+
+	// stream_options 注入
+	if gjson.GetBytes(body, "stream").Bool() && !gjson.GetBytes(body, "stream_options").Exists() {
+		body, _ = sjson.SetBytes(body, "stream_options", map[string]bool{"include_usage": true})
+	}
+
+	// 检查是否有 web_search 工具
+	hasWebSearch := false
+	tools := gjson.GetBytes(body, "tools")
+	if tools.IsArray() {
+		tools.ForEach(func(_, tool gjson.Result) bool {
+			if tool.Get("type").String() == "web_search" {
+				hasWebSearch = true
+				return false
+			}
+			return true
+		})
+	}
+
+	// Token Plan 账号 + 搜索已启用 = 自动搜索注入
+	if hasWebSearch && IsSearchEnabled() {
+		// 提取搜索查询（从最后一条 user 消息）
+		query := ""
+		messages := gjson.GetBytes(body, "messages")
+		if messages.IsArray() {
+			// 从后往前找 user 消息
+			for i := len(messages.Array()) - 1; i >= 0; i-- {
+				msg := messages.Array()[i]
+				if msg.Get("role").String() == "user" {
+					query = msg.Get("content").String()
+					break
+				}
+			}
+		}
+
+		if query != "" {
+			slog.Info("auto search triggered for chat completions", "query", query)
+
+			// 执行搜索
+			searchResults, err := PerformSearch(query, 5)
+			if err != nil {
+				slog.Warn("auto search failed", "error", err)
+			} else if searchResults != nil && len(searchResults.Results) > 0 {
+				// 注入搜索结果到 system 消息
+				formattedResults := FormatSearchResultsForPrompt(searchResults)
+				body = injectSearchResultsToChatBody(body, formattedResults)
+				slog.Info("search results injected", "count", len(searchResults.Results))
+			}
+
+			// 移除 web_search 工具
+			body = removeWebSearchFromBody(body)
+		}
+	}
+
+	return body, model, nil
+}
+
+// injectSearchResultsToChatBody 将搜索结果注入到 Chat Completions body 的 system 消息中
+func injectSearchResultsToChatBody(body []byte, searchResults string) []byte {
+	messages := gjson.GetBytes(body, "messages")
+	if !messages.IsArray() {
+		return body
+	}
+
+	// 查找并更新 system 消息
+	found := false
+	messages.ForEach(func(_, msg gjson.Result) bool {
+		if msg.Get("role").String() == "system" {
+			found = true
+			return false
+		}
+		return true
+	})
+
+	if found {
+		// 追加到现有 system 消息
+		body, _ = sjson.SetBytes(body, "messages.0.content",
+			gjson.GetBytes(body, "messages.0.content").String()+"\n\n"+searchResults)
+	} else {
+		// 插入新的 system 消息
+		systemMsg := map[string]string{
+			"role":    "system",
+			"content": searchResults,
+		}
+		// 在 messages 数组开头插入
+		newMessages := []interface{}{systemMsg}
+		for _, msg := range messages.Array() {
+			newMessages = append(newMessages, msg.Value())
+		}
+		body, _ = sjson.SetBytes(body, "messages", newMessages)
+	}
+
+	return body
+}
+
+// removeWebSearchFromBody 从 Chat Completions body 中移除 web_search 工具
+func removeWebSearchFromBody(body []byte) []byte {
+	tools := gjson.GetBytes(body, "tools")
+	if !tools.IsArray() {
+		return body
+	}
+
+	var newTools []interface{}
+	tools.ForEach(func(_, tool gjson.Result) bool {
+		if tool.Get("type").String() != "web_search" {
+			newTools = append(newTools, tool.Value())
+		}
+		return true
+	})
+
+	body, _ = sjson.SetBytes(body, "tools", newTools)
+	return body
+}

--- a/proxy/mimo_translator.go
+++ b/proxy/mimo_translator.go
@@ -81,6 +81,56 @@ type MimoWebSearchTool struct {
 	Type string `json:"type"` // "web_search"
 }
 
+// ==================== 输入聚合状态 ====================
+// 移植自 mimo2codex/src/translate/reqToChat.ts 的 AssemblyState 机制
+// 将多个 Responses input items 聚合为符合 Chat Completions 规范的消息序列
+
+// AssemblyState 用于聚合多个 input items 为单条 assistant 消息
+type AssemblyState struct {
+	pendingReasoning     string         // 累积的推理内容
+	pendingToolCalls     []MimoToolCall // 累积的 tool_calls
+	pendingAssistantText string         // 累积的 assistant 文本
+	hasPendingAssistant  bool           // 是否有待处理的 assistant 状态
+}
+
+// assemblyFlushAssistant 将当前累积的 assistant 状态 flush 为一条消息
+// 关键规则:
+//   - tool_calls 存在时不带 content 字段（DeepSeek V4 兼容）
+//   - reasoning_content 放在同一消息中
+//   - 纯推理回合需要空 content
+func assemblyFlushAssistant(messages *[]MimoChatMessage, state *AssemblyState) {
+	hasReasoning := state.pendingReasoning != ""
+	hasTools := len(state.pendingToolCalls) > 0
+	hasText := state.pendingAssistantText != ""
+	if !hasReasoning && !hasTools && !hasText {
+		return
+	}
+
+	msg := MimoChatMessage{Role: "assistant"}
+
+	if hasText {
+		msg.Content = state.pendingAssistantText
+	} else if !hasTools {
+		// 纯推理回合: 需要空 content 以满足 "content 或 tool_calls 必须存在"
+		msg.Content = ""
+	}
+	// tool_calls 存在时不设置 content 字段（DeepSeek V4 兼容 issue #29）
+	if hasTools {
+		msg.ToolCalls = state.pendingToolCalls
+	}
+	if hasReasoning {
+		msg.ReasoningContent = state.pendingReasoning
+	}
+
+	*messages = append(*messages, msg)
+
+	// 重置状态
+	state.pendingReasoning = ""
+	state.pendingToolCalls = nil
+	state.pendingAssistantText = ""
+	state.hasPendingAssistant = false
+}
+
 // ==================== Responses → Chat Completions 翻译 ====================
 
 // ResponsesToMimoChat 将 OpenAI Responses API 请求翻译为 MiMo Chat Completions 请求
@@ -204,112 +254,158 @@ func ResponsesToMimoChat(responsesBody []byte, isTokenPlan bool) ([]byte, string
 }
 
 // translateResponsesInputToMessages 翻译 Responses input 到 Chat messages
+// 使用 AssemblyState 聚合多个 input items 为符合 Chat Completions 规范的消息序列
 func translateResponsesInputToMessages(input gjson.Result, model string) []MimoChatMessage {
-	var messages []MimoChatMessage
-
 	if input.Type == gjson.String {
 		// 简单字符串 input → user message
-		messages = append(messages, MimoChatMessage{
-			Role:    "user",
-			Content: input.String(),
-		})
-		return messages
+		return []MimoChatMessage{
+			{Role: "user", Content: input.String()},
+		}
 	}
 
 	if !input.IsArray() {
-		return messages
+		return nil
 	}
 
+	messages := make([]MimoChatMessage, 0)
 	supportsImages := MimoModelSupportsImages(model)
+	state := &AssemblyState{}
 
 	input.ForEach(func(_, item gjson.Result) bool {
-		msg := translateResponsesInputItem(item, supportsImages)
-		if msg != nil {
-			messages = append(messages, *msg)
+		// 兼容 Chat-Completions 形状的探测请求: {role, content} 无 type 字段
+		if !item.Get("type").Exists() {
+			if role := item.Get("role").String(); role != "" {
+				content := item.Get("content")
+				text := ""
+				if content.Type == gjson.String {
+					text = content.String()
+				}
+				// 构造一个等价的 message item
+				if role == "assistant" {
+					state.pendingAssistantText = text
+					state.hasPendingAssistant = true
+				} else {
+					assemblyFlushAssistant(&messages, state)
+					messages = append(messages, MimoChatMessage{
+						Role:    role,
+						Content: text,
+					})
+				}
+				return true
+			}
 		}
+
+		itemType := item.Get("type").String()
+
+		switch itemType {
+		case "message":
+			role := item.Get("role").String()
+			if role == "developer" {
+				// developer 消息通过 instructions 处理，跳过
+				return true
+			}
+			if role == "assistant" {
+				// Buffer assistant text into pending, 不立即 flush —— 后续的
+				// function_call items 需要合并到同一条 assistant 消息中
+				if state.pendingAssistantText != "" {
+					assemblyFlushAssistant(&messages, state)
+				}
+				content := translateResponsesInputItemContent(item, supportsImages)
+				text := ""
+				if s, ok := content.(string); ok {
+					text = s
+				}
+				state.pendingAssistantText = text
+				state.hasPendingAssistant = true
+			} else {
+				// user / system / 其他角色: 先 flush assistant 状态，然后添加消息
+				assemblyFlushAssistant(&messages, state)
+				// role=system 保持为 system（已由 instructions 处理，但直接传入时也接受）
+				messages = append(messages, MimoChatMessage{
+					Role:    role,
+					Content: translateResponsesInputItemContent(item, supportsImages),
+				})
+			}
+
+		case "reasoning":
+			// reasoning item: 优先使用 encrypted_content（Codex 跨轮次回传必需）
+			// 累积到 pendingReasoning，不立即 flush
+			text := extractReasoningText(item)
+			if text == "" {
+				return true
+			}
+			// 如果已有 pending tool_calls 或 assistant text，合并到同一消息
+			if len(state.pendingToolCalls) > 0 || state.pendingAssistantText != "" {
+				if state.pendingReasoning != "" {
+					state.pendingReasoning += text
+				} else {
+					state.pendingReasoning = text
+				}
+			} else {
+				assemblyFlushAssistant(&messages, state)
+				state.pendingReasoning = text
+			}
+
+		case "function_call":
+			// function_call item: 累积到 pendingToolCalls，不立即 flush
+			state.pendingToolCalls = append(state.pendingToolCalls, MimoToolCall{
+				ID:   item.Get("call_id").String(),
+				Type: "function",
+				Function: struct {
+					Name      string `json:"name"`
+					Arguments string `json:"arguments"`
+				}{
+					Name:      item.Get("name").String(),
+					Arguments: sanitizeFunctionCallArguments(item.Get("arguments").String(), item.Get("name").String()),
+				},
+			})
+
+		case "function_call_output":
+			// function_call_output: 先 flush 当前 assistant 状态，然后作为 tool 消息
+			assemblyFlushAssistant(&messages, state)
+			messages = append(messages, MimoChatMessage{
+				Role:       "tool",
+				ToolCallID: item.Get("call_id").String(),
+				Content:    extractOutputText(item.Get("output")),
+			})
+		}
+
 		return true
 	})
+
+	// flush 最后剩余的 assistant 状态
+	assemblyFlushAssistant(&messages, state)
+
+	// 后处理: 清理孤立 tool 消息 + 补全缺失 tool output
+	removeOrphanToolMessages(&messages)
+	ensureToolCallHaveOutputs(&messages)
 
 	return messages
 }
 
-// translateResponsesInputItem 翻译单个 Responses input item
-func translateResponsesInputItem(item gjson.Result, supportsImages bool) *MimoChatMessage {
-	itemType := item.Get("type").String()
-
-	switch itemType {
-	case "message":
-		return translateResponsesMessage(item, supportsImages)
-	case "function_call":
-		// function_call items 在 Chat Completions 中是 assistant message 的一部分
-		// 这里返回一个带 tool_calls 的 assistant message
-		return &MimoChatMessage{
-			Role: "assistant",
-			ToolCalls: []MimoToolCall{
-				{
-					ID:   item.Get("call_id").String(),
-					Type: "function",
-					Function: struct {
-						Name      string `json:"name"`
-						Arguments string `json:"arguments"`
-					}{
-						Name:      item.Get("name").String(),
-						Arguments: item.Get("arguments").String(),
-					},
-				},
-			},
-		}
-	case "function_call_output":
-		return &MimoChatMessage{
-			Role:       "tool",
-			ToolCallID: item.Get("call_id").String(),
-			Content:    extractOutputText(item.Get("output")),
-		}
-	case "reasoning":
-		// reasoning item → assistant message with reasoning_content
-		text := extractReasoningText(item)
-		if text != "" {
-			return &MimoChatMessage{
-				Role:             "assistant",
-				ReasoningContent: text,
-			}
-		}
-	}
-
-	return nil
-}
-
-// translateResponsesMessage 翻译 Responses message item
-func translateResponsesMessage(item gjson.Result, supportsImages bool) *MimoChatMessage {
-	role := item.Get("role").String()
-	if role == "developer" {
-		role = "system"
-	}
-
+// translateResponsesInputItemContent 翻译 input item 的 content 字段
+func translateResponsesInputItemContent(item gjson.Result, supportsImages bool) any {
 	content := item.Get("content")
 	if !content.Exists() {
-		return &MimoChatMessage{Role: role, Content: ""}
+		return ""
 	}
 
-	// 处理 content 为字符串的情况
 	if content.Type == gjson.String {
-		return &MimoChatMessage{Role: role, Content: content.String()}
+		return content.String()
 	}
 
-	// 处理 content 为数组的情况
 	if content.IsArray() {
 		parts := translateContentParts(content, supportsImages)
 		if len(parts) == 0 {
-			return &MimoChatMessage{Role: role, Content: ""}
+			return ""
 		}
-		// 如果只有一個 text part，简化为字符串
 		if len(parts) == 1 && parts[0].Type == "text" {
-			return &MimoChatMessage{Role: role, Content: parts[0].Text}
+			return parts[0].Text
 		}
-		return &MimoChatMessage{Role: role, Content: parts}
+		return parts
 	}
 
-	return &MimoChatMessage{Role: role, Content: ""}
+	return content.String()
 }
 
 // translateContentParts 翻译内容部分
@@ -386,6 +482,143 @@ func extractReasoningText(item gjson.Result) string {
 	return ""
 }
 
+// ==================== 输入后处理函数 ====================
+
+// sanitizeFunctionCallArguments 校验 tool call arguments 是否为合法 JSON
+// 如果不合法（不完整 JSON），替换为 "{}"
+// 不删除整个 tool_call —— 保持消息对结构
+func sanitizeFunctionCallArguments(raw string, name string) string {
+	if raw == "" {
+		return "{}"
+	}
+	if json.Valid([]byte(raw)) {
+		return raw
+	}
+	slog.Warn("salvaging malformed tool_call arguments",
+		"name", name,
+		"len", len(raw),
+		"preview", truncateString(raw, 80),
+	)
+	return "{}"
+}
+
+// sanitizeToolCallArgumentsOutput 校验响应方向的 tool call arguments
+func sanitizeToolCallArgumentsOutput(raw string, name, callID, finishReason string) string {
+	if raw == "" {
+		return raw
+	}
+	if json.Valid([]byte(raw)) {
+		return raw
+	}
+	reason := "upstream returned malformed JSON in arguments"
+	if finishReason == "length" {
+		reason = "response truncated by length limit"
+	}
+	slog.Warn("tool_call arguments not valid JSON; salvaged to \"{}\"",
+		"name", name,
+		"call_id", callID,
+		"len", len(raw),
+		"finish_reason", finishReason,
+		"cause", reason,
+		"preview", truncateString(raw, 80),
+	)
+	return "{}"
+}
+
+// truncateString 截断字符串用于日志
+func truncateString(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "..."
+}
+
+// removeOrphanToolMessages 清理孤立的 tool 消息
+// 当 Codex session 状态失同步时（用户中断并行工具调用、crash 后部分回放等），
+// 可能出现 role=tool 的消息但其 tool_call_id 在前面的 assistant 消息中找不到匹配。
+// DeepSeek V4 会拒绝这些消息并返回 400。
+func removeOrphanToolMessages(messages *[]MimoChatMessage) {
+	var validIDs map[string]bool
+	i := 0
+	for i < len(*messages) {
+		m := &(*messages)[i]
+		if m.Role == "assistant" {
+			if len(m.ToolCalls) > 0 {
+				validIDs = make(map[string]bool)
+				for _, tc := range m.ToolCalls {
+					if tc.ID != "" {
+						validIDs[tc.ID] = true
+					}
+				}
+			} else {
+				validIDs = nil
+			}
+			i++
+		} else if m.Role == "tool" {
+			if validIDs != nil && m.ToolCallID != "" && validIDs[m.ToolCallID] {
+				i++
+			} else {
+				slog.Warn("dropped orphan tool message",
+					"tool_call_id", m.ToolCallID,
+				)
+				// splice: 不递增 i，下一个元素已经移到当前位置
+				*messages = append((*messages)[:i], (*messages)[i+1:]...)
+			}
+		} else {
+			// user / system / 其他: 重置 tool 接收窗口
+			validIDs = nil
+			i++
+		}
+	}
+}
+
+// ensureToolCallHaveOutputs 确保每个带 tool_calls 的 assistant 消息后面
+// 都有对应的 role=tool 消息。如果缺少，添加占位消息。
+func ensureToolCallHaveOutputs(messages *[]MimoChatMessage) {
+	for i := 0; i < len(*messages); i++ {
+		m := &(*messages)[i]
+		if m.Role != "assistant" || len(m.ToolCalls) == 0 {
+			continue
+		}
+
+		// 收集后面连续的 tool 消息中的 tool_call_id
+		seen := make(map[string]bool)
+		j := i + 1
+		for j < len(*messages) && (*messages)[j].Role == "tool" {
+			if (*messages)[j].ToolCallID != "" {
+				seen[(*messages)[j].ToolCallID] = true
+			}
+			j++
+		}
+
+		// 查找缺失的 tool_call_id
+		var missing []string
+		for _, tc := range m.ToolCalls {
+			if tc.ID != "" && !seen[tc.ID] {
+				missing = append(missing, tc.ID)
+			}
+		}
+		if len(missing) == 0 {
+			continue
+		}
+
+		// 在位置 j 插入占位 tool 消息
+		placeholders := make([]MimoChatMessage, 0, len(missing))
+		for _, id := range missing {
+			placeholders = append(placeholders, MimoChatMessage{
+				Role:       "tool",
+				ToolCallID: id,
+				Content:    "[tool output missing]",
+			})
+		}
+
+		// 插入占位消息
+		*messages = append((*messages)[:j], append(placeholders, (*messages)[j:]...)...)
+		// 跳过刚插入的占位消息，避免重复扫描
+		i = j + len(placeholders) - 1
+	}
+}
+
 // translateResponsesTools 翻译 Responses tools 到 Chat tools
 func translateResponsesTools(tools gjson.Result, isTokenPlan bool) ([]MimoChatTool, bool) {
 	var chatTools []MimoChatTool
@@ -454,8 +687,25 @@ func translateResponsesTools(tools gjson.Result, isTokenPlan bool) ([]MimoChatTo
 				slog.Debug("web_search skipped for token-plan account (set MIMO_FORCE_WEB_SEARCH=true to override)")
 			}
 
+		case "tool_search":
+			// Codex Desktop 的 tool_search builtin -- 延迟工具发现机制
+			// 翻译为普通 function tool，name="tool_search"
+			toolSearch := MimoChatTool{
+				Type: "function",
+				Function: &MimoToolFunc{
+					Name: "tool_search",
+				},
+			}
+			if desc := tool.Get("description").String(); desc != "" {
+				toolSearch.Function.Description = desc
+			}
+			if params := tool.Get("parameters"); params.Exists() && params.Raw != "" {
+				toolSearch.Function.Parameters = json.RawMessage(params.Raw)
+			}
+			chatTools = append(chatTools, toolSearch)
+
 		case "code_interpreter", "file_search", "image_generation",
-			"computer_use_preview", "computer_use", "tool_search":
+			"computer_use_preview", "computer_use":
 			// 这些工具 MiMo 不支持，静默丢弃
 
 		case "namespace":
@@ -563,7 +813,58 @@ func ChatChunkToResponsesEvent(chunk []byte, responseID string) ([]string, error
 	return events, nil
 }
 
+// MimoStreamState 流式响应累积状态
+type MimoStreamState struct {
+	ResponseID      string
+	Model           string
+	ReasoningText   string
+	OutputText      string
+	HasReasoning    bool
+	HasOutput       bool
+	HasToolCalls    bool
+	ToolCalls       []MimoStreamToolCall
+	Usage           *MimoUsageData
+	FinishReason    string
+	OutputIndex     int                                    // 当前 output item 索引
+	SequenceNumber  int                                    // 全局序列号（从 0 开始递增）
+	FunctionCallSeq map[int]*MimoStreamFunctionCallState   // index → function call state
+}
+
+// NextSeq 返回下一个序列号并递增
+func (s *MimoStreamState) NextSeq() int {
+	n := s.SequenceNumber
+	s.SequenceNumber++
+	return n
+}
+
+// MimoStreamToolCall 流式 tool call 累积
+type MimoStreamToolCall struct {
+	ID        string
+	CallID    string
+	Name      string
+	Arguments string
+}
+
+// MimoStreamFunctionCallState 流式 function call 累积状态
+type MimoStreamFunctionCallState struct {
+	ItemID     string
+	CallID     string
+	Name       string
+	ArgsBuffer string
+	OutputIdx  int
+	Opened     bool // 是否已发送 output_item.added
+}
+
+// MimoUsageData usage 数据
+type MimoUsageData struct {
+	InputTokens  int64 `json:"input_tokens"`
+	OutputTokens int64 `json:"output_tokens"`
+	TotalTokens  int64 `json:"total_tokens"`
+}
+
 // translateChatStreamChunk 翻译流式 chunk
+// 注意: 此函数现在仅用于非流式路径（ChatChunkToResponsesEvent）
+// 流式路径由 handleMimoStreamResponse 直接处理
 func translateChatStreamChunk(chunk []byte, responseID string) []string {
 	var events []string
 
@@ -571,36 +872,39 @@ func translateChatStreamChunk(chunk []byte, responseID string) []string {
 	if !choices.IsArray() {
 		// 可能是 usage-only chunk
 		if usage := gjson.GetBytes(chunk, "usage"); usage.Exists() {
-			events = append(events, buildResponsesUsageEvent(usage, responseID))
+			events = append(events, buildResponsesUsageEvent(usage, responseID, 0))
 		}
 		return events
 	}
 
 	choices.ForEach(func(_, choice gjson.Result) bool {
 		delta := choice.Get("delta")
-		finishReason := choice.Get("finish_reason").String()
 
 		// reasoning_content → reasoning event
 		if rc := delta.Get("reasoning_content"); rc.Exists() && rc.String() != "" {
-			events = append(events, buildResponsesReasoningDelta(rc.String(), responseID))
+			events = append(events, buildResponsesReasoningDelta(rc.String(), responseID, 0))
 		}
 
 		// content → output_text delta
 		if content := delta.Get("content"); content.Exists() && content.String() != "" {
-			events = append(events, buildResponsesTextDelta(content.String(), responseID))
+			events = append(events, buildResponsesTextDelta(content.String(), responseID, 0))
 		}
 
-		// tool_calls → function_call events
+		// tool_calls → function_call events (简化版，用于非流式路径)
 		if toolCalls := delta.Get("tool_calls"); toolCalls.IsArray() {
 			toolCalls.ForEach(func(_, tc gjson.Result) bool {
-				events = append(events, buildResponsesFunctionCallDelta(tc, responseID))
+				callID := tc.Get("id").String()
+				name := tc.Get("function.name").String()
+				args := tc.Get("function.arguments").String()
+				if name != "" && callID != "" {
+					itemID := "fc_" + callID
+					// arguments delta
+					if args != "" {
+						events = append(events, buildResponsesFunctionCallArgumentsDeltaEvent(itemID, args, 0, 0))
+					}
+				}
 				return true
 			})
-		}
-
-		// finish_reason → completed event
-		if finishReason == "stop" || finishReason == "tool_calls" {
-			events = append(events, buildResponsesCompletedEvent(responseID))
 		}
 
 		return true
@@ -608,7 +912,7 @@ func translateChatStreamChunk(chunk []byte, responseID string) []string {
 
 	// usage event (通常在最后一个 chunk)
 	if usage := gjson.GetBytes(chunk, "usage"); usage.Exists() {
-		events = append(events, buildResponsesUsageEvent(usage, responseID))
+		events = append(events, buildResponsesUsageEvent(usage, responseID, 0))
 	}
 
 	return events
@@ -640,11 +944,9 @@ func translateChatCompletion(completion []byte, responseID string) []string {
 		// reasoning_content → reasoning item
 		if rc := message.Get("reasoning_content"); rc.Exists() && rc.String() != "" {
 			outputItems = append(outputItems, map[string]any{
-				"type":   "reasoning",
-				"id":     "rs_" + responseID,
-				"summary": []map[string]any{
-					{"type": "summary_text", "text": rc.String()},
-				},
+				"type":              "reasoning",
+				"id":                "rs_" + responseID,
+				"summary":           []map[string]any{{"type": "summary_text", "text": rc.String()}},
 				"encrypted_content": rc.String(),
 				"status":            "completed",
 			})
@@ -698,80 +1000,399 @@ func translateChatCompletion(completion []byte, responseID string) []string {
 
 // ==================== SSE 事件构建函数 ====================
 
-func buildResponsesTextDelta(text, responseID string) string {
+func buildResponsesTextDelta(text, responseID string, seq int) string {
 	event := map[string]any{
-		"type":         "response.output_text.delta",
-		"item_id":      "msg_" + responseID,
-		"output_index": 0,
-		"content_index": 0,
-		"delta":        text,
+		"type":            "response.output_text.delta",
+		"item_id":         "msg_" + responseID,
+		"output_index":    0,
+		"content_index":   0,
+		"delta":           text,
+		"sequence_number": seq,
 	}
 	data, _ := json.Marshal(event)
 	return "event: response.output_text.delta\ndata: " + string(data)
 }
 
-func buildResponsesReasoningDelta(text, responseID string) string {
+func buildResponsesReasoningDelta(text, responseID string, seq int) string {
 	event := map[string]any{
 		"type":            "response.reasoning_summary_text.delta",
 		"item_id":         "rs_" + responseID,
 		"output_index":    0,
 		"summary_index":   0,
 		"delta":           text,
+		"sequence_number": seq,
 	}
 	data, _ := json.Marshal(event)
 	return "event: response.reasoning_summary_text.delta\ndata: " + string(data)
 }
 
-func buildResponsesFunctionCallDelta(tc gjson.Result, responseID string) string {
-	name := tc.Get("function.name").String()
-	args := tc.Get("function.arguments").String()
-	callID := tc.Get("id").String()
-
-	var events []string
-
-	if name != "" {
-		// function_call arguments.start
-		startEvent := map[string]any{
-			"type":        "response.function_call_arguments.done",
-			"item_id":     "fc_" + callID,
-			"output_index": 0,
-			"name":        name,
-			"call_id":     callID,
-			"arguments":   args,
-		}
-		data, _ := json.Marshal(startEvent)
-		events = append(events, "event: response.function_call_arguments.done\ndata: "+string(data))
+// buildResponsesReasoningSummaryPartAddedEvent 构建 response.reasoning_summary_part.added 事件
+func buildResponsesReasoningSummaryPartAddedEvent(responseID string, outputIndex int, seq int) string {
+	event := map[string]any{
+		"type":            "response.reasoning_summary_part.added",
+		"item_id":         "rs_" + responseID,
+		"output_index":    outputIndex,
+		"summary_index":   0,
+		"part":            map[string]any{"type": "summary_text", "text": ""},
+		"sequence_number": seq,
 	}
-
-	if len(events) > 0 {
-		return events[0]
-	}
-	return ""
+	data, _ := json.Marshal(event)
+	return "event: response.reasoning_summary_part.added\ndata: " + string(data)
 }
 
-func buildResponsesUsageEvent(usage gjson.Result, responseID string) string {
+// buildResponsesReasoningSummaryPartDoneEvent 构建 response.reasoning_summary_part.done 事件
+func buildResponsesReasoningSummaryPartDoneEvent(text, responseID string, outputIndex, seq int) string {
+	event := map[string]any{
+		"type":            "response.reasoning_summary_part.done",
+		"item_id":         "rs_" + responseID,
+		"output_index":    outputIndex,
+		"summary_index":   0,
+		"part":            map[string]any{"type": "summary_text", "text": text},
+		"sequence_number": seq,
+	}
+	data, _ := json.Marshal(event)
+	return "event: response.reasoning_summary_part.done\ndata: " + string(data)
+}
+
+// buildResponsesFunctionCallAddedEvent 构建 function_call 的 output_item.added 事件
+func buildResponsesFunctionCallAddedEvent(responseID, itemID, callID, name string, outputIndex, seq int) string {
+	item := map[string]any{
+		"id":       itemID,
+		"type":     "function_call",
+		"call_id":  callID,
+		"name":     name,
+		"arguments": "",
+		"status":   "in_progress",
+	}
+	event := map[string]any{
+		"type":            "response.output_item.added",
+		"output_index":    outputIndex,
+		"item":            item,
+		"sequence_number": seq,
+	}
+	data, _ := json.Marshal(event)
+	return "event: response.output_item.added\ndata: " + string(data)
+}
+
+// buildResponsesFunctionCallArgumentsDeltaEvent 构建 function_call arguments delta 事件
+func buildResponsesFunctionCallArgumentsDeltaEvent(itemID string, argsDelta string, outputIndex, seq int) string {
+	event := map[string]any{
+		"type":            "response.function_call_arguments.delta",
+		"item_id":         itemID,
+		"output_index":    outputIndex,
+		"delta":           argsDelta,
+		"sequence_number": seq,
+	}
+	data, _ := json.Marshal(event)
+	return "event: response.function_call_arguments.delta\ndata: " + string(data)
+}
+
+// buildResponsesFunctionCallArgumentsDoneEvent 构建 function_call arguments done 事件
+func buildResponsesFunctionCallArgumentsDoneEvent(itemID, args string, outputIndex, seq int) string {
+	event := map[string]any{
+		"type":            "response.function_call_arguments.done",
+		"item_id":         itemID,
+		"output_index":    outputIndex,
+		"arguments":       args,
+		"sequence_number": seq,
+	}
+	data, _ := json.Marshal(event)
+	return "event: response.function_call_arguments.done\ndata: " + string(data)
+}
+
+func buildResponsesUsageEvent(usage gjson.Result, responseID string, seq int) string {
+	// 兼容两种格式：prompt_tokens/completion_tokens 和 input_tokens/output_tokens
+	inputTokens := usage.Get("prompt_tokens").Int()
+	if inputTokens == 0 {
+		inputTokens = usage.Get("input_tokens").Int()
+	}
+	outputTokens := usage.Get("completion_tokens").Int()
+	if outputTokens == 0 {
+		outputTokens = usage.Get("output_tokens").Int()
+	}
+	totalTokens := usage.Get("total_tokens").Int()
+	if totalTokens == 0 {
+		totalTokens = inputTokens + outputTokens
+	}
 	event := map[string]any{
 		"type": "response.usage",
 		"usage": map[string]any{
-			"input_tokens":  usage.Get("prompt_tokens").Int(),
-			"output_tokens": usage.Get("completion_tokens").Int(),
-			"total_tokens":  usage.Get("total_tokens").Int(),
+			"input_tokens":  inputTokens,
+			"output_tokens": outputTokens,
+			"total_tokens":  totalTokens,
 		},
+		"sequence_number": seq,
 	}
 	data, _ := json.Marshal(event)
 	return "event: response.usage\ndata: " + string(data)
 }
 
+// buildResponsesCompletedEvent 构建完整的 response.completed 事件
+// 包含完整的 output items、usage、model 等所有必要字段
 func buildResponsesCompletedEvent(responseID string) string {
-	event := map[string]any{
-		"type":    "response.completed",
-		"response": map[string]any{
-			"id":     responseID,
+	// 简单版本 — 用于非累积场景（如流式 chunk 中不再调用）
+	return buildResponsesCompletedEventWithData(responseID, "mimo", nil, nil, "")
+}
+
+// buildResponsesCompletedEventWithData 构建包含完整数据的 response.completed 事件
+func buildResponsesCompletedEventWithData(responseID, model string, reasoningText, outputText *string, usageJSON string) string {
+	var outputItems []any
+
+	// reasoning item
+	if reasoningText != nil && *reasoningText != "" {
+		outputItems = append(outputItems, map[string]any{
+			"type":              "reasoning",
+			"id":                "rs_" + responseID,
+			"summary":           []map[string]any{{"type": "summary_text", "text": *reasoningText}},
+			"encrypted_content": *reasoningText,
+			"status":            "completed",
+		})
+	}
+
+	// message item
+	if outputText != nil && *outputText != "" {
+		outputItems = append(outputItems, map[string]any{
+			"type": "message",
+			"id":   "msg_" + responseID,
+			"role": "assistant",
+			"content": []map[string]any{
+				{"type": "output_text", "text": *outputText, "annotations": []any{}},
+			},
 			"status": "completed",
-		},
+		})
+	}
+
+	if outputItems == nil {
+		outputItems = []any{}
+	}
+
+	resp := map[string]any{
+		"id":          responseID,
+		"object":      "response",
+		"created_at":  0,
+		"status":      "completed",
+		"model":       model,
+		"output":      outputItems,
+		"instructions": "",
+		"tools":       []any{},
+		"tool_choice": "auto",
+		"temperature": nil,
+		"max_output_tokens": nil,
+		"top_p":       nil,
+		"parallel_tool_calls": true,
+	}
+
+	// 添加 usage — 转换 MiMo 字段名为 Responses API 格式
+	if usageJSON != "" {
+		var usageData map[string]any
+		if err := json.Unmarshal([]byte(usageJSON), &usageData); err == nil {
+			resp["usage"] = convertUsageToResponsesFormat(usageData)
+		}
+	} else {
+		resp["usage"] = map[string]any{
+			"input_tokens":  0,
+			"output_tokens": 0,
+			"total_tokens":  0,
+		}
+	}
+
+	event := map[string]any{
+		"type":     "response.completed",
+		"response": resp,
 	}
 	data, _ := json.Marshal(event)
 	return "event: response.completed\ndata: " + string(data)
+}
+
+// convertUsageToResponsesFormat 将 MiMo/Chat Completions 的 usage 格式转换为 Responses API 格式
+// prompt_tokens → input_tokens, completion_tokens → output_tokens
+func convertUsageToResponsesFormat(usage map[string]any) map[string]any {
+	result := map[string]any{}
+
+	// input_tokens: 优先使用 input_tokens，回退到 prompt_tokens
+	if v, ok := usage["input_tokens"]; ok {
+		result["input_tokens"] = v
+	} else if v, ok := usage["prompt_tokens"]; ok {
+		result["input_tokens"] = v
+	} else {
+		result["input_tokens"] = 0
+	}
+
+	// output_tokens: 优先使用 output_tokens，回退到 completion_tokens
+	if v, ok := usage["output_tokens"]; ok {
+		result["output_tokens"] = v
+	} else if v, ok := usage["completion_tokens"]; ok {
+		result["output_tokens"] = v
+	} else {
+		result["output_tokens"] = 0
+	}
+
+	// total_tokens
+	if v, ok := usage["total_tokens"]; ok {
+		result["total_tokens"] = v
+	} else {
+		// json.Unmarshal 产生 float64，需要兼容处理
+		var inp, out int64
+		switch v := result["input_tokens"].(type) {
+		case float64:
+			inp = int64(v)
+		case int64:
+			inp = v
+		case int:
+			inp = int64(v)
+		}
+		switch v := result["output_tokens"].(type) {
+		case float64:
+			out = int64(v)
+		case int64:
+			out = v
+		case int:
+			out = int64(v)
+		}
+		result["total_tokens"] = inp + out
+	}
+
+	return result
+}
+
+// ==================== 生命周期事件构建函数 ====================
+
+// buildResponseInProgressEvent 构建 response.in_progress 事件
+func buildResponseInProgressEvent(responseID, model string, seq int) string {
+	resp := map[string]any{
+		"id":         responseID,
+		"object":     "response",
+		"status":     "in_progress",
+		"model":      model,
+		"output":     []any{},
+	}
+	event := map[string]any{
+		"type":            "response.in_progress",
+		"response":        resp,
+		"sequence_number": seq,
+	}
+	data, _ := json.Marshal(event)
+	return "event: response.in_progress\ndata: " + string(data)
+}
+
+// buildResponseOutputItemAddedEvent 构建 response.output_item.added 事件
+func buildResponseOutputItemAddedEvent(responseID, itemID, itemType string, outputIndex, seq int) string {
+	var item map[string]any
+	switch itemType {
+	case "reasoning":
+		item = map[string]any{
+			"type":              "reasoning",
+			"id":                itemID,
+			"summary":           []any{},
+			"encrypted_content": nil,
+			"status":            "in_progress",
+		}
+	case "message":
+		item = map[string]any{
+			"type":    "message",
+			"id":      itemID,
+			"role":    "assistant",
+			"content": []any{},
+			"status":  "in_progress",
+		}
+	case "function_call":
+		item = map[string]any{
+			"type":   "function_call",
+			"id":     itemID,
+			"status": "in_progress",
+		}
+	default:
+		item = map[string]any{"type": itemType, "id": itemID, "status": "in_progress"}
+	}
+	event := map[string]any{
+		"type":            "response.output_item.added",
+		"output_index":    outputIndex,
+		"item":            item,
+		"sequence_number": seq,
+	}
+	data, _ := json.Marshal(event)
+	return "event: response.output_item.added\ndata: " + string(data)
+}
+
+// buildResponseOutputItemDoneEvent 构建 response.output_item.done 事件
+func buildResponseOutputItemDoneEvent(outputIndex int, itemData any, seq int) string {
+	event := map[string]any{
+		"type":            "response.output_item.done",
+		"output_index":    outputIndex,
+		"item":            itemData,
+		"sequence_number": seq,
+	}
+	data, _ := json.Marshal(event)
+	return "event: response.output_item.done\ndata: " + string(data)
+}
+
+// buildResponseContentPartAddedEvent 构建 response.content_part.added 事件
+func buildResponseContentPartAddedEvent(partType string, outputIndex, contentIndex, seq int) string {
+	var part map[string]any
+	switch partType {
+	case "reasoning_summary":
+		part = map[string]any{
+			"type": "reasoning_summary",
+		}
+	case "output_text":
+		part = map[string]any{
+			"type":        "output_text",
+			"annotations": []any{},
+		}
+	default:
+		part = map[string]any{"type": partType}
+	}
+	event := map[string]any{
+		"type":            "response.content_part.added",
+		"output_index":    outputIndex,
+		"content_index":   contentIndex,
+		"part":            part,
+		"sequence_number": seq,
+	}
+	data, _ := json.Marshal(event)
+	return "event: response.content_part.added\ndata: " + string(data)
+}
+
+// buildResponseContentPartDoneEvent 构建 response.content_part.done 事件
+func buildResponseContentPartDoneEvent(part any, outputIndex, contentIndex, seq int) string {
+	event := map[string]any{
+		"type":            "response.content_part.done",
+		"output_index":    outputIndex,
+		"content_index":   contentIndex,
+		"part":            part,
+		"sequence_number": seq,
+	}
+	data, _ := json.Marshal(event)
+	return "event: response.content_part.done\ndata: " + string(data)
+}
+
+// buildResponseReasoningTextDoneEvent 构建 response.reasoning_summary_text.done 事件
+func buildResponseReasoningTextDoneEvent(text, responseID string, summaryIndex, seq int) string {
+	event := map[string]any{
+		"type":            "response.reasoning_summary_text.done",
+		"item_id":         "rs_" + responseID,
+		"output_index":    0,
+		"summary_index":   summaryIndex,
+		"text":            text,
+		"sequence_number": seq,
+	}
+	data, _ := json.Marshal(event)
+	return "event: response.reasoning_summary_text.done\ndata: " + string(data)
+}
+
+// buildResponseOutputTextDoneEvent 构建 response.output_text.done 事件
+func buildResponseOutputTextDoneEvent(text, responseID string, seq int) string {
+	event := map[string]any{
+		"type":            "response.output_text.done",
+		"item_id":         "msg_" + responseID,
+		"output_index":    0,
+		"content_index":   0,
+		"text":            text,
+		"annotations":     []any{},
+		"sequence_number": seq,
+	}
+	data, _ := json.Marshal(event)
+	return "event: response.output_text.done\ndata: " + string(data)
 }
 
 // ==================== Chat Completions API 请求处理 ====================
@@ -874,19 +1495,20 @@ func injectSearchResultsToChatBody(body []byte, searchResults string) []byte {
 	}
 
 	// 查找并更新 system 消息
-	found := false
-	messages.ForEach(func(_, msg gjson.Result) bool {
+	systemIdx := -1
+	messages.ForEach(func(idx gjson.Result, msg gjson.Result) bool {
 		if msg.Get("role").String() == "system" {
-			found = true
+			systemIdx = int(idx.Int())
 			return false
 		}
 		return true
 	})
 
-	if found {
+	if systemIdx >= 0 {
 		// 追加到现有 system 消息
-		body, _ = sjson.SetBytes(body, "messages.0.content",
-			gjson.GetBytes(body, "messages.0.content").String()+"\n\n"+searchResults)
+		path := fmt.Sprintf("messages.%d.content", systemIdx)
+		body, _ = sjson.SetBytes(body, path,
+			gjson.GetBytes(body, path).String()+"\n\n"+searchResults)
 	} else {
 		// 插入新的 system 消息
 		systemMsg := map[string]string{


### PR DESCRIPTION
## Summary

Add MiMo upstream integration supporting both Responses API and Chat Completions API, with automatic client type detection and format translation.

## Features
- MiMo upstream executor (Responses + Chat Completions endpoints)
- MiMo format translator (OpenAI Responses <-> MiMo wire format)
- MiMo provider detection (API key pattern, base_url, upstream_type)
- Account-level model mapping for MiMo accounts
- Automatic client type switching (Responses API vs Chat Completions)

## Fixes found during integration
- Fix gjson.Result.Get() returning 0 after json.Unmarshal
- Fix int64 type assertion in convertUsageToResponsesFormat
- Support prompt_tokens/input_tokens and completion_tokens/output_tokens formats
- Extract cached_tokens and reasoning_tokens in MiMo usage path
- Add User-Agent to all upstream requests
- Pass ReasoningTokens to logUsageForRequest in MiMo path

## Files changed
- proxy/mimo_executor.go (new) - MiMo upstream request executor
- proxy/mimo_translator.go (new) - MiMo format translation layer
- proxy/executor.go - User-Agent header for all upstream requests
- proxy/handler.go - MiMo routing, account-level mapping, usage tracking

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MiMo upstream routing with per-account model mapping and configurable upstream settings
  * Automatically inject web search results for Token Plan accounts
  * Translated MiMo Chat Completions to Responses, including full streaming event support
  * Improved tool/function calling support across routed backends
* **Bug Fixes**
  * Improved request-body handling for Responses, Responses Compact, and Chat Completions
  * Refreshed Codex usage snapshot handling to ensure correct 5h reset tracking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->