### PR TITLE
feat: 支持配置 5h 保护带算法与降速并发

### DIFF
--- a/admin/bootstrap.go
+++ b/admin/bootstrap.go
@@ -367,5 +367,7 @@ func defaultBootstrapSettings() *database.SystemSettings {
 		CodexWSHideUpstreamErrors:        true,
 		CodexWSSilentRetryEnabled:        true,
 		CodexWSSilentMaxRetries:          2,
+		AutoPause5hGuardBandPercent:      5,
+		AutoPause5hGuardConcurrency:      1,
 	}
 }

--- a/admin/handler.go
+++ b/admin/handler.go
@@ -5146,6 +5146,8 @@ type settingsResponse struct {
 	ImageS3ForcePathStyle              bool    `json:"image_s3_force_path_style"`
 	AutoPause5hThreshold               float64 `json:"auto_pause_5h_threshold"`
 	AutoPause7dThreshold               float64 `json:"auto_pause_7d_threshold"`
+	AutoPause5hGuardBandPercent        float64 `json:"auto_pause_5h_guard_band_percent"`
+	AutoPause5hGuardConcurrency        int     `json:"auto_pause_5h_guard_concurrency"`
 }
 
 type updateSettingsReq struct {
@@ -5229,6 +5231,8 @@ type updateSettingsReq struct {
 	ImageS3ForcePathStyle              *bool    `json:"image_s3_force_path_style"`
 	AutoPause5hThreshold               *float64 `json:"auto_pause_5h_threshold"`
 	AutoPause7dThreshold               *float64 `json:"auto_pause_7d_threshold"`
+	AutoPause5hGuardBandPercent        *float64 `json:"auto_pause_5h_guard_band_percent"`
+	AutoPause5hGuardConcurrency        *int     `json:"auto_pause_5h_guard_concurrency"`
 }
 
 type brandingResponse struct {
@@ -5805,6 +5809,8 @@ func (h *Handler) GetSettings(c *gin.Context) {
 		ImageS3ForcePathStyle:              imgCfg.ForcePathStyle,
 		AutoPause5hThreshold:               h.store.GetGlobalAutoPause5hThreshold(),
 		AutoPause7dThreshold:               h.store.GetGlobalAutoPause7dThreshold(),
+		AutoPause5hGuardBandPercent:        h.store.GetAutoPause5hGuardBandPercent(),
+		AutoPause5hGuardConcurrency:        h.store.GetAutoPause5hGuardConcurrency(),
 	})
 }
 
@@ -5824,6 +5830,19 @@ func (h *Handler) UpdateSettings(c *gin.Context) {
 	if req.AutoPause7dThreshold != nil {
 		if err := validateAutoPauseThreshold("auto_pause_7d_threshold", *req.AutoPause7dThreshold); err != nil {
 			writeError(c, http.StatusBadRequest, err.Error())
+			return
+		}
+	}
+
+	if req.AutoPause5hGuardBandPercent != nil {
+		if *req.AutoPause5hGuardBandPercent < 0 || *req.AutoPause5hGuardBandPercent > 100 {
+			writeError(c, http.StatusBadRequest, "auto_pause_5h_guard_band_percent 需在 0 到 100 之间")
+			return
+		}
+	}
+	if req.AutoPause5hGuardConcurrency != nil {
+		if *req.AutoPause5hGuardConcurrency < 0 || *req.AutoPause5hGuardConcurrency > 1000 {
+			writeError(c, http.StatusBadRequest, "auto_pause_5h_guard_concurrency 需在 0 到 1000 之间")
 			return
 		}
 	}
@@ -6214,6 +6233,14 @@ func (h *Handler) UpdateSettings(c *gin.Context) {
 		h.store.SetGlobalAutoPauseThresholds(t5h, t7d)
 		log.Printf("设置已更新: auto_pause thresholds 5h=%.4f 7d=%.4f", t5h, t7d)
 	}
+	if req.AutoPause5hGuardBandPercent != nil {
+		h.store.SetAutoPause5hGuardBandPercent(*req.AutoPause5hGuardBandPercent)
+		log.Printf("设置已更新: auto_pause_5h_guard_band_percent = %.2f", *req.AutoPause5hGuardBandPercent)
+	}
+	if req.AutoPause5hGuardConcurrency != nil {
+		h.store.SetAutoPause5hGuardConcurrency(*req.AutoPause5hGuardConcurrency)
+		log.Printf("设置已更新: auto_pause_5h_guard_concurrency = %d", *req.AutoPause5hGuardConcurrency)
+	}
 	runtimeCfg = proxy.ApplyRuntimeSettings(runtimeCfg)
 
 	usageLogChanged := false
@@ -6482,6 +6509,8 @@ func (h *Handler) UpdateSettings(c *gin.Context) {
 		BackgroundConfig:                   encodeBackgroundConfig(bgCfg),
 		AutoPause5hThreshold:               h.store.GetGlobalAutoPause5hThreshold(),
 		AutoPause7dThreshold:               h.store.GetGlobalAutoPause7dThreshold(),
+		AutoPause5hGuardBandPercent:        h.store.GetAutoPause5hGuardBandPercent(),
+		AutoPause5hGuardConcurrency:        h.store.GetAutoPause5hGuardConcurrency(),
 	})
 	if err != nil {
 		log.Printf("无法持久化保存设置: %v", err)
@@ -6575,6 +6604,7 @@ func (h *Handler) UpdateSettings(c *gin.Context) {
 		StreamFlushIntervalMS:              runtimeCfg.StreamFlushIntervalMS,
 		FirstTokenMode:                     runtimeCfg.FirstTokenMode,
 		FirstTokenTimeoutSeconds:           runtimeCfg.FirstTokenTimeoutSec,
+		BillingTierPolicy:                  runtimeCfg.BillingTierPolicy,
 		ShowFullUsageNumbers:               showFullUsageNumbers,
 		ImageStorageBackend:                imgCfg.Backend,
 		ImageS3Endpoint:                    imgCfg.Endpoint,
@@ -6586,6 +6616,8 @@ func (h *Handler) UpdateSettings(c *gin.Context) {
 		ImageS3ForcePathStyle:              imgCfg.ForcePathStyle,
 		AutoPause5hThreshold:               h.store.GetGlobalAutoPause5hThreshold(),
 		AutoPause7dThreshold:               h.store.GetGlobalAutoPause7dThreshold(),
+		AutoPause5hGuardBandPercent:        h.store.GetAutoPause5hGuardBandPercent(),
+		AutoPause5hGuardConcurrency:        h.store.GetAutoPause5hGuardConcurrency(),
 	})
 }
 

--- a/auth/fast_scheduler.go
+++ b/auth/fast_scheduler.go
@@ -480,7 +480,7 @@ func (a *Account) fastSchedulerSnapshot(baseLimit int64, now time.Time) (Account
 		if baseConcurrencyEffective <= 0 {
 			baseConcurrencyEffective = a.effectiveBaseConcurrencyLocked(baseLimit)
 		}
-		limit = concurrencyLimitForTier(baseConcurrencyEffective, tier)
+		limit = a.quotaAutoPause5hGuardConcurrencyLimitLocked(concurrencyLimitForTier(baseConcurrencyEffective, tier), now)
 	}
 
 	available := a.Status != StatusError && tier != HealthTierBanned && a.hasDispatchCredentialLocked()

--- a/auth/quota_auto_pause_test.go
+++ b/auth/quota_auto_pause_test.go
@@ -1,11 +1,17 @@
 package auth
 
 import (
+	"math"
 	"testing"
 	"time"
 
 	"github.com/codex2api/database"
 )
