### PR TITLE
fix: 禁用 Gin 默认可信代理

### DIFF
--- a/main.go
+++ b/main.go
@@ -255,6 +255,11 @@ func main() {
 	// 6. 启动 HTTP 服务
 	gin.SetMode(gin.ReleaseMode)
 	r := gin.New()
+	// Gin 默认信任所有代理头（X-Forwarded-For/X-Real-IP），会让公网客户端伪造 c.ClientIP()。
+	// 默认禁用可信代理，避免绕过 bootstrap 本机来源限制与 IP 限流；如需反代真实 IP，后续应显式配置可信代理 CIDR。
+	if err := configureTrustedProxies(r); err != nil {
+		log.Fatalf("配置可信代理失败: %v", err)
+	}
 	r.Use(api.RecoveryMiddleware())
 	r.Use(api.RequestContextMiddleware())
 	r.Use(api.VersionMiddleware())
@@ -393,6 +398,13 @@ func main() {
 	wsrelay.ShutdownExecutor()
 	proxy.CloseErrorLogger()
 	log.Println("已关闭")
+}
+
+func configureTrustedProxies(r *gin.Engine) error {
+	if r == nil {
+		return nil
+	}
+	return r.SetTrustedProxies(nil)
 }
 
 // loggerMiddleware 简单日志中间件（增强版，支持敏感信息脱敏）

--- a/main_test.go
+++ b/main_test.go
@@ -11,6 +11,32 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+func TestConfigureTrustedProxiesRejectsForwardedForSpoofing(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	r := gin.New()
+	if err := configureTrustedProxies(r); err != nil {
+		t.Fatalf("configureTrustedProxies() error = %v", err)
+	}
+	r.GET("/client-ip", func(c *gin.Context) {
+		c.String(http.StatusOK, c.ClientIP())
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/client-ip", nil)
+	req.RemoteAddr = "203.0.113.10:12345"
+	req.Header.Set("X-Forwarded-For", "127.0.0.1")
+	req.Header.Set("X-Real-IP", "127.0.0.1")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	if got := strings.TrimSpace(w.Body.String()); got != "203.0.113.10" {
+		t.Fatalf("ClientIP() = %q, want remote addr and not spoofed loopback", got)
+	}
+}
+
 func TestLoggerMiddlewareRedactsSensitiveContext(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
@@ -54,5 +80,4 @@ func TestLoggerMiddlewareRedactsSensitiveContext(t *testing.T) {
 			t.Fatalf("log output missing %q: %s", expected, got)
 		}
 	}
-
 }


### PR DESCRIPTION
## 背景

本次安全 CodeReview 发现，项目使用 `gin.New()` 创建 HTTP Engine 后没有显式配置可信代理。Gin v1.12 默认会信任所有代理来源，并从 `X-Forwarded-For` / `X-Real-IP` 解析 `c.ClientIP()`。

项目的首次初始化接口 `/api/admin/bootstrap` 依赖 `c.ClientIP()` 判断来源是否为本机或 `BOOTSTRAP_ALLOWED_CIDR` 白名单。如果服务在未初始化状态下直接暴露端口，攻击者可能通过伪造：

```http
X-Forwarded-For: 127.0.0.1
X-Real-IP: 127.0.0.1
```

使服务误判请求来自本机，从而绕过 bootstrap 来源限制并设置管理密钥。

## 修改前

`main.go` 中仅创建 Gin Engine：

```go
r := gin.New()
```

在 Gin 默认配置下，`c.ClientIP()` 可能信任客户端提供的转发头，导致依赖客户端 IP 的安全逻辑受到影响，包括：

- `/api/admin/bootstrap` 本机来源限制；
- 管理端与 API 鉴权失败审计日志中的 IP；
- 使用 `c.ClientIP()` 的 IP 维度限流逻辑。

## 修改后

在 Gin Engine 创建后、注册任何中间件和路由前，显式禁用默认可信代理：

```go
if err := configureTrustedProxies(r); err != nil {
    log.Fatalf("配置可信代理失败: %v", err)
}
```

并新增：

```go
func configureTrustedProxies(r *gin.Engine) error {
    if r == nil {
        return nil
    }
    return r.SetTrustedProxies(nil)
}
```

这样默认情况下 `c.ClientIP()` 会使用 TCP 连接的 `RemoteAddr`，不再信任客户端可伪造的 `X-Forwarded-For` / `X-Real-IP`。

同时新增回归测试 `TestConfigureTrustedProxiesRejectsForwardedForSpoofing`，验证当请求伪造 `X-Forwarded-For: 127.0.0.1` 和 `X-Real-IP: 127.0.0.1` 时，`c.ClientIP()` 仍返回真实 RemoteAddr，而不是伪造的 loopback 地址。

## 前后对比分析

- 安全性：修复 bootstrap 来源校验可被转发头伪造绕过的问题。
- 默认行为：从“信任所有代理头”改为“不信任任何代理头”，默认更安全。
- 兼容性：部署在反向代理后时，日志和 IP 限流会看到反代的 TCP 地址，而不再自动使用最终用户 IP。这是安全修复的预期行为。后续如需支持反代真实 IP，建议新增显式可信代理 CIDR 配置，而不是恢复 Gin 默认信任所有代理。
- 风险控制：配置失败时启动阶段直接 `log.Fatalf`，避免服务在不明确的安全配置下继续运行。

## 测试情况

已执行以下验证：

```powershell
gofmt -w "main.go" "main_test.go"
```

第一次直接执行根包测试时，由于当前 worktree 没有 `frontend/dist`，`//go:embed frontend/dist/*` 在 setup 阶段失败；随后安装前端依赖并构建前端产物后重新验证：

```powershell
npm --prefix "frontend" ci
npm --prefix "frontend" run build
go test . ./admin ./security ./api
```

结果：

```text
added 209 packages, and audited 210 packages in 5s
found 0 vulnerabilities
vite v8.0.16 building client environment for production...
✓ 2560 modules transformed.
✓ built in 583ms
ok   github.com/codex2api          3.595s
ok   github.com/codex2api/admin    4.852s
ok   github.com/codex2api/security (cached)
ok   github.com/codex2api/api      (cached)
```

## 修改总结

本次变更通过显式调用 `SetTrustedProxies(nil)` 关闭 Gin 默认的“信任所有代理”行为，防止外部请求伪造 `X-Forwarded-For` / `X-Real-IP` 影响 `c.ClientIP()`，从而修复首次初始化来源限制可被绕过的安全问题，并增加回归测试防止后续配置回退。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security by preventing IP address spoofing through forwarded proxy headers, ensuring accurate client IP identification.

* **Tests**
  * Added test to verify IP spoofing prevention functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->