### PR TITLE
feat: 新增外部异步图片任务接口

### DIFF
--- a/admin/image_studio.go
+++ b/admin/image_studio.go
@@ -54,20 +54,25 @@ type imagePromptTemplatePayload struct {
 }
 
 type imageGenerationJobPayload struct {
-	Prompt       string `json:"prompt"`
-	Model        string `json:"model"`
-	Size         string `json:"size"`
-	Quality      string `json:"quality"`
-	OutputFormat string `json:"output_format"`
-	Background   string `json:"background"`
-	Style        string `json:"style"`
-	Upscale      string `json:"upscale"`
-	APIKeyID     int64  `json:"api_key_id"`
+	Prompt       string   `json:"prompt"`
+	Model        string   `json:"model"`
+	Size         string   `json:"size"`
+	Quality      string   `json:"quality"`
+	OutputFormat string   `json:"output_format"`
+	Background   string   `json:"background"`
+	Style        string   `json:"style"`
+	Upscale      string   `json:"upscale"`
+	APIKeyID     int64    `json:"api_key_id"`
 	TemplateID   int64    `json:"template_id"`
 	InputImages  []string `json:"input_images"`
+	External     bool     `json:"-"`
 }
 
 type imageJobResponse struct {
+	Job *database.ImageGenerationJob `json:"job"`
+}
+
+type externalImageJobResponse struct {
 	Job *database.ImageGenerationJob `json:"job"`
 }
 
@@ -776,7 +781,7 @@ func (h *Handler) runImageGenerationJob(jobID int64, req imageGenerationJobPaylo
 		_ = h.db.MarkImageJobFailed(ctx, jobID, err.Error(), durationMs)
 		return
 	}
