### PR TITLE
fix: 修复 Claude Code 工具参数兼容清洗

### DIFF
--- a/proxy/anthropic.go
+++ b/proxy/anthropic.go
@@ -881,31 +881,6 @@ func (t *anthropicStreamTranslator) closeCurrentBlock() []anthropicStreamEvent {
 	return events
 }
 
-// sanitizeToolInputJSON 清洗工具调用 arguments JSON。
-// 只处理 Claude Code Read 工具已知兼容问题：上游 gpt-5.5 偶尔会给
-// Read 工具加 "pages":""，导致 claudecode 看到无效空字段。
-// 其他工具的空字符串和 null 参数可能有合法语义，不能泛化删除。
-func sanitizeToolInputJSON(toolName string, raw string) string {
-	raw = strings.TrimSpace(raw)
-	if toolName != "Read" || raw == "" {
-		return raw
-	}
-	var obj map[string]json.RawMessage
-	if err := json.Unmarshal([]byte(raw), &obj); err != nil {
-		return raw
-	}
-	pages, ok := obj["pages"]
-	if !ok || strings.TrimSpace(string(pages)) != `""` {
-		return raw
-	}
-	delete(obj, "pages")
-	out, err := json.Marshal(obj)
-	if err != nil {
-		return raw
-	}
-	return string(out)
-}
-
 // finalize 在流结束时补齐缺失的事件
 func (t *anthropicStreamTranslator) finalize() []anthropicStreamEvent {
 	var events []anthropicStreamEvent

--- a/proxy/anthropic_test.go
+++ b/proxy/anthropic_test.go
@@ -308,6 +308,30 @@ func TestSanitizeToolInputJSON(t *testing.T) {
 			want:     `{"file_path":"/etc/hosts"}`,
 		},
 		{
+			name:     "enter worktree drops empty name when path is set",
+			toolName: "EnterWorktree",
+			in:       `{"name":"","path":"F:\\Github\\codex2api\\.claude\\worktrees\\existing"}`,
+			want:     `{"path":"F:\\Github\\codex2api\\.claude\\worktrees\\existing"}`,
+		},
+		{
+			name:     "enter worktree drops empty path when name is set",
+			toolName: "EnterWorktree",
+			in:       `{"name":"feature-x","path":""}`,
+			want:     `{"name":"feature-x"}`,
+		},
+		{
+			name:     "enter worktree preserves both non-empty mutually exclusive fields",
+			toolName: "EnterWorktree",
+			in:       `{"name":"feature-x","path":"F:\\Github\\codex2api\\.claude\\worktrees\\existing"}`,
+			want:     `{"name":"feature-x","path":"F:\\Github\\codex2api\\.claude\\worktrees\\existing"}`,
+		},
+		{
+			name:     "enter worktree preserves both empty fields",
+			toolName: "EnterWorktree",
+			in:       `{"name":"","path":""}`,
+			want:     `{"name":"","path":""}`,
+		},
+		{
 			name:     "invalid JSON returned as-is",
 			toolName: "Read",
 			in:       `{"file_path":`,
@@ -376,6 +400,18 @@ func TestBuildAnthropicResponseFromCompletedPreservesToolInputByToolName(t *test
 			toolName:  "Write",
 			arguments: `{"file_path":"/tmp/empty.txt","content":""}`,
 			wantInput: `{"file_path":"/tmp/empty.txt","content":""}`,
+		},
+		{
+			name:      "enter worktree drops empty name when path is set",
+			toolName:  "EnterWorktree",
+			arguments: `{"name":"","path":"F:\\Github\\codex2api\\.claude\\worktrees\\existing"}`,
+			wantInput: `{"path":"F:\\Github\\codex2api\\.claude\\worktrees\\existing"}`,
+		},
+		{
+			name:      "enter worktree preserves both non-empty mutually exclusive fields",
+			toolName:  "EnterWorktree",
+			arguments: `{"name":"feature-x","path":"F:\\Github\\codex2api\\.claude\\worktrees\\existing"}`,
+			wantInput: `{"name":"feature-x","path":"F:\\Github\\codex2api\\.claude\\worktrees\\existing"}`,
 		},
 	}
 
@@ -454,6 +490,26 @@ func TestAnthropicStreamTranslator_ToolInputBufferedAndCleaned(t *testing.T) {
 				`}`,
 			},
 			wantInput: `{"file_path":"/tmp/empty.txt","content":""}`,
+		},
+		{
+			name:     "enter worktree drops empty name when path is set",
+			toolName: "EnterWorktree",
+			deltas: []string{
+				`{"name":""`,
+				`,"path":"F:\\Github\\codex2api\\.claude\\worktrees\\existing"`,
+				`}`,
+			},
+			wantInput: `{"path":"F:\\Github\\codex2api\\.claude\\worktrees\\existing"}`,
+		},
+		{
+			name:     "enter worktree drops empty path when name is set",
+			toolName: "EnterWorktree",
+			deltas: []string{
+				`{"name":"feature-x"`,
+				`,"path":""`,
+				`}`,
+			},
+			wantInput: `{"name":"feature-x"}`,
 		},
 	}
 

