### PR TITLE
fix: 优化 Prompt Filter 命中日志上下文展示

### DIFF
--- a/admin/prompt_filter.go
+++ b/admin/prompt_filter.go
@@ -65,7 +65,7 @@ func (h *Handler) inspectImagePromptFilter(c *gin.Context, text string, model st
 	if verdict.Action != promptfilter.ActionBlock {
 		return false
 	}
-	textPreview := verdict.TextPreview
+	textPreview := promptfilter.RedactedPreview(verdict.TextPreview, 500)
 	if redactPreview {
 		textPreview = "[redacted]"
 	}

--- a/auth/store.go
+++ b/auth/store.go
@@ -4757,6 +4757,49 @@ func (s *Store) PersistUsageSnapshot(acc *Account, pct7d float64) {
 	}
 }
 
+// UpdateAccountSubscriptionExpiresAt persists the latest subscription expiration observed from upstream.
+func (s *Store) UpdateAccountSubscriptionExpiresAt(acc *Account, expiresAt time.Time) bool {
+	if s == nil || acc == nil || expiresAt.IsZero() {
+		return false
+	}
+
+	acc.mu.Lock()
+	changed := acc.SubscriptionExpiresAt.IsZero() || !acc.SubscriptionExpiresAt.Equal(expiresAt)
+	if changed {
+		acc.SubscriptionExpiresAt = expiresAt
+		acc.recomputeSchedulerLocked(atomic.LoadInt64(&s.maxConcurrency))
+	}
+	acc.mu.Unlock()
+	if changed {
+		s.fastSchedulerUpdate(acc)
+	}
+
+	if s.db == nil {
+		return changed
+	}
+
+	formatted := expiresAt.Format(time.RFC3339)
+	if !changed {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		row, err := s.db.GetAccountByID(ctx, acc.DBID)
+		if err != nil {
+			log.Printf("[账号 %d] 读取 subscription_expires_at 失败: %v", acc.DBID, err)
+			return changed
+		}
+		if row.GetCredential("subscription_expires_at") == formatted {
+			return changed
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := s.db.UpdateCredentials(ctx, acc.DBID, map[string]interface{}{"subscription_expires_at": formatted}); err != nil {
+		log.Printf("[账号 %d] 持久化 subscription_expires_at 失败: %v", acc.DBID, err)
+	}
+	return changed
+}
+
 // UpdateAccountPlanType persists the latest Codex plan type observed from upstream headers.
 func (s *Store) UpdateAccountPlanType(acc *Account, planType string) bool {
 	if s == nil || acc == nil {

--- a/frontend/src/pages/PromptFilter.tsx
+++ b/frontend/src/pages/PromptFilter.tsx
@@ -37,6 +37,8 @@ import {
 import { cn } from '@/lib/utils'
 
 const PROMPT_FILTER_VIEWS = ['overview', 'logs', 'rules'] as const
+const HIT_START_MARKER = '⟦PF_HIT⟧'
+const HIT_END_MARKER = '⟦/PF_HIT⟧'
 type PromptFilterView = typeof PROMPT_FILTER_VIEWS[number]
 
 type PromptFilterForm = Pick<
@@ -1067,15 +1069,15 @@ function PromptFilterLogsTable({ logs, compact = false }: { logs: PromptFilterLo
   const { t } = useTranslation()
   return (
     <div className="rounded-lg border border-border">
-      <Table>
+      <Table className="table-fixed">
         <TableHeader>
           <TableRow>
-            <TableHead>{t('promptFilter.colTime')}</TableHead>
-            <TableHead>{t('promptFilter.colAction')}</TableHead>
-            <TableHead>{t('promptFilter.colEndpoint')}</TableHead>
-            <TableHead>{t('promptFilter.colScore')}</TableHead>
-            <TableHead>{t('promptFilter.colMatch')}</TableHead>
-            <TableHead>{t('promptFilter.colApiKey')}</TableHead>
+            <TableHead className={compact ? 'w-[92px]' : 'w-[150px]'}>{t('promptFilter.colTime')}</TableHead>
+            <TableHead className={compact ? 'w-[82px]' : 'w-[96px]'}>{t('promptFilter.colAction')}</TableHead>
+            <TableHead className={compact ? 'w-[150px]' : 'w-[180px]'}>{t('promptFilter.colEndpoint')}</TableHead>
+            <TableHead className={compact ? 'w-[72px]' : 'w-[88px]'}>{t('promptFilter.colScore')}</TableHead>
+            <TableHead className={compact ? 'w-[150px]' : 'w-[220px]'}>{t('promptFilter.colMatch')}</TableHead>
+            <TableHead className={compact ? 'w-[118px]' : 'w-[160px]'}>{t('promptFilter.colApiKey')}</TableHead>
             <TableHead>{t('promptFilter.colPreview')}</TableHead>
           </TableRow>
         </TableHeader>
@@ -1172,10 +1174,104 @@ function VerdictPanel({ verdict }: { verdict: PromptFilterVerdict }) {
         </div>
       ) : null}
       {verdict.text_preview ? (
-        <pre className="mt-3 max-h-28 overflow-auto rounded-md bg-background p-2 text-xs leading-5 text-muted-foreground">{verdict.text_preview}</pre>
+        <pre className="mt-3 max-h-28 overflow-auto rounded-md bg-background p-2 text-xs leading-5 text-muted-foreground"><HighlightedPromptPreview text={verdict.text_preview} /></pre>
       ) : null}
     </div>
   )
+}
+
+function HighlightedPromptPreview({ text, className }: { text: string; className?: string }) {
+  const parts = parseHitMarkedText(text)
+  return <HighlightedParts parts={parts} className={className} />
+}
+
+function HighlightedPromptText({ text, terms, className }: { text: string; terms: string[]; className?: string }) {
+  return <HighlightedParts parts={splitTextByHitTerms(text, terms)} className={className} />
+}
+
+function HighlightedParts({ parts, className }: { parts: Array<{ text: string; hit: boolean }>; className?: string }) {
+  return (
+    <span className={className}>
+      {parts.map((part, index) => part.hit ? (
+        <mark key={index} className="rounded bg-amber-200 px-1 py-0.5 font-medium text-amber-950 dark:bg-amber-400/25 dark:text-amber-100">
+          {part.text}
+        </mark>
+      ) : <span key={index}>{part.text}</span>)}
+    </span>
+  )
+}
+
+function parseHitMarkedText(text: string): Array<{ text: string; hit: boolean }> {
+  const parts: Array<{ text: string; hit: boolean }> = []
+  let cursor = 0
+  while (cursor < text.length) {
+    const start = text.indexOf(HIT_START_MARKER, cursor)
+    if (start < 0) {
+      parts.push({ text: text.slice(cursor), hit: false })
+      break
+    }
+    const end = text.indexOf(HIT_END_MARKER, start + HIT_START_MARKER.length)
+    if (end < 0) {
+      parts.push({ text: text.slice(cursor), hit: false })
+      break
+    }
+    if (start > cursor) {
+      parts.push({ text: text.slice(cursor, start), hit: false })
+    }
+    parts.push({ text: text.slice(start + HIT_START_MARKER.length, end), hit: true })
+    cursor = end + HIT_END_MARKER.length
+  }
+  return parts.length ? parts : [{ text, hit: false }]
+}
+
+function extractHitTerms(text: string): string[] {
+  const terms: string[] = []
+  for (const part of parseHitMarkedText(text)) {
+    const term = stripHitMarkers(part.text).trim()
+    if (part.hit && term && !terms.some((existing) => existing.toLowerCase() === term.toLowerCase())) {
+      terms.push(term)
+    }
+  }
+  return terms
+}
+
+function splitTextByHitTerms(text: string, terms: string[]): Array<{ text: string; hit: boolean }> {
+  const normalizedTerms = terms
+    .map((term) => term.trim())
+    .filter((term) => term.length > 0)
+    .sort((a, b) => b.length - a.length)
+  if (text === '' || normalizedTerms.length === 0) {
+    return [{ text, hit: false }]
+  }
+
+  const lowerText = text.toLowerCase()
+  const parts: Array<{ text: string; hit: boolean }> = []
+  let cursor = 0
+  while (cursor < text.length) {
+    let bestIndex = -1
+    let bestTerm = ''
+    for (const term of normalizedTerms) {
+      const index = lowerText.indexOf(term.toLowerCase(), cursor)
+      if (index >= 0 && (bestIndex < 0 || index < bestIndex || (index === bestIndex && term.length > bestTerm.length))) {
+        bestIndex = index
+        bestTerm = term
+      }
+    }
+    if (bestIndex < 0) {
+      parts.push({ text: text.slice(cursor), hit: false })
+      break
+    }
+    if (bestIndex > cursor) {
+      parts.push({ text: text.slice(cursor, bestIndex), hit: false })
+    }
+    parts.push({ text: text.slice(bestIndex, bestIndex + bestTerm.length), hit: true })
+    cursor = bestIndex + bestTerm.length
+  }
+  return parts.length ? parts : [{ text, hit: false }]
+}
+
+function stripHitMarkers(text: string): string {
+  return text.split(HIT_START_MARKER).join('').split(HIT_END_MARKER).join('')
 }
 
 function MiniStat({ label, value }: { label: string; value: string }) {
@@ -1193,10 +1289,11 @@ function PromptFilterLogRow({ log, compact }: { log: PromptFilterLog; compact?: 
   const [expanded, setExpanded] = useState(false)
   const fullText = (log.full_text || '').trim()
   const hasFull = fullText.length > 0
+  const hitTerms = extractHitTerms(log.text_preview || '')
   return (
     <>
     <TableRow>
-      <TableCell className="min-w-[150px]">
+      <TableCell className={compact ? 'w-[92px] min-w-0' : 'w-[150px] min-w-0'}>
         <div className="font-medium text-foreground">{formatRelativeTime(log.created_at, { variant: 'compact' })}</div>
         {!compact ? <div className="text-xs text-muted-foreground">{formatBeijingTime(log.created_at)}</div> : null}
       </TableCell>
@@ -1208,14 +1305,14 @@ function PromptFilterLogRow({ log, compact }: { log: PromptFilterLog; compact?: 
         </div>
       </TableCell>
       <TableCell>
-        <div className="font-mono text-xs text-foreground">{log.endpoint || '-'}</div>
-        <div className="font-mono text-xs text-muted-foreground">{log.model || '-'}</div>
+        <div className="truncate font-mono text-xs text-foreground">{log.endpoint || '-'}</div>
+        <div className="truncate font-mono text-xs text-muted-foreground">{log.model || '-'}</div>
       </TableCell>
       <TableCell>
         <span className="font-semibold">{log.score}</span>
         <span className="text-muted-foreground"> / {log.threshold}</span>
       </TableCell>
-      <TableCell className="max-w-[220px]">
+      <TableCell className={compact ? 'w-[150px] min-w-0' : 'w-[220px] min-w-0'}>
         {matches.length ? (
           <div className="flex flex-wrap gap-1">
             {matches.slice(0, 3).map((match, index) => <Badge key={`${match.name}-${index}`} variant="outline">{match.name}</Badge>)}
@@ -1224,11 +1321,11 @@ function PromptFilterLogRow({ log, compact }: { log: PromptFilterLog; compact?: 
         ) : <span className="text-muted-foreground">-</span>}
       </TableCell>
       <TableCell>
-        <div className="max-w-[160px] truncate">{log.api_key_name || log.api_key_masked || '-'}</div>
+        <div className={compact ? 'max-w-[110px] truncate' : 'max-w-[160px] truncate'}>{log.api_key_name || log.api_key_masked || '-'}</div>
         {!compact && log.client_ip ? <div className="text-xs text-muted-foreground">{log.client_ip}</div> : null}
       </TableCell>
-      <TableCell className="max-w-[360px]">
-        <div className="truncate text-muted-foreground" title={log.text_preview || log.error_code || log.review_error || ''}>{log.text_preview || log.error_code || log.review_error || '-'}</div>
+      <TableCell className="min-w-0">
+        <div className="truncate text-muted-foreground" title={stripHitMarkers(log.text_preview || log.error_code || log.review_error || '')}>{log.text_preview ? <HighlightedPromptPreview text={log.text_preview} /> : (log.error_code || log.review_error || '-')}</div>
         {hasFull ? (
           <button
             type="button"
@@ -1255,7 +1352,7 @@ function PromptFilterLogRow({ log, compact }: { log: PromptFilterLog; compact?: 
               {t('common.copy')}
             </button>
           </div>
-          <pre className="max-h-80 overflow-auto whitespace-pre-wrap break-words rounded-md border border-border bg-background p-3 text-xs leading-relaxed text-foreground">{fullText}</pre>
+          <pre className="max-h-80 overflow-auto whitespace-pre-wrap break-words rounded-md border border-border bg-background p-3 text-xs leading-relaxed text-foreground"><HighlightedPromptText text={fullText} terms={hitTerms} /></pre>
         </TableCell>
       </TableRow>
     ) : null}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -732,8 +732,8 @@ export interface SetupHintsResponse {
 export interface PromptFilterMatch {
   name: string
   weight: number
-  category: string
-  strict: boolean
+  category?: string
+  strict?: boolean
 }
 
 export interface PromptFilterVerdict {
@@ -745,8 +745,8 @@ export interface PromptFilterVerdict {
   threshold: number
   strict_hit: boolean
   matched: PromptFilterMatch[]
-  text_preview: string
-  reason: string
+  text_preview?: string
+  reason?: string
   extracted_chars: number
   reviewed?: boolean
   review_flagged?: boolean

--- a/proxy/prompt_filter.go
+++ b/proxy/prompt_filter.go
@@ -13,8 +13,7 @@ import (
 	"github.com/tidwall/gjson"
 )
 
-// promptFilterFullTextMaxRunes 限制被拦截请求记录的完整文本长度（按字符截断），
-// 避免单条日志过大撑爆数据库；80KB 提取上限下取 ~32K 字符足够定位问题。
+// promptFilterFullTextMaxRunes limits the persisted redacted blocked-request text preview.
 const promptFilterFullTextMaxRunes = 32000
 
 func (h *Handler) inspectPromptFilterOpenAI(c *gin.Context, rawBody []byte, endpoint string, model string) bool {
@@ -109,17 +108,17 @@ func (h *Handler) logPromptFilterVerdict(c *gin.Context, endpoint string, model 
 		Score:           verdict.Score,
 		Threshold:       verdict.Threshold,
 		MatchedPatterns: promptfilter.MatchesJSON(verdict.Matched),
-		TextPreview:     verdict.TextPreview,
+		TextPreview:     promptfilter.RedactedPreview(verdict.TextPreview, 500),
 		ClientIP:        c.ClientIP(),
 		ErrorCode:       errorCode,
 		ReviewModel:     verdict.ReviewModel,
 		ReviewFlagged:   verdict.ReviewFlagged,
 		ReviewError:     verdict.ReviewError,
 	}
-	// 被拦截（block）的请求记录完整检查文本，便于排查到底是什么触发了拦截
-	// （预览只有 500 字往往看不出内容）；放行/告警仍只存预览以控制存储。
+	// 被拦截（block）的请求仅记录脱敏后的检查文本预览，便于排查触发原因，
+	// 同时避免把 Authorization/API Key/token 等敏感值持久化到日志。
 	if verdict.Action == promptfilter.ActionBlock {
-		input.FullText = promptfilter.Preview(verdict.FullText, promptFilterFullTextMaxRunes)
+		input.FullText = promptfilter.RedactedPreview(verdict.FullText, promptFilterFullTextMaxRunes)
 	}
 	populatePromptFilterAPIKeyMeta(c, input)
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
@@ -143,9 +142,9 @@ func (h *Handler) logUpstreamCyberPolicy(c *gin.Context, endpoint string, model 
 		Score:     0,
 		Threshold: cfg.Threshold,
 		Reason:    "upstream returned cyber policy",
-		// 上游 cyber_policy 没有本地提取文本，把上游错误体作为「详细内容」记录，
-		// 方便在日志里看清触发详情。
-		FullText: string(body),
+		// 上游 cyber_policy 没有本地提取文本，把脱敏后的上游错误体作为「详细内容」记录，
+		// 方便在日志里看清触发详情，同时避免持久化敏感字段。
+		FullText: promptfilter.RedactSensitive(string(body)),
 	}
 	h.logPromptFilterVerdict(c, endpoint, model, "upstream_cyber_policy", errorCode, verdict)
 }

--- a/proxy/usage_wham.go
+++ b/proxy/usage_wham.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -34,6 +35,12 @@ type WhamUsage struct {
 	Email     string `json:"email"`
 	PlanType  string `json:"plan_type"`
 
+	// OpenAI 续费后 JWT 里的 chatgpt_subscription_active_until 不一定会立即随授权刷新，
+	// wham/usage 返回的服务端当前订阅到期时间用于同步管理端展示与调度权重。
+	SubscriptionExpiresAtRaw          whamTimeRaw `json:"subscription_expires_at,omitempty"`
+	SubscriptionActiveUntilRaw        whamTimeRaw `json:"subscription_active_until,omitempty"`
+	ChatGPTSubscriptionActiveUntilRaw whamTimeRaw `json:"chatgpt_subscription_active_until,omitempty"`
+
 	RateLimit struct {
 		Allowed         bool             `json:"allowed"`
 		LimitReached    bool             `json:"limit_reached"`
@@ -60,6 +67,64 @@ type WhamUsage struct {
 	RateLimitResetCredits *struct {
 		AvailableCount int `json:"available_count"`
 	} `json:"rate_limit_reset_credits,omitempty"`
+}
+
+type whamTimeRaw string
+
+func (w *whamTimeRaw) UnmarshalJSON(data []byte) error {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		*w = ""
+		return nil
+	}
+	var s string
+	if err := json.Unmarshal(trimmed, &s); err == nil {
+		*w = whamTimeRaw(s)
+		return nil
+	}
+	var n json.Number
+	if err := json.Unmarshal(trimmed, &n); err == nil {
+		*w = whamTimeRaw(n.String())
+		return nil
+	}
+	return nil
+}
+
+func (w *WhamUsage) SubscriptionExpiresAt() time.Time {
+	if w == nil {
+		return time.Time{}
+	}
+	for _, raw := range []whamTimeRaw{
+		w.SubscriptionExpiresAtRaw,
+		w.SubscriptionActiveUntilRaw,
+		w.ChatGPTSubscriptionActiveUntilRaw,
+	} {
+		if t := parseWhamTime(string(raw)); !t.IsZero() {
+			return t
+		}
+	}
+	return time.Time{}
+}
+
+func parseWhamTime(raw string) time.Time {
+	s := strings.TrimSpace(raw)
+	if s == "" {
+		return time.Time{}
+	}
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t
+	}
+	if t, err := time.Parse(time.RFC3339Nano, s); err == nil {
+		return t
+	}
+	if unix, err := strconv.ParseInt(s, 10, 64); err == nil && unix > 0 {
+		// 兼容秒级与毫秒级 unix 时间戳。
+		if unix > 1_000_000_000_000 {
+			return time.UnixMilli(unix)
+		}
+		return time.Unix(unix, 0)
+	}
+	return time.Time{}
 }
 
 // WhamUsageWindow 是单个限流窗口（primary=5h，secondary=7d）。
@@ -235,6 +300,9 @@ func ApplyWhamUsage(store *auth.Store, account *auth.Account, usage *WhamUsage) 
 
 	if store != nil && usage.PlanType != "" {
 		store.UpdateAccountPlanType(account, usage.PlanType)
+	}
+	if store != nil {
+		store.UpdateAccountSubscriptionExpiresAt(account, usage.SubscriptionExpiresAt())
 	}
 
 	// 记录「主动重置次数」（OpenAI 官方剩余的手动重置额度次数）。

--- a/proxy/usage_wham_test.go
+++ b/proxy/usage_wham_test.go
@@ -21,6 +21,7 @@ func TestQueryWhamUsage_ParsesPlusAccountResponse(t *testing.T) {
 		"account_id": "user-abc",
 		"email": "rundown_consist_3o@icloud.com",
 		"plan_type": "plus",
+		"subscription_expires_at": "2026-07-17T09:30:23Z",
 		"rate_limit": {
 			"allowed": true,
 			"limit_reached": false,
@@ -79,6 +80,10 @@ func TestQueryWhamUsage_ParsesPlusAccountResponse(t *testing.T) {
 	if usage.PlanType != "plus" {
 		t.Errorf("PlanType = %q, want plus", usage.PlanType)
 	}
+	wantSubscriptionExpiresAt := time.Date(2026, 7, 17, 9, 30, 23, 0, time.UTC)
+	if got := usage.SubscriptionExpiresAt(); !got.Equal(wantSubscriptionExpiresAt) {
+		t.Errorf("SubscriptionExpiresAt() = %s, want %s", got.Format(time.RFC3339), wantSubscriptionExpiresAt.Format(time.RFC3339))
+	}
 	if usage.RateLimit.PrimaryWindow == nil || usage.RateLimit.PrimaryWindow.UsedPercent != 83 {
 		t.Errorf("primary used_percent = %+v, want 83", usage.RateLimit.PrimaryWindow)
 	}
@@ -108,6 +113,7 @@ func TestApplyWhamUsage_PersistsPlanAnd5h7d(t *testing.T) {
 	reset5h := now.Add(3 * time.Hour).Unix()
 	reset7d := now.Add(5 * 24 * time.Hour).Unix()
 	usage := &WhamUsage{PlanType: "plus"}
+	usage.SubscriptionExpiresAtRaw = whamTimeRaw("2026-07-17T09:30:23Z")
 	usage.RateLimit.PrimaryWindow = &WhamUsageWindow{UsedPercent: 83, LimitWindowSeconds: 18000, ResetAt: reset5h}
 	usage.RateLimit.SecondaryWindow = &WhamUsageWindow{UsedPercent: 30, LimitWindowSeconds: 604800, ResetAt: reset7d}
 
@@ -132,6 +138,84 @@ func TestApplyWhamUsage_PersistsPlanAnd5h7d(t *testing.T) {
 	}
 	if got := row.GetCredential("plan_type"); got != "plus" {
 		t.Errorf("persisted plan_type = %q, want plus", got)
+	}
+	wantSubscriptionExpiresAt := time.Date(2026, 7, 17, 9, 30, 23, 0, time.UTC)
+	if !account.SubscriptionExpiresAt.Equal(wantSubscriptionExpiresAt) {
+		t.Errorf("account SubscriptionExpiresAt = %s, want %s", account.SubscriptionExpiresAt.Format(time.RFC3339), wantSubscriptionExpiresAt.Format(time.RFC3339))
+	}
+	if got := row.GetCredential("subscription_expires_at"); got != wantSubscriptionExpiresAt.Format(time.RFC3339) {
+		t.Errorf("persisted subscription_expires_at = %q, want %q", got, wantSubscriptionExpiresAt.Format(time.RFC3339))
+	}
+}
+
+func TestApplyWhamUsage_PersistsSubscriptionExpiresAtWhenMemoryAlreadyMatches(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "codex2api.db")
+	db, err := database.New("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("database.New: %v", err)
+	}
+	defer db.Close()
+
+	id, err := db.InsertAccountWithCredentials(ctx, "wham-subscription-retry", map[string]interface{}{"plan_type": "plus"}, "")
+	if err != nil {
+		t.Fatalf("InsertAccountWithCredentials: %v", err)
+	}
+
+	store := auth.NewStore(db, nil, &database.SystemSettings{MaxConcurrency: 2, TestConcurrency: 1, TestModel: "gpt-5.4"})
+	expiresAt := time.Date(2026, 7, 17, 9, 30, 23, 0, time.UTC)
+	account := &auth.Account{DBID: id, AccessToken: "at", PlanType: "plus", AccountID: "acc", SubscriptionExpiresAt: expiresAt}
+	usage := &WhamUsage{PlanType: "plus"}
+	usage.SubscriptionExpiresAtRaw = whamTimeRaw(expiresAt.Format(time.RFC3339))
+
+	ApplyWhamUsage(store, account, usage)
+
+	row, err := db.GetAccountByID(ctx, id)
+	if err != nil {
+		t.Fatalf("GetAccountByID: %v", err)
+	}
+	if got := row.GetCredential("subscription_expires_at"); got != expiresAt.Format(time.RFC3339) {
+		t.Fatalf("persisted subscription_expires_at = %q, want %q", got, expiresAt.Format(time.RFC3339))
+	}
+}
+
+func TestWhamUsageSubscriptionExpiresAtFallbacks(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want time.Time
+	}{
+		{
+			name: "subscription_active_until",
+			body: `{"subscription_active_until":"2026-07-17T09:30:23.123Z"}`,
+			want: time.Date(2026, 7, 17, 9, 30, 23, 123000000, time.UTC),
+		},
+		{
+			name: "chatgpt_subscription_active_until",
+			body: `{"chatgpt_subscription_active_until":"2026-07-17T09:30:23Z"}`,
+			want: time.Date(2026, 7, 17, 9, 30, 23, 0, time.UTC),
+		},
+		{
+			name: "unix_seconds",
+			body: `{"subscription_expires_at":1784280623}`,
+			want: time.Unix(1784280623, 0),
+		},
+		{
+			name: "unix_milliseconds",
+			body: `{"subscription_expires_at":1784280623000}`,
+			want: time.UnixMilli(1784280623000),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var usage WhamUsage
+			if err := json.Unmarshal([]byte(tc.body), &usage); err != nil {
+				t.Fatalf("json.Unmarshal: %v", err)
+			}
+			if got := usage.SubscriptionExpiresAt(); !got.Equal(tc.want) {
+				t.Fatalf("SubscriptionExpiresAt() = %s, want %s", got.Format(time.RFC3339Nano), tc.want.Format(time.RFC3339Nano))
+			}
+		})
 	}
 }
 
@@ -343,6 +427,7 @@ func TestWhamUsageJSON_RoundTrip(t *testing.T) {
 func TestQueryWhamUsage_ParsesRateLimitResetCredits(t *testing.T) {
 	body := `{
 		"plan_type": "plus",
+		"subscription_expires_at": "2026-07-17T09:30:23Z",
 		"rate_limit": {"allowed": true},
 		"rate_limit_reset_credits": {"available_count": 4}
 	}`

--- a/security/promptfilter/filter.go
+++ b/security/promptfilter/filter.go
@@ -26,6 +26,8 @@ const (
 	DefaultMaxTextLength   = 80 * 1024
 	defaultHeadScanLength  = 64 * 1024
 	defaultTailScanLength  = 16 * 1024
+	HitStartMarker         = "⟦PF_HIT⟧"
+	HitEndMarker           = "⟦/PF_HIT⟧"
 )
 
 type Config struct {
@@ -292,6 +294,19 @@ func (e *Engine) InspectText(text string) Verdict {
 		return verdict
 	}
 
+	matchContexts := make([]string, 0, 3)
+	recordContext := func(context string) {
+		context = strings.TrimSpace(context)
+		if context == "" || len(matchContexts) >= 3 {
+			return
+		}
+		for _, existing := range matchContexts {
+			if existing == context {
+				return
+			}
+		}
+		matchContexts = append(matchContexts, context)
+	}
 	matchesByName := map[string]Match{}
 	rawScore := 0
 	strictScore := 0
@@ -300,18 +315,22 @@ func (e *Engine) InspectText(text string) Verdict {
 			continue
 		}
 		if strings.Contains(scanText, word) {
-			match := Match{Name: "sensitive_word:" + word, Weight: 100, Category: "sensitive_word", Strict: true}
-			matchesByName[match.Name] = match
+			match := Match{Name: "sensitive_word", Weight: 100, Category: "sensitive_word", Strict: true}
+			_, context := matchContextFromLiteral(scanText, word)
+			recordContext(context)
+			matchesByName[match.Name+":"+word] = match
 		}
 	}
 	for _, pattern := range e.patterns {
-		if pattern.re.MatchString(scanText) {
+		if loc := pattern.re.FindStringIndex(scanText); loc != nil {
 			match := Match{
 				Name:     pattern.cfg.Name,
 				Weight:   pattern.cfg.Weight,
 				Category: pattern.cfg.Category,
 				Strict:   pattern.cfg.Strict,
 			}
+			_, context := regexMatchContext(scanText, loc)
+			recordContext(context)
 			matchesByName[match.Name] = match
 		}
 	}
@@ -359,6 +378,9 @@ func (e *Engine) InspectText(text string) Verdict {
 	if len(matches) > 0 {
 		verdict.Reason = reasonForVerdict(action, score, cfg.Threshold, matches)
 	}
+	if len(matchContexts) > 0 {
+		verdict.TextPreview = strings.Join(matchContexts, "\n---\n")
+	}
 	return verdict
 }
 
@@ -405,6 +427,101 @@ func Preview(text string, maxRunes int) string {
 	return string(runes[:maxRunes]) + "..."
 }
 
+func RedactedPreview(text string, maxRunes int) string {
+	return Preview(RedactSensitive(text), maxRunes)
+}
+
+func RedactSensitive(text string) string {
+	if text == "" {
+		return ""
+	}
+	redacted := text
+	for _, pattern := range sensitiveRedactionPatterns {
+		redacted = pattern.re.ReplaceAllString(redacted, pattern.replacement)
+	}
+	return redacted
+}
+
+func matchContextFromLiteral(text string, literal string) (string, string) {
+	start := strings.Index(text, literal)
+	if start < 0 {
+		return "", ""
+	}
+	return matchContext(text, start, start+len(literal))
+}
+
+func regexMatchContext(text string, loc []int) (string, string) {
+	if len(loc) != 2 {
+		return "", ""
+	}
+	return matchContext(text, loc[0], loc[1])
+}
+
+func matchContext(text string, start int, end int) (string, string) {
+	if start < 0 || end < start || start > len(text) {
+		return "", ""
+	}
+	if end > len(text) {
+		end = len(text)
+	}
+	sample := RedactedPreview(text[start:end], 120)
+	contextStart := byteOffsetBefore(text, start, 80)
+	contextEnd := byteOffsetAfter(text, end, 80)
+	rawContext := strings.TrimSpace(text[contextStart:contextEnd])
+	redactedContext := RedactSensitive(rawContext)
+	if redactedContext != rawContext {
+		if contextStart > 0 {
+			redactedContext = "..." + redactedContext
+		}
+		return sample, redactedContext
+	}
+
+	before := strings.TrimSpace(text[contextStart:start])
+	hit := text[start:end]
+	after := strings.TrimSpace(text[end:contextEnd])
+	parts := make([]string, 0, 3)
+	if before != "" {
+		parts = append(parts, before)
+	}
+	parts = append(parts, HitStartMarker+hit+HitEndMarker)
+	if after != "" {
+		parts = append(parts, after)
+	}
+	context := strings.Join(parts, " ")
+	if contextStart > 0 {
+		context = "..." + context
+	}
+	return sample, context
+}
+
+func byteOffsetBefore(text string, start int, maxRunes int) int {
+	if start <= 0 || maxRunes <= 0 {
+		return start
+	}
+	offsets := make([]int, 0, maxRunes+1)
+	for idx := range text[:start] {
+		offsets = append(offsets, idx)
+	}
+	if len(offsets) <= maxRunes {
+		return 0
+	}
+	return offsets[len(offsets)-maxRunes]
+}
+
+func byteOffsetAfter(text string, end int, maxRunes int) int {
+	if end >= len(text) || maxRunes <= 0 {
+		return end
+	}
+	count := 0
+	for idx := range text[end:] {
+		if count >= maxRunes {
+			return end + idx
+		}
+		count++
+	}
+	return len(text)
+}
+
 func MatchesJSON(matches []Match) string {
 	if len(matches) == 0 {
 		return "[]"
@@ -426,15 +543,23 @@ func collectGJSONText(result gjson.Result, parts *[]string) {
 			collectGJSONText(item, parts)
 		}
 	case result.IsObject():
-		if t := strings.TrimSpace(result.Get("text").String()); t != "" {
-			*parts = append(*parts, t)
+		if textValue := result.Get("text"); textValue.Type == gjson.String {
+			if t := strings.TrimSpace(textValue.String()); t != "" {
+				*parts = append(*parts, t)
+			}
 		}
-		if t := strings.TrimSpace(result.Get("content").String()); t != "" {
-			*parts = append(*parts, t)
+		if contentValue := result.Get("content"); contentValue.Exists() {
+			if contentValue.Type == gjson.String {
+				if t := strings.TrimSpace(contentValue.String()); t != "" {
+					*parts = append(*parts, t)
+				}
+			} else {
+				collectGJSONText(contentValue, parts)
+			}
 		}
 		result.ForEach(func(key, value gjson.Result) bool {
-			switch key.String() {
-			case "image_url", "file_id", "result":
+			switch strings.ToLower(key.String()) {
+			case "text", "content", "image_url", "url", "file_id", "result", "data", "b64_json", "source", "file", "type", "role":
 				return true
 			}
 			collectGJSONText(value, parts)
@@ -526,7 +651,34 @@ func limitScanText(text string, maxLen int) string {
 	if tail > len(text)-head {
 		tail = len(text) - head
 	}
-	return text[:head] + "\n" + text[len(text)-tail:]
+	return safeUTF8Prefix(text, head) + "\n" + safeUTF8Suffix(text, tail)
+}
+
+func safeUTF8Prefix(text string, maxBytes int) string {
+	if maxBytes <= 0 {
+		return ""
+	}
+	if maxBytes >= len(text) {
+		return text
+	}
+	for maxBytes > 0 && !utf8.ValidString(text[:maxBytes]) {
+		maxBytes--
+	}
+	return text[:maxBytes]
+}
+
+func safeUTF8Suffix(text string, maxBytes int) string {
+	if maxBytes <= 0 {
+		return ""
+	}
+	if maxBytes >= len(text) {
+		return text
+	}
+	start := len(text) - maxBytes
+	for start < len(text) && !utf8.RuneStart(text[start]) {
+		start++
+	}
+	return text[start:]
 }
 
 func defensiveContextDiscount(text string) int {

--- a/security/promptfilter/filter_test.go
+++ b/security/promptfilter/filter_test.go
@@ -3,6 +3,7 @@ package promptfilter
 import (
 	"strings"
 	"testing"
+	"unicode/utf8"
 )
 
 func testConfig(mode string) Config {
@@ -139,6 +140,44 @@ func TestExtractTextResponses(t *testing.T) {
 	}
 	if !strings.Contains(got, "SQL injection prevention") {
 		t.Fatalf("ExtractText = %q, want prompt text", got)
+	}
+}
+
+func TestExtractTextSkipsMultimodalNonTextFields(t *testing.T) {
+	body := []byte(`{"messages":[{"role":"user","content":[{"type":"text","text":"Explain DDoS detection"},{"type":"image_url","image_url":{"url":"https://private.example/secret.png"}},{"type":"input_image","source":{"type":"base64","data":"BASE64SECRET"}}]}]}`)
+	got := ExtractText(body, "/v1/messages", DefaultMaxTextLength)
+	if !strings.Contains(got, "Explain DDoS detection") {
+		t.Fatalf("ExtractText = %q, want text content", got)
+	}
+	for _, leaked := range []string{"private.example", "secret.png", "BASE64SECRET"} {
+		if strings.Contains(got, leaked) {
+			t.Fatalf("ExtractText leaked non-text field %q in %q", leaked, got)
+		}
+	}
+}
+
+func TestLimitScanTextPreservesUTF8(t *testing.T) {
+	text := strings.Repeat("界", 40000) + strings.Repeat("🙂", 1000) + "tail关键字"
+	got := limitScanText(text, 80*1024)
+	if !utf8.ValidString(got) {
+		t.Fatalf("limitScanText returned invalid UTF-8")
+	}
+	if !strings.Contains(got, "tail关键字") {
+		t.Fatalf("limitScanText lost tail content")
+	}
+}
+
+func TestSensitiveWordMatchDoesNotExposeWordInName(t *testing.T) {
+	cfg := testConfig(ModeBlock)
+	cfg.SensitiveWords = "customer-secret-keyword"
+	v := InspectText("please check customer-secret-keyword", cfg)
+	if len(v.Matched) == 0 {
+		t.Fatalf("matched = 0; verdict=%+v", v)
+	}
+	for _, match := range v.Matched {
+		if strings.Contains(match.Name, "customer-secret-keyword") {
+			t.Fatalf("match name leaked sensitive word: %+v", match)
+		}
 	}
 }
 

--- a/security/promptfilter/match_context_test.go
+++ b/security/promptfilter/match_context_test.go
@@ -1,0 +1,79 @@
+package promptfilter
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestInspectTextHighlightsNonSensitiveMatchContext(t *testing.T) {
+	cfg := testConfig(ModeBlock)
+	v := InspectText("Classify Codex ambient suggestion candidates for policy safety. Later text asks for a ddos attack plan.", cfg)
+	if len(v.Matched) == 0 {
+		t.Fatalf("matched = 0; verdict=%+v", v)
+	}
+	if !strings.Contains(v.TextPreview, HitStartMarker) || !strings.Contains(v.TextPreview, HitEndMarker) {
+		t.Fatalf("text_preview = %q, want hit markers", v.TextPreview)
+	}
+	if !strings.Contains(v.TextPreview, "ddos") {
+		t.Fatalf("text_preview = %q, want hit context containing ddos", v.TextPreview)
+	}
+}
+
+func TestInspectTextSkipsHighlightWhenContextContainsSensitiveData(t *testing.T) {
+	cfg := testConfig(ModeBlock)
+	v := InspectText("Classify Codex ambient suggestion candidates for policy safety. Authorization: Bearer sk-sensitive123456 Later text asks for a ddos attack plan.", cfg)
+	if len(v.Matched) == 0 {
+		t.Fatalf("matched = 0; verdict=%+v", v)
+	}
+	var found Match
+	for _, match := range v.Matched {
+		if match.Name == "ddos_attack" {
+			found = match
+			break
+		}
+	}
+	if found.Name == "" {
+		t.Fatalf("ddos_attack not found in matches: %+v", v.Matched)
+	}
+	if strings.Contains(v.TextPreview, "sk-sensitive123456") {
+		t.Fatalf("text_preview leaked API key: %q", v.TextPreview)
+	}
+	if strings.Contains(v.TextPreview, HitStartMarker) || strings.Contains(v.TextPreview, HitEndMarker) {
+		t.Fatalf("text_preview = %q, want no hit markers when sensitive data is present", v.TextPreview)
+	}
+	if !strings.Contains(v.TextPreview, "ddos") {
+		t.Fatalf("text_preview = %q, want hit context containing ddos", v.TextPreview)
+	}
+	if !strings.Contains(v.TextPreview, "[REDACTED]") && !strings.Contains(v.TextPreview, "[REDACTED_API_KEY]") {
+		t.Fatalf("text_preview = %q, want redaction marker", v.TextPreview)
+	}
+}
+
+func TestMatchesJSONDoesNotIncludeContextFields(t *testing.T) {
+	matches := []Match{{Name: "rule", Weight: 50, Category: "custom"}}
+	raw := MatchesJSON(matches)
+	var parsed []map[string]any
+	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+		t.Fatalf("MatchesJSON returned invalid JSON %q: %v", raw, err)
+	}
+	if len(parsed) != 1 {
+		t.Fatalf("parsed matches length = %d, want 1", len(parsed))
+	}
+	if _, ok := parsed[0]["sample"]; ok {
+		t.Fatalf("matched_patterns unexpectedly contains sample: %q", raw)
+	}
+	if _, ok := parsed[0]["context"]; ok {
+		t.Fatalf("matched_patterns unexpectedly contains context: %q", raw)
+	}
+}
+
+func TestRedactSensitiveMasksCommonSecrets(t *testing.T) {
+	input := `Authorization: Bearer sk-live123456 password="hunter2" api_key=sk-testabcdef email admin@example.com jwt eyJabc1234567890.eyJdef1234567890.sig1234567890`
+	got := RedactSensitive(input)
+	for _, leaked := range []string{"sk-live123456", "hunter2", "sk-testabcdef", "admin@example.com", "eyJabc1234567890.eyJdef1234567890.sig1234567890"} {
+		if strings.Contains(got, leaked) {
+			t.Fatalf("RedactSensitive leaked %q in %q", leaked, got)
+		}
+	}
+}

--- a/security/promptfilter/patterns.go
+++ b/security/promptfilter/patterns.go
@@ -71,6 +71,18 @@ var defaultPatternConfigs = []PatternConfig{
 	{Name: "social_media_hijack", Pattern: `(?i)\b(account\s+takeover|social\s+media\s+hijacking|credential\s+stuffing)\b|账号接管|撞库攻击`, Weight: 40, Category: "credential_attack"},
 }
 
+var sensitiveRedactionPatterns = []struct {
+	re          *regexp.Regexp
+	replacement string
+}{
+	{regexp.MustCompile(`(?i)\b(authorization\s*[:=]\s*(?:bearer|basic)\s+)[^\s,;]+`), `${1}[REDACTED]`},
+	{regexp.MustCompile(`(?i)(["']?\b(?:password|passwd|pwd|token|api[_-]?key|secret|client[_-]?secret|access[_-]?token|refresh[_-]?token|session[_-]?id)\b["']?\s*[:=]\s*["']?)[^"',\s}]+`), `${1}[REDACTED]`},
+	{regexp.MustCompile(`(?i)\b(cookie\s*[:=]\s*)[^\n]+`), `${1}[REDACTED]`},
+	{regexp.MustCompile(`\bsk-[A-Za-z0-9][A-Za-z0-9_-]{7,}\b`), `[REDACTED_API_KEY]`},
+	{regexp.MustCompile(`\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b`), `[REDACTED_JWT]`},
+	{regexp.MustCompile(`\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b`), `[REDACTED_EMAIL]`},
+}
+
 var defensiveContextPatterns = []*regexp.Regexp{
 	regexp.MustCompile(`(?i)\b(defensive|defense|prevent|prevention|mitigation|detect|detection|hardening|patch|remediation|incident\s+response)\b`),
 	regexp.MustCompile(`(?i)\b(do\s+not\s+provide|without\s+code|no\s+commands|high\s+level|non[-\s]?operational|refusal|unsafe)\b`),


### PR DESCRIPTION
## 背景

`/admin/prompt-filter/logs` 的记录预览此前只展示请求文本开头片段。对于 Codex/Claude 等请求，开头通常是固定系统提示词，管理员无法从日志判断实际命中规则的关键词或上下文，排查拦截/告警原因困难。

同时，命中上下文如果直接放入 `matched_patterns` 会混淆规则元信息与展示内容，并可能增加敏感信息泄露风险。因此本次调整保持 `matched_patterns` 仅承载规则元信息，将脱敏后的命中上下文写入 `text_preview` 用于展示。

## 修改前

- `text_preview` 主要展示请求开头，无法体现实际命中位置。
- `matched_patterns` 仅能看到规则名、权重、分类等信息，管理员不知道具体命中片段。
- `full_text` 场景下缺少与命中词对应的前端高亮能力。
- 多模态请求抽取文本时存在把非文本字段纳入扫描/日志的风险。
- 长文本扫描截断按字节处理，存在切断 UTF-8 字符的风险。
- 自定义敏感词命中时，如果把敏感词原文拼入匹配名称，会造成日志泄露风险。

## 修改后

- 后端在 Prompt Filter 命中时提取命中位置附近上下文，将脱敏后的上下文写入 `text_preview`。
- `matched_patterns` 保持只包含规则元信息，不新增 `context` / `sample` 字段。
- 非敏感上下文使用纯文本命中标记：
  - `⟦PF_HIT⟧`
  - `⟦/PF_HIT⟧`
- 前端解析上述纯文本标记并以安全方式渲染高亮，不使用 `dangerouslySetInnerHTML`。
- 点击查看完整消息内容时，会基于 `text_preview` 中提取的命中词，在 `full_text` 展开区域同步高亮。
- 如果命中上下文包含 Authorization、token、API key、JWT、email 等敏感内容，后端先整体脱敏，并跳过高亮标记，避免高亮标记切开 secret 导致脱敏绕过。
- 多模态提取逻辑只直接提取字符串型 `text` / `content`，跳过 `image_url`、`url`、`file_id`、`result`、`data`、`b64_json` 等非文本或大载荷字段。
- 长文本扫描截断改为 UTF-8 安全截断。
- 自定义敏感词命中日志统一显示为 `sensitive_word`，不泄露敏感词原文。
- 最近 5 条触发日志表格调整列宽，为预览列提供更多展示空间。

## 前后对比分析

- 兼容性：
  - `matched_patterns` JSON 结构保持规则元信息，不引入上下文字段；前端类型同步保持 `PromptFilterMatch` 不包含 `sample` / `context`。
  - `text_preview` 仍为字符串字段，只是内容从“请求开头片段”改为“命中上下文片段”。
- 安全性：
  - 写入日志前统一进行敏感信息脱敏。
  - 敏感上下文不插入高亮标记，避免破坏 secret 格式后绕过脱敏正则。
  - 前端高亮通过 React 节点分段渲染，不执行 HTML。
- 行为变化：
  - 管理端日志预览现在优先展示命中附近文本，而不是请求开头。
  - block / cyber_policy 等完整内容展示场景支持查看并高亮命中词。
- 影响范围：
  - 后端影响 Prompt Filter 检测结果的日志展示字段生成。
  - 前端影响 Prompt Filter 页面日志列表、最近触发日志和完整内容展开展示。

## 测试情况

已执行并通过：

```powershell
go test ./...
npm --prefix "frontend" run typecheck
npm --prefix "frontend" run build
git diff --check
```

结果：

- Go 全量测试通过。
- 前端 TypeScript 类型检查通过。
- 前端生产构建通过。
- `git diff --check` 通过；仅出现 Windows 工作区 LF/CRLF 提示，不影响检查结果。

## 修改总结

本次变更让 Prompt Filter 日志直接展示脱敏后的命中上下文，并在预览与完整内容中高亮命中关键词，显著提升管理员排查命中原因的效率。同时保留 `matched_patterns` 的规则元信息定位，补强敏感信息脱敏、多模态文本抽取和 UTF-8 截断安全性，并优化最近触发日志表格的预览列展示空间。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Prompt Filter UI now highlights matched prompt segments and surfaces contextual “hit” snippets in verdict and log views.
  * Prompt Filter logs and previews are improved with clearer, compact-friendly table formatting.

* **Bug Fixes**
  * Improved redaction for stored prompt-filter previews and sensitive data, reducing exposure of sensitive keywords.
  * Enhanced text extraction and safe truncation (including valid UTF-8 handling) to improve reliability.

* **Other**
  * Subscription expiration from WHAM usage is now captured and persisted when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->