-	log.Printf("[image-studio] job=%d upstream request model=%s size=%s quality=%s format=%s body_bytes=%d prompt_chars=%d prompt=%q",
+	log.Printf("[image-studio] job=%d upstream request model=%s size=%s quality=%s format=%s body_bytes=%d prompt_chars=%d%s",
 		jobID,
 		imageLogValue(gjson.GetBytes(rawBody, "model").String()),
 		imageLogValue(gjson.GetBytes(rawBody, "size").String()),
@@ -784,7 +789,7 @@ func (h *Handler) runImageGenerationJob(jobID int64, req imageGenerationJobPaylo
 		imageLogValue(gjson.GetBytes(rawBody, "output_format").String()),
 		len(rawBody),
 		len([]rune(styledPrompt)),
-		imageLogPromptPreview(styledPrompt),
+		imageLogPromptSuffix(styledPrompt, req.External),
 	)
 	imageProxy := h.imageProxy
 	if imageProxy == nil {
@@ -803,7 +808,7 @@ func (h *Handler) runImageGenerationJob(jobID int64, req imageGenerationJobPaylo
 			return
 		}
 		fallbackStyledPrompt := proxy.AppendImageStyleToPrompt(fallbackReq.Prompt, fallbackReq.Style)
-		log.Printf("[image-studio] job=%d png_failed_retrying_jpeg upstream_status=%d error=%s fallback_size=%s fallback_quality=%s fallback_background=%s fallback_prompt_chars=%d fallback_prompt=%q",
+		log.Printf("[image-studio] job=%d png_failed_retrying_jpeg upstream_status=%d error=%s fallback_size=%s fallback_quality=%s fallback_background=%s fallback_prompt_chars=%d%s",
 			jobID,
 			pngStatus,
 			security.SanitizeLog(pngErr.Error()),
@@ -811,7 +816,7 @@ func (h *Handler) runImageGenerationJob(jobID int64, req imageGenerationJobPaylo
 			imageLogValue(fallbackReq.Quality),
 			imageLogValue(fallbackReq.Background),
 			len([]rune(fallbackStyledPrompt)),
-			imageLogPromptPreview(fallbackStyledPrompt),
+			imageLogPromptSuffix(fallbackStyledPrompt, req.External),
 		)
 		responseJSON, upstreamStatus, err = imageProxy.GenerateImageOnceForAdmin(ctx, fallbackBody, apiKey)
 		if err == nil {
@@ -1428,6 +1433,13 @@ func imageLogPromptPreview(prompt string) string {
 		prompt = string(runes[:96]) + "..."
 	}
 	return security.SanitizeLog(prompt)
+}
+
+func imageLogPromptSuffix(prompt string, redact bool) string {
+	if redact {
+		return ""
+	}
+	return fmt.Sprintf(" prompt=%q", imageLogPromptPreview(prompt))
 }
 
 func imageLogAPIKeyLabel(id int64, name string, masked string) string {

--- a/admin/image_studio_external.go
+++ b/admin/image_studio_external.go
@@ -1,0 +1,416 @@
+package admin
+
+import (
+	"context"
+	"database/sql"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"mime"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/codex2api/database"
+	"github.com/codex2api/internal/imageproc"
+	"github.com/codex2api/proxy"
+	"github.com/codex2api/security"
+	"github.com/gin-gonic/gin"
+)
+
+// RegisterExternalImageRoutes registers API-key authenticated async Image Studio
+// task endpoints for external clients.
+func (h *Handler) RegisterExternalImageRoutes(r *gin.Engine, imageProxy *proxy.Handler) {
+	if h == nil || r == nil || imageProxy == nil {
+		return
+	}
+	h.imageProxy = imageProxy
+	v1 := r.Group("/v1")
+	v1.Use(imageProxy.APIKeyAuthMiddleware())
+	v1.POST("/images/jobs", h.CreateExternalImageJob)
+	v1.GET("/images/jobs/:id", h.GetExternalImageJob)
+}
+
+func (h *Handler) CreateExternalImageJob(c *gin.Context) {
+	var req imageGenerationJobPayload
+	if err := c.ShouldBindJSON(&req); err != nil {
+		writeExternalImageError(c, http.StatusBadRequest, "Invalid request: body must be valid JSON")
+		return
+	}
+	imageCount := len(req.InputImages)
+	if imageCount < 1 {
+		imageCount = 1
+	}
+	normalizeCtx, cancel := context.WithTimeout(c.Request.Context(), externalInputImageFetchTimeout*time.Duration(imageCount))
+	editMode, err := normalizeExternalImageJobPayload(normalizeCtx, &req)
+	cancel()
+	if err != nil {
+		writeExternalImageError(c, http.StatusBadRequest, "Invalid request: "+err.Error())
+		return
+	}
+	req.External = true
+
+	apiKey := proxy.APIKeyRowFromContext(c)
+	if apiKey == nil {
+		writeExternalImageError(c, http.StatusUnauthorized, "Missing or invalid API key")
+		return
+	}
+	req.APIKeyID = apiKey.ID
+	keyID, keyName, keyMasked := imageJobAPIKeyMeta(apiKey)
+	endpoint := "/v1/images/jobs"
+	if editMode {
+		endpoint = "/v1/images/jobs:edit"
+	}
+	if h.inspectImagePromptFilter(c, proxy.AppendImageStyleToPrompt(req.Prompt, req.Style), req.Model, keyID, keyName, keyMasked, endpoint, func(c *gin.Context) {
+		writeExternalImageError(c, http.StatusBadRequest, "Prompt was blocked by prompt filter")
+	}, true) {
+		return
+	}
+
+	imageProxy := h.imageProxy
+	if imageProxy == nil {
+		imageProxy = proxy.NewHandler(h.store, h.db, nil, nil)
+	}
+	// The in-process image handler intentionally does not run the /v1 auth
+	// middleware again. Enforce API-key limits and hold the concurrency slot here
+	// from enqueue through background completion so async jobs match /v1 policy
+	// without double-counting the same request.
+	if status, msg := imageProxy.EnforceAPIKeyLimits(c, req.Model); status != 0 {
+		proxy.SendAPIKeyLimitError(c, status, msg)
+		return
+	}
+	releaseAPIKeyConcurrency, ok := imageProxy.AcquireAPIKeyConcurrency(c)
+	if !ok {
+		return
+	}
+	jobStarted := false
+	defer func() {
+		if !jobStarted && releaseAPIKeyConcurrency != nil {
+			releaseAPIKeyConcurrency()
+		}
+	}()
+
+	paramsJSON, _ := json.Marshal(req)
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 10*time.Second)
+	defer cancel()
+	jobID, err := h.db.InsertImageGenerationJob(ctx, database.ImageGenerationJobInput{
+		Prompt:       req.Prompt,
+		ParamsJSON:   string(paramsJSON),
+		APIKeyID:     keyID,
+		APIKeyName:   keyName,
+		APIKeyMasked: keyMasked,
+	})
+	if err != nil {
+		writeInternalError(c, err)
+		return
+	}
+	if req.TemplateID > 0 {
+		_ = h.db.IncrementImagePromptTemplateUsage(ctx, req.TemplateID)
+	}
+	job, err := h.db.GetImageGenerationJob(ctx, jobID)
+	if err != nil {
+		writeInternalError(c, err)
+		return
+	}
+	log.Printf("[image-studio] external job=%d queued mode=%s model=%s size=%s quality=%s format=%s api_key=%s prompt_chars=%d",
+		jobID,
+		externalImageJobMode(editMode),
+		imageLogValue(req.Model),
+		imageLogValue(req.Size),
+		imageLogValue(req.Quality),
+		imageLogValue(req.OutputFormat),
+		imageLogAPIKeyLabel(keyID, keyName, keyMasked),
+		len([]rune(req.Prompt)),
+	)
+	jobStarted = true
+	go func() {
+		if releaseAPIKeyConcurrency != nil {
+			defer releaseAPIKeyConcurrency()
+		}
+		if editMode {
+			h.runImageEditJob(jobID, req, apiKey)
+			return
+		}
+		h.runImageGenerationJob(jobID, req, apiKey)
+	}()
+	c.JSON(http.StatusAccepted, externalImageJobResponse{Job: job})
+}
+
+func (h *Handler) GetExternalImageJob(c *gin.Context) {
+	apiKey := proxy.APIKeyRowFromContext(c)
+	if apiKey == nil {
+		writeExternalImageError(c, http.StatusUnauthorized, "Missing or invalid API key")
+		return
+	}
+	id, err := parsePositiveIDParam(c, "id")
+	if err != nil {
+		writeExternalImageError(c, http.StatusBadRequest, "Invalid request: invalid job id")
+		return
+	}
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 10*time.Second)
+	defer cancel()
+	job, err := h.db.GetImageGenerationJob(ctx, id)
+	if errors.Is(err, sql.ErrNoRows) {
+		writeExternalImageError(c, http.StatusNotFound, "Image job not found")
+		return
+	}
+	if err != nil {
+		writeInternalError(c, err)
+		return
+	}
+	if job.APIKeyID != apiKey.ID {
+		writeExternalImageError(c, http.StatusNotFound, "Image job not found")
+		return
+	}
+	if c.Query("include_cache") == "1" {
+		h.attachImageJobAssetCachePayload(job)
+	}
+	decorateImageJobAssets(job)
+	c.JSON(http.StatusOK, externalImageJobResponse{Job: job})
+}
+
+func normalizeExternalImageJobPayload(ctx context.Context, req *imageGenerationJobPayload) (bool, error) {
+	if req == nil {
+		return false, fmt.Errorf("body is required")
+	}
+	req.Prompt = strings.TrimSpace(req.Prompt)
+	if req.Prompt == "" {
+		return false, fmt.Errorf("prompt is required")
+	}
+	if len([]rune(req.Prompt)) > 8000 {
+		return false, fmt.Errorf("prompt must be at most 8000 characters")
+	}
+	req.Model = normalizeImageStudioModel(req.Model)
+	if req.Model == "" {
+		req.Model = "gpt-image-2"
+	}
+	req.Size = normalizeOptionalImageParam(req.Size)
+	req.Quality = normalizeOptionalImageParam(req.Quality)
+	req.OutputFormat = normalizeOptionalImageParam(req.OutputFormat)
+	if req.OutputFormat == "" {
+		req.OutputFormat = "png"
+	}
+	req.Background = normalizeOptionalImageParam(req.Background)
+	req.Style = normalizeOptionalImageParam(req.Style)
+	req.Upscale = imageproc.NormalizeUpscale(req.Upscale)
+
+	images := make([]string, 0, len(req.InputImages))
+	for _, imageURL := range req.InputImages {
+		imageURL = strings.TrimSpace(imageURL)
+		if imageURL == "" {
+			continue
+		}
+		normalizedImage, err := normalizeExternalInputImage(ctx, imageURL)
+		if err != nil {
+			return false, err
+		}
+		images = append(images, normalizedImage)
+	}
+	req.InputImages = images
+	editMode := len(req.InputImages) > 0
+	if len(req.InputImages) > proxy.MaxImageEditInputCount {
+		return false, fmt.Errorf("too many input_images (%d, max %d)", len(req.InputImages), proxy.MaxImageEditInputCount)
+	}
+	return editMode, nil
+}
+
+const (
+	externalInputImageFetchTimeout  = 20 * time.Second
+	externalInputImageMaxBytes      = 20 << 20
+	externalInputImageMaxEncodedLen = (externalInputImageMaxBytes+2)/3*4 + 128
+)
+
+func normalizeExternalInputImage(ctx context.Context, raw string) (string, error) {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return "", fmt.Errorf("input_images contains empty image URL")
+	}
+	lower := strings.ToLower(value)
+	if strings.HasPrefix(lower, "data:image/") {
+		if err := validateExternalInputImageDataURL(value); err != nil {
+			return "", err
+		}
+		return value, nil
+	}
+	return fetchExternalInputImageAsDataURL(ctx, value)
+}
+
+func validateExternalInputImageDataURL(value string) error {
+	if len(value) > externalInputImageMaxEncodedLen {
+		return fmt.Errorf("input_images data URL is too large")
+	}
+	comma := strings.Index(value, ",")
+	if comma < 0 {
+		return fmt.Errorf("input_images data URLs must be base64 encoded images")
+	}
+	header := strings.ToLower(value[:comma])
+	if !strings.HasPrefix(header, "data:image/") || !strings.Contains(header, ";base64") {
+		return fmt.Errorf("input_images data URLs must be base64 encoded images")
+	}
+	encoded := value[comma+1:]
+	if encoded == "" {
+		return fmt.Errorf("input_images data URL image data is empty")
+	}
+	if _, err := base64.StdEncoding.DecodeString(encoded); err != nil {
+		return fmt.Errorf("input_images data URL image data is not valid base64")
+	}
+	return nil
+}
+
+func fetchExternalInputImageAsDataURL(ctx context.Context, raw string) (string, error) {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || parsed == nil || parsed.Host == "" {
+		return "", fmt.Errorf("input_images contains invalid URL")
+	}
+	if parsed.User != nil {
+		return "", fmt.Errorf("input_images URL userinfo is not allowed")
+	}
+	scheme := strings.ToLower(parsed.Scheme)
+	if scheme != "http" && scheme != "https" {
+		return "", fmt.Errorf("input_images URL scheme must be http, https, or data:image")
+	}
+	if parsed.Hostname() == "" || strings.EqualFold(parsed.Hostname(), "localhost") {
+		return "", fmt.Errorf("input_images URL host is not allowed")
+	}
+
+	fetchCtx, cancel := context.WithTimeout(ctx, externalInputImageFetchTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(fetchCtx, http.MethodGet, parsed.String(), nil)
+	if err != nil {
+		return "", fmt.Errorf("input_images contains invalid URL")
+	}
+	req.Header.Set("Accept", "image/*")
+	client := &http.Client{
+		Timeout:       externalInputImageFetchTimeout,
+		Transport:     newExternalInputImageTransport(),
+		CheckRedirect: rejectExternalInputImageRedirect,
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("input_images URL cannot be fetched safely")
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 && resp.StatusCode < 400 {
+		return "", fmt.Errorf("input_images URL redirects are not allowed")
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("input_images URL returned HTTP %d", resp.StatusCode)
+	}
+	if resp.ContentLength > externalInputImageMaxBytes {
+		return "", fmt.Errorf("input_images URL image is too large")
+	}
+
+	contentType := resp.Header.Get("Content-Type")
+	mediaType, _, _ := mime.ParseMediaType(contentType)
+	mediaType = strings.ToLower(strings.TrimSpace(mediaType))
+	if mediaType != "" && !strings.HasPrefix(mediaType, "image/") {
+		return "", fmt.Errorf("input_images URL content type must be an image")
+	}
+	data, err := io.ReadAll(io.LimitReader(resp.Body, externalInputImageMaxBytes+1))
+	if err != nil {
+		return "", fmt.Errorf("input_images URL image could not be read")
+	}
+	if len(data) == 0 {
+		return "", fmt.Errorf("input_images URL image data is empty")
+	}
+	if len(data) > externalInputImageMaxBytes {
+		return "", fmt.Errorf("input_images URL image is too large")
+	}
+	if mediaType == "" {
+		mediaType = strings.ToLower(http.DetectContentType(data))
+	}
+	if !strings.HasPrefix(mediaType, "image/") {
+		return "", fmt.Errorf("input_images URL content type must be an image")
+	}
+	return "data:" + mediaType + ";base64," + base64.StdEncoding.EncodeToString(data), nil
+}
+
+func rejectExternalInputImageRedirect(req *http.Request, via []*http.Request) error {
+	return http.ErrUseLastResponse
+}
+
+func newExternalInputImageTransport() *http.Transport {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.Proxy = nil
+	transport.DialContext = dialPublicExternalInputImageAddress
+	return transport
+}
+
+var dialPublicExternalInputImageAddress = func(ctx context.Context, network, address string) (net.Conn, error) {
+	host, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return nil, err
+	}
+	if host == "" || strings.EqualFold(host, "localhost") {
+		return nil, fmt.Errorf("blocked private or reserved address")
+	}
+	ips, err := net.DefaultResolver.LookupIP(ctx, "ip", host)
+	if err != nil || len(ips) == 0 {
+		return nil, fmt.Errorf("input_images URL host cannot be resolved")
+	}
+	for _, ip := range ips {
+		if !isPublicImageURLIP(ip) {
+			return nil, fmt.Errorf("blocked private or reserved address")
+		}
+	}
+	network = "tcp"
+	dialer := &net.Dialer{Timeout: externalInputImageFetchTimeout}
+	var lastErr error
+	for _, ip := range ips {
+		conn, err := dialer.DialContext(ctx, network, net.JoinHostPort(ip.String(), port))
+		if err == nil {
+			return conn, nil
+		}
+		lastErr = err
+	}
+	return nil, lastErr
+}
+
+func isPublicImageURLIP(ip net.IP) bool {
+	if ip == nil {
+		return false
+	}
+	if ip.IsLoopback() || ip.IsPrivate() || ip.IsUnspecified() || ip.IsMulticast() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() {
+		return false
+	}
+	if ip4 := ip.To4(); ip4 != nil {
+		return !(ip4[0] == 0 || ip4[0] == 10 || ip4[0] == 127 ||
+			(ip4[0] == 169 && ip4[1] == 254) ||
+			(ip4[0] == 172 && ip4[1] >= 16 && ip4[1] <= 31) ||
+			(ip4[0] == 192 && ip4[1] == 168) ||
+			(ip4[0] == 100 && ip4[1] >= 64 && ip4[1] <= 127) ||
+			(ip4[0] == 192 && ip4[1] == 0 && ip4[2] == 0) ||
+			(ip4[0] == 192 && ip4[1] == 0 && ip4[2] == 2) ||
+			(ip4[0] == 198 && ip4[1] == 18) ||
+			(ip4[0] == 198 && ip4[1] == 19) ||
+			(ip4[0] == 198 && ip4[1] == 51 && ip4[2] == 100) ||
+			(ip4[0] == 203 && ip4[1] == 0 && ip4[2] == 113) ||
+			ip4[0] >= 224)
+	}
+	return !(ip.IsInterfaceLocalMulticast() || ip.IsLinkLocalMulticast())
+}
+
+func externalImageJobMode(editMode bool) string {
+	if editMode {
+		return "edit"
+	}
+	return "generation"
+}
+
+func writeExternalImageError(c *gin.Context, status int, message string) {
+	message = strings.TrimSpace(message)
+	if message == "" {
+		message = http.StatusText(status)
+	}
+	c.JSON(status, gin.H{
+		"error": gin.H{
+			"message": security.SanitizeInput(message),
+			"type":    "invalid_request_error",
+		},
+	})
+}

--- a/admin/image_studio_test.go
+++ b/admin/image_studio_test.go
@@ -7,8 +7,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -20,6 +22,7 @@ import (
 	"github.com/codex2api/cache"
 	"github.com/codex2api/database"
 	"github.com/codex2api/internal/imagestore"
+	"github.com/codex2api/proxy"
 	"github.com/gin-gonic/gin"
 )
 
@@ -260,6 +263,288 @@ func TestDeleteImageGenerationJobRouteDeletesAssetsAndFiles(t *testing.T) {
 	}
 	if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("asset file stat err = %v, want not exist", err)
+	}
+}
+
+func TestExternalImageJobRoutesCreateAndQueryOwnJob(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	db := newTestAdminDB(t)
+	tc := cache.NewMemory(1)
+	defer tc.Close()
+	store := auth.NewStore(db, tc, nil)
+	handler := NewHandler(store, db, tc, nil, "admin-secret")
+	imageProxy := proxy.NewHandler(store, db, nil, nil)
+	imageProxy.SetRuntimeCache(tc)
+	router := gin.New()
+	handler.RegisterExternalImageRoutes(router, imageProxy)
+
+	keyID, err := db.InsertAPIKey(context.Background(), "external", "sk-external")
+	if err != nil {
+		t.Fatalf("InsertAPIKey 返回错误: %v", err)
+	}
+
+	body := strings.NewReader(`{"prompt":"draw a cat","model":"gpt-image-2","size":"auto","quality":"auto","output_format":"png"}`)
+	req := httptest.NewRequest(http.MethodPost, "/v1/images/jobs", body)
+	req.Header.Set("Authorization", "Bearer sk-external")
+	req.Header.Set("Content-Type", "application/json")
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202 body=%s", recorder.Code, recorder.Body.String())
+	}
+	var created imageJobResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if created.Job == nil || created.Job.ID <= 0 || created.Job.APIKeyID != keyID || created.Job.APIKeyName != "external" {
+		t.Fatalf("created job = %#v, want api key metadata", created.Job)
+	}
+	if created.Job.Status != database.ImageJobQueued {
+		t.Fatalf("job status = %q, want queued", created.Job.Status)
+	}
+
+	getReq := httptest.NewRequest(http.MethodGet, "/v1/images/jobs/"+strconv.FormatInt(created.Job.ID, 10), nil)
+	getReq.Header.Set("Authorization", "Bearer sk-external")
+	getRecorder := httptest.NewRecorder()
+	router.ServeHTTP(getRecorder, getReq)
+	if getRecorder.Code != http.StatusOK {
+		t.Fatalf("get status = %d, want 200 body=%s", getRecorder.Code, getRecorder.Body.String())
+	}
+}
+
+func TestExternalImageJobRouteRejectsOtherAPIKeyJob(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	db := newTestAdminDB(t)
+	tc := cache.NewMemory(1)
+	defer tc.Close()
+	store := auth.NewStore(db, tc, nil)
+	handler := NewHandler(store, db, tc, nil, "admin-secret")
+	imageProxy := proxy.NewHandler(store, db, nil, nil)
+	imageProxy.SetRuntimeCache(tc)
+	router := gin.New()
+	handler.RegisterExternalImageRoutes(router, imageProxy)
+
+	ownerID, err := db.InsertAPIKey(context.Background(), "owner", "sk-owner")
+	if err != nil {
+		t.Fatalf("InsertAPIKey owner 返回错误: %v", err)
+	}
+	if _, err := db.InsertAPIKey(context.Background(), "other", "sk-other"); err != nil {
+		t.Fatalf("InsertAPIKey other 返回错误: %v", err)
+	}
+	jobID, err := db.InsertImageGenerationJob(context.Background(), database.ImageGenerationJobInput{
+		Prompt:       "private job",
+		ParamsJSON:   `{}`,
+		APIKeyID:     ownerID,
+		APIKeyName:   "owner",
+		APIKeyMasked: "sk-o...wner",
+	})
+	if err != nil {
+		t.Fatalf("InsertImageGenerationJob 返回错误: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/images/jobs/"+strconv.FormatInt(jobID, 10), nil)
+	req.Header.Set("Authorization", "Bearer sk-other")
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404 body=%s", recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestExternalImageJobRouteRequiresAPIKey(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	db := newTestAdminDB(t)
+	tc := cache.NewMemory(1)
+	defer tc.Close()
+	store := auth.NewStore(db, tc, nil)
+	handler := NewHandler(store, db, tc, nil, "admin-secret")
+	imageProxy := proxy.NewHandler(store, db, nil, nil)
+	imageProxy.SetRuntimeCache(tc)
+	router := gin.New()
+	handler.RegisterExternalImageRoutes(router, imageProxy)
+	if _, err := db.InsertAPIKey(context.Background(), "existing", "sk-existing"); err != nil {
+		t.Fatalf("InsertAPIKey 返回错误: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/images/jobs", strings.NewReader(`{"prompt":"draw"}`))
+	req.Header.Set("Content-Type", "application/json")
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401 body=%s", recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestExternalImageJobRouteEnforcesModelAllowList(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	db := newTestAdminDB(t)
+	tc := cache.NewMemory(1)
+	defer tc.Close()
+	store := auth.NewStore(db, tc, nil)
+	handler := NewHandler(store, db, tc, nil, "admin-secret")
+	imageProxy := proxy.NewHandler(store, db, nil, nil)
+	imageProxy.SetRuntimeCache(tc)
+	router := gin.New()
+	handler.RegisterExternalImageRoutes(router, imageProxy)
+
+	if _, err := db.InsertAPIKeyWithOptions(context.Background(), database.APIKeyInput{
+		Name: "limited",
+		Key:  "sk-limited",
+		Limits: database.APIKeyLimits{
+			ModelAllow: []string{"gpt-5.4"},
+		},
+	}); err != nil {
+		t.Fatalf("InsertAPIKeyWithOptions 返回错误: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/images/jobs", strings.NewReader(`{"prompt":"draw","model":"gpt-image-2"}`))
+	req.Header.Set("Authorization", "Bearer sk-limited")
+	req.Header.Set("Content-Type", "application/json")
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403 body=%s", recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestExternalImageJobRouteNormalizesEditPayload(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	db := newTestAdminDB(t)
+	tc := cache.NewMemory(1)
+	defer tc.Close()
+	store := auth.NewStore(db, tc, nil)
+	handler := NewHandler(store, db, tc, nil, "admin-secret")
+	imageProxy := proxy.NewHandler(store, db, nil, nil)
+	imageProxy.SetRuntimeCache(tc)
+	router := gin.New()
+	handler.RegisterExternalImageRoutes(router, imageProxy)
+
+	keyID, err := db.InsertAPIKey(context.Background(), "external-edit", "sk-external-edit")
+	if err != nil {
+		t.Fatalf("InsertAPIKey 返回错误: %v", err)
+	}
+
+	body := strings.NewReader(`{"prompt":" edit this ","model":"unknown-model","input_images":["","data:image/png;base64,aGk="],"output_format":""}`)
+	req := httptest.NewRequest(http.MethodPost, "/v1/images/jobs", body)
+	req.Header.Set("Authorization", "Bearer sk-external-edit")
+	req.Header.Set("Content-Type", "application/json")
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202 body=%s", recorder.Code, recorder.Body.String())
+	}
+	var created imageJobResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if created.Job == nil || created.Job.APIKeyID != keyID {
+		t.Fatalf("created job = %#v, want api key id %d", created.Job, keyID)
+	}
+	var params imageGenerationJobPayload
+	if err := json.Unmarshal([]byte(created.Job.ParamsJSON), &params); err != nil {
+		t.Fatalf("decode params_json: %v", err)
+	}
+	if params.Prompt != "edit this" || params.Model != "gpt-image-2" || params.OutputFormat != "png" {
+		t.Fatalf("params = %#v, want normalized prompt/model/output format", params)
+	}
+	if len(params.InputImages) != 1 || params.InputImages[0] != "data:image/png;base64,aGk=" {
+		t.Fatalf("input_images = %#v, want trimmed single image", params.InputImages)
+	}
+}
+
+func TestExternalImageJobRouteRejectsPrivateInputImageURL(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	db := newTestAdminDB(t)
+	tc := cache.NewMemory(1)
+	defer tc.Close()
+	store := auth.NewStore(db, tc, nil)
+	handler := NewHandler(store, db, tc, nil, "admin-secret")
+	imageProxy := proxy.NewHandler(store, db, nil, nil)
+	imageProxy.SetRuntimeCache(tc)
+	router := gin.New()
+	handler.RegisterExternalImageRoutes(router, imageProxy)
+
+	if _, err := db.InsertAPIKey(context.Background(), "external-private-url", "sk-private-url"); err != nil {
+		t.Fatalf("InsertAPIKey 返回错误: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/images/jobs", strings.NewReader(`{"prompt":"edit","input_images":["http://127.0.0.1/private.png"]}`))
+	req.Header.Set("Authorization", "Bearer sk-private-url")
+	req.Header.Set("Content-Type", "application/json")
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 body=%s", recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestExternalImageJobRouteFetchesPublicInputImageAsDataURL(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tiny := tinyPNG(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write(tiny)
+	}))
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse test server URL: %v", err)
+	}
+	oldDialer := dialPublicExternalInputImageAddress
+	dialPublicExternalInputImageAddress = func(ctx context.Context, network, address string) (net.Conn, error) {
+		_, port, err := net.SplitHostPort(address)
+		if err != nil {
+			return nil, err
+		}
+		return (&net.Dialer{}).DialContext(ctx, "tcp", net.JoinHostPort(serverURL.Hostname(), port))
+	}
+	defer func() { dialPublicExternalInputImageAddress = oldDialer }()
+
+	db := newTestAdminDB(t)
+	tc := cache.NewMemory(1)
+	defer tc.Close()
+	store := auth.NewStore(db, tc, nil)
+	handler := NewHandler(store, db, tc, nil, "admin-secret")
+	imageProxy := proxy.NewHandler(store, db, nil, nil)
+	imageProxy.SetRuntimeCache(tc)
+	router := gin.New()
+	handler.RegisterExternalImageRoutes(router, imageProxy)
+
+	if _, err := db.InsertAPIKey(context.Background(), "external-fetch-url", "sk-fetch-url"); err != nil {
+		t.Fatalf("InsertAPIKey 返回错误: %v", err)
+	}
+
+	body := fmt.Sprintf(`{"prompt":"edit","input_images":["http://example.com:%s/source.png"]}`, serverURL.Port())
+	req := httptest.NewRequest(http.MethodPost, "/v1/images/jobs", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer sk-fetch-url")
+	req.Header.Set("Content-Type", "application/json")
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202 body=%s", recorder.Code, recorder.Body.String())
+	}
+	var created imageJobResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if created.Job == nil {
+		t.Fatalf("created job is nil")
+	}
+	var params imageGenerationJobPayload
+	if err := json.Unmarshal([]byte(created.Job.ParamsJSON), &params); err != nil {
+		t.Fatalf("decode params_json: %v", err)
+	}
+	want := "data:image/png;base64," + base64.StdEncoding.EncodeToString(tiny)
+	if len(params.InputImages) != 1 || params.InputImages[0] != want {
+		t.Fatalf("input_images = %#v, want fetched data URL", params.InputImages)
 	}
 }
 

