### PR TITLE
perf: 优化后端流式转发性能

### DIFF
--- a/proxy/error_logger.go
+++ b/proxy/error_logger.go
@@ -26,6 +26,21 @@ var (
 )
 
 const defaultLogDir = "logs"
+const upstreamErrorLogBodyMaxBytes = 8 * 1024
+
+func upstreamErrorLogBody(body []byte) string {
+	truncated := false
+	if len(body) > upstreamErrorLogBodyMaxBytes {
+		body = body[:upstreamErrorLogBodyMaxBytes]
+		truncated = true
+	}
+	bodyStr := security.MaskSensitiveData(string(body))
+	bodyStr = security.SafeTruncate(bodyStr, 5000)
+	if truncated {
+		bodyStr += " ... [truncated]"
+	}
+	return bodyStr
+}
 
 func errorLogDir() string {
 	if dir := strings.TrimSpace(os.Getenv("LOG_DIR")); dir != "" {
@@ -73,11 +88,7 @@ func (fl *fileLogger) writeEntry(endpoint string, statusCode int, model string, 
 	// 脱敏日志内容
 	safeEndpoint := security.SanitizeLog(endpoint)
 	safeModel := security.SanitizeLog(model)
-	bodyStr := string(body)
-
-	// 检查并脱敏响应体中的敏感信息
-	bodyStr = security.MaskSensitiveData(bodyStr)
-	bodyStr = security.SafeTruncate(bodyStr, 5000) // 限制日志大小
+	bodyStr := upstreamErrorLogBody(body)
 
 	ts := time.Now().Format("2006/01/02 15:04:05")
 	l.Printf("========== %s ==========\nEndpoint: %s\nStatus: %d\nModel: %s\nAccount: %d\nResponse:\n%s\n",

--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -28,6 +28,21 @@ import (
 	"github.com/tidwall/sjson"
 )
 
+const consoleUpstreamErrorLogMaxBytes = 4 * 1024
+
+func upstreamErrorConsoleBody(body []byte) string {
+	truncated := false
+	if len(body) > consoleUpstreamErrorLogMaxBytes {
+		body = body[:consoleUpstreamErrorLogMaxBytes]
+		truncated = true
+	}
+	bodyStr := security.SafeTruncate(security.SanitizeLog(string(body)), consoleUpstreamErrorLogMaxBytes)
+	if truncated {
+		bodyStr += " ... [truncated]"
+	}
+	return bodyStr
+}
+
 // Handler API 路由处理器
 type Handler struct {
 	store        *auth.Store
@@ -899,6 +914,19 @@ func shouldTransparentRetryStream(outcome streamOutcome, attempt int, maxRetries
 	return true
 }
 
+func shouldSuppressRetryableResponseFailedBeforeFirstToken(eventType string, terminalFailurePayload []byte, ttftRecorded bool, wroteAnyBody bool, attempt int, maxRetries int, ctxErr, writeErr error) bool {
+	if eventType != "response.failed" {
+		return false
+	}
+	if ttftRecorded || wroteAnyBody || ctxErr != nil || writeErr != nil {
+		return false
+	}
+	if attempt >= maxRetries {
+		return false
+	}
+	return responseFailedRetryable(terminalFailurePayload)
+}
+
 func imageGenerationOutputKey(item gjson.Result) string {
 	if key := strings.TrimSpace(item.Get("id").String()); key != "" {
 		return key
@@ -1423,9 +1451,19 @@ func (h *Handler) Responses(c *gin.Context) {
 		c.Set("x-service-tier", resolveServiceTier("", serviceTier))
 	}
 
-	// 2. 准备上游请求体（Unmarshal→map→Marshal，一次序列化）
+	// 2. 准备 Codex 上游请求体（Unmarshal→map→Marshal，一次序列化）。
+	// OpenAI Responses relay body 仅在实际命中 relay 账号时惰性生成，避免 Codex 路径重复转换。
 	codexBody, expandedInputRaw := PrepareResponsesBody(rawBody)
-	openAIResponsesBody := PrepareOpenAIResponsesBody(rawBody)
+	var openAIResponsesBody []byte
+	resetOpenAIResponsesBody := func() {
+		openAIResponsesBody = nil
+	}
+	getOpenAIResponsesBody := func() []byte {
+		if openAIResponsesBody == nil {
+			openAIResponsesBody = PrepareOpenAIResponsesBody(rawBody)
+		}
+		return openAIResponsesBody
+	}
 	if err := validateResponsesImageGenerationSizes(codexBody); err != nil {
 		api.SendError(c, api.NewAPIError(api.ErrCodeInvalidParameter, err.Error(), api.ErrorTypeInvalidRequest))
 		return
@@ -1520,7 +1558,7 @@ func (h *Handler) Responses(c *gin.Context) {
 			}
 			baseURL, _ := account.OpenAIResponsesCredentials()
 			upstreamEndpoint := auth.OpenAIResponsesEndpoint(baseURL, "/v1/responses")
-			resp, reqErr := ExecuteOpenAIResponsesRequest(upstreamCtx, account, openAIResponsesBody, proxyURL, downstreamHeaders)
+			resp, reqErr := ExecuteOpenAIResponsesRequest(upstreamCtx, account, getOpenAIResponsesBody(), proxyURL, downstreamHeaders)
 			durationMs := int(time.Since(start).Milliseconds())
 
 			if reqErr != nil {
@@ -1577,7 +1615,7 @@ func (h *Handler) Responses(c *gin.Context) {
 						invalidEncryptedContentRetried = true
 						if rawChanged {
 							rawBody = strippedRawBody
-							openAIResponsesBody = PrepareOpenAIResponsesBody(rawBody)
+							resetOpenAIResponsesBody()
 						}
 						if codexChanged {
 							codexBody = strippedCodexBody
@@ -1597,7 +1635,7 @@ func (h *Handler) Responses(c *gin.Context) {
 				h.store.UnbindSessionAffinity(affinityKey, account.ID())
 				retryExclusions.MarkHard(account.ID())
 
-				log.Printf("OpenAI Responses 上游返回错误 (attempt %d, status %d): %s", attempt+1, resp.StatusCode, string(errBody))
+				log.Printf("OpenAI Responses 上游返回错误 (attempt %d, status %d): %s", attempt+1, resp.StatusCode, upstreamErrorConsoleBody(errBody))
 				logUpstreamError("/v1/responses", resp.StatusCode, logModel, account.ID(), errBody)
 				h.logUpstreamCyberPolicy(c, "/v1/responses", logModel, errBody)
 				decision := h.applyCooldownForModel(account, resp.StatusCode, errBody, resp, effectiveModel)
@@ -1694,27 +1732,20 @@ func (h *Handler) Responses(c *gin.Context) {
 						terminalFailurePayload = append([]byte(nil), data...)
 						gotTerminal = true
 					}
+					if !clientGone && shouldSuppressRetryableResponseFailedBeforeFirstToken(eventType, terminalFailurePayload, ttftRecorded, wroteAnyBody, attempt, maxRetries, c.Request.Context().Err(), writeErr) {
+						pendingFirstTokenEvents.Reset()
+						return false
+					}
 					if image, ok := extractImageFromOutputItemDone(data, logModel); ok {
 						imageLogInfo = mergeImageUsageLogInfo(imageLogInfo, imageUsageLogInfoFromImage(image))
 					}
 					if !clientGone {
-						payload := fmt.Sprintf("data: %s\n\n", data)
 						shouldDefer := !ttftRecorded && !gotTerminal && isPreContentLifecycleEvent(eventType)
-						if shouldDefer {
-							pendingFirstTokenEvents.WriteString(payload)
-							if pendingFirstTokenEvents.Len() <= 1024*1024 {
-								return eventType != "response.completed" && eventType != "response.failed"
-							}
-							payload = pendingFirstTokenEvents.String()
-							pendingFirstTokenEvents.Reset()
-						} else if pendingFirstTokenEvents.Len() > 0 {
-							payload = pendingFirstTokenEvents.String() + payload
-							pendingFirstTokenEvents.Reset()
-						}
-						if err := streamWriter.WriteString(payload); err != nil {
+						wrote, err := writeDeferredSSEData(streamWriter, &pendingFirstTokenEvents, data, shouldDefer)
+						if err != nil {
 							writeErr = err
 							clientGone = true
-						} else {
+						} else if wrote {
 							wroteAnyBody = true
 						}
 					}
@@ -1917,7 +1948,7 @@ func (h *Handler) Responses(c *gin.Context) {
 					invalidEncryptedContentRetried = true
 					if rawChanged {
 						rawBody = strippedRawBody
-						openAIResponsesBody = PrepareOpenAIResponsesBody(rawBody)
+						resetOpenAIResponsesBody()
 					}
 					if codexChanged {
 						codexBody = strippedCodexBody
@@ -1938,7 +1969,7 @@ func (h *Handler) Responses(c *gin.Context) {
 			h.store.UnbindSessionAffinity(affinityKey, account.ID())
 			retryExclusions.MarkHard(account.ID())
 
-			log.Printf("上游返回错误 (attempt %d, status %d): %s", attempt+1, resp.StatusCode, string(errBody))
+			log.Printf("上游返回错误 (attempt %d, status %d): %s", attempt+1, resp.StatusCode, upstreamErrorConsoleBody(errBody))
 			logUpstreamError("/v1/responses", resp.StatusCode, logModel, account.ID(), errBody)
 			h.logUpstreamCyberPolicy(c, "/v1/responses", logModel, errBody)
 			decision := h.applyCooldownForModel(account, resp.StatusCode, errBody, resp, effectiveModel)
@@ -2056,24 +2087,18 @@ func (h *Handler) Responses(c *gin.Context) {
 					gotTerminal = true
 				}
 
+				if !clientGone && shouldSuppressRetryableResponseFailedBeforeFirstToken(eventType, terminalFailurePayload, ttftRecorded, wroteAnyBody, attempt, maxRetries, c.Request.Context().Err(), writeErr) {
+					pendingFirstTokenEvents.Reset()
+					return false
+				}
+
 				if !clientGone {
-					payload := fmt.Sprintf("data: %s\n\n", data)
 					shouldDefer := !ttftRecorded && !gotTerminal && isPreContentLifecycleEvent(eventType)
-					if shouldDefer {
-						pendingFirstTokenEvents.WriteString(payload)
-						if pendingFirstTokenEvents.Len() <= 1024*1024 {
-							return eventType != "response.completed" && eventType != "response.failed"
-						}
-						payload = pendingFirstTokenEvents.String()
-						pendingFirstTokenEvents.Reset()
-					} else if pendingFirstTokenEvents.Len() > 0 {
-						payload = pendingFirstTokenEvents.String() + payload
-						pendingFirstTokenEvents.Reset()
-					}
-					if err := streamWriter.WriteString(payload); err != nil {
+					wrote, err := writeDeferredSSEData(streamWriter, &pendingFirstTokenEvents, data, shouldDefer)
+					if err != nil {
 						writeErr = err
 						clientGone = true
-					} else {
+					} else if wrote {
 						wroteAnyBody = true
 					}
 				}
@@ -2996,7 +3021,7 @@ func (h *Handler) ChatCompletions(c *gin.Context) {
 			h.store.UnbindSessionAffinity(affinityKey, account.ID())
 			retryExclusions.MarkHard(account.ID())
 
-			log.Printf("上游返回错误 (attempt %d, status %d): %s", attempt+1, resp.StatusCode, string(errBody))
+			log.Printf("上游返回错误 (attempt %d, status %d): %s", attempt+1, resp.StatusCode, upstreamErrorConsoleBody(errBody))
 			logUpstreamError("/v1/chat/completions", resp.StatusCode, logModel, account.ID(), errBody)
 			h.logUpstreamCyberPolicy(c, "/v1/chat/completions", logModel, errBody)
 			decision := h.applyCooldownForModel(account, resp.StatusCode, errBody, resp, effectiveModel)
@@ -3082,9 +3107,9 @@ func (h *Handler) ChatCompletions(c *gin.Context) {
 			clientGone := false
 			var pendingFirstTokenChunks bytes.Buffer
 			readErr = ReadSSEStream(resp.Body, func(data []byte) bool {
-				chunk, done := streamTranslator.Translate(data)
-
 				parsed := gjson.ParseBytes(data)
+				chunk, done := streamTranslator.TranslateParsed(parsed)
+
 				eventType := parsed.Get("type").String()
 				ttftGuard.MarkProgress(eventType)
 				isFirstToken := isFirstTokenResultForMode(parsed, currentFirstTokenMode())
@@ -3108,35 +3133,33 @@ func (h *Handler) ChatCompletions(c *gin.Context) {
 					gotTerminal = true
 				}
 
+				if !clientGone && shouldSuppressRetryableResponseFailedBeforeFirstToken(eventType, terminalFailurePayload, ttftRecorded, wroteAnyBody, attempt, maxRetries, c.Request.Context().Err(), writeErr) {
+					pendingFirstTokenChunks.Reset()
+					return false
+				}
+
 				if !clientGone && chunk != nil {
-					payload := fmt.Sprintf("data: %s\n\n", chunk)
 					shouldDefer := !ttftRecorded && !gotTerminal && isPreContentLifecycleEvent(eventType)
-					if shouldDefer {
-						pendingFirstTokenChunks.WriteString(payload)
-						if pendingFirstTokenChunks.Len() <= 1024*1024 {
-							return eventType != "response.completed" && eventType != "response.failed"
-						}
-						payload = pendingFirstTokenChunks.String()
-						pendingFirstTokenChunks.Reset()
-					} else if pendingFirstTokenChunks.Len() > 0 {
-						payload = pendingFirstTokenChunks.String() + payload
-						pendingFirstTokenChunks.Reset()
-					}
-					if err := streamWriter.WriteString(payload); err != nil {
+					wrote, err := writeDeferredSSEData(streamWriter, &pendingFirstTokenChunks, chunk, shouldDefer)
+					if err != nil {
 						writeErr = err
 						clientGone = true
-					} else {
+					} else if wrote {
 						wroteAnyBody = true
+					}
+					if shouldDefer && !wrote {
+						return eventType != "response.completed" && eventType != "response.failed"
 					}
 				}
 				if !clientGone && done {
-					payload := "data: [DONE]\n\n"
 					if pendingFirstTokenChunks.Len() > 0 {
-						payload = pendingFirstTokenChunks.String() + payload
+						pendingFirstTokenChunks.WriteString("data: [DONE]\n\n")
+						writeErr = streamWriter.WriteBytes(pendingFirstTokenChunks.Bytes())
 						pendingFirstTokenChunks.Reset()
+					} else {
+						writeErr = streamWriter.WriteString("data: [DONE]\n\n")
 					}
-					if err := streamWriter.WriteString(payload); err != nil {
-						writeErr = err
+					if writeErr != nil {
 						clientGone = true
 					} else if err := streamWriter.Flush(); err != nil {
 						writeErr = err
@@ -3335,7 +3358,7 @@ func (h *Handler) handleStreamResponse(c *gin.Context, body io.Reader, model, ch
 	err := ReadSSEStream(body, func(data []byte) bool {
 		chunk, done := TranslateStreamChunk(data, model, chunkID, created)
 		if chunk != nil {
-			if err := streamWriter.WriteString(fmt.Sprintf("data: %s\n\n", chunk)); err != nil {
+			if err := streamWriter.WriteSSEData(chunk); err != nil {
 				return false
 			}
 		}

--- a/proxy/responses_ws.go
+++ b/proxy/responses_ws.go
@@ -374,7 +374,7 @@ func (h *Handler) forwardResponsesWebSocketTurn(c *gin.Context, conn *websocket.
 			h.store.UnbindSessionAffinity(affinityKey, account.ID())
 			retryExclusions.MarkHard(account.ID())
 
-			log.Printf("Responses WebSocket upstream returned error (attempt %d, status %d): %s", attempt+1, resp.StatusCode, string(errBody))
+			log.Printf("Responses WebSocket upstream returned error (attempt %d, status %d): %s", attempt+1, resp.StatusCode, upstreamErrorConsoleBody(errBody))
 			logUpstreamError("/v1/responses", resp.StatusCode, logModel, account.ID(), errBody)
 			h.logUpstreamCyberPolicy(c, "/v1/responses", logModel, errBody)
 			decision := h.applyCooldownForModel(account, resp.StatusCode, errBody, resp, effectiveModel)

--- a/proxy/stream_flush_writer.go
+++ b/proxy/stream_flush_writer.go
@@ -7,6 +7,13 @@ import (
 	"time"
 )
 
+const pendingFirstTokenFlushBytes = 1024 * 1024
+
+var (
+	sseDataPrefix = []byte("data: ")
+	sseDataSuffix = []byte("\n\n")
+)
+
 type streamFlushWriter struct {
 	writer    io.Writer
 	flusher   http.Flusher
@@ -24,6 +31,44 @@ func newStreamFlushWriter(writer io.Writer, flusher http.Flusher) *streamFlushWr
 		policy:   settings.StreamFlushPolicy,
 		interval: currentStreamFlushInterval(),
 	}
+}
+
+func appendSSEData(buf *bytes.Buffer, data []byte) {
+	if buf == nil {
+		return
+	}
+	buf.Write(sseDataPrefix)
+	buf.Write(data)
+	buf.Write(sseDataSuffix)
+}
+
+func writeDeferredSSEData(streamWriter *streamFlushWriter, pending *bytes.Buffer, data []byte, shouldDefer bool) (bool, error) {
+	if streamWriter == nil {
+		return false, nil
+	}
+	if shouldDefer {
+		appendSSEData(pending, data)
+		if pending != nil && pending.Len() <= pendingFirstTokenFlushBytes {
+			return false, nil
+		}
+	}
+	if pending != nil && pending.Len() > 0 {
+		if !shouldDefer {
+			appendSSEData(pending, data)
+		}
+		if err := streamWriter.WriteBytes(pending.Bytes()); err != nil {
+			return false, err
+		}
+		pending.Reset()
+		return true, nil
+	}
+	if shouldDefer {
+		return false, nil
+	}
+	if err := streamWriter.WriteSSEData(data); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 func (w *streamFlushWriter) WriteString(data string) error {
@@ -47,10 +92,47 @@ func (w *streamFlushWriter) WriteString(data string) error {
 }
 
 func (w *streamFlushWriter) WriteBytes(data []byte) error {
-	if w == nil || len(data) == 0 {
+	if w == nil || w.writer == nil || len(data) == 0 {
 		return nil
 	}
-	return w.WriteString(string(data))
+	if w.policy != StreamFlushPolicyCoalesce {
+		if _, err := w.writer.Write(data); err != nil {
+			return err
+		}
+		w.flushTransport()
+		return nil
+	}
+	if _, err := w.buffer.Write(data); err != nil {
+		return err
+	}
+	if w.lastFlush.IsZero() || time.Since(w.lastFlush) >= w.interval {
+		return w.Flush()
+	}
+	return nil
+}
+
+func (w *streamFlushWriter) WriteSSEData(data []byte) error {
+	if w == nil || w.writer == nil {
+		return nil
+	}
+	if w.policy != StreamFlushPolicyCoalesce {
+		if _, err := w.writer.Write(sseDataPrefix); err != nil {
+			return err
+		}
+		if _, err := w.writer.Write(data); err != nil {
+			return err
+		}
+		if _, err := w.writer.Write(sseDataSuffix); err != nil {
+			return err
+		}
+		w.flushTransport()
+		return nil
+	}
+	appendSSEData(&w.buffer, data)
+	if w.lastFlush.IsZero() || time.Since(w.lastFlush) >= w.interval {
+		return w.Flush()
+	}
+	return nil
 }
 
 func (w *streamFlushWriter) Flush() error {

--- a/proxy/stream_perf_test.go
+++ b/proxy/stream_perf_test.go
@@ -1,0 +1,184 @@
+package proxy
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestStreamFlushWriterWriteSSEData(t *testing.T) {
+	var buf bytes.Buffer
+	writer := &streamFlushWriter{writer: &buf}
+
+	if err := writer.WriteSSEData([]byte(`{"type":"response.output_text.delta","delta":"hi"}`)); err != nil {
+		t.Fatalf("WriteSSEData returned error: %v", err)
+	}
+
+	want := "data: {\"type\":\"response.output_text.delta\",\"delta\":\"hi\"}\n\n"
+	if got := buf.String(); got != want {
+		t.Fatalf("unexpected SSE payload:\n got %q\nwant %q", got, want)
+	}
+}
+
+func TestStreamFlushWriterWriteBytesNoStringConversionRequired(t *testing.T) {
+	var buf bytes.Buffer
+	writer := &streamFlushWriter{writer: &buf}
+
+	payload := []byte("data: [DONE]\n\n")
+	if err := writer.WriteBytes(payload); err != nil {
+		t.Fatalf("WriteBytes returned error: %v", err)
+	}
+	if got := buf.String(); got != string(payload) {
+		t.Fatalf("unexpected payload: got %q want %q", got, string(payload))
+	}
+}
+
+func TestStreamTranslatorTranslateParsedMatchesTranslate(t *testing.T) {
+	events := [][]byte{
+		[]byte(`{"type":"response.output_item.added","item":{"type":"function_call","id":"item_1","call_id":"call_1","name":"lookup"}}`),
+		[]byte(`{"type":"response.function_call_arguments.delta","item_id":"item_1","delta":"{\"city\":\"Paris\"}"}`),
+		[]byte(`{"type":"response.completed","response":{"usage":{"input_tokens":7,"output_tokens":3,"total_tokens":10}}}`),
+	}
+
+	fromRaw := NewStreamTranslator("chatcmpl-test", "gpt-test", 123)
+	fromParsed := NewStreamTranslator("chatcmpl-test", "gpt-test", 123)
+
+	for _, event := range events {
+		rawChunk, rawDone := fromRaw.Translate(event)
+		parsedChunk, parsedDone := fromParsed.TranslateParsed(gjson.ParseBytes(event))
+
+		if rawDone != parsedDone {
+			t.Fatalf("done mismatch for %s: raw=%v parsed=%v", event, rawDone, parsedDone)
+		}
+		if string(rawChunk) != string(parsedChunk) {
+			t.Fatalf("chunk mismatch for %s:\n raw=%s\nparsed=%s", event, rawChunk, parsedChunk)
+		}
+	}
+}
+
+func TestUpstreamErrorConsoleBodyTruncatesLargePayload(t *testing.T) {
+	body := []byte(strings.Repeat("x", consoleUpstreamErrorLogMaxBytes+128))
+	got := upstreamErrorConsoleBody(body)
+	if !strings.Contains(got, "[truncated]") {
+		t.Fatalf("expected truncation marker, got %q", got)
+	}
+	if len(got) > consoleUpstreamErrorLogMaxBytes+len(" ... [truncated]") {
+		t.Fatalf("truncated console body too large: %d", len(got))
+	}
+}
+
+func TestUpstreamErrorFileLogBodyTruncatesLargePayload(t *testing.T) {
+	body := []byte(strings.Repeat("x", upstreamErrorLogBodyMaxBytes+128))
+	got := upstreamErrorLogBody(body)
+	if !strings.Contains(got, "[truncated]") {
+		t.Fatalf("expected truncation marker, got %q", got)
+	}
+	if len(got) > 5000+len(" ... [truncated]") {
+		t.Fatalf("truncated file log body too large: %d", len(got))
+	}
+}
+
+func TestWriteDeferredSSEDataFlushesPendingWithCurrentEvent(t *testing.T) {
+	var buf bytes.Buffer
+	writer := &streamFlushWriter{writer: &buf}
+	var pending bytes.Buffer
+
+	wrote, err := writeDeferredSSEData(writer, &pending, []byte(`{"type":"response.created"}`), true)
+	if err != nil {
+		t.Fatalf("defer lifecycle event returned error: %v", err)
+	}
+	if wrote {
+		t.Fatal("deferred lifecycle event should not write before first token")
+	}
+	if buf.Len() != 0 {
+		t.Fatalf("unexpected early output: %q", buf.String())
+	}
+
+	wrote, err = writeDeferredSSEData(writer, &pending, []byte(`{"type":"response.output_text.delta","delta":"hi"}`), false)
+	if err != nil {
+		t.Fatalf("first content event returned error: %v", err)
+	}
+	if !wrote {
+		t.Fatal("first content event should flush pending data")
+	}
+
+	want := "data: {\"type\":\"response.created\"}\n\n" +
+		"data: {\"type\":\"response.output_text.delta\",\"delta\":\"hi\"}\n\n"
+	if got := buf.String(); got != want {
+		t.Fatalf("unexpected deferred SSE output:\n got %q\nwant %q", got, want)
+	}
+	if pending.Len() != 0 {
+		t.Fatalf("pending buffer not reset: %d", pending.Len())
+	}
+}
+
+func TestWriteDeferredSSEDataFlushesLargeDeferredEventOnce(t *testing.T) {
+	var buf bytes.Buffer
+	writer := &streamFlushWriter{writer: &buf}
+	var pending bytes.Buffer
+	payload := []byte(strings.Repeat("x", pendingFirstTokenFlushBytes))
+
+	wrote, err := writeDeferredSSEData(writer, &pending, payload, true)
+	if err != nil {
+		t.Fatalf("large deferred event returned error: %v", err)
+	}
+	if !wrote {
+		t.Fatal("large deferred event should force a flush")
+	}
+	want := "data: " + string(payload) + "\n\n"
+	if got := buf.String(); got != want {
+		t.Fatalf("unexpected large deferred output length/content: got len=%d want len=%d equal=%v", len(got), len(want), got == want)
+	}
+	if strings.Count(buf.String(), "data: ") != 1 {
+		t.Fatalf("large deferred event should be written once, got %d data frames", strings.Count(buf.String(), "data: "))
+	}
+	if pending.Len() != 0 {
+		t.Fatalf("pending buffer not reset: %d", pending.Len())
+	}
+}
+
+func TestShouldSuppressRetryableResponseFailedBeforeFirstToken(t *testing.T) {
+	retryableFailed := []byte(`{"type":"response.failed","response":{"error":{"message":"rate limited","status_code":429,"code":"rate_limit_exceeded"}}}`)
+	nonRetryableFailed := []byte(`{"type":"response.failed","response":{"error":{"message":"bad request","status_code":400,"code":"invalid_request_error"}}}`)
+
+	if !shouldSuppressRetryableResponseFailedBeforeFirstToken("response.failed", retryableFailed, false, false, 0, 1, nil, nil) {
+		t.Fatal("retryable response.failed before first token should be suppressed while another attempt remains")
+	}
+	if shouldSuppressRetryableResponseFailedBeforeFirstToken("response.failed", retryableFailed, false, false, 1, 1, nil, nil) {
+		t.Fatal("last attempt should not suppress response.failed")
+	}
+	if shouldSuppressRetryableResponseFailedBeforeFirstToken("response.failed", nonRetryableFailed, false, false, 0, 1, nil, nil) {
+		t.Fatal("non-retryable response.failed should still be sent to the client")
+	}
+	if shouldSuppressRetryableResponseFailedBeforeFirstToken("response.failed", retryableFailed, true, false, 0, 1, nil, nil) {
+		t.Fatal("response.failed after first token should not be suppressed")
+	}
+	if shouldSuppressRetryableResponseFailedBeforeFirstToken("response.failed", retryableFailed, false, true, 0, 1, nil, nil) {
+		t.Fatal("response.failed after writing any body should not be suppressed")
+	}
+}
+
+func BenchmarkStreamFlushWriterWriteSSEData(b *testing.B) {
+	payload := []byte(`{"type":"response.output_text.delta","delta":"hello"}`)
+	for i := 0; i < b.N; i++ {
+		var buf bytes.Buffer
+		writer := &streamFlushWriter{writer: &buf}
+		if err := writer.WriteSSEData(payload); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkStreamTranslatorTranslateParsed(b *testing.B) {
+	event := []byte(`{"type":"response.output_text.delta","delta":"hello"}`)
+	parsed := gjson.ParseBytes(event)
+	st := NewStreamTranslator("chatcmpl-bench", "gpt-test", 123)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if chunk, done := st.TranslateParsed(parsed); done || chunk == nil {
+			b.Fatalf("unexpected translation result: done=%v chunk=%s", done, chunk)
+		}
+	}
+}

--- a/proxy/translator.go
+++ b/proxy/translator.go
@@ -2680,25 +2680,30 @@ func NewStreamTranslator(chunkID, model string, created int64) *StreamTranslator
 
 // Translate 将单个 Codex SSE 事件翻译为 OpenAI Chat Completions 流式格式
 func (st *StreamTranslator) Translate(eventData []byte) ([]byte, bool) {
-	eventType := gjson.GetBytes(eventData, "type").String()
+	return st.TranslateParsed(gjson.ParseBytes(eventData))
+}
+
+// TranslateParsed 将已解析的 Codex SSE 事件翻译为 OpenAI Chat Completions 流式格式。
+func (st *StreamTranslator) TranslateParsed(parsed gjson.Result) ([]byte, bool) {
+	eventType := parsed.Get("type").String()
 
 	switch eventType {
 	case "response.output_text.delta":
-		delta := gjson.GetBytes(eventData, "delta").String()
+		delta := parsed.Get("delta").String()
 		return newContentChunk(st.ChunkID, st.Model, st.Created, delta), false
 
 	case "response.reasoning_summary_text.delta", "response.reasoning_text.delta":
-		delta := gjson.GetBytes(eventData, "delta").String()
+		delta := parsed.Get("delta").String()
 		return newReasoningChunk(st.ChunkID, st.Model, st.Created, delta), false
 
 	case "response.output_item.added":
-		itemType := gjson.GetBytes(eventData, "item.type").String()
+		itemType := parsed.Get("item.type").String()
 		if itemType != "function_call" {
 			return nil, false
 		}
-		callID := gjson.GetBytes(eventData, "item.call_id").String()
-		name := gjson.GetBytes(eventData, "item.name").String()
-		itemID := gjson.GetBytes(eventData, "item.id").String()
+		callID := parsed.Get("item.call_id").String()
+		name := parsed.Get("item.name").String()
+		itemID := parsed.Get("item.id").String()
 
 		tcIdx := st.nextIdx
 		st.toolCallMap[itemID] = tcIdx
@@ -2708,19 +2713,19 @@ func (st *StreamTranslator) Translate(eventData []byte) ([]byte, bool) {
 		return newToolCallAnnouncementChunk(st.ChunkID, st.Model, st.Created, tcIdx, callID, name), false
 
 	case "response.function_call_arguments.delta":
-		itemID := gjson.GetBytes(eventData, "item_id").String()
+		itemID := parsed.Get("item_id").String()
 		tcIdx, ok := st.toolCallMap[itemID]
 		if !ok {
 			return nil, false
 		}
-		delta := gjson.GetBytes(eventData, "delta").String()
+		delta := parsed.Get("delta").String()
 		return newToolCallDeltaChunk(st.ChunkID, st.Model, st.Created, tcIdx, delta), false
 
 	case "response.function_call_arguments.done":
 		return nil, false
 
 	case "response.completed":
-		usage := extractUsage(eventData)
+		usage := extractUsageFromResult(parsed.Get("response.usage"))
 		finishReason := "stop"
 		if st.HasToolCalls {
 			finishReason = "tool_calls"
@@ -2728,7 +2733,7 @@ func (st *StreamTranslator) Translate(eventData []byte) ([]byte, bool) {
 		return newFinalChunk(st.ChunkID, st.Model, st.Created, finishReason, usage), true
 
 	case "response.failed":
-		errMsg := gjson.GetBytes(eventData, "response.error.message").String()
+		errMsg := parsed.Get("response.error.message").String()
 		if errMsg == "" {
 			errMsg = "Codex upstream error"
 		}
@@ -2743,7 +2748,7 @@ func (st *StreamTranslator) Translate(eventData []byte) ([]byte, bool) {
 		return nil, false
 
 	default:
-		if delta := gjson.GetBytes(eventData, "delta"); delta.Exists() && delta.Type == gjson.String {
+		if delta := parsed.Get("delta"); delta.Exists() && delta.Type == gjson.String {
 			return newContentChunk(st.ChunkID, st.Model, st.Created, delta.String()), false
 		}
 		return nil, false

--- a/proxy/wsrelay/executor.go
+++ b/proxy/wsrelay/executor.go
@@ -548,8 +548,13 @@ func websocketResponseToHTTP(ctx context.Context, wsResp *WsResponse, statusCode
 
 		err := wsResp.ReadStream(func(data []byte) bool {
 			// 将数据编码为 SSE 格式
-			line := fmt.Sprintf("data: %s\n\n", string(data))
-			if _, err := pw.Write([]byte(line)); err != nil {
+			if _, err := pw.Write([]byte("data: ")); err != nil {
+				return false
+			}
+			if _, err := pw.Write(data); err != nil {
+				return false
+			}
+			if _, err := pw.Write([]byte("\n\n")); err != nil {
 				return false
 			}
 			return true


### PR DESCRIPTION
## 背景

本次变更来自对后端请求转发链路的性能 CodeReview。现有 `/v1/responses`、`/v1/chat/completions` 以及 WebSocket relay 到 HTTP SSE 的流式转发热路径中，存在较多低风险但高频的字符串格式化、重复 JSON 解析和大错误体日志输出问题。在高并发或长流式响应场景下，这些问题会放大为额外 GC 压力、CPU 开销和日志 I/O/存储压力。

同时，流式首 token 前会缓冲 lifecycle 事件以优化客户端可见的首包行为；优化过程中需要保持透明重试语义：如果首 token 前收到可换号重试的 `response.failed`，不能先把失败帧写给客户端，否则会使外层 `wroteAnyBody` 变为 true，导致透明重试被禁用。

## 修改前

- SSE 写出路径大量使用 `fmt.Sprintf("data: %s\n\n", ...)` 和 `string([]byte)` 拼接：
  - 每个 chunk 都会产生额外字符串/字节分配。
  - pending-first-token 缓冲中还会再次拼接字符串，增加内存峰值。
- Chat Completions 流式转换中同一个 Codex SSE 事件会被重复解析：
  - handler 解析一次用于统计/TTFT/终止事件判断。
  - `StreamTranslator.Translate` 内部再解析一次用于生成 OpenAI chunk。
- 上游错误响应会直接打印较大的 body 到控制台/错误日志：
  - 大响应体可能造成日志膨胀和额外内存/CPU 开销。
- OpenAI Responses relay body 在进入 `/v1/responses` 后立即生成：
  - 即使最终走 Codex 账号，也会提前做一次无用转换。
- 首 token 前 pending lifecycle 事件与可重试 `response.failed` 的处理边界较脆弱：
  - 可重试失败帧如果先写给客户端，会阻止后续透明重试。

## 修改后

- 新增低分配 SSE 写出辅助能力：
  - `streamFlushWriter.WriteBytes`
  - `streamFlushWriter.WriteSSEData`
  - `writeDeferredSSEData`
  - 统一复用 `data: ` / `\n\n` 字节前后缀，减少格式化和字符串转换。
- `/v1/responses` 和 `/v1/chat/completions` 流式分支统一使用 `writeDeferredSSEData` 处理 pending-first-token 事件：
  - 保持 lifecycle 事件在首 token 前延迟下发。
  - 首个真实输出到达时按原顺序一起写出。
  - pending 超过 1MiB 时强制 flush，避免极端情况下无限积累。
- 新增 `shouldSuppressRetryableResponseFailedBeforeFirstToken`：
  - 在非最后一次 attempt、尚未记录 TTFT、尚未写出任何 body、无客户端/写入错误时，首 token 前的可重试 `response.failed` 会被静默抑制并触发外层透明重试。
  - 最后一次 attempt、不可重试失败、已写出 body 或已到首 token 后，仍保持原有透传行为，避免客户端收到空流。
- `StreamTranslator` 新增 `TranslateParsed`，Chat 流式热路径复用 handler 已解析的 `gjson.Result`，避免重复 parse。
- OpenAI Responses relay body 改为按需惰性生成，并在 encrypted content strip 导致 raw body 变化时重置缓存。
- 控制台和文件错误日志增加安全截断：
  - 控制台上游错误 body 最大约 4KiB。
  - 文件上游错误 body 先限制原始读取片段，再脱敏并安全截断。
- WebSocket relay 转 HTTP SSE pipe 写入避免 `fmt.Sprintf` + `string(data)` 转换，改为直接写前缀、原始 data、后缀。
- 新增 `proxy/stream_perf_test.go`，覆盖 SSE 写出、pending flush、错误日志截断、`TranslateParsed` 一致性，以及首 token 前可重试 `response.failed` 抑制条件。

## 前后对比分析

- 性能收益：
  - 减少流式高频路径中的字符串格式化和重复 JSON 解析。
  - 降低大错误响应日志造成的内存、CPU 和 I/O 压力。
  - 避免 Codex 路径提前生成 OpenAI Responses relay body 的无效转换。
- 兼容性：
  - SSE wire 格式仍为 `data: <payload>\n\n`，不改变客户端协议。
  - pending-first-token lifecycle 事件仍按原顺序输出；首个真实输出到达时会携带此前 pending 事件。
  - 非可重试 `response.failed`、最后一次 attempt 的失败帧、首 token 后失败帧仍照常下发。
- 风险控制：
  - 对透明重试只在“尚未向客户端写任何 body 且仍有重试机会”的条件下启用静默抑制，避免吞掉最终错误。
  - 新增聚焦测试覆盖 pending 顺序、大 pending 强制 flush、重试失败帧抑制/不抑制分支。
  - `go test -race ./proxy` 已通过，降低并发路径回归风险。
- 影响范围：
  - 主要影响 `proxy` 包中的 SSE/WS 转发、Chat Completions 翻译、Responses relay body 构造与错误日志输出。
  - 未修改 API 协议结构、账号选择策略或持久化 schema。

## 测试情况

已执行并通过：

```bash
go test -C "F:/Github/codex2api/.claude/worktrees/perf-forwarding-review-fixes" ./proxy -run "Test(StreamFlushWriter|StreamTranslatorTranslateParsed|UpstreamError|WriteDeferred|ShouldSuppress)" -count=1 -v
go test -C "F:/Github/codex2api/.claude/worktrees/perf-forwarding-review-fixes" ./proxy -count=1
go test -C "F:/Github/codex2api/.claude/worktrees/perf-forwarding-review-fixes" -race ./proxy -count=1
go test -C "F:/Github/codex2api/.claude/worktrees/perf-forwarding-review-fixes" ./admin ./api ./auth ./cache ./config ./database ./internal/imageproc ./internal/imagestore ./internal/signedasset ./proxy ./proxy/wsrelay ./security ./security/promptfilter
git -C "F:/Github/codex2api/.claude/worktrees/perf-forwarding-review-fixes" diff --check
```

性能基准：

```text
BenchmarkStreamFlushWriterWriteSSEData-20       18640776    57.37 ns/op    112 B/op    2 allocs/op
BenchmarkStreamTranslatorTranslateParsed-20      1818309   643.9 ns/op     376 B/op    5 allocs/op
```

已知未通过项：

```bash
go test -C "F:/Github/codex2api/.claude/worktrees/perf-forwarding-review-fixes" ./...
```

失败原因是 root package 缺少前端构建产物，并非本次 Go 代码改动导致：

```text
main.go:29:12: pattern frontend/dist/*: no matching files found
FAIL github.com/codex2api [setup failed]
```

`git diff --check` 仅输出 Windows 下 LF/CRLF 提示，没有空白错误。

## 修改总结

- 优化 SSE/WS 请求转发热路径，减少字符串格式化、字节转换和重复 JSON parse。
- 保持并强化首 token 前 pending lifecycle 事件与透明重试语义。
- 限制上游错误日志体积，降低异常场景日志放大风险。
- OpenAI Responses relay body 改为惰性生成，避免 Codex 路径无效转换。
- 补充测试与 benchmark，验证行为兼容性和关键性能路径。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error message logging with better truncation and sensitive data masking
  * Enhanced retry handling for streaming responses before content begins
  * Refined upstream error reporting for clearer error visibility

* **Performance**
  * Optimized streaming response processing and message buffering efficiency
  * Reduced unnecessary parsing operations in stream translation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->