### PR TITLE
fix: /v1/messages usage 扣除缓存 token 避免重复计费 (#253)

### DIFF
--- a/proxy/anthropic.go
+++ b/proxy/anthropic.go
@@ -794,9 +794,12 @@ func (t *anthropicStreamTranslator) handleCompleted(data []byte) []anthropicStre
 	// 提取 usage
 	usage := gjson.GetBytes(data, "response.usage")
 	if usage.Exists() {
-		t.inputTokens = int(usage.Get("input_tokens").Int())
-		t.outputTokens = int(usage.Get("output_tokens").Int())
+		// OpenAI Responses 的 input_tokens 含缓存命中部分，而 Anthropic Messages
+		// 的 input_tokens 不含缓存（缓存另计在 cache_read_input_tokens）。
+		// 直接透传会把缓存 token 重复计入，导致费用偏高，因此这里扣除缓存部分。
 		t.cachedTokens = int(usage.Get("input_tokens_details.cached_tokens").Int())
+		t.inputTokens = max(int(usage.Get("input_tokens").Int())-t.cachedTokens, 0)
+		t.outputTokens = int(usage.Get("output_tokens").Int())
 	}
 
 	// 确定 stop_reason
@@ -1118,10 +1121,13 @@ func buildAnthropicResponseFromCompleted(completedData []byte, model string) *an
 	// usage
 	usage := gjson.GetBytes(completedData, "response.usage")
 	if usage.Exists() {
+		// 见流式分支说明：扣除缓存命中部分，避免缓存 token 被重复计入。
+		cached := int(usage.Get("input_tokens_details.cached_tokens").Int())
+		input := max(int(usage.Get("input_tokens").Int())-cached, 0)
 		resp.Usage = anthropicUsage{
-			InputTokens:          int(usage.Get("input_tokens").Int()),
+			InputTokens:          input,
 			OutputTokens:         int(usage.Get("output_tokens").Int()),
-			CacheReadInputTokens: int(usage.Get("input_tokens_details.cached_tokens").Int()),
+			CacheReadInputTokens: cached,
 		}
 	}
 

--- a/proxy/anthropic_test.go
+++ b/proxy/anthropic_test.go
@@ -613,8 +613,43 @@ func TestAnthropicResponseAccumulatorUsesStreamDeltasWhenCompletedOutputIsEmpty(
 	if resp.StopReason != "end_turn" {
 		t.Fatalf("stop_reason = %q, want end_turn", resp.StopReason)
 	}
-	if resp.Usage.InputTokens != 10 || resp.Usage.OutputTokens != 2 || resp.Usage.CacheReadInputTokens != 3 {
-		t.Fatalf("usage = %+v, want input=10 output=2 cache_read=3", resp.Usage)
+	// 上游 input_tokens=10 含 3 个缓存命中；Anthropic 语义下 input_tokens 不含
+	// 缓存，应对外报 input=7（10-3）、cache_read=3，避免缓存 token 被重复计费。
+	if resp.Usage.InputTokens != 7 || resp.Usage.OutputTokens != 2 || resp.Usage.CacheReadInputTokens != 3 {
+		t.Fatalf("usage = %+v, want input=7 output=2 cache_read=3", resp.Usage)
+	}
+}
+
+// TestAnthropicStreamTranslatorUsageExcludesCachedTokens 验证流式 message_delta
+// 的 usage 把缓存命中从 input_tokens 中扣除，避免缓存 token 被重复计费。
+func TestAnthropicStreamTranslatorUsageExcludesCachedTokens(t *testing.T) {
+	tr := newAnthropicStreamTranslator("claude-sonnet-4-5")
+	tr.translateEvent([]byte(`{"type":"response.created"}`))
+
+	completed := []byte(`{
+		"type":"response.completed",
+		"response":{
+			"status":"completed",
+			"usage":{
+				"input_tokens":10,
+				"output_tokens":2,
+				"input_tokens_details":{"cached_tokens":3}
+			}
+		}
+	}`)
+
+	var usage *anthropicUsage
+	for _, evt := range tr.translateEvent(completed) {
+		if evt.Type == "message_delta" && evt.Usage != nil {
+			usage = evt.Usage
+		}
+	}
+	if usage == nil {
+		t.Fatal("expected message_delta with usage")
+	}
+	// input_tokens=10 含 3 个缓存 → 对外 input=7、cache_read=3
+	if usage.InputTokens != 7 || usage.OutputTokens != 2 || usage.CacheReadInputTokens != 3 {
+		t.Fatalf("usage = %+v, want input=7 output=2 cache_read=3", *usage)
 	}
 }
 


### PR DESCRIPTION
## 问题

issue #253：`/v1/messages` 返回的 token 用量把**缓存 token 重复计入**，导致费用比实际偏高，与 sub2api 显示对不上。

## 根因

两套 API 的 `input_tokens` 语义不同：

| API | `input_tokens` 含义 |
|-----|---------------------|
| OpenAI Responses（上游） | **含**缓存命中（`input_tokens` = 总输入） |
| Anthropic Messages（下游） | **不含**缓存（缓存另计在 `cache_read_input_tokens`） |

原代码直接透传上游 `input_tokens`，又把 cached 部分赋给 `cache_read_input_tokens`，导致缓存 token 被**算两次**。

## 改动

`proxy/anthropic.go` 流式 + 非流式两条路径均改为：

```go
input_tokens = max(上游 input_tokens - cached_tokens, 0)
cache_read_input_tokens = cached_tokens
```

- 流式 `handleCompleted`：在提取处扣除，自动惠及 `message_delta` 与 `finalize` 两处
- 非流式 `buildAnthropicResponseFromCompleted`：同样逻辑

## 测试

- 修正了一处固化错误行为的现存断言（`input=10` → 正确的 `input=7`）
- 新增 `TestAnthropicStreamTranslatorUsageExcludesCachedTokens` 锁定流式路径
- 全量 `proxy` 测试通过

`input_tokens:10 + cached:3` 现正确输出为 `input=7, cache_read=3`。

Closes #253

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed token usage accounting to properly exclude cached tokens from input token billing, preventing duplicate token charges in both streaming and non-streaming request handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->