--- a/admin/prompt_filter.go
+++ b/admin/prompt_filter.go
@@ -46,6 +46,10 @@ type promptFilterRulesResponse struct {
 }
 
 func (h *Handler) inspectImageStudioPromptFilter(c *gin.Context, text string, model string, keyID int64, keyName string, keyMasked string) bool {
+	return h.inspectImagePromptFilter(c, text, model, keyID, keyName, keyMasked, "/api/admin/images/jobs", nil, false)
+}
+
+func (h *Handler) inspectImagePromptFilter(c *gin.Context, text string, model string, keyID int64, keyName string, keyMasked string, endpoint string, writeBlock func(*gin.Context), redactPreview bool) bool {
 	if h == nil || h.store == nil {
 		return false
 	}
@@ -58,22 +62,30 @@ func (h *Handler) inspectImageStudioPromptFilter(c *gin.Context, text string, mo
 	if verdict.Action != promptfilter.ActionBlock {
 		return false
 	}
+	textPreview := verdict.TextPreview
+	if redactPreview {
+		textPreview = "[redacted]"
+	}
 	h.recordPromptFilterLog(c, &database.PromptFilterLogInput{
 		Source:          "local_filter",
-		Endpoint:        "/api/admin/images/jobs",
+		Endpoint:        endpoint,
 		Model:           model,
 		Action:          verdict.Action,
 		Mode:            verdict.Mode,
 		Score:           verdict.Score,
 		Threshold:       verdict.Threshold,
 		MatchedPatterns: promptfilter.MatchesJSON(verdict.Matched),
-		TextPreview:     verdict.TextPreview,
+		TextPreview:     textPreview,
 		APIKeyID:        keyID,
 		APIKeyName:      keyName,
 		APIKeyMasked:    keyMasked,
 		ClientIP:        c.ClientIP(),
 	})
-	writeError(c, http.StatusBadRequest, "Prompt 被检查规则拦截")
+	if writeBlock != nil {
+		writeBlock(c)
+	} else {
+		writeError(c, http.StatusBadRequest, "Prompt 被检查规则拦截")
+	}
 	return true
 }
 

--- a/main.go
+++ b/main.go
@@ -290,6 +290,7 @@ func main() {
 	log.Printf("单账号并发上限: %d", settings.MaxConcurrency)
 
 	handler.RegisterRoutes(r)
+	adminHandler.RegisterExternalImageRoutes(r, handler)
 	adminHandler.RegisterRoutes(r)
 
 	// 管理后台前端静态文件
@@ -356,7 +357,8 @@ func main() {
 	log.Printf("  API:    POST /v1/chat/completions")
 	log.Printf("  API:    POST /v1/responses")
 	log.Printf("  API:    POST /v1/images/generations")
-	log.Printf("  API:    POST /v1/images/edits")
+	log.Printf("  API:    POST /v1/images/jobs")
+	log.Printf("  API:    GET  /v1/images/jobs/:id")
 	log.Printf("  API:    POST /v1/messages")
 	log.Printf("  API:    GET  /v1/models")
 	log.Println("==========================================")

--- a/proxy/apikey_concurrency.go
+++ b/proxy/apikey_concurrency.go
@@ -81,6 +81,10 @@ func (h *Handler) apiKeyConcurrencyLimiter() *apiKeyConcurrencyLimiter {
 	return h.apiKeyGate
 }
 
+func (h *Handler) AcquireAPIKeyConcurrency(c *gin.Context) (func(), bool) {
+	return h.acquireAPIKeyConcurrency(c)
+}
+
 func (h *Handler) acquireAPIKeyConcurrency(c *gin.Context) (func(), bool) {
 	row := apiKeyRowFromContext(c)
 	if row == nil || row.ID <= 0 || row.Limits.MaxConcurrency <= 0 {

--- a/proxy/apikey_limits.go
+++ b/proxy/apikey_limits.go
@@ -49,6 +49,16 @@ func apiKeyRowFromContext(c *gin.Context) *database.APIKeyRow {
 	return row
 }
 
+// APIKeyRowFromContext returns the API key metadata stored by the /v1 auth middleware.
+func APIKeyRowFromContext(c *gin.Context) *database.APIKeyRow {
+	return apiKeyRowFromContext(c)
+}
+
+// EnforceAPIKeyLimits checks API key scoped model and rate/cost limits.
+func (h *Handler) EnforceAPIKeyLimits(c *gin.Context, model string) (int, string) {
+	return h.enforceAPIKeyLimits(c, model)
+}
+
 // enforceAPIKeyLimits 检查 API Key 的所有限制条件。
 // 命中限制时返回 (status, errorMessage),handler 应立即以该响应短路;
 // 全部通过返回 (0, "")。
@@ -131,13 +141,8 @@ func (h *Handler) enforceAPIKeyLimits(c *gin.Context, model string) (int, string
 	return 0, ""
 }
 
-// enforceAPIKeyLimitsAndReply 在请求转发前调用,命中限制时已向客户端写入响应并返回 true。
-// handler 应在 true 时立即 return,无需再处理。
-func (h *Handler) enforceAPIKeyLimitsAndReply(c *gin.Context, model string) bool {
-	status, msg := h.enforceAPIKeyLimits(c, model)
-	if status == 0 {
-		return false
-	}
+// SendAPIKeyLimitError writes a standard /v1 API key limit error response.
+func SendAPIKeyLimitError(c *gin.Context, status int, msg string) {
 	errType := api.ErrorTypeRateLimit
 	errCode := api.ErrCodeRateLimitReached
 	if status == http.StatusForbidden {
@@ -145,6 +150,16 @@ func (h *Handler) enforceAPIKeyLimitsAndReply(c *gin.Context, model string) bool
 		errCode = api.ErrCodeInvalidRequest
 	}
 	api.SendErrorWithStatus(c, api.NewAPIError(errCode, msg, errType), status)
+}
+
+// enforceAPIKeyLimitsAndReply 在请求转发前调用,命中限制时已向客户端写入响应并返回 true。
+// handler 应在 true 时立即 return,无需再处理。
+func (h *Handler) enforceAPIKeyLimitsAndReply(c *gin.Context, model string) bool {
+	status, msg := h.enforceAPIKeyLimits(c, model)
+	if status == 0 {
+		return false
+	}
+	SendAPIKeyLimitError(c, status, msg)
 	return true
 }
 

--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -1117,6 +1117,12 @@ func (h *Handler) RegisterRoutes(r *gin.Engine) {
 	})
 }
 
+// APIKeyAuthMiddleware exposes the standard /v1 API key authentication middleware
+// for companion routes that live outside proxy.RegisterRoutes.
+func (h *Handler) APIKeyAuthMiddleware() gin.HandlerFunc {
+	return h.authMiddleware()
+}
+
 // authMiddleware API Key 鉴权中间件（增强版，带安全日志）
 //
 // 安全策略（fail-closed）：


### PR DESCRIPTION
## 背景

当前后台 Image Studio 已支持在 `/api/admin/images/studio` 页面通过管理端接口提交图片生成/编辑任务，并通过任务状态查看结果。但外部客户端缺少一个可用 API Key 鉴权调用的异步图片任务接口，无法像调用 `/v1` 兼容接口一样提交任务后异步轮询结果。

本次变更新增 `/v1/images/jobs` 外部异步图片任务接口，使外部客户端可以用 API Key 提交文生图或图生图任务，并通过任务 ID 查询任务状态与生成结果。同时复用现有 Image Studio 后台任务、图片资产保存、账号池动态调度、API Key 限额/并发控制和 Prompt Filter 能力。

## 修改前

- 图片任务主要面向管理端页面使用，外部客户端没有独立的异步任务创建/查询接口。
- 管理端接口不适合直接暴露给外部客户端：
  - 鉴权模型不同；
  - `api_key_id` 等字段不应由外部调用方选择；
  - 查询任务需要按调用方 API Key 做隔离，避免 IDOR；
  - 外部请求日志不应记录 prompt preview 等敏感内容。
- 图生图 `input_images` 如果直接透传外部 URL，存在 SSRF 风险，需要在外部入口做更严格的 URL/拉取防护。

## 修改后

### 新增外部异步图片任务接口

新增 API Key 鉴权的 `/v1` 接口：

- `POST /v1/images/jobs`：提交图片生成/编辑异步任务；
- `GET /v1/images/jobs/:id`：查询当前 API Key 创建的任务；
- `GET /v1/images/jobs/:id?include_cache=1`：查询任务并可附带图片缓存 payload。

外部接口会：

- 复用 `/v1` API Key 鉴权 middleware；
- 强制将任务绑定到当前 API Key，不接受客户端指定任意 `api_key_id`；
- 在创建阶段执行 API Key 模型 allow/deny、RPM/RPD、费用/Token、并发限制；
- 后台任务执行期间持有并发槽，任务结束后释放；
- 查询接口按 `job.APIKeyID == currentAPIKey.ID` 隔离，不属于当前 key 的任务返回 404；
- 继续复用现有 Image Studio 后台任务执行与图片资产保存逻辑。

### 继续复用账号池动态负载均衡

外部异步任务后台执行仍调用现有 Image Studio 内部入口：

- 文生图：`GenerateImageOnceForAdmin`
- 图生图：`GenerateImageEditForAdmin`

最终仍进入 proxy 图片链路和账号池调度逻辑，因此继续复用账号池动态负载均衡、账号筛选、冷却和重试能力。

### 日志与 Prompt Filter 脱敏

- 外部任务排队日志不再记录 prompt 内容，只记录 `prompt_chars`；
- 后台图片请求日志对外部任务不再输出 prompt preview；
- Prompt Filter 对外部接口阻断日志使用 redacted preview，避免敏感 prompt 出现在日志中；
- 管理端 Image Studio 原有 prompt preview 行为保持不变。

### SSRF 防护

外部 `input_images` 处理改为：

- `data:image/*;base64,...`：校验 base64、大小上限和内容有效性；
- `http/https` 图片 URL：不再透传给上游，而是由本服务用安全 HTTP client 拉取后转为 `data:image/...;base64,...` 再进入后台任务。

安全 HTTP client 做了以下限制：

- 禁用代理；
- 禁止自动 redirect，3xx 直接拒绝；
- 自定义 `DialContext`，每次连接前解析并校验目标 IP；
- 拒绝 loopback、private、link-local、multicast、unspecified、保留网段等地址；
- 实际连接校验后的 IP，降低 DNS rebinding 风险；
- 限制响应大小；
- 要求响应内容为 `image/*`。

## 前后对比分析

- 兼容性：
  - 新增 `/v1/images/jobs` 接口，不改变现有管理端接口路径和行为；
  - 管理端 Image Studio 继续可用；
  - 已有 `/v1/images/generations`、`/v1/images/edits` 等同步接口不受影响。

- 权限与隔离：
  - 外部创建任务时只绑定当前 API Key；
  - 查询任务时按 API Key 隔离，避免通过递增 ID 查询其他调用方任务。

- 风险控制：
  - API Key 限额和并发限制在异步任务入队阶段执行，并覆盖后台执行周期；
  - 外部日志和 Prompt Filter 日志进行脱敏；
  - `input_images` URL 不再直接透传给通用 fetcher 或上游，降低 SSRF 风险。

- 行为变化：
  - 对外部图生图请求，公网 URL 会被服务端先拉取并转为 data URL；
  - 私网、本机、保留地址、跳转 URL、非图片响应、过大图片会被拒绝；
  - 不影响管理端已有的图片任务提交能力。

## 测试情况

已执行并通过：

```powershell
gofmt -w "admin/image_studio_external.go" "admin/image_studio_test.go" && go test ./admin -run "TestExternalImageJob"
```

结果：

```text
ok  	github.com/codex2api/admin	4.190s
```

```powershell
go test ./admin ./proxy ./database
```

结果：

```text
ok  	github.com/codex2api/admin	2.879s
ok  	github.com/codex2api/proxy	(cached)
ok  	github.com/codex2api/database	(cached)
```

```powershell
go test -race ./admin ./proxy
```

结果：

```text
ok  	github.com/codex2api/admin	30.373s
ok  	github.com/codex2api/proxy	11.271s
```

```powershell
git diff --check
```

结果：通过，退出码 0。输出仅包含 Windows 环境下 LF/CRLF warning，无 whitespace error。

## 修改总结

本次变更新增了 API Key 鉴权的外部异步图片任务接口，支持外部客户端提交文生图/图生图任务并异步查询结果。实现中复用现有 Image Studio 和 proxy 图片链路，保留账号池动态负载均衡能力，同时补齐外部接口所需的 API Key 限额/并发控制、任务归属隔离、日志脱敏和 SSRF 防护。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added external API endpoints for image generation and editing authenticated via API keys
  * Added job status and results retrieval endpoint for API users
  * Implemented secure input image URL validation and conversion for external requests

* **Tests**
  * Added comprehensive test coverage for external image API endpoints, including authentication, authorization, and validation scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->