--- a/proxy/tool_input_corrector.go
+++ b/proxy/tool_input_corrector.go
@@ -1,0 +1,161 @@
+package proxy
+
+import (
+	"encoding/json"
+	"strings"
+	"sync"
+)
+
+// ToolInputCorrectionStats records automatic tool input corrections.
+type ToolInputCorrectionStats struct {
+	TotalCorrected      int            `json:"total_corrected"`
+	CorrectionsByTool   map[string]int `json:"corrections_by_tool"`
+	CorrectionsByReason map[string]int `json:"corrections_by_reason"`
+}
+
+// ToolInputCorrector applies narrow, tool-specific compatibility fixes to
+// upstream function_call arguments before Claude Code validates tool inputs.
+type ToolInputCorrector struct {
+	mu    sync.RWMutex
+	stats ToolInputCorrectionStats
+}
+
+// ClaudeToolCorrector is a Claude Code-oriented alias for ToolInputCorrector.
+// It mirrors sub2api's centralized corrector pattern while keeping the more
+// explicit tool-input name available to existing call sites and tests.
+type ClaudeToolCorrector = ToolInputCorrector
+
+// NewToolInputCorrector creates a tool input corrector with empty stats.
+func NewToolInputCorrector() *ToolInputCorrector {
+	return &ToolInputCorrector{
+		stats: ToolInputCorrectionStats{
+			CorrectionsByTool:   make(map[string]int),
+			CorrectionsByReason: make(map[string]int),
+		},
+	}
+}
+
+// NewClaudeToolCorrector creates a Claude tool corrector with empty stats.
+func NewClaudeToolCorrector() *ClaudeToolCorrector {
+	return NewToolInputCorrector()
+}
+
+var defaultClaudeToolCorrector = NewClaudeToolCorrector()
+
+// CorrectToolInputJSON cleans a tool arguments JSON object. It deliberately
+// handles only known Claude Code compatibility issues; empty strings and nulls
+// can be meaningful for many tools and must not be removed generically.
+func (c *ToolInputCorrector) CorrectToolInputJSON(toolName string, raw string) (string, bool) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return raw, false
+	}
+
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(raw), &obj); err != nil {
+		return raw, false
+	}
+
+	var correctionReasons []string
+	switch toolName {
+	case "Read":
+		if isJSONStringLiteral(obj["pages"], "") {
+			delete(obj, "pages")
+			correctionReasons = append(correctionReasons, "Read.pages:empty")
+		}
+	case "EnterWorktree":
+		if isJSONStringLiteral(obj["name"], "") && hasNonEmptyJSONString(obj["path"]) {
+			delete(obj, "name")
+			correctionReasons = append(correctionReasons, "EnterWorktree.name:empty-with-path")
+		}
+		if isJSONStringLiteral(obj["path"], "") && hasNonEmptyJSONString(obj["name"]) {
+			delete(obj, "path")
+			correctionReasons = append(correctionReasons, "EnterWorktree.path:empty-with-name")
+		}
+	}
+
+	if len(correctionReasons) == 0 {
+		return raw, false
+	}
+	out, err := json.Marshal(obj)
+	if err != nil {
+		return raw, false
+	}
+	for _, reason := range correctionReasons {
+		c.recordCorrection(toolName, reason)
+	}
+	return string(out), true
+}
+
+// GetStats returns a copy of correction statistics.
+func (c *ToolInputCorrector) GetStats() ToolInputCorrectionStats {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	stats := ToolInputCorrectionStats{
+		TotalCorrected:      c.stats.TotalCorrected,
+		CorrectionsByTool:   make(map[string]int, len(c.stats.CorrectionsByTool)),
+		CorrectionsByReason: make(map[string]int, len(c.stats.CorrectionsByReason)),
+	}
+	for k, v := range c.stats.CorrectionsByTool {
+		stats.CorrectionsByTool[k] = v
+	}
+	for k, v := range c.stats.CorrectionsByReason {
+		stats.CorrectionsByReason[k] = v
+	}
+	return stats
+}
+
+// ResetStats resets correction statistics.
+func (c *ToolInputCorrector) ResetStats() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.stats.TotalCorrected = 0
+	c.stats.CorrectionsByTool = make(map[string]int)
+	c.stats.CorrectionsByReason = make(map[string]int)
+}
+
+func (c *ToolInputCorrector) recordCorrection(toolName string, reason string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.stats.CorrectionsByTool == nil {
+		c.stats.CorrectionsByTool = make(map[string]int)
+	}
+	if c.stats.CorrectionsByReason == nil {
+		c.stats.CorrectionsByReason = make(map[string]int)
+	}
+	c.stats.TotalCorrected++
+	c.stats.CorrectionsByTool[toolName]++
+	c.stats.CorrectionsByReason[reason]++
+}
+
+func isJSONStringLiteral(raw json.RawMessage, want string) bool {
+	if len(raw) == 0 {
+		return false
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return false
+	}
+	return s == want
+}
+
+func hasNonEmptyJSONString(raw json.RawMessage) bool {
+	if len(raw) == 0 {
+		return false
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return false
+	}
+	return s != ""
+}
+
+// sanitizeToolInputJSON preserves the existing call-site contract while routing
+// corrections through the centralized ToolInputCorrector.
+func sanitizeToolInputJSON(toolName string, raw string) string {
+	if cleaned, corrected := defaultClaudeToolCorrector.CorrectToolInputJSON(toolName, raw); corrected {
+		return cleaned
+	}
+	return strings.TrimSpace(raw)
+}