+
+func nearlyEqualFloat64(a, b float64) bool {
+	const epsilon = 1e-6
+	return math.Abs(a-b) < epsilon
+}
 
 func newQuotaAutoPauseTestAccount() *Account {
 	acc := &Account{
@@ -249,7 +255,7 @@ func TestQuotaAutoPause5hGuardReducesDispatchScoreNearThreshold(t *testing.T) {
 	recomputeTestAccount(baseline, 4)
 
 	penalty := baseline.DispatchScore - guarded.DispatchScore
-	if penalty != 20 {
+	if !nearlyEqualFloat64(penalty, 20) {
 		t.Fatalf("guard penalty = %v, want 20 (baseline=%v guarded=%v)", penalty, baseline.DispatchScore, guarded.DispatchScore)
 	}
 }
@@ -268,7 +274,7 @@ func TestQuotaAutoPause5hGuardDoesNotReduceDispatchScoreOutsideBandOrDisabled(t 
 		setAutoPauseThresholdsWithGuard(baseline, 0)
 		recomputeTestAccount(baseline, 4)
 
-		if guarded.DispatchScore != baseline.DispatchScore {
+		if !nearlyEqualFloat64(guarded.DispatchScore, baseline.DispatchScore) {
 			t.Fatalf("DispatchScore = %v, want baseline %v outside guard band", guarded.DispatchScore, baseline.DispatchScore)
 		}
 	})
@@ -286,7 +292,7 @@ func TestQuotaAutoPause5hGuardDoesNotReduceDispatchScoreOutsideBandOrDisabled(t 
 		setAutoPauseThresholdsWithGuard(baseline, 0)
 		recomputeTestAccount(baseline, 4)
 
-		if acc.DispatchScore != baseline.DispatchScore {
+		if !nearlyEqualFloat64(acc.DispatchScore, baseline.DispatchScore) {
 			t.Fatalf("DispatchScore = %v, want baseline %v when guard band is disabled", acc.DispatchScore, baseline.DispatchScore)
 		}
 	})

--- a/auth/quota_auto_pause_test.go
+++ b/auth/quota_auto_pause_test.go
@@ -3,6 +3,8 @@ package auth
 import (
 	"testing"
 	"time"
+
+	"github.com/codex2api/database"
 )
 
 func newQuotaAutoPauseTestAccount() *Account {
@@ -16,8 +18,19 @@ func newQuotaAutoPauseTestAccount() *Account {
 	return acc
 }
 
-func setAutoPauseThresholds(acc *Account) {
-	acc.recomputeEffectiveAutoPause(nil)
+func setAutoPauseThresholdsWithGuard(acc *Account, guardBandPercent float64) {
+	setAutoPauseThresholdsWithGuardConcurrency(acc, guardBandPercent, 1)
+}
+
+func setAutoPauseThresholdsWithGuardConcurrency(acc *Account, guardBandPercent float64, guardConcurrency int) {
+	store := NewStore(nil, nil, &database.SystemSettings{
+		MaxConcurrency:              4,
+		TestConcurrency:             1,
+		TestModel:                   "gpt-5.4",
+		AutoPause5hGuardBandPercent: guardBandPercent,
+		AutoPause5hGuardConcurrency: guardConcurrency,
+	})
+	acc.recomputeEffectiveAutoPause(store)
 }
 
 func TestQuotaAutoPause5hThresholdFencesAccount(t *testing.T) {
@@ -26,7 +39,7 @@ func TestQuotaAutoPause5hThresholdFencesAccount(t *testing.T) {
 	acc.UsagePercent5h = 95
 	acc.UsagePercent5hValid = true
 	acc.Reset5hAt = time.Now().Add(time.Hour)
-	setAutoPauseThresholds(acc)
+	setAutoPauseThresholdsWithGuard(acc, 5)
 
 	if acc.IsAvailable() {
 		t.Fatal("IsAvailable() = true, want false after 5h auto-pause threshold is reached")
@@ -46,7 +59,7 @@ func TestQuotaAutoPause5hThresholdRefreshesMissing5hBeforeFencing(t *testing.T) 
 	acc.UsagePercent7d = 12
 	acc.UsagePercent7dValid = true
 	acc.UsageUpdatedAt = time.Now()
-	setAutoPauseThresholds(acc)
+	setAutoPauseThresholdsWithGuard(acc, 5)
 
 	if !acc.NeedsUsageProbe(10 * time.Minute) {
 		t.Fatal("NeedsUsageProbe() = false, want true when 7d is fresh but 5h snapshot is missing")
@@ -68,7 +81,7 @@ func TestQuotaAutoPauseIgnoresBelowThresholdAndDisabledWindow(t *testing.T) {
 	acc.UsagePercent5h = 94.9
 	acc.UsagePercent5hValid = true
 	acc.Reset5hAt = time.Now().Add(time.Hour)
-	setAutoPauseThresholds(acc)
+	setAutoPauseThresholdsWithGuard(acc, 5)
 
 	if !acc.IsAvailable() {
 		t.Fatal("IsAvailable() = false, want true below threshold")
@@ -76,7 +89,7 @@ func TestQuotaAutoPauseIgnoresBelowThresholdAndDisabledWindow(t *testing.T) {
 
 	acc.UsagePercent5h = 99
 	acc.AutoPause5hDisabled = true
-	setAutoPauseThresholds(acc)
+	setAutoPauseThresholdsWithGuard(acc, 5)
 	if !acc.IsAvailable() {
 		t.Fatal("IsAvailable() = false, want true when 5h auto-pause is disabled")
 	}
@@ -91,11 +104,192 @@ func TestQuotaAutoPauseStopsAfterResetTime(t *testing.T) {
 	acc.UsagePercent5h = 99
 	acc.UsagePercent5hValid = true
 	acc.Reset5hAt = time.Now().Add(-time.Minute)
-	setAutoPauseThresholds(acc)
+	setAutoPauseThresholdsWithGuard(acc, 5)
 
 	if !acc.IsAvailable() {
 		t.Fatal("IsAvailable() = false, want true after reset time has passed")
 	}
+}
+
+func TestQuotaAutoPause5hNearThresholdLimitsConcurrency(t *testing.T) {
+	acc := newQuotaAutoPauseTestAccount()
+	acc.AutoPause5hThreshold = 0.9
+	acc.BaseConcurrencyOverride = int64Ptr(4)
+	acc.SetUsageSnapshot5h(86, time.Now().Add(time.Hour))
+	setAutoPauseThresholdsWithGuard(acc, 5)
+	recomputeTestAccount(acc, 4)
+
+	if !acc.IsAvailable() {
+		t.Fatal("IsAvailable() = false, want true before threshold is reached")
+	}
+	if acc.DynamicConcurrencyLimit != 1 {
+		t.Fatalf("DynamicConcurrencyLimit = %d, want 1 near 5h auto-pause threshold", acc.DynamicConcurrencyLimit)
+	}
+	_, _, limit, _, available := acc.fastSchedulerSnapshot(4, time.Now())
+	if !available {
+		t.Fatal("fastSchedulerSnapshot available = false, want true before threshold is reached")
+	}
+	if limit != 1 {
+		t.Fatalf("fastSchedulerSnapshot limit = %d, want 1 near 5h auto-pause threshold", limit)
+	}
+}
+
+func TestQuotaAutoPause5hNearThresholdUsesConfiguredGuardConcurrency(t *testing.T) {
+	acc := newQuotaAutoPauseTestAccount()
+	acc.AutoPause5hThreshold = 0.9
+	acc.BaseConcurrencyOverride = int64Ptr(4)
+	acc.SetUsageSnapshot5h(86, time.Now().Add(time.Hour))
+	setAutoPauseThresholdsWithGuardConcurrency(acc, 5, 2)
+	recomputeTestAccount(acc, 4)
+
+	if acc.DynamicConcurrencyLimit != 2 {
+		t.Fatalf("DynamicConcurrencyLimit = %d, want configured guard concurrency 2", acc.DynamicConcurrencyLimit)
+	}
+	_, _, limit, _, available := acc.fastSchedulerSnapshot(4, time.Now())
+	if !available {
+		t.Fatal("fastSchedulerSnapshot available = false, want true before threshold is reached")
+	}
+	if limit != 2 {
+		t.Fatalf("fastSchedulerSnapshot limit = %d, want configured guard concurrency 2", limit)
+	}
+}
+
+func TestQuotaAutoPause5hGuardConcurrencyCanBeDisabled(t *testing.T) {
+	acc := newQuotaAutoPauseTestAccount()
+	acc.AutoPause5hThreshold = 0.9
+	acc.BaseConcurrencyOverride = int64Ptr(4)
+	acc.SetUsageSnapshot5h(86, time.Now().Add(time.Hour))
+	setAutoPauseThresholdsWithGuardConcurrency(acc, 5, 0)
+	recomputeTestAccount(acc, 4)
+
+	if acc.DynamicConcurrencyLimit != 4 {
+		t.Fatalf("DynamicConcurrencyLimit = %d, want base limit when guard concurrency is 0", acc.DynamicConcurrencyLimit)
+	}
+}
+
+func TestQuotaAutoPause5hGuardConcurrencyDoesNotIncreaseLimit(t *testing.T) {
+	acc := newQuotaAutoPauseTestAccount()
+	acc.AutoPause5hThreshold = 0.9
+	acc.BaseConcurrencyOverride = int64Ptr(2)
+	acc.SetUsageSnapshot5h(86, time.Now().Add(time.Hour))
+	setAutoPauseThresholdsWithGuardConcurrency(acc, 5, 4)
+	recomputeTestAccount(acc, 2)
+
+	if acc.DynamicConcurrencyLimit != 2 {
+		t.Fatalf("DynamicConcurrencyLimit = %d, want original limit when guard concurrency is higher", acc.DynamicConcurrencyLimit)
+	}
+}
+
+func TestQuotaAutoPause5hGuardKeepsNormalConcurrencyOutsideGuardBand(t *testing.T) {
+	acc := newQuotaAutoPauseTestAccount()
+	acc.AutoPause5hThreshold = 0.9
+	acc.BaseConcurrencyOverride = int64Ptr(4)
+	acc.SetUsageSnapshot5h(84.9, time.Now().Add(time.Hour))
+	setAutoPauseThresholdsWithGuard(acc, 5)
+	recomputeTestAccount(acc, 4)
+
+	if acc.DynamicConcurrencyLimit != 4 {
+		t.Fatalf("DynamicConcurrencyLimit = %d, want base limit outside guard band", acc.DynamicConcurrencyLimit)
+	}
+}
+
+func TestQuotaAutoPause5hGuardCanBeDisabledByBand(t *testing.T) {
+	acc := newQuotaAutoPauseTestAccount()
+	acc.AutoPause5hThreshold = 0.9
+	acc.BaseConcurrencyOverride = int64Ptr(4)
+	acc.SetUsageSnapshot5h(86, time.Now().Add(time.Hour))
+	setAutoPauseThresholdsWithGuard(acc, 0)
+	recomputeTestAccount(acc, 4)
+
+	if acc.DynamicConcurrencyLimit != 4 {
+		t.Fatalf("DynamicConcurrencyLimit = %d, want base limit when guard band is 0", acc.DynamicConcurrencyLimit)
+	}
+}
+
+func TestQuotaAutoPause5hGuardIgnoresDisabledOrExpiredWindow(t *testing.T) {
+	t.Run("disabled", func(t *testing.T) {
+		acc := newQuotaAutoPauseTestAccount()
+		acc.AutoPause5hThreshold = 0.9
+		acc.AutoPause5hDisabled = true
+		acc.BaseConcurrencyOverride = int64Ptr(4)
+		acc.SetUsageSnapshot5h(89, time.Now().Add(time.Hour))
+		setAutoPauseThresholdsWithGuard(acc, 5)
+		recomputeTestAccount(acc, 4)
+
+		if acc.DynamicConcurrencyLimit != 4 {
+			t.Fatalf("DynamicConcurrencyLimit = %d, want base limit when 5h auto-pause is disabled", acc.DynamicConcurrencyLimit)
+		}
+	})
+
+	t.Run("expired", func(t *testing.T) {
+		acc := newQuotaAutoPauseTestAccount()
+		acc.AutoPause5hThreshold = 0.9
+		acc.BaseConcurrencyOverride = int64Ptr(4)
+		acc.SetUsageSnapshot5h(89, time.Now().Add(-time.Minute))
+		setAutoPauseThresholdsWithGuard(acc, 5)
+		recomputeTestAccount(acc, 4)
+
+		if acc.DynamicConcurrencyLimit != 4 {
+			t.Fatalf("DynamicConcurrencyLimit = %d, want base limit after 5h window reset", acc.DynamicConcurrencyLimit)
+		}
+	})
+}
+
+func TestQuotaAutoPause5hGuardReducesDispatchScoreNearThreshold(t *testing.T) {
+	guarded := newQuotaAutoPauseTestAccount()
+	guarded.AutoPause5hThreshold = 0.9
+	guarded.SetUsageSnapshot5h(87, time.Now().Add(time.Hour)) // remaining 3pp inside a 5pp band => 40% of max penalty
+	setAutoPauseThresholdsWithGuard(guarded, 5)
+	recomputeTestAccount(guarded, 4)
+
+	baseline := newQuotaAutoPauseTestAccount()
+	baseline.AutoPause5hThreshold = 0.9
+	baseline.SetUsageSnapshot5h(87, time.Now().Add(time.Hour))
+	setAutoPauseThresholdsWithGuard(baseline, 0)
+	recomputeTestAccount(baseline, 4)
+
+	penalty := baseline.DispatchScore - guarded.DispatchScore
+	if penalty != 20 {
+		t.Fatalf("guard penalty = %v, want 20 (baseline=%v guarded=%v)", penalty, baseline.DispatchScore, guarded.DispatchScore)
+	}
+}
+
+func TestQuotaAutoPause5hGuardDoesNotReduceDispatchScoreOutsideBandOrDisabled(t *testing.T) {
+	t.Run("outside band", func(t *testing.T) {
+		guarded := newQuotaAutoPauseTestAccount()
+		guarded.AutoPause5hThreshold = 0.9
+		guarded.SetUsageSnapshot5h(84.9, time.Now().Add(time.Hour))
+		setAutoPauseThresholdsWithGuard(guarded, 5)
+		recomputeTestAccount(guarded, 4)
+
+		baseline := newQuotaAutoPauseTestAccount()
+		baseline.AutoPause5hThreshold = 0.9
+		baseline.SetUsageSnapshot5h(84.9, time.Now().Add(time.Hour))
+		setAutoPauseThresholdsWithGuard(baseline, 0)
+		recomputeTestAccount(baseline, 4)
+
+		if guarded.DispatchScore != baseline.DispatchScore {
+			t.Fatalf("DispatchScore = %v, want baseline %v outside guard band", guarded.DispatchScore, baseline.DispatchScore)
+		}
+	})
+
+	t.Run("band disabled", func(t *testing.T) {
+		acc := newQuotaAutoPauseTestAccount()
+		acc.AutoPause5hThreshold = 0.9
+		acc.SetUsageSnapshot5h(87, time.Now().Add(time.Hour))
+		setAutoPauseThresholdsWithGuard(acc, 0)
+		recomputeTestAccount(acc, 4)
+
+		baseline := newQuotaAutoPauseTestAccount()
+		baseline.AutoPause5hThreshold = 0.9
+		baseline.SetUsageSnapshot5h(87, time.Now().Add(time.Hour))
+		setAutoPauseThresholdsWithGuard(baseline, 0)
+		recomputeTestAccount(baseline, 4)
+
+		if acc.DispatchScore != baseline.DispatchScore {
+			t.Fatalf("DispatchScore = %v, want baseline %v when guard band is disabled", acc.DispatchScore, baseline.DispatchScore)
+		}
+	})
 }
 
 func TestQuotaAutoPause7dThresholdFencesAccount(t *testing.T) {
@@ -103,7 +297,7 @@ func TestQuotaAutoPause7dThresholdFencesAccount(t *testing.T) {
 	acc.AutoPause7dThreshold = 0.9
 	acc.UsagePercent7d = 91
 	acc.UsagePercent7dValid = true
-	setAutoPauseThresholds(acc)
+	setAutoPauseThresholdsWithGuard(acc, 5)
 
 	if acc.IsAvailable() {
 		t.Fatal("IsAvailable() = true, want false after 7d auto-pause threshold is reached")

--- a/auth/quota_auto_pause_test.go
+++ b/auth/quota_auto_pause_test.go
@@ -8,9 +8,11 @@ import (
 	"github.com/codex2api/database"
 )
 
+const quotaAutoPauseFloatTolerance = 1e-6
+
 func nearlyEqualFloat64(a, b float64) bool {
-	const epsilon = 1e-6
-	return math.Abs(a-b) < epsilon
+	diff := math.Abs(a - b)
+	return diff <= quotaAutoPauseFloatTolerance && !math.IsNaN(diff)
 }
 
 func newQuotaAutoPauseTestAccount() *Account {
@@ -279,11 +281,11 @@ func TestQuotaAutoPause5hGuardDoesNotReduceDispatchScoreOutsideBandOrDisabled(t 
 		}
 	})
 
-	t.Run("band disabled", func(t *testing.T) {
+	t.Run("guard concurrency disabled", func(t *testing.T) {
 		acc := newQuotaAutoPauseTestAccount()
 		acc.AutoPause5hThreshold = 0.9
 		acc.SetUsageSnapshot5h(87, time.Now().Add(time.Hour))
-		setAutoPauseThresholdsWithGuard(acc, 0)
+		setAutoPauseThresholdsWithGuardConcurrency(acc, 5, 0)
 		recomputeTestAccount(acc, 4)
 
 		baseline := newQuotaAutoPauseTestAccount()
@@ -293,7 +295,7 @@ func TestQuotaAutoPause5hGuardDoesNotReduceDispatchScoreOutsideBandOrDisabled(t 
 		recomputeTestAccount(baseline, 4)
 
 		if !nearlyEqualFloat64(acc.DispatchScore, baseline.DispatchScore) {
-			t.Fatalf("DispatchScore = %v, want baseline %v when guard band is disabled", acc.DispatchScore, baseline.DispatchScore)
+			t.Fatalf("DispatchScore = %v, want baseline %v when guard concurrency is disabled", acc.DispatchScore, baseline.DispatchScore)
 		}
 	})
 }

--- a/auth/store.go
+++ b/auth/store.go
@@ -84,14 +84,16 @@ type Account struct {
 	// 因此用它独立判断重置次数是否过期，避免活跃账号因用量快照一直被流量刷新而长期不探针。
 	resetCreditsProbedAt time.Time
 
-	usageProbeInFlight    bool
-	recoveryProbeInFlight bool
-	AutoPause5hThreshold  float64 // 0..1, 0 = disabled
-	AutoPause7dThreshold  float64 // 0..1, 0 = disabled
-	AutoPause5hDisabled   bool
-	AutoPause7dDisabled   bool
-	effectiveAutoPause5h  float64 // resolved: account > group > global
-	effectiveAutoPause7d  float64
+	usageProbeInFlight          bool
+	recoveryProbeInFlight       bool
+	AutoPause5hThreshold        float64 // 0..1, 0 = disabled
+	AutoPause7dThreshold        float64 // 0..1, 0 = disabled
+	AutoPause5hDisabled         bool
+	AutoPause7dDisabled         bool
+	effectiveAutoPause5h        float64 // resolved: account > group > global
+	effectiveAutoPause7d        float64
+	autoPause5hGuardBandPercent float64 // percentage points, 0 = disabled
+	autoPause5hGuardConcurrency int     // 0 = disabled; otherwise guard-band concurrency cap
 
 	// 调度健康信号
 	HealthTier               AccountHealthTier
@@ -882,14 +884,14 @@ func (a *Account) recomputeSchedulerLocked(baseLimit int64) {
 		breakdown.UsageUrgencyBonus7d = a.premium7dUsageUrgencyBonusLocked(now)
 		breakdown.ExpiryUrgencyBonus = a.expiryUrgencyBonusLocked(now)
 	}
-	dispatchScore := score + float64(scoreBiasEffective) + breakdown.UsageUrgencyBonus5h + breakdown.UsageUrgencyBonus7d + breakdown.ExpiryUrgencyBonus
+	dispatchScore := score + float64(scoreBiasEffective) + breakdown.UsageUrgencyBonus5h + breakdown.UsageUrgencyBonus7d + breakdown.ExpiryUrgencyBonus - a.quotaAutoPause5hGuardDispatchPenaltyLocked(now)
 
 	a.HealthTier = tier
 	a.SchedulerScore = score
 	a.DispatchScore = dispatchScore
 	a.ScoreBiasEffective = scoreBiasEffective
 	a.BaseConcurrencyEffective = baseConcurrencyEffective
-	a.DynamicConcurrencyLimit = concurrencyLimitForTier(baseConcurrencyEffective, tier)
+	a.DynamicConcurrencyLimit = a.quotaAutoPause5hGuardConcurrencyLimitLocked(concurrencyLimitForTier(baseConcurrencyEffective, tier), now)
 	if a.premium5hRateLimitedLocked(now) && a.DynamicConcurrencyLimit > 1 {
 		a.DynamicConcurrencyLimit = 1
 	}
@@ -953,6 +955,32 @@ func normalizeQuotaAutoPauseThreshold(value float64) float64 {
 	}
 }
 
+const (
+	defaultAutoPause5hGuardBandPercent = 5.0
+	defaultAutoPause5hGuardConcurrency = 1
+	maxAutoPause5hGuardDispatchPenalty = 50.0
+)
+
+func normalizeAutoPause5hGuardBandPercent(value float64) float64 {
+	if value < 0 {
+		return 0
+	}
+	if value > 100 {
+		return 100
+	}
+	return value
+}
+
+func normalizeAutoPause5hGuardConcurrency(value int) int {
+	if value < 0 {
+		return 0
+	}
+	if value > 1000 {
+		return 1000
+	}
+	return value
+}
+
 func quotaAutoPausedByWindow(usage float64, valid bool, resetAt time.Time, threshold float64, disabled bool, now time.Time) bool {
 	if disabled || threshold <= 0 || !valid {
 		return false
@@ -961,6 +989,40 @@ func quotaAutoPausedByWindow(usage float64, valid bool, resetAt time.Time, thres
 		return false
 	}
 	return usage/100 >= threshold
+}
+
+func (a *Account) quotaAutoPause5hGuardConcurrencyLimitLocked(limit int64, now time.Time) int64 {
+	if limit <= 1 || a.AutoPause5hDisabled || a.effectiveAutoPause5h <= 0 || !a.UsagePercent5hValid || a.autoPause5hGuardBandPercent <= 0 || a.autoPause5hGuardConcurrency <= 0 {
+		return limit
+	}
+	if !a.Reset5hAt.IsZero() && !now.Before(a.Reset5hAt) {
+		return limit
+	}
+
+	remainingPercent := a.effectiveAutoPause5h*100 - a.UsagePercent5h
+	if remainingPercent <= 0 {
+		return 0
+	}
+	if remainingPercent <= a.autoPause5hGuardBandPercent && limit > int64(a.autoPause5hGuardConcurrency) {
+		return int64(a.autoPause5hGuardConcurrency)
+	}
+	return limit
+}
+
+func (a *Account) quotaAutoPause5hGuardDispatchPenaltyLocked(now time.Time) float64 {
+	if a.AutoPause5hDisabled || a.effectiveAutoPause5h <= 0 || !a.UsagePercent5hValid || a.autoPause5hGuardBandPercent <= 0 {
+		return 0
+	}
+	if !a.Reset5hAt.IsZero() && !now.Before(a.Reset5hAt) {
+		return 0
+	}
+
+	remainingPercent := a.effectiveAutoPause5h*100 - a.UsagePercent5h
+	if remainingPercent <= 0 || remainingPercent > a.autoPause5hGuardBandPercent {
+		return 0
+	}
+	progress := (a.autoPause5hGuardBandPercent - remainingPercent) / a.autoPause5hGuardBandPercent
+	return progress * maxAutoPause5hGuardDispatchPenalty
 }
 
 func (a *Account) quotaAutoPausedLocked(now time.Time) bool {
@@ -973,6 +1035,13 @@ func (a *Account) quotaAutoPausedLocked(now time.Time) bool {
 func (a *Account) recomputeEffectiveAutoPause(s *Store) {
 	a.effectiveAutoPause5h = resolveEffectiveThreshold(a.AutoPause5hThreshold, a.GroupIDs, s, true)
 	a.effectiveAutoPause7d = resolveEffectiveThreshold(a.AutoPause7dThreshold, a.GroupIDs, s, false)
+	if s != nil {
+		a.autoPause5hGuardBandPercent = s.GetAutoPause5hGuardBandPercent()
+		a.autoPause5hGuardConcurrency = s.GetAutoPause5hGuardConcurrency()
+	} else {
+		a.autoPause5hGuardBandPercent = defaultAutoPause5hGuardBandPercent
+		a.autoPause5hGuardConcurrency = defaultAutoPause5hGuardConcurrency
+	}
 }
 
 func resolveEffectiveThreshold(accountThreshold float64, groupIDs []int64, s *Store, is5h bool) float64 {
@@ -1770,9 +1839,11 @@ type Store struct {
 	sessionMu             sync.RWMutex
 	sessionBindings       map[string]sessionAffinity
 
-	globalAutoPause5hThreshold float64  // protected by mu
-	globalAutoPause7dThreshold float64  // protected by mu
-	groupAutoPauseThresholds   sync.Map // int64 -> [2]float64 {5h, 7d}
+	globalAutoPause5hThreshold  float64  // protected by mu
+	globalAutoPause7dThreshold  float64  // protected by mu
+	autoPause5hGuardBandPercent float64  // protected by mu, percentage points
+	autoPause5hGuardConcurrency int      // protected by mu, 0 = disabled
+	groupAutoPauseThresholds    sync.Map // int64 -> [2]float64 {5h, 7d}
 }
 
 // sessionAffinity 记录某个 sessionKey 当前粘附到哪个账号/代理。
@@ -2150,6 +2221,8 @@ func NewStore(db *database.DB, tc cache.TokenCache, settings *database.SystemSet
 			CodexWSHideUpstreamErrors:          true,
 			CodexWSSilentRetryEnabled:          true,
 			CodexWSSilentMaxRetries:            2,
+			AutoPause5hGuardBandPercent:        defaultAutoPause5hGuardBandPercent,
+			AutoPause5hGuardConcurrency:        defaultAutoPause5hGuardConcurrency,
 		}
 	}
 	s := &Store{
@@ -2216,6 +2289,8 @@ func NewStore(db *database.DB, tc cache.TokenCache, settings *database.SystemSet
 
 	s.globalAutoPause5hThreshold = normalizeQuotaAutoPauseThreshold(settings.AutoPause5hThreshold)
 	s.globalAutoPause7dThreshold = normalizeQuotaAutoPauseThreshold(settings.AutoPause7dThreshold)
+	s.autoPause5hGuardBandPercent = normalizeAutoPause5hGuardBandPercent(settings.AutoPause5hGuardBandPercent)
+	s.autoPause5hGuardConcurrency = normalizeAutoPause5hGuardConcurrency(settings.AutoPause5hGuardConcurrency)
 
 	// 加载代理池
 	if settings.ProxyPoolEnabled {
@@ -3959,6 +4034,34 @@ func (s *Store) GetGlobalAutoPause5hThreshold() float64 {
 func (s *Store) GetGlobalAutoPause7dThreshold() float64 {
 	s.mu.RLock()
 	v := s.globalAutoPause7dThreshold
+	s.mu.RUnlock()
+	return v
+}
+
+func (s *Store) SetAutoPause5hGuardBandPercent(value float64) {
+	s.mu.Lock()
+	s.autoPause5hGuardBandPercent = normalizeAutoPause5hGuardBandPercent(value)
+	s.mu.Unlock()
+	s.recomputeAllEffectiveAutoPause()
+}
+
+func (s *Store) GetAutoPause5hGuardBandPercent() float64 {
+	s.mu.RLock()
+	v := s.autoPause5hGuardBandPercent
+	s.mu.RUnlock()
+	return v
+}
+
+func (s *Store) SetAutoPause5hGuardConcurrency(value int) {
+	s.mu.Lock()
+	s.autoPause5hGuardConcurrency = normalizeAutoPause5hGuardConcurrency(value)
+	s.mu.Unlock()
+	s.recomputeAllEffectiveAutoPause()
+}
+
+func (s *Store) GetAutoPause5hGuardConcurrency() int {
+	s.mu.RLock()
+	v := s.autoPause5hGuardConcurrency
 	s.mu.RUnlock()
 	return v
 }

--- a/auth/store.go
+++ b/auth/store.go
@@ -1010,7 +1010,7 @@ func (a *Account) quotaAutoPause5hGuardConcurrencyLimitLocked(limit int64, now t
 }
 
 func (a *Account) quotaAutoPause5hGuardDispatchPenaltyLocked(now time.Time) float64 {
-	if a.AutoPause5hDisabled || a.effectiveAutoPause5h <= 0 || !a.UsagePercent5hValid || a.autoPause5hGuardBandPercent <= 0 {
+	if a.AutoPause5hDisabled || a.effectiveAutoPause5h <= 0 || !a.UsagePercent5hValid || a.autoPause5hGuardBandPercent <= 0 || a.autoPause5hGuardConcurrency <= 0 {
 		return 0
 	}
 	if !a.Reset5hAt.IsZero() && !now.Before(a.Reset5hAt) {

--- a/database/postgres.go
+++ b/database/postgres.go
@@ -781,6 +781,8 @@ func (db *DB) migrate(ctx context.Context) error {
 	ALTER TABLE system_settings ADD COLUMN IF NOT EXISTS codex_ws_silent_max_retries INT DEFAULT 2;
 	ALTER TABLE system_settings ADD COLUMN IF NOT EXISTS auto_pause_5h_threshold DOUBLE PRECISION DEFAULT 0;
 	ALTER TABLE system_settings ADD COLUMN IF NOT EXISTS auto_pause_7d_threshold DOUBLE PRECISION DEFAULT 0;
+	ALTER TABLE system_settings ADD COLUMN IF NOT EXISTS auto_pause_5h_guard_band_percent DOUBLE PRECISION DEFAULT 5;
+	ALTER TABLE system_settings ADD COLUMN IF NOT EXISTS auto_pause_5h_guard_concurrency INT DEFAULT 1;
 
 	ALTER TABLE account_groups ADD COLUMN IF NOT EXISTS auto_pause_5h_threshold DOUBLE PRECISION DEFAULT 0;
 	ALTER TABLE account_groups ADD COLUMN IF NOT EXISTS auto_pause_7d_threshold DOUBLE PRECISION DEFAULT 0;
@@ -1354,6 +1356,8 @@ type SystemSettings struct {
 	CodexWSSilentMaxRetries            int  // WS 静默换号最大重试次数，默认 2
 	AutoPause5hThreshold               float64
 	AutoPause7dThreshold               float64
+	AutoPause5hGuardBandPercent        float64
+	AutoPause5hGuardConcurrency        int
 }
 
 func normalizeBillingTierPolicy(policy string) string {
@@ -1436,7 +1440,9 @@ func (db *DB) GetSystemSettings(ctx context.Context) (*SystemSettings, error) {
 			       COALESCE(codex_ws_silent_retry_enabled, true),
 			       COALESCE(codex_ws_silent_max_retries, 2),
 			       COALESCE(auto_pause_5h_threshold, 0),
-			       COALESCE(auto_pause_7d_threshold, 0)
+			       COALESCE(auto_pause_7d_threshold, 0),
+			       COALESCE(auto_pause_5h_guard_band_percent, 5),
+			       COALESCE(auto_pause_5h_guard_concurrency, 1)
 			FROM system_settings WHERE id = 1
 		`).Scan(
 		&s.SiteName, &s.SiteLogo,
@@ -1470,6 +1476,8 @@ func (db *DB) GetSystemSettings(ctx context.Context) (*SystemSettings, error) {
 		&s.CodexWSSilentMaxRetries,
 		&s.AutoPause5hThreshold,
 		&s.AutoPause7dThreshold,
+		&s.AutoPause5hGuardBandPercent,
+		&s.AutoPause5hGuardConcurrency,
 	)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
@@ -1522,9 +1530,11 @@ func (db *DB) UpdateSystemSettings(ctx context.Context, s *SystemSettings) error
 					codex_ws_silent_retry_enabled,
 					codex_ws_silent_max_retries,
 					auto_pause_5h_threshold,
-					auto_pause_7d_threshold
+					auto_pause_7d_threshold,
+					auto_pause_5h_guard_band_percent,
+					auto_pause_5h_guard_concurrency
 					)
-						VALUES (1, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43, $44, $45, $46, $47, $48, $49, $50, $51, $52, $53, $54, $55, $56, $57, $58, $59, $60, $61, $62, $63, $64, $65, $66, $67, $68, $69)
+						VALUES (1, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43, $44, $45, $46, $47, $48, $49, $50, $51, $52, $53, $54, $55, $56, $57, $58, $59, $60, $61, $62, $63, $64, $65, $66, $67, $68, $69, $70, $71)
 				ON CONFLICT (id) DO UPDATE SET
 				site_name               = EXCLUDED.site_name,
 				site_logo               = EXCLUDED.site_logo,
@@ -1594,7 +1604,9 @@ func (db *DB) UpdateSystemSettings(ctx context.Context, s *SystemSettings) error
 					codex_ws_silent_retry_enabled = EXCLUDED.codex_ws_silent_retry_enabled,
 					codex_ws_silent_max_retries = EXCLUDED.codex_ws_silent_max_retries,
 					auto_pause_5h_threshold = EXCLUDED.auto_pause_5h_threshold,
-					auto_pause_7d_threshold = EXCLUDED.auto_pause_7d_threshold
+					auto_pause_7d_threshold = EXCLUDED.auto_pause_7d_threshold,
+					auto_pause_5h_guard_band_percent = EXCLUDED.auto_pause_5h_guard_band_percent,
+					auto_pause_5h_guard_concurrency = EXCLUDED.auto_pause_5h_guard_concurrency
 			`, NormalizeSiteName(s.SiteName), strings.TrimSpace(s.SiteLogo),
 		s.MaxConcurrency, s.GlobalRPM, s.TestModel, s.TestConcurrency, s.ProxyURL, s.PgMaxConns, s.RedisPoolSize,
 		s.AutoCleanUnauthorized, s.AutoCleanRateLimited, s.AdminSecret, s.AutoCleanFullUsage, s.ProxyPoolEnabled,
@@ -1611,7 +1623,7 @@ func (db *DB) UpdateSystemSettings(ctx context.Context, s *SystemSettings) error
 		s.FirstTokenTimeoutSeconds, firstTokenMode, billingTierPolicy, s.ImageStorageConfig, s.SchedulerMode, normalizeAffinityMode(s.AffinityMode), s.BackgroundConfig, s.ShowFullUsageNumbers, reasoningEffortModels,
 		s.CodexForceWebsocket, s.CodexWSKeepaliveEnabled, normalizeCodexWSKeepaliveInterval(s.CodexWSKeepaliveIntervalSec),
 		s.CodexWSHideUpstreamErrors, s.CodexWSSilentRetryEnabled, normalizeCodexWSSilentMaxRetries(s.CodexWSSilentMaxRetries),
-		s.AutoPause5hThreshold, s.AutoPause7dThreshold)
+		s.AutoPause5hThreshold, s.AutoPause7dThreshold, s.AutoPause5hGuardBandPercent, s.AutoPause5hGuardConcurrency)
 	return err
 }
 

--- a/database/sqlite.go
+++ b/database/sqlite.go
@@ -455,6 +455,8 @@ func (db *DB) migrateSQLite(ctx context.Context) error {
 		{"system_settings", "affinity_mode", "TEXT DEFAULT 'bounded'"},
 		{"system_settings", "auto_pause_5h_threshold", "REAL DEFAULT 0"},
 		{"system_settings", "auto_pause_7d_threshold", "REAL DEFAULT 0"},
+		{"system_settings", "auto_pause_5h_guard_band_percent", "REAL DEFAULT 5"},
+		{"system_settings", "auto_pause_5h_guard_concurrency", "INTEGER DEFAULT 1"},
 		{"account_groups", "auto_pause_5h_threshold", "REAL DEFAULT 0"},
 		{"account_groups", "auto_pause_7d_threshold", "REAL DEFAULT 0"},
 		{"accounts", "enabled", "INTEGER DEFAULT 1"},

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1753,6 +1753,11 @@
     "globalAutoPauseDesc": "Set default auto-pause thresholds for all accounts. Account-level or group-level settings take priority.",
     "globalAutoPause5h": "Global 5h Threshold (%)",
     "globalAutoPause7d": "Global 7d Threshold (%)",
+    "autoPause5hGuardBand": "5h Guard Band (%)",
+    "autoPause5hGuardBandHint": "Reduce concurrency when 5h usage nears the pause line to slow quota consumption. Enter how many percentage points early to start; 0 turns it off.",
+    "autoPause5hGuardBandPlaceholder": "Blank or 0 to disable",
+    "autoPause5hGuardConcurrency": "5h Guard Concurrency Cap",
+    "autoPause5hGuardConcurrencyHint": "When an account enters the 5h guard band, cap its concurrency at this value. Default is 1. Enter 0 to disable guard-band concurrency reduction.",
     "globalAutoPausePlaceholder": "Blank or 0 to disable",
     "globalAutoPauseHint": "Enter 0 to disable global default. Priority: Account > Group > Global."
   },

--- a/frontend/src/locales/zh.json
+++ b/frontend/src/locales/zh.json
@@ -1753,6 +1753,11 @@
     "globalAutoPauseDesc": "为所有账号设置默认的自动暂停阈值。账号级别或分组级别的设置优先于全局设置。",
     "globalAutoPause5h": "全局 5h 阈值(%)",
     "globalAutoPause7d": "全局 7d 阈值(%)",
+    "autoPause5hGuardBand": "5h 保护带(%)",
+    "autoPause5hGuardBandHint": "5h 用量接近暂停线时提前降并发，减慢额度消耗。填写提前多少个百分点开始保护；0 表示关闭。",
+    "autoPause5hGuardBandPlaceholder": "留空或 0 表示不启用",
+    "autoPause5hGuardConcurrency": "5h 保护带并发上限",
+    "autoPause5hGuardConcurrencyHint": "账号进入 5h 保护带后并发上限降到该值，默认 1。填 0 表示不启用保护带降并发。",
     "globalAutoPausePlaceholder": "留空或 0 表示不启用",
     "globalAutoPauseHint": "填 0 表示不启用全局默认阈值。优先级: 账号 > 分组 > 全局。"
   },

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -736,6 +736,8 @@ export default function Settings() {
     image_s3_force_path_style: false,
     auto_pause_5h_threshold: 0,
     auto_pause_7d_threshold: 0,
+    auto_pause_5h_guard_band_percent: 5,
+    auto_pause_5h_guard_concurrency: 1,
   })
   const lazyModeActive = settingsForm.lazy_mode
   const [savingSettings, setSavingSettings] = useState(false)
@@ -1373,6 +1375,44 @@ export default function Settings() {
                   }}
                   onBlur={() => {
                     void autoSaveSettingsPatch({ auto_pause_7d_threshold: settingsForm.auto_pause_7d_threshold })
+                  }}
+                />
+              </SettingField>
+              <SettingField label={t('settings.autoPause5hGuardBand')} description={t('settings.autoPause5hGuardBandHint')}>
+                <Input
+                  type="number"
+                  min={0}
+                  max={100}
+                  step={0.1}
+                  inputMode="decimal"
+                  placeholder={t('settings.autoPause5hGuardBandPlaceholder')}
+                  value={settingsForm.auto_pause_5h_guard_band_percent > 0 ? settingsForm.auto_pause_5h_guard_band_percent : ''}
+                  onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                    const raw = e.target.value
+                    const value = raw === '' ? 0 : Math.max(0, Math.min(100, parseFloat(raw)))
+                    setSettingsForm(f => ({ ...f, auto_pause_5h_guard_band_percent: isNaN(value) ? 5 : value }))
+                  }}
+                  onBlur={() => {
+                    void autoSaveSettingsPatch({ auto_pause_5h_guard_band_percent: settingsForm.auto_pause_5h_guard_band_percent })
+                  }}
+                />
+              </SettingField>
+              <SettingField label={t('settings.autoPause5hGuardConcurrency')} description={t('settings.autoPause5hGuardConcurrencyHint')}>
+                <Input
+                  type="number"
+                  min={0}
+                  max={1000}
+                  step={1}
+                  inputMode="numeric"
+                  value={settingsForm.auto_pause_5h_guard_concurrency ?? 1}
+                  onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                    const raw = e.target.value
+                    const parsed = raw === '' ? 0 : Math.floor(parseFloat(raw))
+                    const value = Math.max(0, Math.min(1000, parsed))
+                    setSettingsForm(f => ({ ...f, auto_pause_5h_guard_concurrency: isNaN(value) ? 1 : value }))
+                  }}
+                  onBlur={() => {
+                    void autoSaveSettingsPatch({ auto_pause_5h_guard_concurrency: settingsForm.auto_pause_5h_guard_concurrency })
                   }}
                 />
               </SettingField>

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1389,8 +1389,14 @@ export default function Settings() {
                   value={settingsForm.auto_pause_5h_guard_band_percent > 0 ? settingsForm.auto_pause_5h_guard_band_percent : ''}
                   onChange={(e: ChangeEvent<HTMLInputElement>) => {
                     const raw = e.target.value
-                    const value = raw === '' ? 0 : Math.max(0, Math.min(100, parseFloat(raw)))
-                    setSettingsForm(f => ({ ...f, auto_pause_5h_guard_band_percent: isNaN(value) ? 5 : value }))
+                    if (raw === '') {
+                      setSettingsForm(f => ({ ...f, auto_pause_5h_guard_band_percent: 0 }))
+                      return
+                    }
+                    const parsed = parseFloat(raw)
+                    if (Number.isNaN(parsed)) return
+                    const value = Math.max(0, Math.min(100, parsed))
+                    setSettingsForm(f => ({ ...f, auto_pause_5h_guard_band_percent: value }))
                   }}
                   onBlur={() => {
                     void autoSaveSettingsPatch({ auto_pause_5h_guard_band_percent: settingsForm.auto_pause_5h_guard_band_percent })
@@ -1407,9 +1413,14 @@ export default function Settings() {
                   value={settingsForm.auto_pause_5h_guard_concurrency ?? 1}
                   onChange={(e: ChangeEvent<HTMLInputElement>) => {
                     const raw = e.target.value
-                    const parsed = raw === '' ? 0 : Math.floor(parseFloat(raw))
+                    if (raw === '') {
+                      setSettingsForm(f => ({ ...f, auto_pause_5h_guard_concurrency: 0 }))
+                      return
+                    }
+                    const parsed = Number.parseInt(raw, 10)
+                    if (Number.isNaN(parsed)) return
                     const value = Math.max(0, Math.min(1000, parsed))
-                    setSettingsForm(f => ({ ...f, auto_pause_5h_guard_concurrency: isNaN(value) ? 1 : value }))
+                    setSettingsForm(f => ({ ...f, auto_pause_5h_guard_concurrency: value }))
                   }}
                   onBlur={() => {
                     void autoSaveSettingsPatch({ auto_pause_5h_guard_concurrency: settingsForm.auto_pause_5h_guard_concurrency })

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -702,6 +702,8 @@ export interface SystemSettings {
   image_s3_force_path_style: boolean
   auto_pause_5h_threshold: number
   auto_pause_7d_threshold: number
+  auto_pause_5h_guard_band_percent: number
+  auto_pause_5h_guard_concurrency: number
 }
 
 export interface SetupHintsResponse {

--- a/main.go
+++ b/main.go
@@ -103,6 +103,8 @@ func main() {
 			CodexWSHideUpstreamErrors:        true,
 			CodexWSSilentRetryEnabled:        true,
 			CodexWSSilentMaxRetries:          2,
+			AutoPause5hGuardBandPercent:      5,
+			AutoPause5hGuardConcurrency:      1,
 		}
 		_ = db.UpdateSystemSettings(context.Background(), settings)
 	} else if err != nil {
@@ -142,6 +144,8 @@ func main() {
 			CodexWSHideUpstreamErrors:        true,
 			CodexWSSilentRetryEnabled:        true,
 			CodexWSSilentMaxRetries:          2,
+			AutoPause5hGuardBandPercent:      5,
+			AutoPause5hGuardConcurrency:      1,
 		}
 	} else {
 		log.Printf("已加载持久化业务设置: ProxyURL=%s, MaxConcurrency=%d, GlobalRPM=%d, PgMaxConns=%d, RedisPoolSize=%d",


### PR DESCRIPTION
## 背景

本分支的核心是解决 5h 使用量刷新存在时间间隔时，账号可能在两次刷新之间快速越过自动暂停阈值的问题。

例如：5h 自动暂停阈值设置为 `90%`，使用量更新时间间隔约为 5 分钟。当某次刷新看到账号还没到 90% 时，账号仍会继续按正常并发参与调度；但在下一次使用量刷新前，这 5 分钟内可能继续快速消耗额度，下一次刷新时就已经直接接近或达到 `100%`。也就是说，仅靠“达到 90% 后暂停”会有滞后窗口，无法在接近阈值时提前减速。

因此本次变更增加 5h 保护带算法控制：在账号距离 5h 自动暂停阈值还剩一定百分点时，就提前降低账号并发并降低调度优先级，减慢额度消耗，降低在使用量刷新间隔内直接冲到 100% 的概率。同时，保护带内降速并发支持系统级配置，方便不同部署按账号池规模和额度策略调整。

## 修改前

- 5h 用量达到自动暂停阈值后，账号会被自动暂停。
- 5h 使用量不是实时连续刷新，刷新间隔内账号仍可能继续消耗额度。
- 当 5h 阈值设置为 `90%`、使用量刷新间隔约 5 分钟时，账号可能在下一次刷新前从阈值附近直接冲到 `100%`。
- 缺少“接近 5h 自动暂停阈值时提前降速”的保护带算法控制。
- 缺少保护带相关系统设置，无法配置提前保护的百分点和保护带内的降速并发。
- 调度层缺少针对接近 5h 暂停线账号的提前并发收缩和优先级降低策略。

## 修改后

### 5h 保护带算法控制

- 新增 5h 保护带控制逻辑：当账号 5h 用量接近自动暂停阈值时，提前降低账号并发，减慢额度消耗。
- 新增 `auto_pause_5h_guard_band_percent`，用于配置距离 5h 自动暂停阈值还剩多少个百分点时开始保护。
- 保护带按“距离阈值还剩多少个百分点”触发。例如阈值为 `90%`、保护带为 `5%` 时，账号用量达到约 `85%` 后就开始进入保护带降速阶段。
- 新增系统设置 `auto_pause_5h_guard_concurrency`，控制账号进入 5h 保护带后的并发上限。
- 默认值为 `1`，提供最保守保护行为。
- 配置为 `0` 时，不启用保护带降并发；但账号达到 5h 自动暂停阈值后仍会按原逻辑暂停。
- 配置范围限制为 `0~1000`，避免异常值进入运行时逻辑。
- 实际生效并发不会超过账号原本动态并发上限：如果账号原本只能跑 2，即使配置保护带并发为 4，也不会被提升到 4。
- 当 5h 自动暂停被禁用、5h 窗口已重置、保护带百分点为 0、保护带并发为 0、或用量快照无效时，不应用保护带降并发。

### 调度与运行时链路

- `auth.Store` 增加保护带百分点和保护带并发运行时配置，并提供 getter/setter。
- `Account` 缓存当前 Store 下的保护带百分点和保护带并发，重新计算自动暂停策略时同步刷新。
- 动态并发计算接入保护带并发配置，在保护带内提前收缩账号并发。
- `fastSchedulerSnapshot` 同步接入保护带并发配置，保证快速调度器和普通调度路径一致。
- 调度分算法增加保护带内降权逻辑，用于在接近 5h 暂停线时降低账号被选择的优先级，进一步减少保护带账号继续被高频调度的概率。

### 系统设置与数据库

- `system_settings` 增加 `auto_pause_5h_guard_band_percent` 和 `auto_pause_5h_guard_concurrency` 相关配置。
- PostgreSQL / SQLite migration 补齐新字段，保护带并发默认值为 `1`。
- 启动默认配置、PostBootstrap 默认配置、读取系统设置失败时的 fallback 默认配置均补齐保护带配置。
- Admin API 的读取、更新、校验、持久化和响应体均包含保护带配置。

### 管理后台

- `/admin/settings` 新增“5h 保护带(%)”配置项，用于设置提前多少个百分点开始保护。
- `/admin/settings` 新增“5h 保护带并发上限”配置项，用于设置进入保护带后的并发上限。
- “5h 保护带(%)”文案调整为更通俗的说明：当 5h 用量接近自动暂停线时提前降并发，减慢额度消耗。
- 占位保持与其他参数一致：`留空或 0 表示不启用`。
- 中英文 i18n 文案同步更新。

### 其他修复

- 补齐 `UpdateSettings` 响应中的 `BillingTierPolicy` 字段，避免保存设置后前端状态回退。
- 修复保护带调度分测试中的浮点严格相等断言，改为容差比较，避免 CI 因极小浮点误差失败。

## 前后对比分析

- 问题场景：当 5h 阈值为 `90%` 且使用量刷新存在约 5 分钟间隔时，账号可能在刷新间隔内继续高并发消耗，下一次刷新直接到 `100%`。
- 新行为：保护带会在达到自动暂停阈值前提前介入，通过降低并发和调度优先级减慢额度消耗。
- 可配置性：部署方可配置提前保护的百分点，并根据账号池规模和额度策略，把保护带内并发调整为 1、2、3 等值，也可以设置为 0 关闭保护带降并发。
- 算法一致性：普通动态并发、快速调度器、调度分降权都围绕同一套保护带配置生效，避免不同调度路径结果不一致。
- 风险控制：保护带并发只会收缩账号原有并发，不会提高账号原本的动态并发上限。
- 行为边界：保护带只影响接近 5h 自动暂停线之前的降速阶段，不改变达到阈值后的自动暂停判断。
- 影响范围：涉及数据库迁移、系统设置读写、运行时 Store、账号动态并发计算、快速调度器、Admin API、前端设置页和测试用例。

## 测试情况

已执行并通过：

```bash
go test ./auth
go test ./database ./admin
npm --prefix frontend ci
npm --prefix frontend run typecheck
go test ./...
```

结果：

- `go test ./auth`：通过
- `go test ./database ./admin`：通过
- `npm --prefix frontend ci`：依赖安装成功，0 vulnerabilities
- `npm --prefix frontend run typecheck`：通过
- `go test ./...`：通过

PR checks 已通过：

- CodeRabbit：通过
- backend-security：通过
- frontend：通过
- frontend-security：通过
- golangci-lint：通过
- test：通过

## 修改总结

本次变更针对“5h 使用量刷新存在间隔，账号可能在阈值附近继续快速消耗并直接冲到 100%”的问题，增加了 5h 保护带算法控制。账号接近 5h 自动暂停线时会提前进入降速阶段，通过降低并发和调度优先级减慢额度消耗；同时保护带触发百分点和保护带内并发上限支持系统配置，默认并发 1 提供保守保护，也允许不同部署按实际情况调整或关闭保护带降并发。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
- Added 5h auto-pause guard band configuration settings (guard band percentage: 0-100, concurrency cap) to the admin API.
- Extended Settings page with input controls for configuring guard band parameters.

**Localization**
- Added English and Chinese translations for the new guard band configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->