### PR TITLE
feat: Deduplicate accounts by OAuth identity

### DIFF
--- a/admin/handler.go
+++ b/admin/handler.go
@@ -1717,6 +1717,21 @@ func (h *Handler) AddATAccount(c *gin.Context) {
 			name = fmt.Sprintf("%s-%d", req.Name, i+1)
 		}
 
+		seed := normalizeTokenCredentialSeed(tokenCredentialSeed{
+			accessToken: at,
+		})
+		if seed.email != "" && seed.accountID != "" {
+			id, _, err := h.upsertOAuthIdentityAccount(ctx, name, req.ProxyURL, seed, "manual_at")
+			if err != nil {
+				log.Printf("添加 AT 账号 %d 失败: %v", i+1, err)
+				failCount++
+				continue
+			}
+			successCount++
+			log.Printf("AT 账号 %d 已加入或更新号池 (id=%d)", i+1, id)
+			continue
+		}
+
 		id, err := h.db.InsertATAccount(ctx, name, at, req.ProxyURL)
 		if err != nil {
 			log.Printf("添加 AT 账号 %d 失败: %v", i+1, err)
@@ -2333,6 +2348,26 @@ func importTokenCredentialIdentity(t importToken) string {
 	}
 }
 
+func importCredentialFingerprint(refreshToken, sessionToken, accessToken string) string {
+	return strings.TrimSpace(refreshToken) + "\x00" + strings.TrimSpace(sessionToken) + "\x00" + strings.TrimSpace(accessToken)
+}
+
+func importTokenCredentialFingerprint(t importToken, conflicts map[string]bool) string {
+	seed := importTokenSeed(t, conflicts)
+	return importCredentialFingerprint(seed.refreshToken, seed.sessionToken, seed.accessToken)
+}
+
+func importAccountCredentialFingerprint(row *database.AccountRow) string {
+	if row == nil {
+		return ""
+	}
+	return importCredentialFingerprint(
+		row.GetCredential("refresh_token"),
+		row.GetCredential("session_token"),
+		row.GetCredential("access_token"),
+	)
+}
+
 func conflictingImportChatGPTIDs(tokens []importToken) map[string]bool {
 	identitiesByID := make(map[string]map[string]struct{})
 	for _, t := range tokens {
@@ -2374,6 +2409,38 @@ func importStoredAccountID(t importToken, conflicts map[string]bool) string {
 		return strings.TrimSpace(t.accountID)
 	}
 	return reliableImportChatGPTID(t, conflicts)
+}
+
+func importTokenSeed(t importToken, conflicts map[string]bool) tokenCredentialSeed {
+	return normalizeTokenCredentialSeed(tokenCredentialSeed{
+		refreshToken:          t.refreshToken,
+		sessionToken:          t.sessionToken,
+		accessToken:           t.accessToken,
+		idToken:               t.idToken,
+		accountID:             importStoredAccountID(t, conflicts),
+		email:                 t.email,
+		planType:              t.planType,
+		expiresAtRaw:          t.expiresAt,
+		codex7DUsedPercent:    t.codex7DUsedPercent,
+		codex7DResetAt:        t.codex7DResetAt,
+		codex5HUsedPercent:    t.codex5HUsedPercent,
+		codex5HResetAt:        t.codex5HResetAt,
+		codex5HUsageUpdatedAt: t.codex5HUsageUpdatedAt,
+		codexUsageUpdatedAt:   t.codexUsageUpdatedAt,
+	})
+}
+
+func importTokenOAuthIdentityKey(t importToken, conflicts map[string]bool) string {
+	seed := importTokenSeed(t, conflicts)
+	email := strings.ToLower(strings.TrimSpace(seed.email))
+	accountID := strings.TrimSpace(seed.accountID)
+	if accountID == "" && strings.TrimSpace(t.accountID) == "" {
+		accountID = strings.TrimSpace(t.chatgptAccountID)
+	}
+	if email == "" || accountID == "" {
+		return ""
+	}
+	return email + "\x00" + accountID
 }
 
 // ImportAccounts 批量导入账号（支持 TXT / JSON）
@@ -2613,25 +2680,52 @@ func sendSSEJSON(c *gin.Context, event any) {
 // importAccountsCommon 公共的去重、并发插入、SSE 进度推送逻辑（支持 RT 和 AT-only 混合导入）
 func (h *Handler) importAccountsCommon(c *gin.Context, tokens []importToken, proxyURL string) {
 	// 文件内去重：
-	// 1) 当 chatgpt_account_id 在本批次内与凭据一一对应时，以它作为唯一键。
-	//    如果同一个 chatgpt_account_id 对应多个不同 RT / ST / AT，说明导出工具把非账号唯一字段写进了这里，
-	//    此时把它视为不可靠并回退到 RT / ST / AT 去重。
-	// 2) 没有 chatgpt_account_id 时，退回到 RT / ST / AT 顺序去重（兼容旧导出格式）。
+	// 1) 当条目可解析出 email + account_id 时，以它作为 OAuth 身份键；
+	//    同身份同 RT/ST/AT 折叠，同身份不同 RT/ST/AT 整组跳过，避免任选一个覆盖。
+	// 2) 没有 OAuth 身份时，退回到 RT / ST / AT 顺序去重（兼容旧导出格式）。
 	// 3) 同一份文件内若出现"同一个 RT 对应多个不同 chatgpt_account_id"，
 	//    会被全部保留为独立账号；数据库层面 refresh_token 没有 UNIQUE 约束，因此安全。
 	conflictingChatGPTIDs := conflictingImportChatGPTIDs(tokens)
-	seenChatGPTID := make(map[string]bool)
+	type oauthIdentityImportState struct {
+		count        int
+		fingerprints map[string]struct{}
+	}
+	oauthIdentityStates := make(map[string]*oauthIdentityImportState)
+	for _, t := range tokens {
+		oauthIdentity := importTokenOAuthIdentityKey(t, conflictingChatGPTIDs)
+		if oauthIdentity == "" {
+			continue
+		}
+		state := oauthIdentityStates[oauthIdentity]
+		if state == nil {
+			state = &oauthIdentityImportState{fingerprints: make(map[string]struct{}, 1)}
+			oauthIdentityStates[oauthIdentity] = state
+		}
+		state.count++
+		state.fingerprints[importTokenCredentialFingerprint(t, conflictingChatGPTIDs)] = struct{}{}
+	}
+
+	seenOAuthIdentity := make(map[string]bool)
 	seenRT := make(map[string]bool)
 	seenST := make(map[string]bool)
 	seenAT := make(map[string]bool)
 	var unique []importToken
+	ambiguousOAuthIdentityCount := 0
 	for _, t := range tokens {
-		reliableChatGPTID := reliableImportChatGPTID(t, conflictingChatGPTIDs)
-		if reliableChatGPTID != "" {
-			if seenChatGPTID[reliableChatGPTID] {
+		oauthIdentity := importTokenOAuthIdentityKey(t, conflictingChatGPTIDs)
+		if oauthIdentity != "" {
+			state := oauthIdentityStates[oauthIdentity]
+			if state != nil && len(state.fingerprints) > 1 {
+				if !seenOAuthIdentity[oauthIdentity] {
+					ambiguousOAuthIdentityCount += state.count
+					seenOAuthIdentity[oauthIdentity] = true
+				}
 				continue
 			}
-			seenChatGPTID[reliableChatGPTID] = true
+			if seenOAuthIdentity[oauthIdentity] {
+				continue
+			}
+			seenOAuthIdentity[oauthIdentity] = true
 			if t.refreshToken != "" {
 				seenRT[t.refreshToken] = true
 			}
@@ -2675,7 +2769,11 @@ func (h *Handler) importAccountsCommon(c *gin.Context, tokens []importToken, pro
 	dedupeCtx, dedupeCancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer dedupeCancel()
 
-	log.Printf("导入解析: 文件内 %d 条, 去重后 %d 条（%d 条文件内重复）", len(tokens), len(unique), len(tokens)-len(unique))
+	fileDuplicateCount := len(tokens) - len(unique) - ambiguousOAuthIdentityCount
+	if fileDuplicateCount < 0 {
+		fileDuplicateCount = 0
+	}
+	log.Printf("导入解析: 文件内 %d 条, 去重后 %d 条（%d 条文件内重复，%d 条 OAuth 身份冲突跳过）", len(tokens), len(unique), fileDuplicateCount, ambiguousOAuthIdentityCount)
 
 	existingRTs, err := h.db.GetAllRefreshTokens(dedupeCtx)
 	if err != nil {
@@ -2703,42 +2801,33 @@ func (h *Handler) importAccountsCommon(c *gin.Context, tokens []importToken, pro
 		}
 	}
 
-	// 当导入条目带 chatgpt_account_id 时，按它查数据库已有账号 —— 这是 ChatGPT 端真实的账号唯一标识。
-	hasChatGPTID := false
-	for _, t := range unique {
-		if reliableImportChatGPTID(t, conflictingChatGPTIDs) != "" {
-			hasChatGPTID = true
-			break
-		}
-	}
-	var existingChatGPTIDs map[string]bool
-	if hasChatGPTID {
-		existingChatGPTIDs, err = h.db.GetAllChatGPTAccountIDs(dedupeCtx)
-		if err != nil {
-			log.Printf("查询已有 chatgpt_account_id 失败: %v", err)
-			existingChatGPTIDs = make(map[string]bool)
-		}
-	}
-
 	var newTokens []importToken
-	duplicateCount := 0
+	duplicateCount := ambiguousOAuthIdentityCount
 	for _, t := range unique {
-		reliableChatGPTID := reliableImportChatGPTID(t, conflictingChatGPTIDs)
-		// 优先按 chatgpt_account_id 判定数据库内是否已存在该账号；
-		// 命中则跳过，避免同一账号被重复导入。
-		if reliableChatGPTID != "" && existingChatGPTIDs[reliableChatGPTID] {
-			duplicateCount++
+		oauthIdentity := importTokenOAuthIdentityKey(t, conflictingChatGPTIDs)
+		if oauthIdentity != "" {
+			seed := importTokenSeed(t, conflictingChatGPTIDs)
+			if duplicateID, err := h.findOAuthIdentityDuplicate(dedupeCtx, seed, 0); err != nil {
+				log.Printf("查询已有 OAuth 身份失败: %v", err)
+			} else if duplicateID > 0 {
+				row, err := h.db.GetAccountByID(dedupeCtx, duplicateID)
+				if err != nil {
+					log.Printf("查询已有 OAuth 账号 %d 失败: %v", duplicateID, err)
+				} else if importAccountCredentialFingerprint(row) == importTokenCredentialFingerprint(t, conflictingChatGPTIDs) {
+					duplicateCount++
+					continue
+				}
+			}
+			newTokens = append(newTokens, t)
 			continue
 		}
 		switch {
 		case t.refreshToken != "":
-			// 已经按 chatgpt_account_id 排除过重复账号；此处仅当条目没有 chatgpt_account_id 时才回退到 RT 去重，
-			// 否则当多个不同账号共享同一 RT（部分导出工具的常见格式）时会被错误判定为重复。
-			if reliableChatGPTID == "" && existingRTs[t.refreshToken] {
+			if existingRTs[t.refreshToken] {
 				duplicateCount++
-			} else if reliableChatGPTID == "" && t.sessionToken != "" && existingSTs[t.sessionToken] {
+			} else if t.sessionToken != "" && existingSTs[t.sessionToken] {
 				duplicateCount++
-			} else if reliableChatGPTID == "" && t.accessToken != "" && existingATs[t.accessToken] {
+			} else if t.accessToken != "" && existingATs[t.accessToken] {
 				duplicateCount++
 			} else {
 				newTokens = append(newTokens, t)
@@ -2760,13 +2849,13 @@ func (h *Handler) importAccountsCommon(c *gin.Context, tokens []importToken, pro
 		}
 	}
 
-	total := len(unique)
+	total := len(unique) + ambiguousOAuthIdentityCount
 
 	log.Printf("导入去重: 总计 %d 条, 数据库已存在 %d 条, 待导入 %d 条", total, duplicateCount, len(newTokens))
 
 	if len(newTokens) == 0 {
 		c.JSON(http.StatusOK, gin.H{
-			"message":   fmt.Sprintf("所有 %d 个 Token 已存在，无需导入", total),
+			"message":   fmt.Sprintf("所有 %d 个 Token 已存在或已跳过，无需导入", total),
 			"success":   0,
 			"duplicate": duplicateCount,
 			"failed":    0,
@@ -2814,6 +2903,43 @@ func (h *Handler) importAccountsCommon(c *gin.Context, tokens []importToken, pro
 
 			name := tok.name
 
+			seed := importTokenSeed(tok, conflictingChatGPTIDs)
+			importSource := "import"
+			if tok.accessToken != "" && tok.refreshToken == "" {
+				importSource = "import_at"
+			}
+			if seed.email != "" && seed.accountID != "" {
+				if name == "" {
+					if importSource == "import_at" {
+						name = fmt.Sprintf("at-import-%d", idx+1)
+					} else {
+						name = fmt.Sprintf("import-%d", idx+1)
+					}
+				}
+
+				upsertCtx, upsertCancel := context.WithTimeout(context.Background(), 5*time.Second)
+				id, _, err := h.upsertOAuthIdentityAccount(upsertCtx, name, proxyURL, seed, importSource)
+				upsertCancel()
+				if err != nil {
+					log.Printf("导入账号 %d/%d 更新或写入失败: %v", idx+1, len(newTokens), err)
+					atomic.AddInt64(&failCount, 1)
+					atomic.AddInt64(&current, 1)
+					return
+				}
+
+				atomic.AddInt64(&successCount, 1)
+				atomic.AddInt64(&current, 1)
+				if h.store != nil {
+					if acc := h.store.FindByID(id); acc != nil {
+						h.applyImportedAccountUsageState(acc, importSource)
+						if acc.GetAccessToken() == "" && !h.store.GetLazyMode() {
+							go h.refreshImportedAccountAndProbe(id, importSource+"_refresh")
+						}
+					}
+				}
+				return
+			}
+
 			if tok.accessToken != "" && tok.refreshToken == "" {
 				// AT-only 导入路径
 				if name == "" {
@@ -2835,21 +2961,6 @@ func (h *Handler) importAccountsCommon(c *gin.Context, tokens []importToken, pro
 				atomic.AddInt64(&current, 1)
 				h.db.InsertAccountEventAsync(id, "added", "import_at")
 
-				seed := normalizeTokenCredentialSeed(tokenCredentialSeed{
-					sessionToken:          tok.sessionToken,
-					accessToken:           tok.accessToken,
-					idToken:               tok.idToken,
-					accountID:             importStoredAccountID(tok, conflictingChatGPTIDs),
-					email:                 tok.email,
-					planType:              tok.planType,
-					expiresAtRaw:          tok.expiresAt,
-					codex7DUsedPercent:    tok.codex7DUsedPercent,
-					codex7DResetAt:        tok.codex7DResetAt,
-					codex5HUsedPercent:    tok.codex5HUsedPercent,
-					codex5HResetAt:        tok.codex5HResetAt,
-					codex5HUsageUpdatedAt: tok.codex5HUsageUpdatedAt,
-					codexUsageUpdatedAt:   tok.codexUsageUpdatedAt,
-				})
 				newAcc := accountFromCredentialSeed(id, proxyURL, seed)
 				if len(tokenCredentialMap(seed)) > 0 {
 					credCtx, credCancel := context.WithTimeout(context.Background(), 3*time.Second)
@@ -2873,21 +2984,6 @@ func (h *Handler) importAccountsCommon(c *gin.Context, tokens []importToken, pro
 				if tok.refreshToken != "" {
 					id, err = h.db.InsertAccount(insertCtx, name, tok.refreshToken, proxyURL)
 				} else {
-					seed := normalizeTokenCredentialSeed(tokenCredentialSeed{
-						sessionToken:          tok.sessionToken,
-						accessToken:           tok.accessToken,
-						idToken:               tok.idToken,
-						accountID:             importStoredAccountID(tok, conflictingChatGPTIDs),
-						email:                 tok.email,
-						planType:              tok.planType,
-						expiresAtRaw:          tok.expiresAt,
-						codex7DUsedPercent:    tok.codex7DUsedPercent,
-						codex7DResetAt:        tok.codex7DResetAt,
-						codex5HUsedPercent:    tok.codex5HUsedPercent,
-						codex5HResetAt:        tok.codex5HResetAt,
-						codex5HUsageUpdatedAt: tok.codex5HUsageUpdatedAt,
-						codexUsageUpdatedAt:   tok.codexUsageUpdatedAt,
-					})
 					id, err = h.db.InsertAccountWithCredentials(insertCtx, name, tokenCredentialMap(seed), proxyURL)
 				}
 				insertCancel()
@@ -2903,22 +2999,6 @@ func (h *Handler) importAccountsCommon(c *gin.Context, tokens []importToken, pro
 				atomic.AddInt64(&current, 1)
 				h.db.InsertAccountEventAsync(id, "added", "import")
 
-				seed := normalizeTokenCredentialSeed(tokenCredentialSeed{
-					refreshToken:          tok.refreshToken,
-					sessionToken:          tok.sessionToken,
-					accessToken:           tok.accessToken,
-					idToken:               tok.idToken,
-					accountID:             importStoredAccountID(tok, conflictingChatGPTIDs),
-					email:                 tok.email,
-					planType:              tok.planType,
-					expiresAtRaw:          tok.expiresAt,
-					codex7DUsedPercent:    tok.codex7DUsedPercent,
-					codex7DResetAt:        tok.codex7DResetAt,
-					codex5HUsedPercent:    tok.codex5HUsedPercent,
-					codex5HResetAt:        tok.codex5HResetAt,
-					codex5HUsageUpdatedAt: tok.codex5HUsageUpdatedAt,
-					codexUsageUpdatedAt:   tok.codexUsageUpdatedAt,
-				})
 				if len(tokenCredentialMap(seed)) > 0 {
 					credCtx, credCancel := context.WithTimeout(context.Background(), 3*time.Second)
 					if err := h.db.UpdateCredentials(credCtx, id, tokenCredentialMap(seed)); err != nil {
@@ -3120,6 +3200,10 @@ func (h *Handler) RestoreAccount(c *gin.Context) {
 			writeError(c, http.StatusNotFound, "回收站中不存在该账号")
 			return
 		}
+		if errors.Is(err, errDuplicateOAuthIdentity) {
+			writeError(c, http.StatusConflict, "恢复失败: "+err.Error())
+			return
+		}
 		writeError(c, http.StatusInternalServerError, "恢复失败: "+err.Error())
 		return
 	}
@@ -3128,14 +3212,50 @@ func (h *Handler) RestoreAccount(c *gin.Context) {
 
 // restoreAccountByID 将回收站账号恢复为 active 并重新加入运行时池。
 func (h *Handler) restoreAccountByID(ctx context.Context, id int64) error {
+	row, err := h.db.GetAccountByIDIncludingDeleted(ctx, id)
+	if err != nil {
+		return err
+	}
+	seed := tokenCredentialSeedFromAccountRow(row)
+	if duplicateID, err := h.findOAuthIdentityDuplicate(ctx, seed, id); err != nil {
+		return err
+	} else if duplicateID > 0 {
+		return fmt.Errorf("%w: 已存在相同 OAuth 账号 (id=%d)，请先删除正常账号或清理回收站账号", errDuplicateOAuthIdentity, duplicateID)
+	}
+
 	if err := h.db.RestoreAccount(ctx, id); err != nil {
 		return err
 	}
-	if err := h.store.LoadAccountByID(ctx, id); err != nil {
-		log.Printf("恢复账号 %d 后加载运行时失败: %v", id, err)
+	if h.store != nil {
+		if err := h.store.LoadAccountByID(ctx, id); err != nil {
+			log.Printf("恢复账号 %d 后加载运行时失败: %v", id, err)
+			return fmt.Errorf("恢复账号后加载运行时失败: %w", err)
+		}
 	}
 	h.db.InsertAccountEventAsync(id, "restored", "recycle_bin")
 	return nil
+}
+
+func tokenCredentialSeedFromAccountRow(row *database.AccountRow) tokenCredentialSeed {
+	if row == nil {
+		return tokenCredentialSeed{}
+	}
+	return normalizeTokenCredentialSeed(tokenCredentialSeed{
+		refreshToken:          row.GetCredential("refresh_token"),
+		sessionToken:          row.GetCredential("session_token"),
+		accessToken:           row.GetCredential("access_token"),
+		idToken:               row.GetCredential("id_token"),
+		accountID:             firstNonEmpty(row.GetCredential("account_id"), row.GetCredential("chatgpt_account_id")),
+		email:                 row.GetCredential("email"),
+		planType:              row.GetCredential("plan_type"),
+		expiresAtRaw:          row.GetCredential("expires_at"),
+		codex7DUsedPercent:    row.GetCredential("codex_7d_used_percent"),
+		codex7DResetAt:        row.GetCredential("codex_7d_reset_at"),
+		codex5HUsedPercent:    row.GetCredential("codex_5h_used_percent"),
+		codex5HResetAt:        row.GetCredential("codex_5h_reset_at"),
+		codex5HUsageUpdatedAt: row.GetCredential("codex_5h_usage_updated_at"),
+		codexUsageUpdatedAt:   row.GetCredential("codex_usage_updated_at"),
+	})
 }
 
 // PurgeAccount 从回收站彻底删除账号（物理删除）

--- a/admin/handler_test.go
+++ b/admin/handler_test.go
@@ -1665,6 +1665,83 @@ func TestForceUsageProbeTriggersInLazyMode(t *testing.T) {
 	}
 }
 
+func TestRestoreAccountRejectsDuplicateOAuthIdentity(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	db := newTestAdminDB(t)
+	handler := &Handler{db: db}
+
+	activeID, err := db.InsertAccountWithCredentials(context.Background(), "active", map[string]interface{}{
+		"refresh_token": "rt-active",
+		"email":         "restore@example.com",
+		"account_id":    "acc-restore",
+	}, "")
+	if err != nil {
+		t.Fatalf("Insert active: %v", err)
+	}
+	deletedID, err := db.InsertAccountWithCredentials(context.Background(), "deleted", map[string]interface{}{
+		"refresh_token": "rt-deleted",
+		"email":         "Restore@Example.com",
+		"account_id":    "acc-restore",
+	}, "")
+	if err != nil {
+		t.Fatalf("Insert deleted: %v", err)
+	}
+	if err := db.SoftDeleteAccount(context.Background(), deletedID); err != nil {
+		t.Fatalf("SoftDeleteAccount: %v", err)
+	}
+
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Params = gin.Params{{Key: "id", Value: fmt.Sprintf("%d", deletedID)}}
+	ctx.Request = httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/admin/accounts/%d/restore", deletedID), nil)
+
+	handler.RestoreAccount(ctx)
+
+	if recorder.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want %d: %s", recorder.Code, http.StatusConflict, recorder.Body.String())
+	}
+	if !strings.Contains(recorder.Body.String(), fmt.Sprintf("%d", activeID)) {
+		t.Fatalf("response = %s, want active duplicate id %d", recorder.Body.String(), activeID)
+	}
+	if _, err := db.GetAccountByID(context.Background(), deletedID); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("deleted account should remain outside active pool, err=%v", err)
+	}
+}
+
+func TestRestoreAccountReportsRuntimeLoadFailure(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	db := newTestAdminDB(t)
+	store := auth.NewStore(db, nil, &database.SystemSettings{MaxConcurrency: 2, TestConcurrency: 1, TestModel: "gpt-5.4"})
+	handler := &Handler{db: db, store: store}
+
+	deletedID, err := db.InsertAccountWithCredentials(context.Background(), "deleted-empty", map[string]interface{}{}, "")
+	if err != nil {
+		t.Fatalf("Insert deleted-empty: %v", err)
+	}
+	if err := db.SoftDeleteAccount(context.Background(), deletedID); err != nil {
+		t.Fatalf("SoftDeleteAccount: %v", err)
+	}
+
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Params = gin.Params{{Key: "id", Value: fmt.Sprintf("%d", deletedID)}}
+	ctx.Request = httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/admin/accounts/%d/restore", deletedID), nil)
+
+	handler.RestoreAccount(ctx)
+
+	if recorder.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d: %s", recorder.Code, http.StatusInternalServerError, recorder.Body.String())
+	}
+	if !strings.Contains(recorder.Body.String(), "加载运行时失败") {
+		t.Fatalf("response = %s, want runtime load failure", recorder.Body.String())
+	}
+	if account := store.FindByID(deletedID); account != nil {
+		t.Fatalf("account %d should not be in runtime store", deletedID)
+	}
+}
+
 func newTestAdminDB(t *testing.T) *database.DB {
 	t.Helper()
 

--- a/admin/import_json_test.go
+++ b/admin/import_json_test.go
@@ -448,6 +448,275 @@ func TestImportAccountsCommonDoesNotCollapseConflictingChatGPTAccountID(t *testi
 	}
 }
 
+func TestImportAccountsCommonUpdatesExistingOAuthIdentity(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	db := newTestAdminDB(t)
+	store := auth.NewStore(db, nil, &database.SystemSettings{MaxConcurrency: 2, TestConcurrency: 1, TestModel: "gpt-5.4"})
+	probed := make(chan int64, 1)
+	handler := &Handler{
+		db:    db,
+		store: store,
+		probeUsage: func(_ context.Context, acc *auth.Account) error {
+			probed <- acc.DBID
+			return nil
+		},
+	}
+
+	existingID, err := db.InsertAccountWithCredentials(context.Background(), "existing", map[string]interface{}{
+		"refresh_token": "rt-old",
+		"email":         "import@example.com",
+		"account_id":    "acc-import",
+	}, "")
+	if err != nil {
+		t.Fatalf("InsertAccountWithCredentials: %v", err)
+	}
+
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Request = httptest.NewRequest(http.MethodPost, "/api/admin/accounts/import", nil)
+
+	handler.importAccountsCommon(ctx, []importToken{{
+		refreshToken: "rt-new",
+		accessToken:  "at-new",
+		email:        "Import@Example.com",
+		accountID:    "acc-import",
+		planType:     "team",
+	}}, "")
+
+	select {
+	case id := <-probed:
+		if id != existingID {
+			t.Fatalf("probed account id = %d, want %d", id, existingID)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("usage probe was not triggered for updated OAuth identity")
+	}
+
+	rows, err := db.ListActive(context.Background())
+	if err != nil {
+		t.Fatalf("ListActive: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("active rows = %d, want 1", len(rows))
+	}
+	row, err := db.GetAccountByID(context.Background(), existingID)
+	if err != nil {
+		t.Fatalf("GetAccountByID: %v", err)
+	}
+	if got := row.GetCredential("refresh_token"); got != "rt-new" {
+		t.Fatalf("refresh_token = %q, want rt-new", got)
+	}
+	if got := row.GetCredential("access_token"); got != "at-new" {
+		t.Fatalf("access_token = %q, want at-new", got)
+	}
+	if got := row.GetCredential("plan_type"); got != "team" {
+		t.Fatalf("plan_type = %q, want team", got)
+	}
+	if account := store.FindByID(existingID); account == nil {
+		t.Fatalf("runtime account %d not found after import update", existingID)
+	}
+}
+
+func TestImportAccountsCommonSkipsExistingOAuthIdentityWithSameCredentials(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	db := newTestAdminDB(t)
+	store := auth.NewStore(db, nil, &database.SystemSettings{MaxConcurrency: 2, TestConcurrency: 1, TestModel: "gpt-5.4"})
+	handler := &Handler{
+		db:    db,
+		store: store,
+		probeUsage: func(context.Context, *auth.Account) error {
+			t.Fatal("usage probe should not run for unchanged duplicate import")
+			return nil
+		},
+	}
+
+	existingID, err := db.InsertAccountWithCredentials(context.Background(), "existing", map[string]interface{}{
+		"refresh_token": "rt-same",
+		"session_token": "st-same",
+		"access_token":  "at-same",
+		"email":         "same@example.com",
+		"account_id":    "acc-same",
+	}, "")
+	if err != nil {
+		t.Fatalf("InsertAccountWithCredentials: %v", err)
+	}
+
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Request = httptest.NewRequest(http.MethodPost, "/api/admin/accounts/import", nil)
+
+	handler.importAccountsCommon(ctx, []importToken{{
+		refreshToken: "rt-same",
+		sessionToken: "st-same",
+		accessToken:  "at-same",
+		email:        "Same@Example.com",
+		accountID:    "acc-same",
+	}}, "")
+
+	var payload map[string]interface{}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode response: %v; body=%s", err, recorder.Body.String())
+	}
+	if got := int(payload["success"].(float64)); got != 0 {
+		t.Fatalf("success = %d, want 0", got)
+	}
+	if got := int(payload["duplicate"].(float64)); got != 1 {
+		t.Fatalf("duplicate = %d, want 1", got)
+	}
+	if got := int(payload["total"].(float64)); got != 1 {
+		t.Fatalf("total = %d, want 1", got)
+	}
+
+	rows, err := db.ListActive(context.Background())
+	if err != nil {
+		t.Fatalf("ListActive: %v", err)
+	}
+	if len(rows) != 1 || rows[0].ID != existingID {
+		t.Fatalf("active rows = %+v, want only existing id %d", rows, existingID)
+	}
+}
+
+func TestImportAccountsCommonSkipsAmbiguousOAuthIdentityWithExistingAccount(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	db := newTestAdminDB(t)
+	store := auth.NewStore(db, nil, &database.SystemSettings{MaxConcurrency: 2, TestConcurrency: 1, TestModel: "gpt-5.4"})
+	handler := &Handler{
+		db:    db,
+		store: store,
+		probeUsage: func(context.Context, *auth.Account) error {
+			return nil
+		},
+	}
+
+	existingID, err := db.InsertAccountWithCredentials(context.Background(), "existing", map[string]interface{}{
+		"refresh_token": "rt-old",
+		"email":         "ambiguous@example.com",
+		"account_id":    "acc-ambiguous",
+	}, "")
+	if err != nil {
+		t.Fatalf("InsertAccountWithCredentials: %v", err)
+	}
+
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Request = httptest.NewRequest(http.MethodPost, "/api/admin/accounts/import", nil)
+
+	handler.importAccountsCommon(ctx, []importToken{
+		{refreshToken: "rt-new-1", email: "ambiguous@example.com", accountID: "acc-ambiguous"},
+		{refreshToken: "rt-new-2", email: "Ambiguous@Example.com", accountID: "acc-ambiguous"},
+	}, "")
+
+	var payload map[string]interface{}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode response: %v; body=%s", err, recorder.Body.String())
+	}
+	if got := int(payload["success"].(float64)); got != 0 {
+		t.Fatalf("success = %d, want 0", got)
+	}
+	if got := int(payload["duplicate"].(float64)); got != 2 {
+		t.Fatalf("duplicate = %d, want 2", got)
+	}
+	if got := int(payload["total"].(float64)); got != 2 {
+		t.Fatalf("total = %d, want 2", got)
+	}
+
+	row, err := db.GetAccountByID(context.Background(), existingID)
+	if err != nil {
+		t.Fatalf("GetAccountByID: %v", err)
+	}
+	if got := row.GetCredential("refresh_token"); got != "rt-old" {
+		t.Fatalf("refresh_token = %q, want rt-old", got)
+	}
+}
+
+func TestImportAccountsCommonSkipsAmbiguousOAuthIdentityWithoutExistingAccount(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	db := newTestAdminDB(t)
+	store := auth.NewStore(db, nil, &database.SystemSettings{MaxConcurrency: 2, TestConcurrency: 1, TestModel: "gpt-5.4"})
+	handler := &Handler{
+		db:    db,
+		store: store,
+		probeUsage: func(context.Context, *auth.Account) error {
+			return nil
+		},
+	}
+
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Request = httptest.NewRequest(http.MethodPost, "/api/admin/accounts/import", nil)
+
+	handler.importAccountsCommon(ctx, []importToken{
+		{refreshToken: "rt-new-1", email: "new-ambiguous@example.com", accountID: "acc-new-ambiguous"},
+		{refreshToken: "rt-new-2", email: "New-Ambiguous@Example.com", accountID: "acc-new-ambiguous"},
+	}, "")
+
+	var payload map[string]interface{}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode response: %v; body=%s", err, recorder.Body.String())
+	}
+	if got := int(payload["success"].(float64)); got != 0 {
+		t.Fatalf("success = %d, want 0", got)
+	}
+	if got := int(payload["duplicate"].(float64)); got != 2 {
+		t.Fatalf("duplicate = %d, want 2", got)
+	}
+	if got := int(payload["total"].(float64)); got != 2 {
+		t.Fatalf("total = %d, want 2", got)
+	}
+
+	rows, err := db.ListActive(context.Background())
+	if err != nil {
+		t.Fatalf("ListActive: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Fatalf("active rows = %d, want 0", len(rows))
+	}
+}
+
+func TestImportAccountsCommonCollapsesIdenticalOAuthIdentityInFile(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	db := newTestAdminDB(t)
+	store := auth.NewStore(db, nil, &database.SystemSettings{MaxConcurrency: 2, TestConcurrency: 1, TestModel: "gpt-5.4"})
+	handler := &Handler{
+		db:    db,
+		store: store,
+		probeUsage: func(context.Context, *auth.Account) error {
+			return nil
+		},
+	}
+
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Request = httptest.NewRequest(http.MethodPost, "/api/admin/accounts/import", nil)
+
+	handler.importAccountsCommon(ctx, []importToken{
+		{refreshToken: "rt-same-file", accessToken: "at-same-file", email: "same-file@example.com", accountID: "acc-same-file"},
+		{refreshToken: "rt-same-file", accessToken: "at-same-file", email: "Same-File@Example.com", accountID: "acc-same-file"},
+	}, "")
+
+	if !strings.Contains(recorder.Body.String(), `"type":"complete"`) ||
+		!strings.Contains(recorder.Body.String(), `"success":1`) ||
+		!strings.Contains(recorder.Body.String(), `"total":1`) {
+		t.Fatalf("SSE payload = %q, want complete success=1 total=1", recorder.Body.String())
+	}
+
+	rows, err := db.ListActive(context.Background())
+	if err != nil {
+		t.Fatalf("ListActive: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("active rows = %d, want 1", len(rows))
+	}
+	if got := rows[0].GetCredential("refresh_token"); got != "rt-same-file" {
+		t.Fatalf("refresh_token = %q, want rt-same-file", got)
+	}
+}
+
 func TestImportAccountsCommonTriggersUsageProbeForImportedAccountWithAccessToken(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
@@ -568,6 +837,66 @@ func TestImportAccountsCommonRefreshesAndProbesRTOnlyImport(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("usage probe was not triggered after RT-only import refresh")
+	}
+}
+
+func TestImportAccountsCommonRefreshesOAuthIdentityRTOnlyImport(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	db := newTestAdminDB(t)
+	store := auth.NewStore(nil, nil, &database.SystemSettings{MaxConcurrency: 2, TestConcurrency: 1, TestModel: "gpt-5.4"})
+	refreshed := make(chan int64, 2)
+	probed := make(chan int64, 1)
+	handler := &Handler{
+		db:    db,
+		store: store,
+		refreshAccount: func(_ context.Context, id int64) error {
+			refreshed <- id
+			acc := store.FindByID(id)
+			if acc == nil {
+				return fmt.Errorf("account %d not found", id)
+			}
+			acc.Mu().Lock()
+			acc.AccessToken = "at-oauth-identity-refreshed"
+			acc.Mu().Unlock()
+			return nil
+		},
+		probeUsage: func(_ context.Context, acc *auth.Account) error {
+			probed <- acc.DBID
+			return nil
+		},
+	}
+
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Request = httptest.NewRequest(http.MethodPost, "/api/admin/accounts/import", nil)
+
+	handler.importAccountsCommon(ctx, []importToken{{
+		refreshToken: "rt-oauth-identity-refresh-probe",
+		email:        "identity-refresh@example.com",
+		accountID:    "acc-identity-refresh",
+	}}, "")
+
+	select {
+	case id := <-probed:
+		if id == 0 {
+			t.Fatal("probed account id is zero")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("usage probe was not triggered after OAuth identity RT-only import refresh")
+	}
+	select {
+	case id := <-refreshed:
+		if id == 0 {
+			t.Fatal("refreshed account id is zero")
+		}
+	default:
+		t.Fatal("refresh was not triggered")
+	}
+	select {
+	case id := <-refreshed:
+		t.Fatalf("refresh triggered more than once, second id=%d", id)
+	case <-time.After(150 * time.Millisecond):
 	}
 }
 

--- a/admin/oauth.go
+++ b/admin/oauth.go
@@ -251,6 +251,9 @@ func (h *Handler) ExchangeOAuthCode(c *gin.Context) {
 		expiresIn:    tokenResp.ExpiresIn,
 	})
 
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 30*time.Second)
+	defer cancel()
+
 	name := strings.TrimSpace(req.Name)
 	if name == "" && seed.email != "" {
 		name = seed.email
@@ -259,33 +262,13 @@ func (h *Handler) ExchangeOAuthCode(c *gin.Context) {
 		name = "oauth-account"
 	}
 
-	ctx, cancel := context.WithTimeout(c.Request.Context(), 30*time.Second)
-	defer cancel()
-
-	id, err := h.db.InsertAccount(ctx, name, tokenResp.RefreshToken, proxyURL)
+	id, updated, err := h.upsertOAuthIdentityAccount(ctx, name, proxyURL, seed, "oauth")
 	if err != nil {
 		writeError(c, http.StatusInternalServerError, "账号写入数据库失败: "+err.Error())
 		return
 	}
-	if err := h.db.UpdateCredentials(ctx, id, tokenCredentialMap(seed)); err != nil {
-		writeError(c, http.StatusInternalServerError, "Token 写入数据库失败: "+err.Error())
-		return
-	}
-	h.db.InsertAccountEventAsync(id, "added", "oauth")
-
-	// Resin 租约继承
-	if proxy.IsResinEnabled() {
+	if proxy.IsResinEnabled() && !updated {
 		go proxy.InheritLease(resinTempID, fmt.Sprintf("%d", id))
-	}
-
-	newAcc := accountFromCredentialSeed(id, proxyURL, seed)
-	h.store.AddAccount(newAcc)
-
-	if newAcc.GetAccessToken() != "" {
-		h.triggerImportedAccountUsageProbe(id, "oauth")
-	} else if !h.store.GetLazyMode() {
-		// 异步刷新 AT，刷新成功后立即做 wham 用量采样。
-		go h.refreshImportedAccountAndProbe(id, "oauth_refresh")
 	}
 
 	email := ""
@@ -301,12 +284,116 @@ func (h *Handler) ExchangeOAuthCode(c *gin.Context) {
 		planType = seed.planType
 	}
 
+	message := fmt.Sprintf("OAuth 账号 %s 添加成功", name)
+	if updated {
+		message = fmt.Sprintf("OAuth 账号已存在，已更新账号 %d", id)
+	}
 	c.JSON(http.StatusOK, gin.H{
-		"message":   fmt.Sprintf("OAuth 账号 %s 添加成功", name),
+		"message":   message,
 		"id":        id,
 		"email":     email,
 		"plan_type": planType,
+		"updated":   updated,
 	})
+}
+
+var errDuplicateOAuthIdentity = errors.New("duplicate oauth identity")
+
+func oauthIdentityDuplicateMessage(id int64) string {
+	return fmt.Sprintf("OAuth 账号已存在 (id=%d)，请更新已有账号", id)
+}
+
+func (h *Handler) findOAuthIdentityDuplicate(ctx context.Context, seed tokenCredentialSeed, excludeID int64) (int64, error) {
+	if h == nil || h.db == nil {
+		return 0, nil
+	}
+	seed = normalizeTokenCredentialSeed(seed)
+	if seed.email == "" || seed.accountID == "" {
+		return 0, nil
+	}
+	id, err := h.db.FindActiveAccountByOAuthIdentity(ctx, seed.email, seed.accountID, excludeID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return 0, nil
+		}
+		return 0, err
+	}
+	return id, nil
+}
+
+func (h *Handler) upsertOAuthIdentityAccount(ctx context.Context, name, proxyURL string, seed tokenCredentialSeed, source string) (int64, bool, error) {
+	seed = normalizeTokenCredentialSeed(seed)
+	if seed.email == "" || seed.accountID == "" {
+		id, err := h.db.InsertAccountWithCredentials(ctx, name, tokenCredentialMap(seed), proxyURL)
+		if err != nil {
+			return 0, false, err
+		}
+		h.db.InsertAccountEventAsync(id, "added", source)
+		h.loadInsertedTokenAccount(id, proxyURL, seed, source)
+		return id, false, nil
+	}
+
+	if duplicateID, err := h.findOAuthIdentityDuplicate(ctx, seed, 0); err != nil {
+		return 0, false, err
+	} else if duplicateID > 0 {
+		effectiveProxyURL := strings.TrimSpace(proxyURL)
+		if effectiveProxyURL == "" {
+			row, err := h.db.GetAccountByID(ctx, duplicateID)
+			if err != nil {
+				return 0, false, err
+			}
+			effectiveProxyURL = strings.TrimSpace(row.ProxyURL)
+		}
+		if err := h.db.UpdateOAuthAccountCredentials(ctx, duplicateID, tokenCredentialMap(seed), effectiveProxyURL); err != nil {
+			return 0, false, err
+		}
+		if err := h.reloadTokenAccount(ctx, duplicateID, source); err != nil {
+			return 0, false, err
+		}
+		h.db.InsertAccountEventAsync(duplicateID, "updated", source)
+		return duplicateID, true, nil
+	}
+
+	id, err := h.db.InsertAccountWithCredentials(ctx, name, tokenCredentialMap(seed), proxyURL)
+	if err != nil {
+		return 0, false, err
+	}
+	h.db.InsertAccountEventAsync(id, "added", source)
+	h.loadInsertedTokenAccount(id, proxyURL, seed, source)
+	return id, false, nil
+}
+
+func (h *Handler) loadInsertedTokenAccount(id int64, proxyURL string, seed tokenCredentialSeed, source string) {
+	if h == nil || h.store == nil {
+		return
+	}
+	newAcc := accountFromCredentialSeed(id, proxyURL, seed)
+	h.store.AddAccount(newAcc)
+	h.triggerTokenAccountProbe(id, source)
+}
+
+func (h *Handler) reloadTokenAccount(ctx context.Context, id int64, source string) error {
+	if h == nil || h.store == nil {
+		return nil
+	}
+	h.store.RemoveAccount(id)
+	if err := h.store.LoadAccountByID(ctx, id); err != nil {
+		log.Printf("更新账号 %d 后重新加载运行时失败: %v", id, err)
+		return err
+	}
+	h.triggerTokenAccountProbe(id, source)
+	return nil
+}
+
+func (h *Handler) triggerTokenAccountProbe(id int64, source string) {
+	if h == nil || h.store == nil {
+		return
+	}
+	if account := h.store.FindByID(id); account != nil && account.GetAccessToken() != "" {
+		h.triggerImportedAccountUsageProbe(id, source)
+	} else if !h.store.GetLazyMode() && !strings.HasPrefix(source, "import") {
+		go h.refreshImportedAccountAndProbe(id, source+"_refresh")
+	}
 }
 
 // UpdateOAuthAccountCode 用授权码更新已有 OAuth 账号的授权参数。
@@ -394,6 +481,13 @@ func (h *Handler) UpdateOAuthAccountCode(c *gin.Context) {
 		idToken:      tokenResp.IDToken,
 		expiresIn:    tokenResp.ExpiresIn,
 	})
+	if duplicateID, err := h.findOAuthIdentityDuplicate(ctx, seed, id); err != nil {
+		writeInternalError(c, err)
+		return
+	} else if duplicateID > 0 {
+		writeError(c, http.StatusConflict, oauthIdentityDuplicateMessage(duplicateID))
+		return
+	}
 	if err := h.db.UpdateOAuthAccountCredentials(ctx, id, tokenCredentialMap(seed), proxyURL); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			writeError(c, http.StatusNotFound, "账号不存在")
@@ -403,22 +497,11 @@ func (h *Handler) UpdateOAuthAccountCode(c *gin.Context) {
 		return
 	}
 
-	if h.store != nil {
-		h.store.RemoveAccount(id)
-		if err := h.store.LoadAccountByID(ctx, id); err != nil {
-			writeError(c, http.StatusInternalServerError, "重新加载运行时账号失败: "+err.Error())
-			return
-		}
+	if err := h.reloadTokenAccount(ctx, id, "oauth_reauth"); err != nil {
+		writeError(c, http.StatusInternalServerError, "重新加载运行时账号失败: "+err.Error())
+		return
 	}
 	h.db.InsertAccountEventAsync(id, "updated", "oauth_reauth")
-
-	if h.store != nil {
-		if account := h.store.FindByID(id); account != nil && account.GetAccessToken() != "" {
-			h.triggerImportedAccountUsageProbe(id, "oauth_reauth")
-		} else if !h.store.GetLazyMode() {
-			go h.refreshImportedAccountAndProbe(id, "oauth_reauth_refresh")
-		}
-	}
 
 	email := ""
 	planType := ""
@@ -578,7 +661,7 @@ func (h *Handler) OAuthCallback(c *gin.Context) {
 	ctx, cancel := context.WithTimeout(c.Request.Context(), 30*time.Second)
 	defer cancel()
 
-	id, err := h.db.InsertAccount(ctx, name, tokenResp.RefreshToken, proxyURL)
+	id, updated, err := h.upsertOAuthIdentityAccount(ctx, name, proxyURL, seed, "oauth_callback")
 	if err != nil {
 		sess.ExchangeResult = &oauthExchangeResult{
 			Success: false,
@@ -587,29 +670,9 @@ func (h *Handler) OAuthCallback(c *gin.Context) {
 		c.String(http.StatusOK, oauthCallbackPage("授权失败", "写入数据库失败: "+err.Error(), false))
 		return
 	}
-	if err := h.db.UpdateCredentials(ctx, id, tokenCredentialMap(seed)); err != nil {
-		sess.ExchangeResult = &oauthExchangeResult{
-			Success: false,
-			Error:   "Token 写入数据库失败: " + err.Error(),
-		}
-		c.String(http.StatusOK, oauthCallbackPage("授权失败", "写入 token 失败: "+err.Error(), false))
-		return
-	}
-	h.db.InsertAccountEventAsync(id, "added", "oauth_callback")
 
-	// Resin 租约继承：将临时身份的 IP 租约迁移到正式 DBID
-	if proxy.IsResinEnabled() {
+	if proxy.IsResinEnabled() && !updated {
 		go proxy.InheritLease(resinTempID, fmt.Sprintf("%d", id))
-	}
-
-	newAcc := accountFromCredentialSeed(id, proxyURL, seed)
-	h.store.AddAccount(newAcc)
-
-	if newAcc.GetAccessToken() != "" {
-		h.triggerImportedAccountUsageProbe(id, "oauth_callback")
-	} else if !h.store.GetLazyMode() {
-		// 异步刷新 AT，刷新成功后立即做 wham 用量采样。
-		go h.refreshImportedAccountAndProbe(id, "oauth_callback_refresh")
 	}
 
 	email := ""
@@ -625,16 +688,22 @@ func (h *Handler) OAuthCallback(c *gin.Context) {
 		planType = seed.planType
 	}
 
+	message := fmt.Sprintf("账号 %s 添加成功", name)
+	pageMessage := fmt.Sprintf("账号 %s 已自动添加，可以关闭此页面。", name)
+	if updated {
+		message = fmt.Sprintf("账号已存在，已更新账号 %d", id)
+		pageMessage = fmt.Sprintf("账号已存在，已更新账号 %d，可以关闭此页面。", id)
+	}
 	sess.ExchangeResult = &oauthExchangeResult{
 		Success:  true,
-		Message:  fmt.Sprintf("账号 %s 添加成功", name),
+		Message:  message,
 		ID:       id,
 		Email:    email,
 		PlanType: planType,
 	}
 
 	log.Printf("OAuth 回调自动添加账号成功: id=%d email=%s", id, email)
-	c.String(http.StatusOK, oauthCallbackPage("授权成功", fmt.Sprintf("账号 %s 已自动添加，可以关闭此页面。", name), true))
+	c.String(http.StatusOK, oauthCallbackPage("授权成功", pageMessage, true))
 }
 
 // PollOAuthCallback 前端轮询回调结果

--- a/admin/oauth_test.go
+++ b/admin/oauth_test.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -102,14 +103,19 @@ func TestExchangeOAuthCodeSeedsAccessTokenFromExchangeResponse(t *testing.T) {
 
 func newOAuthExchangeTestServer(t *testing.T) *httptest.Server {
 	t.Helper()
+	return newOAuthExchangeTestServerWithIDToken(t, "id-from-exchange")
+}
+
+func newOAuthExchangeTestServerWithIDToken(t *testing.T, idToken string) *httptest.Server {
+	t.Helper()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{
-			"access_token": "access-from-exchange",
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token":  "access-from-exchange",
 			"refresh_token": "refresh-from-exchange",
-			"id_token": "id-from-exchange",
-			"expires_in": 3600
-		}`))
+			"id_token":      idToken,
+			"expires_in":    3600,
+		})
 	}))
 	t.Cleanup(server.Close)
 
@@ -121,6 +127,17 @@ func newOAuthExchangeTestServer(t *testing.T) *httptest.Server {
 		auth.ResinRequestDecorator = oldDecorator
 	})
 	return server
+}
+
+func makeOAuthTestIDToken(email, accountID, planType string) string {
+	payload, _ := json.Marshal(map[string]interface{}{
+		"email": email,
+		"https://api.openai.com/auth": map[string]interface{}{
+			"chatgpt_account_id": accountID,
+			"chatgpt_plan_type":  planType,
+		},
+	})
+	return "eyJhbGciOiJSUzI1NiJ9." + base64.RawURLEncoding.EncodeToString(payload) + ".fake_signature"
 }
 
 func TestExchangeOAuthCodeTriggersUsageProbe(t *testing.T) {
@@ -174,6 +191,78 @@ func TestExchangeOAuthCodeTriggersUsageProbe(t *testing.T) {
 		}
 	case <-time.After(3 * time.Second):
 		t.Fatal("usage probe was not triggered after OAuth account add")
+	}
+}
+
+func TestExchangeOAuthCodeUpdatesDuplicateOAuthIdentity(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	db := newTestAdminDB(t)
+	store := auth.NewStore(db, cache.NewMemory(1), nil)
+	handler := &Handler{db: db, store: store}
+
+	existingID, err := db.InsertAccountWithCredentials(context.Background(), "existing", map[string]interface{}{
+		"refresh_token": "existing-refresh",
+		"email":         "duplicate@example.com",
+		"account_id":    "acc-duplicate",
+	}, "")
+	if err != nil {
+		t.Fatalf("InsertAccountWithCredentials: %v", err)
+	}
+
+	newOAuthExchangeTestServerWithIDToken(t, makeOAuthTestIDToken("Duplicate@Example.com", "acc-duplicate", "team"))
+
+	sessionID := "oauth-duplicate-session"
+	globalOAuthStore.set(sessionID, &oauthSession{
+		State:        "state-duplicate",
+		CodeVerifier: "verifier-duplicate",
+		RedirectURI:  oauthDefaultRedirectURI,
+		CreatedAt:    time.Now(),
+	})
+	t.Cleanup(func() {
+		globalOAuthStore.delete(sessionID)
+	})
+
+	body := `{"session_id":"oauth-duplicate-session","code":"code-duplicate","state":"state-duplicate"}`
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Request = httptest.NewRequest(http.MethodPost, "/api/admin/oauth/exchange-code", strings.NewReader(body))
+	ctx.Request.Header.Set("Content-Type", "application/json")
+
+	handler.ExchangeOAuthCode(ctx)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	var resp struct {
+		ID      int64 `json:"id"`
+		Updated bool  `json:"updated"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.ID != existingID {
+		t.Fatalf("response id = %d, want %d", resp.ID, existingID)
+	}
+	if !resp.Updated {
+		t.Fatal("response updated = false, want true")
+	}
+	count, err := db.CountAll(context.Background())
+	if err != nil {
+		t.Fatalf("CountAll: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("account count = %d, want 1", count)
+	}
+	row, err := db.GetAccountByID(context.Background(), existingID)
+	if err != nil {
+		t.Fatalf("GetAccountByID: %v", err)
+	}
+	if got := row.GetCredential("refresh_token"); got != "refresh-from-exchange" {
+		t.Fatalf("refresh_token = %q, want updated exchange token", got)
+	}
+	if account := store.FindByID(existingID); account == nil {
+		t.Fatalf("runtime account %d not found after update", existingID)
 	}
 }
 
@@ -424,6 +513,71 @@ func TestUpdateOAuthAccountCodeDoesNotExposeTokenErrorBody(t *testing.T) {
 	}
 	if !strings.Contains(body, "token 兑换失败 (HTTP 400)") {
 		t.Fatalf("response = %s, want sanitized HTTP status error", body)
+	}
+}
+
+func TestUpdateOAuthAccountCodeRejectsDuplicateOAuthIdentity(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	db := newTestAdminDB(t)
+	store := auth.NewStore(db, cache.NewMemory(1), nil)
+	handler := &Handler{db: db, store: store}
+
+	targetID, err := db.InsertAccountWithCredentials(context.Background(), "target", map[string]interface{}{
+		"refresh_token": "target-refresh",
+		"email":         "target@example.com",
+		"account_id":    "acc-target",
+	}, "")
+	if err != nil {
+		t.Fatalf("Insert target: %v", err)
+	}
+	duplicateID, err := db.InsertAccountWithCredentials(context.Background(), "duplicate", map[string]interface{}{
+		"refresh_token": "duplicate-refresh",
+		"email":         "duplicate@example.com",
+		"account_id":    "acc-duplicate",
+	}, "")
+	if err != nil {
+		t.Fatalf("Insert duplicate: %v", err)
+	}
+	if err := store.LoadAccountByID(context.Background(), targetID); err != nil {
+		t.Fatalf("LoadAccountByID: %v", err)
+	}
+
+	newOAuthExchangeTestServerWithIDToken(t, makeOAuthTestIDToken("duplicate@example.com", "acc-duplicate", "team"))
+
+	sessionID := "oauth-edit-duplicate-session"
+	globalOAuthStore.set(sessionID, &oauthSession{
+		State:        "state-edit-duplicate",
+		CodeVerifier: "verifier-edit-duplicate",
+		RedirectURI:  oauthDefaultRedirectURI,
+		CreatedAt:    time.Now(),
+	})
+	t.Cleanup(func() { globalOAuthStore.delete(sessionID) })
+
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Params = gin.Params{{Key: "id", Value: fmt.Sprintf("%d", targetID)}}
+	ctx.Request = newOAuthEditRequest(sessionID, "code-edit-duplicate", "state-edit-duplicate", "")
+
+	handler.UpdateOAuthAccountCode(ctx)
+
+	if recorder.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want %d: %s", recorder.Code, http.StatusConflict, recorder.Body.String())
+	}
+	var errResp struct {
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &errResp); err != nil {
+		t.Fatalf("decode error response: %v", err)
+	}
+	if !strings.Contains(errResp.Error, fmt.Sprintf("%d", duplicateID)) {
+		t.Fatalf("error = %q, want duplicate account id %d", errResp.Error, duplicateID)
+	}
+	row, err := db.GetAccountByID(context.Background(), targetID)
+	if err != nil {
+		t.Fatalf("GetAccountByID: %v", err)
+	}
+	if got := row.GetCredential("refresh_token"); got != "target-refresh" {
+		t.Fatalf("target refresh_token = %q, want unchanged target-refresh", got)
 	}
 }
 

--- a/database/data_migrations.go
+++ b/database/data_migrations.go
@@ -1,0 +1,337 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	dataMigrationOAuthIdentityDedupeV1 = "20260616_oauth_identity_dedupe_v1"
+	dataMigrationTimeout               = 5 * time.Minute
+)
+
+type oauthIdentityDedupeAccount struct {
+	id          int64
+	credentials map[string]interface{}
+	enabled     bool
+	locked      bool
+	createdAt   time.Time
+	updatedAt   time.Time
+}
+
+func (db *DB) runDataMigrations(ctx context.Context) error {
+	if err := db.ensureDataMigrationsTable(ctx); err != nil {
+		return err
+	}
+	return db.runDataMigrationOnce(ctx, dataMigrationOAuthIdentityDedupeV1, db.dedupeOAuthIdentityAccounts)
+}
+
+func (db *DB) runDataMigrationsWithTimeout() error {
+	ctx, cancel := context.WithTimeout(context.Background(), dataMigrationTimeout)
+	defer cancel()
+	return db.runDataMigrations(ctx)
+}
+
+func (db *DB) ensureDataMigrationsTable(ctx context.Context) error {
+	_, err := db.conn.ExecContext(ctx, `
+		CREATE TABLE IF NOT EXISTS data_migrations (
+			version TEXT PRIMARY KEY,
+			applied_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+		)
+	`)
+	if err != nil {
+		return fmt.Errorf("创建 data_migrations 表失败: %w", err)
+	}
+	return nil
+}
+
+func (db *DB) runDataMigrationOnce(ctx context.Context, version string, migrate func(context.Context, *sql.Tx) error) error {
+	return db.withSQLiteWriteLock(ctx, func() error {
+		tx, err := db.conn.BeginTx(ctx, nil)
+		if err != nil {
+			return err
+		}
+		defer tx.Rollback()
+
+		res, err := tx.ExecContext(ctx, `
+			INSERT INTO data_migrations (version, applied_at)
+			VALUES ($1, CURRENT_TIMESTAMP)
+			ON CONFLICT(version) DO NOTHING
+		`, version)
+		if err != nil {
+			return fmt.Errorf("记录 data migration %s 失败: %w", version, err)
+		}
+		affected, err := res.RowsAffected()
+		if err != nil {
+			return err
+		}
+		if affected == 0 {
+			return tx.Commit()
+		}
+
+		if err := migrate(ctx, tx); err != nil {
+			return fmt.Errorf("执行 data migration %s 失败: %w", version, err)
+		}
+		return tx.Commit()
+	})
+}
+
+func (db *DB) dedupeOAuthIdentityAccounts(ctx context.Context, tx *sql.Tx) error {
+	accounts, err := db.listOAuthIdentityDedupeAccounts(ctx, tx)
+	if err != nil {
+		return err
+	}
+
+	parent := make([]int, len(accounts))
+	eligible := make([]bool, len(accounts))
+	for i := range parent {
+		parent[i] = i
+	}
+	var find func(int) int
+	find = func(i int) int {
+		if parent[i] != i {
+			parent[i] = find(parent[i])
+		}
+		return parent[i]
+	}
+	union := func(a, b int) {
+		rootA := find(a)
+		rootB := find(b)
+		if rootA != rootB {
+			parent[rootB] = rootA
+		}
+	}
+
+	aliasOwner := make(map[string]int)
+	for i, account := range accounts {
+		aliases := oauthIdentityDedupeAliases(account.credentials)
+		if len(aliases) == 0 {
+			continue
+		}
+		eligible[i] = true
+		for _, alias := range aliases {
+			if owner, ok := aliasOwner[alias]; ok {
+				union(i, owner)
+				continue
+			}
+			aliasOwner[alias] = i
+		}
+	}
+
+	groups := make(map[int][]oauthIdentityDedupeAccount)
+	for i, account := range accounts {
+		if !eligible[i] {
+			continue
+		}
+		groups[find(i)] = append(groups[find(i)], account)
+	}
+
+	var loserIDs []int64
+	duplicateGroups := 0
+	for _, group := range groups {
+		if len(group) < 2 {
+			continue
+		}
+		duplicateGroups++
+		sort.SliceStable(group, func(i, j int) bool {
+			return oauthIdentityDedupeWinnerLess(group[i], group[j])
+		})
+		for _, loser := range group[1:] {
+			loserIDs = append(loserIDs, loser.id)
+		}
+	}
+	if len(loserIDs) == 0 {
+		return nil
+	}
+
+	sort.Slice(loserIDs, func(i, j int) bool { return loserIDs[i] < loserIDs[j] })
+	if err := softDeleteAccountsTx(ctx, tx, loserIDs); err != nil {
+		return err
+	}
+	if err := insertAccountEventsTx(ctx, tx, loserIDs, "deleted", "oauth_identity_dedupe_v1"); err != nil {
+		return err
+	}
+	log.Printf("[data_migration] %s: 发现 %d 组重复 OAuth 身份，已软删除 %d 个重复账号", dataMigrationOAuthIdentityDedupeV1, duplicateGroups, len(loserIDs))
+	return nil
+}
+
+func (db *DB) listOAuthIdentityDedupeAccounts(ctx context.Context, tx *sql.Tx) ([]oauthIdentityDedupeAccount, error) {
+	rows, err := tx.QueryContext(ctx, `
+		SELECT id, credentials, COALESCE(enabled, true), COALESCE(locked, false), created_at, updated_at
+		FROM accounts
+		WHERE status <> 'deleted' AND COALESCE(error_message, '') <> 'deleted'
+	`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var accounts []oauthIdentityDedupeAccount
+	for rows.Next() {
+		var account oauthIdentityDedupeAccount
+		var rawCredentials interface{}
+		var createdRaw interface{}
+		var updatedRaw interface{}
+		if err := rows.Scan(
+			&account.id,
+			&rawCredentials,
+			&account.enabled,
+			&account.locked,
+			&createdRaw,
+			&updatedRaw,
+		); err != nil {
+			return nil, err
+		}
+		account.credentials = decodeCredentials(rawCredentials)
+		account.createdAt, err = parseDBTimeValue(createdRaw)
+		if err != nil {
+			return nil, fmt.Errorf("解析账号 %d created_at 失败: %w", account.id, err)
+		}
+		account.updatedAt, err = parseDBTimeValue(updatedRaw)
+		if err != nil {
+			return nil, fmt.Errorf("解析账号 %d updated_at 失败: %w", account.id, err)
+		}
+		accounts = append(accounts, account)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return accounts, nil
+}
+
+func oauthIdentityDedupeAliases(credentials map[string]interface{}) []string {
+	email := strings.ToLower(strings.TrimSpace(credentialStringFromMap(credentials, "email")))
+	if email == "" {
+		return nil
+	}
+	seen := make(map[string]struct{}, 2)
+	for _, key := range []string{"account_id", "chatgpt_account_id"} {
+		accountID := strings.TrimSpace(credentialStringFromMap(credentials, key))
+		if accountID == "" {
+			continue
+		}
+		seen[email+"\x00"+accountID] = struct{}{}
+	}
+	aliases := make([]string, 0, len(seen))
+	for alias := range seen {
+		aliases = append(aliases, alias)
+	}
+	sort.Strings(aliases)
+	return aliases
+}
+
+func credentialStringFromMap(credentials map[string]interface{}, key string) string {
+	if credentials == nil {
+		return ""
+	}
+	value, ok := credentials[key]
+	if !ok || value == nil {
+		return ""
+	}
+	switch typed := value.(type) {
+	case string:
+		return typed
+	case float64:
+		return fmt.Sprintf("%v", typed)
+	default:
+		return ""
+	}
+}
+
+func oauthIdentityDedupeWinnerLess(a, b oauthIdentityDedupeAccount) bool {
+	if !a.updatedAt.Equal(b.updatedAt) {
+		return a.updatedAt.After(b.updatedAt)
+	}
+	if scoreA, scoreB := oauthIdentityCredentialScore(a.credentials), oauthIdentityCredentialScore(b.credentials); scoreA != scoreB {
+		return scoreA > scoreB
+	}
+	if a.enabled != b.enabled {
+		return a.enabled
+	}
+	if a.locked != b.locked {
+		return !a.locked
+	}
+	if !a.createdAt.Equal(b.createdAt) {
+		return a.createdAt.After(b.createdAt)
+	}
+	return a.id > b.id
+}
+
+func oauthIdentityCredentialScore(credentials map[string]interface{}) int {
+	score := 0
+	if strings.TrimSpace(credentialStringFromMap(credentials, "access_token")) != "" {
+		score += 4
+	}
+	if strings.TrimSpace(credentialStringFromMap(credentials, "refresh_token")) != "" {
+		score += 2
+	}
+	if strings.TrimSpace(credentialStringFromMap(credentials, "session_token")) != "" {
+		score++
+	}
+	return score
+}
+
+func softDeleteAccountsTx(ctx context.Context, tx *sql.Tx, ids []int64) error {
+	const batchSize = 500
+	for i := 0; i < len(ids); i += batchSize {
+		end := i + batchSize
+		if end > len(ids) {
+			end = len(ids)
+		}
+		batch := ids[i:end]
+		placeholders := make([]string, len(batch))
+		args := make([]interface{}, 0, len(batch))
+		for j, id := range batch {
+			placeholders[j] = fmt.Sprintf("$%d", j+1)
+			args = append(args, id)
+		}
+		query := fmt.Sprintf(`
+			UPDATE accounts
+			SET status = 'deleted',
+				error_message = '',
+				cooldown_reason = '',
+				cooldown_until = NULL,
+				deleted_at = CURRENT_TIMESTAMP,
+				updated_at = CURRENT_TIMESTAMP
+			WHERE status <> 'deleted' AND id IN (%s)
+		`, strings.Join(placeholders, ","))
+		if _, err := tx.ExecContext(ctx, query, args...); err != nil {
+			return fmt.Errorf("软删除重复账号失败: %w", err)
+		}
+
+		query = fmt.Sprintf(`DELETE FROM account_group_members WHERE account_id IN (%s)`, strings.Join(placeholders, ","))
+		if _, err := tx.ExecContext(ctx, query, args...); err != nil {
+			return fmt.Errorf("清理重复账号分组关系失败: %w", err)
+		}
+	}
+	return nil
+}
+
+func insertAccountEventsTx(ctx context.Context, tx *sql.Tx, ids []int64, eventType, source string) error {
+	const batchSize = 500
+	for i := 0; i < len(ids); i += batchSize {
+		end := i + batchSize
+		if end > len(ids) {
+			end = len(ids)
+		}
+		batch := ids[i:end]
+		placeholders := make([]string, len(batch))
+		args := make([]interface{}, 0, len(batch)+2)
+		args = append(args, eventType, source)
+		for j, id := range batch {
+			paramIdx := j + 3
+			placeholders[j] = fmt.Sprintf("($%d, $1, $2)", paramIdx)
+			args = append(args, id)
+		}
+		query := fmt.Sprintf(`INSERT INTO account_events (account_id, event_type, source) VALUES %s`, strings.Join(placeholders, ","))
+		if _, err := tx.ExecContext(ctx, query, args...); err != nil {
+			return fmt.Errorf("记录重复账号清理事件失败: %w", err)
+		}
+	}
+	return nil
+}

--- a/database/postgres.go
+++ b/database/postgres.go
@@ -899,8 +899,10 @@ func (db *DB) migrate(ctx context.Context) error {
 	`
 	migrateCtx, migrateCancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer migrateCancel()
-	_, err = db.conn.ExecContext(migrateCtx, migrateQuery)
-	return err
+	if _, err = db.conn.ExecContext(migrateCtx, migrateQuery); err != nil {
+		return err
+	}
+	return db.runDataMigrationsWithTimeout()
 }
 
 // ==================== API Keys ====================
@@ -4846,6 +4848,51 @@ func (db *DB) GetAllChatGPTAccountIDs(ctx context.Context) (map[string]bool, err
 		}
 	}
 	return result, rows.Err()
+}
+
+// FindActiveAccountByOAuthIdentity returns the first non-deleted account with
+// the same email and ChatGPT account id. It accepts both historical credential
+// key names: account_id and chatgpt_account_id.
+func (db *DB) FindActiveAccountByOAuthIdentity(ctx context.Context, email, accountID string, excludeIDs ...int64) (int64, error) {
+	email = strings.ToLower(strings.TrimSpace(email))
+	accountID = strings.TrimSpace(accountID)
+	if email == "" || accountID == "" {
+		return 0, sql.ErrNoRows
+	}
+	excluded := make(map[int64]struct{}, len(excludeIDs))
+	for _, id := range excludeIDs {
+		if id > 0 {
+			excluded[id] = struct{}{}
+		}
+	}
+
+	rows, err := db.conn.QueryContext(ctx, `SELECT id, credentials FROM accounts WHERE status <> 'deleted' AND COALESCE(error_message, '') <> 'deleted'`)
+	if err != nil {
+		return 0, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var id int64
+		var raw interface{}
+		if err := rows.Scan(&id, &raw); err != nil {
+			return 0, err
+		}
+		if _, ok := excluded[id]; ok {
+			continue
+		}
+		if strings.ToLower(strings.TrimSpace(credentialString(raw, "email"))) != email {
+			continue
+		}
+		if strings.TrimSpace(credentialString(raw, "account_id")) == accountID ||
+			strings.TrimSpace(credentialString(raw, "chatgpt_account_id")) == accountID {
+			return id, nil
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return 0, err
+	}
+	return 0, sql.ErrNoRows
 }
 
 func (db *DB) GetAllOpenAIAPIKeys(ctx context.Context) (map[string]bool, error) {

--- a/database/sqlite.go
+++ b/database/sqlite.go
@@ -506,7 +506,7 @@ func (db *DB) migrateSQLite(ctx context.Context) error {
 		return err
 	}
 
-	return nil
+	return db.runDataMigrationsWithTimeout()
 }
 
 func (db *DB) ensureSQLiteColumn(ctx context.Context, table string, name string, columnDef string) error {

--- a/database/sqlite_test.go
+++ b/database/sqlite_test.go
@@ -179,6 +179,236 @@ func TestSQLiteUpdateCredentialsMergesAtomically(t *testing.T) {
 	}
 }
 
+func TestFindActiveAccountByOAuthIdentity(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "codex2api.db")
+
+	db, err := New("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("New(sqlite) 返回错误: %v", err)
+	}
+	defer db.Close()
+
+	ctx := context.Background()
+	id, err := db.InsertAccountWithCredentials(ctx, "identity", map[string]interface{}{
+		"refresh_token":      "rt-identity",
+		"email":              "User@Example.COM",
+		"chatgpt_account_id": "acc-identity",
+	}, "")
+	if err != nil {
+		t.Fatalf("InsertAccountWithCredentials 返回错误: %v", err)
+	}
+
+	got, err := db.FindActiveAccountByOAuthIdentity(ctx, " user@example.com ", "acc-identity")
+	if err != nil {
+		t.Fatalf("FindActiveAccountByOAuthIdentity 返回错误: %v", err)
+	}
+	if got != id {
+		t.Fatalf("matched id = %d, want %d", got, id)
+	}
+
+	otherID, err := db.InsertAccountWithCredentials(ctx, "identity-other", map[string]interface{}{
+		"refresh_token": "rt-identity-other",
+		"email":         "user@example.com",
+		"account_id":    "acc-identity",
+	}, "")
+	if err != nil {
+		t.Fatalf("InsertAccountWithCredentials other 返回错误: %v", err)
+	}
+	got, err = db.FindActiveAccountByOAuthIdentity(ctx, "user@example.com", "acc-identity", id)
+	if err != nil {
+		t.Fatalf("FindActiveAccountByOAuthIdentity with exclude 返回错误: %v", err)
+	}
+	if got != otherID {
+		t.Fatalf("matched id with exclude = %d, want %d", got, otherID)
+	}
+
+	if err := db.SoftDeleteAccount(ctx, id); err != nil {
+		t.Fatalf("SoftDeleteAccount 返回错误: %v", err)
+	}
+	if err := db.SoftDeleteAccount(ctx, otherID); err != nil {
+		t.Fatalf("SoftDeleteAccount other 返回错误: %v", err)
+	}
+	if _, err := db.FindActiveAccountByOAuthIdentity(ctx, "user@example.com", "acc-identity"); err == nil {
+		t.Fatal("FindActiveAccountByOAuthIdentity 应该排除已删除账号")
+	} else if err != sql.ErrNoRows {
+		t.Fatalf("FindActiveAccountByOAuthIdentity err = %v, want sql.ErrNoRows", err)
+	}
+}
+
+func TestSQLiteDataMigrationDedupesOAuthIdentityOnce(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "codex2api.db")
+	ctx := context.Background()
+
+	db, err := New("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("New(sqlite) 返回错误: %v", err)
+	}
+
+	if _, err := db.conn.ExecContext(ctx, `DELETE FROM data_migrations WHERE version = $1`, dataMigrationOAuthIdentityDedupeV1); err != nil {
+		t.Fatalf("清理 data migration 标记返回错误: %v", err)
+	}
+
+	oldTime := time.Now().Add(-2 * time.Hour).UTC().Truncate(time.Second)
+	midTime := time.Now().Add(-1 * time.Hour).UTC().Truncate(time.Second)
+	newTime := time.Now().UTC().Truncate(time.Second)
+
+	oldID, err := db.InsertAccountWithCredentials(ctx, "old-duplicate", map[string]interface{}{
+		"refresh_token": "rt-old-duplicate",
+		"email":         "User@Example.com",
+		"account_id":    "acc-dedupe",
+	}, "")
+	if err != nil {
+		t.Fatalf("Insert old duplicate 返回错误: %v", err)
+	}
+	midID, err := db.InsertAccountWithCredentials(ctx, "mid-duplicate", map[string]interface{}{
+		"access_token":        "at-mid-duplicate",
+		"email":               "user@example.com",
+		"chatgpt_account_id":  "acc-dedupe",
+		"codex_7d_reset_at":   newTime.Format(time.RFC3339),
+		"codex_5h_reset_at":   newTime.Format(time.RFC3339),
+		"codex_usage_marker":  "keep-credentials-intact",
+		"codex_usage_updated": "true",
+	}, "")
+	if err != nil {
+		t.Fatalf("Insert mid duplicate 返回错误: %v", err)
+	}
+	winnerID, err := db.InsertAccountWithCredentials(ctx, "new-duplicate", map[string]interface{}{
+		"session_token": "st-new-duplicate",
+		"email":         " user@example.com ",
+		"account_id":    "acc-dedupe",
+	}, "")
+	if err != nil {
+		t.Fatalf("Insert winner 返回错误: %v", err)
+	}
+	otherID, err := db.InsertAccountWithCredentials(ctx, "other-workspace", map[string]interface{}{
+		"refresh_token": "rt-other-workspace",
+		"email":         "user@example.com",
+		"account_id":    "acc-other",
+	}, "")
+	if err != nil {
+		t.Fatalf("Insert other 返回错误: %v", err)
+	}
+	bridgeOldID, err := db.InsertAccountWithCredentials(ctx, "bridge-old", map[string]interface{}{
+		"refresh_token":      "rt-bridge-old",
+		"email":              "bridge@example.com",
+		"account_id":         "acc-bridge-old",
+		"chatgpt_account_id": "acc-bridge",
+	}, "")
+	if err != nil {
+		t.Fatalf("Insert bridge old 返回错误: %v", err)
+	}
+	bridgeWinnerID, err := db.InsertAccountWithCredentials(ctx, "bridge-winner", map[string]interface{}{
+		"access_token": "at-bridge-winner",
+		"email":        "Bridge@Example.com",
+		"account_id":   "acc-bridge",
+	}, "")
+	if err != nil {
+		t.Fatalf("Insert bridge winner 返回错误: %v", err)
+	}
+	deletedID, err := db.InsertAccountWithCredentials(ctx, "deleted-duplicate", map[string]interface{}{
+		"refresh_token": "rt-deleted-duplicate",
+		"email":         "user@example.com",
+		"account_id":    "acc-dedupe",
+	}, "")
+	if err != nil {
+		t.Fatalf("Insert deleted 返回错误: %v", err)
+	}
+	if err := db.SoftDeleteAccount(ctx, deletedID); err != nil {
+		t.Fatalf("SoftDeleteAccount 返回错误: %v", err)
+	}
+
+	for id, ts := range map[int64]time.Time{
+		oldID:          oldTime,
+		midID:          midTime,
+		winnerID:       newTime,
+		otherID:        midTime,
+		bridgeOldID:    oldTime,
+		bridgeWinnerID: newTime,
+	} {
+		if _, err := db.conn.ExecContext(ctx, `UPDATE accounts SET updated_at = $1 WHERE id = $2`, sqliteTimeParam(ts), id); err != nil {
+			t.Fatalf("设置账号 %d updated_at 返回错误: %v", id, err)
+		}
+	}
+
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close 返回错误: %v", err)
+	}
+
+	db, err = New("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("reopen New(sqlite) 返回错误: %v", err)
+	}
+
+	activeRows, err := db.ListActive(ctx)
+	if err != nil {
+		t.Fatalf("ListActive 返回错误: %v", err)
+	}
+	activeIDs := map[int64]bool{}
+	for _, row := range activeRows {
+		activeIDs[row.ID] = true
+	}
+	if !activeIDs[winnerID] || !activeIDs[otherID] || !activeIDs[bridgeWinnerID] {
+		t.Fatalf("active ids = %v, want winner %d, other %d and bridge winner %d", activeIDs, winnerID, otherID, bridgeWinnerID)
+	}
+	if activeIDs[oldID] || activeIDs[midID] || activeIDs[bridgeOldID] {
+		t.Fatalf("active ids = %v, want duplicates %d/%d/%d soft-deleted", activeIDs, oldID, midID, bridgeOldID)
+	}
+
+	deletedRows, err := db.ListDeleted(ctx)
+	if err != nil {
+		t.Fatalf("ListDeleted 返回错误: %v", err)
+	}
+	deletedIDs := map[int64]bool{}
+	for _, row := range deletedRows {
+		deletedIDs[row.ID] = true
+	}
+	for _, id := range []int64{oldID, midID, bridgeOldID, deletedID} {
+		if !deletedIDs[id] {
+			t.Fatalf("deleted ids = %v, want id %d", deletedIDs, id)
+		}
+	}
+
+	var migrationCount int
+	if err := db.conn.QueryRowContext(ctx, `SELECT COUNT(*) FROM data_migrations WHERE version = $1`, dataMigrationOAuthIdentityDedupeV1).Scan(&migrationCount); err != nil {
+		t.Fatalf("查询 data_migrations 返回错误: %v", err)
+	}
+	if migrationCount != 1 {
+		t.Fatalf("migration count = %d, want 1", migrationCount)
+	}
+
+	var eventCount int
+	if err := db.conn.QueryRowContext(ctx, `SELECT COUNT(*) FROM account_events WHERE source = 'oauth_identity_dedupe_v1' AND account_id IN ($1, $2, $3)`, oldID, midID, bridgeOldID).Scan(&eventCount); err != nil {
+		t.Fatalf("查询 account_events 返回错误: %v", err)
+	}
+	if eventCount != 3 {
+		t.Fatalf("dedupe event count = %d, want 3", eventCount)
+	}
+
+	postMigrationDuplicateID, err := db.InsertAccountWithCredentials(ctx, "post-migration-duplicate", map[string]interface{}{
+		"refresh_token": "rt-post-migration-duplicate",
+		"email":         "user@example.com",
+		"account_id":    "acc-dedupe",
+	}, "")
+	if err != nil {
+		t.Fatalf("Insert post migration duplicate 返回错误: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close after post migration duplicate 返回错误: %v", err)
+	}
+
+	db, err = New("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("second reopen New(sqlite) 返回错误: %v", err)
+	}
+
+	if _, err := db.GetAccountByID(ctx, postMigrationDuplicateID); err != nil {
+		t.Fatalf("post migration duplicate should remain active because migration is one-shot: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("final Close 返回错误: %v", err)
+	}
+}
+
 func TestSQLiteAPIKeyQuotaAndExpiration(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "codex2api.db")
 


### PR DESCRIPTION
## 背景

OAuth / 导入 / AT 添加链路目前主要按 token 或单一账号字段去重，历史数据中可能存在同一 ChatGPT 账号在正常池重复出现的问题。这个 PR 以 `email + account_id/chatgpt_account_id` 作为 OAuth 身份键，先在应用层阻止新增重复，并加入一次性 data migration 清理已有正常池重复数据。

## 改动

### 后端
- 新增 OAuth 身份查重：按 `lower(trim(email)) + account_id/chatgpt_account_id` 查找正常池账号，排除回收站账号
- OAuth 新增 / 回调：同身份已存在时更新已有账号，而不是插入重复账号
- OAuth 更新：如果新授权身份属于另一个正常账号，返回冲突，避免覆盖错误账号
- 手动 AT 添加：AT 可解析出 `email + account_id` 时走同身份 upsert
- 回收站恢复：如果正常池已有相同 OAuth 身份，拒绝恢复，避免旧回收站账号覆盖正常池

### 导入
- 文件内同一 `email + account_id` 且 RT/ST/AT 完全一致：折叠成一条
- 文件内同一 `email + account_id` 但 RT/ST/AT 不一致：整组跳过，避免任选一条覆盖
- 池子里已有同身份且 RT/ST/AT 一致：跳过
- 池子里已有同身份但 RT/ST/AT 不一致：更新已有账号，并触发后续探针链路
- 没有 OAuth 身份的旧格式继续按 RT / ST / AT 去重

### 数据迁移
- 新增 `data_migrations` 表，记录一次性数据迁移是否已执行
- 新增 `20260616_oauth_identity_dedupe_v1`
  - 只处理正常池账号，回收站不参与
  - 按 `email + account_id/chatgpt_account_id` 分组
  - 每组保留一个 winner，其余软删除到回收站
  - winner 规则：`updated_at` 最新优先，其次 token 完整度、enabled、未 locked、`created_at`、id
  - 不创建唯一索引，本 PR 先做应用层保护 + 一次性历史清理

## 测试
- `go test ./admin ./database ./proxy` ✅
- `go test $(go list -e -f '{{if not .Error}}{{.ImportPath}}{{end}}' ./... | grep -v '^github.com/codex2api$')` ✅
- `git diff --check upstream/main..HEAD` ✅
- 使用 SQLite 副本验证 data migration：
  - migration 可成功写入 `data_migrations`
  - 无重复数据时不改动账号
  - 人工注入重复后可软删除 loser 并记录事件
  - `PRAGMA integrity_check = ok`

## 注意
- 根包 `go test ./...` 需要先构建 `frontend/dist/*`，当前未单独运行根包测试。
- 本 PR 暂不加唯一索引；建议后续版本再跑一次去重后添加部分唯一索引作为数据库层兜底。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth-identity deduplication across OAuth login, token exchange, and token/account updates to prevent credential overwrites and resolve ambiguous matches safely.
  * Account restore now rejects restoring when an active duplicate OAuth identity exists (**409 Conflict**).
  * Token imports now update credentials when appropriate, collapse identical OAuth entries in a single import, and run refresh/usage probing correctly for refresh-token-only imports.
  * Added an automatic one-time data migration to soft-delete duplicate OAuth identity accounts and record deletion events.

* **Tests**
  * Added/expanded coverage for deduplication, conflict rejection on restore and updates, import upsert/skip behavior, and the new one-shot migration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->