### PR TITLE
fix: 同步 WHAM 订阅到期时间

### DIFF
--- a/auth/store.go
+++ b/auth/store.go
@@ -4860,6 +4860,49 @@ func (s *Store) PersistUsageSnapshot(acc *Account, pct7d float64) {
 	}
 }
 
+// UpdateAccountSubscriptionExpiresAt persists the latest subscription expiration observed from upstream.
+func (s *Store) UpdateAccountSubscriptionExpiresAt(acc *Account, expiresAt time.Time) bool {
+	if s == nil || acc == nil || expiresAt.IsZero() {
+		return false
+	}
+
+	acc.mu.Lock()
+	changed := acc.SubscriptionExpiresAt.IsZero() || !acc.SubscriptionExpiresAt.Equal(expiresAt)
+	if changed {
+		acc.SubscriptionExpiresAt = expiresAt
+		acc.recomputeSchedulerLocked(atomic.LoadInt64(&s.maxConcurrency))
+	}
+	acc.mu.Unlock()
+	if changed {
+		s.fastSchedulerUpdate(acc)
+	}
+
+	if s.db == nil {
+		return changed
+	}
+
+	formatted := expiresAt.Format(time.RFC3339)
+	if !changed {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		row, err := s.db.GetAccountByID(ctx, acc.DBID)
+		if err != nil {
+			log.Printf("[账号 %d] 读取 subscription_expires_at 失败: %v", acc.DBID, err)
+			return changed
+		}
+		if row.GetCredential("subscription_expires_at") == formatted {
+			return changed
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := s.db.UpdateCredentials(ctx, acc.DBID, map[string]interface{}{"subscription_expires_at": formatted}); err != nil {
+		log.Printf("[账号 %d] 持久化 subscription_expires_at 失败: %v", acc.DBID, err)
+	}
+	return changed
+}
+
 // UpdateAccountPlanType persists the latest Codex plan type observed from upstream headers.
 func (s *Store) UpdateAccountPlanType(acc *Account, planType string) bool {
 	if s == nil || acc == nil {

--- a/proxy/usage_wham.go
+++ b/proxy/usage_wham.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -34,6 +35,12 @@ type WhamUsage struct {
 	Email     string `json:"email"`
 	PlanType  string `json:"plan_type"`
 
+	// OpenAI 续费后 JWT 里的 chatgpt_subscription_active_until 不一定会立即随授权刷新，
+	// wham/usage 返回的服务端当前订阅到期时间用于同步管理端展示与调度权重。
+	SubscriptionExpiresAtRaw          whamTimeRaw `json:"subscription_expires_at,omitempty"`
+	SubscriptionActiveUntilRaw        whamTimeRaw `json:"subscription_active_until,omitempty"`
+	ChatGPTSubscriptionActiveUntilRaw whamTimeRaw `json:"chatgpt_subscription_active_until,omitempty"`
+
 	RateLimit struct {
 		Allowed         bool             `json:"allowed"`
 		LimitReached    bool             `json:"limit_reached"`
@@ -60,6 +67,64 @@ type WhamUsage struct {
 	RateLimitResetCredits *struct {
 		AvailableCount int `json:"available_count"`
 	} `json:"rate_limit_reset_credits,omitempty"`
+}
+
+type whamTimeRaw string
+
+func (w *whamTimeRaw) UnmarshalJSON(data []byte) error {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		*w = ""
+		return nil
+	}
+	var s string
+	if err := json.Unmarshal(trimmed, &s); err == nil {
+		*w = whamTimeRaw(s)
+		return nil
+	}
+	var n json.Number
+	if err := json.Unmarshal(trimmed, &n); err == nil {
+		*w = whamTimeRaw(n.String())
+		return nil
+	}
+	return nil
+}
+
+func (w *WhamUsage) SubscriptionExpiresAt() time.Time {
+	if w == nil {
+		return time.Time{}
+	}
+	for _, raw := range []whamTimeRaw{
+		w.SubscriptionExpiresAtRaw,
+		w.SubscriptionActiveUntilRaw,
+		w.ChatGPTSubscriptionActiveUntilRaw,
+	} {
+		if t := parseWhamTime(string(raw)); !t.IsZero() {
+			return t
+		}
+	}
+	return time.Time{}
+}
+
+func parseWhamTime(raw string) time.Time {
+	s := strings.TrimSpace(raw)
+	if s == "" {
+		return time.Time{}
+	}
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t
+	}
+	if t, err := time.Parse(time.RFC3339Nano, s); err == nil {
+		return t
+	}
+	if unix, err := strconv.ParseInt(s, 10, 64); err == nil && unix > 0 {
+		// 兼容秒级与毫秒级 unix 时间戳。
+		if unix > 1_000_000_000_000 {
+			return time.UnixMilli(unix)
+		}
+		return time.Unix(unix, 0)
+	}
+	return time.Time{}
 }
 
 // WhamUsageWindow 是单个限流窗口（primary=5h，secondary=7d）。
@@ -235,6 +300,9 @@ func ApplyWhamUsage(store *auth.Store, account *auth.Account, usage *WhamUsage) 
 
 	if store != nil && usage.PlanType != "" {
 		store.UpdateAccountPlanType(account, usage.PlanType)
+	}
+	if store != nil {
+		store.UpdateAccountSubscriptionExpiresAt(account, usage.SubscriptionExpiresAt())
 	}
 
 	// 记录「主动重置次数」（OpenAI 官方剩余的手动重置额度次数）。

--- a/proxy/usage_wham_test.go
+++ b/proxy/usage_wham_test.go
@@ -21,6 +21,7 @@ func TestQueryWhamUsage_ParsesPlusAccountResponse(t *testing.T) {
 		"account_id": "user-abc",
 		"email": "rundown_consist_3o@icloud.com",
 		"plan_type": "plus",
+		"subscription_expires_at": "2026-07-17T09:30:23Z",
 		"rate_limit": {
 			"allowed": true,
 			"limit_reached": false,
@@ -79,6 +80,10 @@ func TestQueryWhamUsage_ParsesPlusAccountResponse(t *testing.T) {
 	if usage.PlanType != "plus" {
 		t.Errorf("PlanType = %q, want plus", usage.PlanType)
 	}
+	wantSubscriptionExpiresAt := time.Date(2026, 7, 17, 9, 30, 23, 0, time.UTC)
+	if got := usage.SubscriptionExpiresAt(); !got.Equal(wantSubscriptionExpiresAt) {
+		t.Errorf("SubscriptionExpiresAt() = %s, want %s", got.Format(time.RFC3339), wantSubscriptionExpiresAt.Format(time.RFC3339))
+	}
 	if usage.RateLimit.PrimaryWindow == nil || usage.RateLimit.PrimaryWindow.UsedPercent != 83 {
 		t.Errorf("primary used_percent = %+v, want 83", usage.RateLimit.PrimaryWindow)
 	}
@@ -108,6 +113,7 @@ func TestApplyWhamUsage_PersistsPlanAnd5h7d(t *testing.T) {
 	reset5h := now.Add(3 * time.Hour).Unix()
 	reset7d := now.Add(5 * 24 * time.Hour).Unix()
 	usage := &WhamUsage{PlanType: "plus"}
+	usage.SubscriptionExpiresAtRaw = whamTimeRaw("2026-07-17T09:30:23Z")
 	usage.RateLimit.PrimaryWindow = &WhamUsageWindow{UsedPercent: 83, LimitWindowSeconds: 18000, ResetAt: reset5h}
 	usage.RateLimit.SecondaryWindow = &WhamUsageWindow{UsedPercent: 30, LimitWindowSeconds: 604800, ResetAt: reset7d}
 
@@ -132,6 +138,84 @@ func TestApplyWhamUsage_PersistsPlanAnd5h7d(t *testing.T) {
 	}
 	if got := row.GetCredential("plan_type"); got != "plus" {
 		t.Errorf("persisted plan_type = %q, want plus", got)
+	}
+	wantSubscriptionExpiresAt := time.Date(2026, 7, 17, 9, 30, 23, 0, time.UTC)
+	if !account.SubscriptionExpiresAt.Equal(wantSubscriptionExpiresAt) {
+		t.Errorf("account SubscriptionExpiresAt = %s, want %s", account.SubscriptionExpiresAt.Format(time.RFC3339), wantSubscriptionExpiresAt.Format(time.RFC3339))
+	}
+	if got := row.GetCredential("subscription_expires_at"); got != wantSubscriptionExpiresAt.Format(time.RFC3339) {
+		t.Errorf("persisted subscription_expires_at = %q, want %q", got, wantSubscriptionExpiresAt.Format(time.RFC3339))
+	}
+}
+
+func TestApplyWhamUsage_PersistsSubscriptionExpiresAtWhenMemoryAlreadyMatches(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "codex2api.db")
+	db, err := database.New("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("database.New: %v", err)
+	}
+	defer db.Close()
+
+	id, err := db.InsertAccountWithCredentials(ctx, "wham-subscription-retry", map[string]interface{}{"plan_type": "plus"}, "")
+	if err != nil {
+		t.Fatalf("InsertAccountWithCredentials: %v", err)
+	}
+
+	store := auth.NewStore(db, nil, &database.SystemSettings{MaxConcurrency: 2, TestConcurrency: 1, TestModel: "gpt-5.4"})
+	expiresAt := time.Date(2026, 7, 17, 9, 30, 23, 0, time.UTC)
+	account := &auth.Account{DBID: id, AccessToken: "at", PlanType: "plus", AccountID: "acc", SubscriptionExpiresAt: expiresAt}
+	usage := &WhamUsage{PlanType: "plus"}
+	usage.SubscriptionExpiresAtRaw = whamTimeRaw(expiresAt.Format(time.RFC3339))
+
+	ApplyWhamUsage(store, account, usage)
+
+	row, err := db.GetAccountByID(ctx, id)
+	if err != nil {
+		t.Fatalf("GetAccountByID: %v", err)
+	}
+	if got := row.GetCredential("subscription_expires_at"); got != expiresAt.Format(time.RFC3339) {
+		t.Fatalf("persisted subscription_expires_at = %q, want %q", got, expiresAt.Format(time.RFC3339))
+	}
+}
+
+func TestWhamUsageSubscriptionExpiresAtFallbacks(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want time.Time
+	}{
+		{
+			name: "subscription_active_until",
+			body: `{"subscription_active_until":"2026-07-17T09:30:23.123Z"}`,
+			want: time.Date(2026, 7, 17, 9, 30, 23, 123000000, time.UTC),
+		},
+		{
+			name: "chatgpt_subscription_active_until",
+			body: `{"chatgpt_subscription_active_until":"2026-07-17T09:30:23Z"}`,
+			want: time.Date(2026, 7, 17, 9, 30, 23, 0, time.UTC),
+		},
+		{
+			name: "unix_seconds",
+			body: `{"subscription_expires_at":1784280623}`,
+			want: time.Unix(1784280623, 0),
+		},
+		{
+			name: "unix_milliseconds",
+			body: `{"subscription_expires_at":1784280623000}`,
+			want: time.UnixMilli(1784280623000),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var usage WhamUsage
+			if err := json.Unmarshal([]byte(tc.body), &usage); err != nil {
+				t.Fatalf("json.Unmarshal: %v", err)
+			}
+			if got := usage.SubscriptionExpiresAt(); !got.Equal(tc.want) {
+				t.Fatalf("SubscriptionExpiresAt() = %s, want %s", got.Format(time.RFC3339Nano), tc.want.Format(time.RFC3339Nano))
+			}
+		})
 	}
 }
 
@@ -343,6 +427,7 @@ func TestWhamUsageJSON_RoundTrip(t *testing.T) {
 func TestQueryWhamUsage_ParsesRateLimitResetCredits(t *testing.T) {
 	body := `{
 		"plan_type": "plus",
+		"subscription_expires_at": "2026-07-17T09:30:23Z",
 		"rate_limit": {"allowed": true},
 		"rate_limit_reset_credits": {"available_count": 4}
 	}`


### PR DESCRIPTION
## 背景

管理端 `/admin/accounts` 返回的 `subscription_expires_at` 当前主要来自账号 `credentials.subscription_expires_at`。旧逻辑只会在添加账号或刷新授权 Token 时，从 JWT 中的 `chatgpt_subscription_active_until` 写入该字段。

当 OpenAI 服务端自动续费后，如果本地授权 Token 没有同步刷新，WHAM 用量探针虽然会刷新 `plan_type`、5h/7d 用量和主动重置次数，但不会刷新订阅到期时间，导致管理端仍显示旧的过期时间。

## 修改前

- `proxy.ApplyWhamUsage()` 只同步：
  - `plan_type`
  - 5h / 7d 用量窗口
  - 7d / 5h 限流状态
  - 主动重置次数
- `subscription_expires_at` 只在授权相关路径写入。
- 服务端自动续费后，管理端账号列表可能继续展示旧日期。

## 修改后

- 扩展 WHAM usage 响应解析，支持从以下字段读取订阅到期时间：
  - `subscription_expires_at`
  - `subscription_active_until`
  - `chatgpt_subscription_active_until`
- 新增时间解析兼容：
  - RFC3339
  - RFC3339Nano
  - 秒级 Unix 时间戳
  - 毫秒级 Unix 时间戳
- `ApplyWhamUsage()` 在 WHAM 探针成功后同步订阅到期时间。
- 新增 `Store.UpdateAccountSubscriptionExpiresAt()`：
  - 更新运行时 `Account.SubscriptionExpiresAt`
  - 重算调度分并刷新 fast scheduler
  - 写入 DB `credentials.subscription_expires_at`
- 修复一致性边界：当运行时内存已是目标值但 DB 缺失/旧值时，会补写 DB，避免之前 DB 写入失败后永远不重试。

## 前后对比分析

- 兼容性：
  - WHAM 响应中没有订阅到期字段时，不会覆盖已有 `subscription_expires_at`。
  - 异常时间格式会被忽略为零值，不影响原有用量同步。
  - 使用现有 `UpdateCredentials()` 合并 credentials，不会覆盖其他凭据字段。
- 行为变化：
  - 服务端自动续费后，后续 WHAM 用量探针可自动刷新管理端展示的订阅到期时间。
  - 订阅到期时间变化会触发调度分重算，保持 `expiry_urgency_bonus` 与最新到期时间一致。
- 风险控制：
  - 只在解析到有效非零时间时写入。
  - DB 已一致时跳过写入，减少无意义更新。
  - DB 不一致但内存一致时补写，提升持久化一致性。

## 测试情况

已执行并通过：

```powershell
go test ./proxy -run "Test(QueryWhamUsage_ParsesPlusAccountResponse|ApplyWhamUsage_PersistsPlanAnd5h7d|ApplyWhamUsage_PersistsSubscriptionExpiresAtWhenMemoryAlreadyMatches|WhamUsageSubscriptionExpiresAtFallbacks)$" -count=1 -v
go test ./proxy ./auth -count=1
go test ./... -count=1
git diff --check
```

提交 PR 前在干净分支上再次执行并通过：

```powershell
go test ./proxy ./auth -count=1
```

测试覆盖：

- WHAM 响应解析 `subscription_expires_at`。
- WHAM 同步时将订阅到期时间写入运行时账号和 DB。
- 内存已匹配但 DB 缺失时仍会补写。
- 备用字段名与多种时间格式解析。
- 全量 Go 测试通过。

## 修改总结

本次变更让 WHAM 用量探针能够同步服务端最新订阅到期时间，解决自动续费后 `/admin/accounts` 中 `subscription_expires_at` 不更新的问题，同时补充了持久化一致性保护和详细测试覆盖。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Subscription expiration dates are now captured from service responses and automatically synchronized with account records for accurate status tracking.

* **Tests**
  * Added comprehensive test coverage for subscription expiration handling, including multiple timestamp formats and persistence verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->