--- a/proxy/tool_input_corrector_test.go
+++ b/proxy/tool_input_corrector_test.go
@@ -1,0 +1,44 @@
+package proxy
+
+import "testing"
+
+func TestToolInputCorrectorStats(t *testing.T) {
+	corrector := NewClaudeToolCorrector()
+
+	if stats := corrector.GetStats(); stats.TotalCorrected != 0 || len(stats.CorrectionsByTool) != 0 || len(stats.CorrectionsByReason) != 0 {
+		t.Fatalf("initial stats = %+v, want empty", stats)
+	}
+
+	if _, corrected := corrector.CorrectToolInputJSON("Read", `{"file_path":"/etc/hosts","pages":""}`); !corrected {
+		t.Fatalf("expected Read pages correction")
+	}
+	if _, corrected := corrector.CorrectToolInputJSON("EnterWorktree", `{"name":"","path":"F:\\Github\\codex2api\\.claude\\worktrees\\existing"}`); !corrected {
+		t.Fatalf("expected EnterWorktree name correction")
+	}
+	if _, corrected := corrector.CorrectToolInputJSON("Write", `{"content":""}`); corrected {
+		t.Fatalf("Write empty content must not be corrected")
+	}
+
+	stats := corrector.GetStats()
+	if stats.TotalCorrected != 2 {
+		t.Fatalf("TotalCorrected = %d, want 2", stats.TotalCorrected)
+	}
+	if stats.CorrectionsByTool["Read"] != 1 {
+		t.Fatalf("Read tool count = %d, want 1", stats.CorrectionsByTool["Read"])
+	}
+	if stats.CorrectionsByTool["EnterWorktree"] != 1 {
+		t.Fatalf("EnterWorktree tool count = %d, want 1", stats.CorrectionsByTool["EnterWorktree"])
+	}
+	if stats.CorrectionsByReason["Read.pages:empty"] != 1 {
+		t.Fatalf("Read.pages:empty count = %d, want 1", stats.CorrectionsByReason["Read.pages:empty"])
+	}
+	if stats.CorrectionsByReason["EnterWorktree.name:empty-with-path"] != 1 {
+		t.Fatalf("EnterWorktree.name count = %d, want 1", stats.CorrectionsByReason["EnterWorktree.name:empty-with-path"])
+	}
+
+	corrector.ResetStats()
+	stats = corrector.GetStats()
+	if stats.TotalCorrected != 0 || len(stats.CorrectionsByTool) != 0 || len(stats.CorrectionsByReason) != 0 {
+		t.Fatalf("stats after reset = %+v, want empty", stats)
+	}
+}


### PR DESCRIPTION
## 背景

Claude Code 通过 codex2api 调用 OpenAI-compatible / Codex Responses 风格模型时，工具调用参数需要在 Anthropic `tool_use.input` 与 Codex `function_call.arguments` 之间转换。此前已知上游可能为 Claude Code 的 `Read` 工具生成 `"pages":""` 这类空可选字段，导致下游本地工具参数校验失败。

本次进一步处理 `EnterWorktree` 工具的兼容问题：上游或中间转换层可能生成同时包含互斥字段的参数，例如：

```json
{"name":"","path":"F:\\Github\\codex2api\\.claude\\worktrees\\existing"}
```

虽然 `name` 是空字符串，但在 Claude Code 的本地 validator 看来，`name` 与 `path` 两个字段都已经出现，仍会触发互斥字段校验错误。

## 修改前

修改前，`proxy/anthropic.go` 中只有一个内联的 `sanitizeToolInputJSON`，并且只处理：

```json
{"pages":""}
```

该逻辑存在两个问题：

1. 修正规则分散在 Anthropic 转换文件中，不利于继续扩展 Claude Code 工具兼容修正。
2. 无法处理 `EnterWorktree` 的空互斥字段占位问题。

例如修改前以下参数会原样传给 Claude Code：

```json
{"name":"","path":"F:\\Github\\codex2api\\.claude\\worktrees\\existing"}
```

最终可能导致 `Invalid tool parameters`。

## 修改后

本次借鉴 sub2api 的集中式 corrector 思路，新增：

- `ToolInputCorrector`
- `ClaudeToolCorrector`
- `NewToolInputCorrector()`
- `NewClaudeToolCorrector()`
- `ToolInputCorrectionStats`

并将原有 `Read.pages == ""` 清洗逻辑迁移到集中 corrector 中。

新增的 `EnterWorktree` 修正规则为：

- `name == ""` 且 `path` 为非空字符串时，删除 `name`。
- `path == ""` 且 `name` 为非空字符串时，删除 `path`。
- `name` 与 `path` 都非空时不自动选择，保留 validator 暴露真实互斥冲突。
- `name` 与 `path` 都为空时不自动修正，保留 validator 暴露真实无效输入。

示例：

```json
{"name":"","path":"F:\\Github\\codex2api\\.claude\\worktrees\\existing"}
```

会被清洗为：

```json
{"path":"F:\\Github\\codex2api\\.claude\\worktrees\\existing"}
```

同时保留 `sanitizeToolInputJSON` 原有调用契约，现有调用点继续通过该函数进入集中 corrector，减少改动范围。

## 前后对比分析

本次修正是白名单式兼容修正，不会泛化删除所有空字符串或 `null` 字段，避免破坏其它工具的合法语义。例如以下情况仍会保留：

- `Write.content == ""`
- `Edit.new_string == ""`
- 自定义工具中的空字符串参数
- `EnterWorktree` 中两个互斥字段都非空的真实冲突

兼容性与风险控制：

- 修正范围限定在 `Read` 与 `EnterWorktree` 两个已知工具。
- 对非法 JSON 原样返回，不引入额外解析失败行为。
- 统计信息使用 mutex 保护，并返回 map copy，避免并发读写问题。
- 统计在 JSON 重新 marshal 成功后才记录，避免统计与实际输出不一致。
- 三条转换路径均继续使用 `sanitizeToolInputJSON`：
  - assistant 历史消息 `tool_use.input` → Codex `function_call.arguments`
  - Codex streaming arguments delta 缓冲后 → Anthropic `input_json_delta`
  - Codex completed response `function_call.arguments` → Anthropic `tool_use.input`

## 测试情况

已执行并通过：

```powershell
gofmt -w "proxy\tool_input_corrector.go" "proxy\tool_input_corrector_test.go" "proxy\anthropic_test.go" && go test -count=1 ./proxy -run "Test(SanitizeToolInputJSON|BuildAnthropicResponseFromCompletedPreservesToolInputByToolName|AnthropicStreamTranslator_ToolInputBufferedAndCleaned|ToolInputCorrectorStats)$" -v
```

```powershell
go test -count=1 ./proxy
```

```powershell
go vet ./proxy
```

```powershell
go test -count=1 ./admin ./api ./auth ./cache ./config ./database ./internal/imageproc ./internal/imagestore ./internal/signedasset ./proxy ./proxy/wsrelay ./security ./security/promptfilter
```

```powershell
go vet ./admin ./api ./auth ./cache ./config ./database ./internal/imageproc ./internal/imagestore ./internal/signedasset ./proxy ./proxy/wsrelay ./security ./security/promptfilter
```

```powershell
git diff --check
```

说明：`git diff --check` 仅提示 Windows 工作区中的 LF/CRLF 换行转换警告，未发现 whitespace error。

已额外执行但受既有环境问题影响失败：

```powershell
go test -count=1 ./...
```

```powershell
go vet ./...
```

失败原因均为根包缺少前端构建产物：

```text
main.go:29:12: pattern frontend/dist/*: no matching files found
```

其它可测子包均通过。该问题不是本次 proxy 改动引入。

## 修改总结

本次变更解决了 Claude Code 工具参数在 OpenAI-compatible / Codex Responses 兼容转换路径中的已知空字段占位问题：

- 将工具参数清洗逻辑集中到 `ToolInputCorrector / ClaudeToolCorrector`。
- 保留原 `Read.pages == ""` 兼容修正。
- 新增 `EnterWorktree` 空互斥字段修正。
- 增加按工具和按原因的修正统计能力。
- 补充单元、非流式、流式和统计回归测试。

该实现可以降低 Claude Code 本地 validator 因上游空字段占位而报 `Invalid tool parameters` 的概率，同时避免对其它工具参数做过度清洗。
