### PR TITLE
feat: 提升 Codex custom tool 事件兼容

### DIFF
--- a/proxy/anthropic.go
+++ b/proxy/anthropic.go
@@ -578,7 +578,7 @@ func (t *anthropicStreamTranslator) translateEvent(eventData []byte) []anthropic
 	case "response.reasoning_summary_text.delta", "response.reasoning_text.delta":
 		return t.handleThinkingDelta(eventData)
 
-	case "response.function_call_arguments.delta":
+	case "response.function_call_arguments.delta", "response.custom_tool_call_input.delta":
 		return t.handleToolInputDelta(eventData)
 
 	case "response.output_text.done", "response.reasoning_summary_text.done",
@@ -645,9 +645,12 @@ func (t *anthropicStreamTranslator) handleOutputItemAdded(data []byte) []anthrop
 			},
 		})
 
-	case "function_call":
+	case "function_call", "custom_tool_call":
 		events = append(events, t.closeCurrentBlock()...)
 		callID := fromCodexCallID(gjson.GetBytes(data, "item.call_id").String())
+		if callID == "" {
+			callID = fromCodexCallID(gjson.GetBytes(data, "item.id").String())
+		}
 		name := gjson.GetBytes(data, "item.name").String()
 		idx := t.contentBlockIndex
 		t.contentBlockIndex++
@@ -1077,11 +1080,17 @@ func buildAnthropicResponseFromCompleted(completedData []byte, model string) *an
 				return true
 			})
 
-		case "function_call":
-			// function_call → tool_use block
+		case "function_call", "custom_tool_call":
+			// function_call/custom_tool_call → tool_use block
 			callID := fromCodexCallID(item.Get("call_id").String())
+			if callID == "" {
+				callID = fromCodexCallID(item.Get("id").String())
+			}
 			name := item.Get("name").String()
 			args := item.Get("arguments").String()
+			if itemType == "custom_tool_call" {
+				args = item.Get("input").String()
+			}
 			if cleaned := sanitizeToolInputJSON(name, args); cleaned != "" {
 				args = cleaned
 			} else {

--- a/proxy/anthropic_test.go
+++ b/proxy/anthropic_test.go
@@ -570,6 +570,42 @@ func TestAnthropicStreamTranslator_ToolInputBufferedAndCleaned(t *testing.T) {
 	}
 }
 
+func TestAnthropicStreamTranslator_CustomToolCallInputDelta(t *testing.T) {
+	tr := newAnthropicStreamTranslator("claude-sonnet-4-5")
+	tr.translateEvent([]byte(`{"type":"response.created"}`))
+	tr.translateEvent([]byte(`{
+		"type":"response.output_item.added",
+		"item":{"type":"custom_tool_call","id":"call_custom","name":"CustomTool"}
+	}`))
+
+	streamed := tr.translateEvent([]byte(`{
+		"type":"response.custom_tool_call_input.delta",
+		"delta":"{\"query\":\"hello\"}"
+	}`))
+	for _, evt := range streamed {
+		if evt.Type == "content_block_delta" {
+			t.Fatalf("expected no content_block_delta during streaming, got %+v", evt)
+		}
+	}
+
+	closing := tr.translateEvent([]byte(`{"type":"response.output_item.done"}`))
+	var sawDelta bool
+	for _, evt := range closing {
+		if evt.Type == "content_block_delta" {
+			sawDelta = true
+			if evt.Delta == nil || evt.Delta.Type != "input_json_delta" {
+				t.Fatalf("expected input_json_delta, got %+v", evt.Delta)
+			}
+			if !jsonEqual(t, evt.Delta.PartialJSON, `{"query":"hello"}`) {
+				t.Fatalf("custom tool input = %q", evt.Delta.PartialJSON)
+			}
+		}
+	}
+	if !sawDelta {
+		t.Fatalf("expected custom tool input_json_delta on close")
+	}
+}
+
 func TestAnthropicResponseAccumulatorUsesStreamDeltasWhenCompletedOutputIsEmpty(t *testing.T) {
 	tr := newAnthropicStreamTranslator("claude-sonnet-4-5")
 	acc := newAnthropicResponseAccumulator("claude-sonnet-4-5")

--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -3144,7 +3144,7 @@ func (h *Handler) ChatCompletions(c *gin.Context) {
 					ttftRecorded = true
 				}
 				// 累计 delta 字符数（文本 + function call 参数）
-				if eventType == "response.output_text.delta" || eventType == "response.function_call_arguments.delta" {
+				if eventType == "response.output_text.delta" || isCodexToolInputDeltaEvent(eventType) {
 					deltaCharCount += len(parsed.Get("delta").String())
 				}
 				if eventType == "response.completed" {
@@ -3226,7 +3226,7 @@ func (h *Handler) ChatCompletions(c *gin.Context) {
 					fullContent.WriteString(delta)
 				case "response.reasoning_summary_text.delta", "response.reasoning_text.delta":
 					fullReasoning.WriteString(parsed.Get("delta").String())
-				case "response.function_call_arguments.delta":
+				case "response.function_call_arguments.delta", "response.custom_tool_call_input.delta":
 					deltaCharCount += len(parsed.Get("delta").String())
 				case "response.completed":
 					usage = extractUsageFromResult(parsed.Get("response.usage"))

--- a/proxy/handler_anthropic.go
+++ b/proxy/handler_anthropic.go
@@ -382,7 +382,7 @@ func (h *Handler) Messages(c *gin.Context) {
 				}
 
 				// 累计 delta 字符数
-				if eventType == "response.output_text.delta" || eventType == "response.function_call_arguments.delta" {
+				if eventType == "response.output_text.delta" || isCodexToolInputDeltaEvent(eventType) {
 					deltaCharCount += len(parsed.Get("delta").String())
 				}
 
@@ -462,7 +462,7 @@ func (h *Handler) Messages(c *gin.Context) {
 					firstTokenMs = int(time.Since(start).Milliseconds())
 					ttftRecorded = true
 				}
-				if eventType == "response.output_text.delta" || eventType == "response.function_call_arguments.delta" {
+				if eventType == "response.output_text.delta" || isCodexToolInputDeltaEvent(eventType) {
 					deltaCharCount += len(parsed.Get("delta").String())
 				}
 				if eventType == "response.completed" {

--- a/proxy/translator.go
+++ b/proxy/translator.go
@@ -1489,6 +1489,47 @@ func PrepareResponsesWebSocketBody(rawBody []byte) ([]byte, string) {
 	})
 }
 
+const codexReasoningEncryptedContentInclude = "reasoning.encrypted_content"
+
+func ensureDefaultCodexInclude(body map[string]any) {
+	if body == nil {
+		return
+	}
+	if _, ok := body["include"]; !ok {
+		body["include"] = []string{codexReasoningEncryptedContentInclude}
+	}
+}
+
+func ensureCodexReasoningInclude(body map[string]any) {
+	if body == nil {
+		return
+	}
+	if _, ok := body["reasoning"]; !ok {
+		return
+	}
+	if _, ok := body["include"]; !ok {
+		body["include"] = []string{codexReasoningEncryptedContentInclude}
+		return
+	}
+
+	switch includes := body["include"].(type) {
+	case []any:
+		for _, item := range includes {
+			if s, ok := item.(string); ok && s == codexReasoningEncryptedContentInclude {
+				return
+			}
+		}
+		body["include"] = append(includes, codexReasoningEncryptedContentInclude)
+	case []string:
+		for _, item := range includes {
+			if item == codexReasoningEncryptedContentInclude {
+				return
+			}
+		}
+		body["include"] = append(includes, codexReasoningEncryptedContentInclude)
+	}
+}
+
 func prepareResponsesBodyWithOptions(rawBody []byte, opts responsesBodyPrepareOptions) ([]byte, string) {
 	var body map[string]any
 	if err := json.Unmarshal(rawBody, &body); err != nil {
@@ -1500,9 +1541,7 @@ func prepareResponsesBodyWithOptions(rawBody []byte, opts responsesBodyPrepareOp
 	if opts.forceStoreFalse {
 		body["store"] = false
 	}
-	if _, ok := body["include"]; !ok {
-		body["include"] = []string{"reasoning.encrypted_content"}
-	}
+	ensureDefaultCodexInclude(body)
 
 	normalizeResponsesImageOnlyModel(body)
 	normalizeResponsesPromptCompat(body)
@@ -1537,6 +1576,7 @@ func prepareResponsesBodyWithOptions(rawBody []byte, opts responsesBodyPrepareOp
 			}
 		}
 	}
+	ensureCodexReasoningInclude(body)
 
 	// 4. service tier 清理（兼容客户端字段；只有 fast/priority 会显式传给 Codex 上游）
 	delete(body, "serviceTier")
@@ -2544,6 +2584,33 @@ func newReasoningChunk(id, model string, created int64, reasoning string) []byte
 	return b
 }
 
+func isCodexToolCallItemType(itemType string) bool {
+	switch itemType {
+	case "function_call", "custom_tool_call":
+		return true
+	default:
+		return false
+	}
+}
+
+func isCodexToolInputDeltaEvent(eventType string) bool {
+	switch eventType {
+	case "response.function_call_arguments.delta", "response.custom_tool_call_input.delta":
+		return true
+	default:
+		return false
+	}
+}
+
+func isCodexToolInputDoneEvent(eventType string) bool {
+	switch eventType {
+	case "response.function_call_arguments.done", "response.custom_tool_call_input.done":
+		return true
+	default:
+		return false
+	}
+}
+
 // newToolCallAnnouncementChunk 构建 tool call 首块（含 id、type、function.name）
 func newToolCallAnnouncementChunk(id, model string, created int64, tcIndex int, callID, funcName string) []byte {
 	chunk := openAIStreamChunk{
@@ -2622,6 +2689,9 @@ func TranslateStreamChunk(eventData []byte, model string, chunkID string, create
 		delta := gjson.GetBytes(eventData, "delta").String()
 		return newReasoningChunk(chunkID, model, created, delta), false
 
+	case "response.custom_tool_call_input.delta", "response.custom_tool_call_input.done":
+		return nil, false
+
 	case "response.completed":
 		usage := extractUsage(eventData)
 		return newFinalChunk(chunkID, model, created, "stop", usage), true
@@ -2698,22 +2768,34 @@ func (st *StreamTranslator) TranslateParsed(parsed gjson.Result) ([]byte, bool) 
 
 	case "response.output_item.added":
 		itemType := parsed.Get("item.type").String()
-		if itemType != "function_call" {
+		if !isCodexToolCallItemType(itemType) {
 			return nil, false
 		}
 		callID := parsed.Get("item.call_id").String()
+		if callID == "" {
+			callID = parsed.Get("item.id").String()
+		}
 		name := parsed.Get("item.name").String()
 		itemID := parsed.Get("item.id").String()
+		if itemID == "" {
+			itemID = callID
+		}
 
 		tcIdx := st.nextIdx
 		st.toolCallMap[itemID] = tcIdx
+		if callID != "" && callID != itemID {
+			st.toolCallMap[callID] = tcIdx
+		}
 		st.nextIdx++
 		st.HasToolCalls = true
 
 		return newToolCallAnnouncementChunk(st.ChunkID, st.Model, st.Created, tcIdx, callID, name), false
 
-	case "response.function_call_arguments.delta":
+	case "response.function_call_arguments.delta", "response.custom_tool_call_input.delta":
 		itemID := parsed.Get("item_id").String()
+		if itemID == "" {
+			itemID = parsed.Get("call_id").String()
+		}
 		tcIdx, ok := st.toolCallMap[itemID]
 		if !ok {
 			return nil, false
@@ -2721,7 +2803,7 @@ func (st *StreamTranslator) TranslateParsed(parsed gjson.Result) ([]byte, bool) 
 		delta := parsed.Get("delta").String()
 		return newToolCallDeltaChunk(st.ChunkID, st.Model, st.Created, tcIdx, delta), false
 
-	case "response.function_call_arguments.done":
+	case "response.function_call_arguments.done", "response.custom_tool_call_input.done":
 		return nil, false
 
 	case "response.completed":
@@ -2897,11 +2979,20 @@ func ExtractToolCallsFromOutput(eventData []byte) []ToolCallResult {
 		return nil
 	}
 	output.ForEach(func(_, item gjson.Result) bool {
-		if item.Get("type").String() == "function_call" {
+		itemType := item.Get("type").String()
+		if isCodexToolCallItemType(itemType) {
+			callID := item.Get("call_id").String()
+			if callID == "" {
+				callID = item.Get("id").String()
+			}
+			arguments := item.Get("arguments").String()
+			if itemType == "custom_tool_call" {
+				arguments = item.Get("input").String()
+			}
 			toolCalls = append(toolCalls, ToolCallResult{
-				ID:        item.Get("call_id").String(),
+				ID:        callID,
 				Name:      item.Get("name").String(),
-				Arguments: item.Get("arguments").String(),
+				Arguments: arguments,
 			})
 		}
 		return true

--- a/proxy/translator_test.go
+++ b/proxy/translator_test.go
@@ -979,6 +979,49 @@ func TestPrepareResponsesBody_DefaultsIncludeForResponses(t *testing.T) {
 	}
 }
 
+func TestPrepareResponsesBody_MergesReasoningInclude(t *testing.T) {
+	raw := []byte(`{
+		"model":"gpt-5.4",
+		"input":"test",
+		"reasoning":{"effort":"high"},
+		"include":["file_search_call.results"]
+	}`)
+
+	got, _ := PrepareResponsesBody(raw)
+
+	include := gjson.GetBytes(got, "include").Array()
+	if len(include) != 2 {
+		t.Fatalf("include length = %d, want 2; body=%s", len(include), got)
+	}
+	if include[0].String() != "file_search_call.results" {
+		t.Fatalf("existing include not preserved first, got %s; body=%s", include[0].Raw, got)
+	}
+	if include[1].String() != codexReasoningEncryptedContentInclude {
+		t.Fatalf("reasoning include not appended, got %s; body=%s", include[1].Raw, got)
+	}
+}
+
+func TestPrepareResponsesBody_DoesNotDuplicateReasoningInclude(t *testing.T) {
+	raw := []byte(`{
+		"model":"gpt-5.4",
+		"input":"test",
+		"reasoning":{"effort":"high"},
+		"include":["reasoning.encrypted_content","file_search_call.results"]
+	}`)
+
+	got, _ := PrepareResponsesBody(raw)
+
+	var count int
+	for _, item := range gjson.GetBytes(got, "include").Array() {
+		if item.String() == codexReasoningEncryptedContentInclude {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("reasoning include count = %d, want 1; body=%s", count, got)
+	}
+}
+
 func TestPrepareResponsesBody_ToolChoiceImageGenerationAutoInjectsTool(t *testing.T) {
 	raw := []byte(`{
 		"model":"gpt-5.4",
@@ -2132,6 +2175,73 @@ func TestStreamTranslator_FunctionCall(t *testing.T) {
 	}
 }
 
+func TestStreamTranslator_CustomToolCallInputDelta(t *testing.T) {
+	st := NewStreamTranslator("chatcmpl-test", "gpt-5.4", 0)
+
+	addedEvent := []byte(`{
+		"type":"response.output_item.added",
+		"output_index":0,
+		"item":{"type":"custom_tool_call","id":"ctc_001","call_id":"call_custom","name":"run_custom"}
+	}`)
+	chunk, done := st.Translate(addedEvent)
+	if done {
+		t.Fatal("should not be done after custom_tool_call added")
+	}
+	if chunk == nil {
+		t.Fatal("should emit chunk for custom_tool_call added")
+	}
+	if got := gjson.GetBytes(chunk, "choices.0.delta.tool_calls.0.id").String(); got != "call_custom" {
+		t.Fatalf("tool call id = %q, want call_custom; chunk=%s", got, chunk)
+	}
+	if got := gjson.GetBytes(chunk, "choices.0.delta.tool_calls.0.function.name").String(); got != "run_custom" {
+		t.Fatalf("tool call name = %q, want run_custom; chunk=%s", got, chunk)
+	}
+
+	deltaEvent := []byte(`{
+		"type":"response.custom_tool_call_input.delta",
+		"item_id":"ctc_001",
+		"delta":"{\"cmd\":"
+	}`)
+	chunk, done = st.Translate(deltaEvent)
+	if done {
+		t.Fatal("should not be done after custom_tool_call_input delta")
+	}
+	if chunk == nil {
+		t.Fatal("should emit chunk for custom_tool_call_input delta")
+	}
+	if got := gjson.GetBytes(chunk, "choices.0.delta.tool_calls.0.function.arguments").String(); got != `{"cmd":` {
+		t.Fatalf("custom tool input delta = %q, want arguments delta; chunk=%s", got, chunk)
+	}
+
+	callIDDeltaEvent := []byte(`{
+		"type":"response.custom_tool_call_input.delta",
+		"call_id":"call_custom",
+		"delta":"\"pwd\"}"
+	}`)
+	chunk, done = st.Translate(callIDDeltaEvent)
+	if done {
+		t.Fatal("should not be done after custom_tool_call_input call_id delta")
+	}
+	if chunk == nil {
+		t.Fatal("should emit chunk for custom_tool_call_input call_id delta")
+	}
+	if got := gjson.GetBytes(chunk, "choices.0.delta.tool_calls.0.function.arguments").String(); got != `"pwd"}` {
+		t.Fatalf("custom tool input call_id delta = %q, want arguments delta; chunk=%s", got, chunk)
+	}
+
+	completedEvent := []byte(`{
+		"type":"response.completed",
+		"response":{"usage":{"input_tokens":10,"output_tokens":5}}
+	}`)
+	chunk, done = st.Translate(completedEvent)
+	if !done {
+		t.Fatal("should be done after response.completed")
+	}
+	if finishReason := gjson.GetBytes(chunk, "choices.0.finish_reason").String(); finishReason != "tool_calls" {
+		t.Fatalf("expected finish_reason tool_calls, got %q", finishReason)
+	}
+}
+
 func TestStreamTranslator_TextOnly(t *testing.T) {
 	st := NewStreamTranslator("chatcmpl-test", "gpt-5.4", 0)
 
@@ -2230,21 +2340,25 @@ func TestExtractToolCallsFromOutput(t *testing.T) {
 			"output":[
 				{"type":"message","content":[{"type":"output_text","text":"hi"}]},
 				{"type":"function_call","call_id":"call_1","name":"get_weather","arguments":"{\"city\":\"NYC\"}"},
-				{"type":"function_call","call_id":"call_2","name":"get_time","arguments":"{}"}
+				{"type":"function_call","call_id":"call_2","name":"get_time","arguments":"{}"},
+				{"type":"custom_tool_call","id":"call_3","name":"custom_exec","input":"{\"cmd\":\"pwd\"}"}
 			],
 			"usage":{"input_tokens":10,"output_tokens":5}
 		}
 	}`)
 
 	tcs := ExtractToolCallsFromOutput(event)
-	if len(tcs) != 2 {
-		t.Fatalf("expected 2 tool calls, got %d", len(tcs))
+	if len(tcs) != 3 {
+		t.Fatalf("expected 3 tool calls, got %d", len(tcs))
 	}
 	if tcs[0].ID != "call_1" || tcs[0].Name != "get_weather" {
 		t.Fatalf("first tool call mismatch: %+v", tcs[0])
 	}
 	if tcs[1].ID != "call_2" || tcs[1].Name != "get_time" {
 		t.Fatalf("second tool call mismatch: %+v", tcs[1])
+	}
+	if tcs[2].ID != "call_3" || tcs[2].Name != "custom_exec" || tcs[2].Arguments != `{"cmd":"pwd"}` {
+		t.Fatalf("custom tool call mismatch: %+v", tcs[2])
 	}
 }
 


### PR DESCRIPTION
## 背景

本次变更参考 Wei-Shaw/sub2api#3065 中 Codex 模拟保真度的低风险部分，聚焦两个已确认范围：

1. 在不改既有可工作请求头的前提下，补齐 Responses 请求中 `include` 的合并逻辑。
2. 补齐上游 `custom_tool_call` / `response.custom_tool_call_input.delta` 事件在 Chat Completions 与 Anthropic 兼容路径中的处理。

现有实现已经具备较完整的 Codex UA / Originator / Session / WebSocket 头部策略，因此本 PR 不调整请求头相关逻辑，避免破坏已有可工作指纹组合。

## 修改前

### include 行为

`PrepareResponsesBody` 在请求没有 `include` 时会默认注入：

```json
["reasoning.encrypted_content"]
```

但如果客户端已经传入了其他 `include`，即使请求包含 `reasoning`，也不会补充 `reasoning.encrypted_content`。例如：

```json
{
  "reasoning": {"effort": "high"},
  "include": ["file_search_call.results"]
}
```

旧行为会原样保留 include，导致 reasoning 加密内容项缺失。

### custom tool call 事件

旧逻辑主要识别：

- `function_call`
- `response.function_call_arguments.delta`

对于新版上游可能返回的：

- `custom_tool_call`
- `response.custom_tool_call_input.delta`

部分路径无法按工具调用处理，可能出现工具参数增量无法映射、非流式工具调用提取缺失，或旧无状态转换 fallback 将 custom tool input delta 当普通文本输出的问题。

## 修改后

### include 合并

新增 Codex include 合并辅助逻辑：

- 无 `include` 时保持原默认行为，注入 `reasoning.encrypted_content`。
- 有 `reasoning` 且已有 `include` 时，如缺少 `reasoning.encrypted_content` 则追加。
- 保留既有 include 项。
- 已存在时不重复追加。
- 非数组 include 保守不覆盖，避免破坏客户端自定义异常输入。

### custom tool call 兼容

补齐以下兼容逻辑：

- Chat Completions 有状态流转换支持 `custom_tool_call`。
- 支持 `response.custom_tool_call_input.delta` / `done`。
- 同时映射 `item.id` 与 `call_id` 到同一 OpenAI tool call index，兼容上游 delta 使用不同 ID 字段回传。
- 非流式 completed output 提取支持 `custom_tool_call`，并从 `input` 字段读取参数。
- Anthropic 流式转换支持 `custom_tool_call` 与 `response.custom_tool_call_input.delta`。
- Anthropic 非流式 completed fallback 支持 `custom_tool_call`。
- Chat / Anthropic handler 的 delta 字符统计纳入 custom tool input delta。
- 旧无状态 `TranslateStreamChunk` 显式忽略 `response.custom_tool_call_input.delta/done`，避免被 fallback 当作普通文本输出；同时保留旧 `function_call_arguments.delta` 行为，减少回归风险。

## 前后对比分析

### 兼容性

- 不修改 Codex HTTP / WebSocket 请求头生成逻辑。
- 不修改 `User-Agent`、`Originator`、`OpenAI-Beta`、`Session_id`、`Conversation_id`、`Authorization` 等既有请求头策略。
- `include` 逻辑为加法合并，保留既有项且不重复。
- `custom_tool_call` 被映射到 OpenAI/Anthropic 现有工具调用结构，对旧 `function_call` 行为保持兼容。

### 风险控制

- 对异常非数组 `include` 不强行覆盖，避免破坏未知客户端输入。
- custom tool delta 同时支持 `item_id` 与 `call_id`，降低上游事件字段差异导致的索引丢失风险。
- 对无状态转换路径只显式忽略 custom tool input delta，不改变旧 function call delta fallback 行为。
- 新增定向测试覆盖 include 合并、去重、custom tool delta、非流式 tool call 提取与 Anthropic 流式转换。

### 行为变化

- 当请求包含 `reasoning` 且已有 include 数组但缺少 `reasoning.encrypted_content` 时，会自动追加该项。
- 上游返回 `custom_tool_call` / `response.custom_tool_call_input.delta` 时，将按工具调用参数增量处理，而不是丢失或误当普通文本。

## 测试情况

已执行以下测试：

```powershell
go test ./proxy -run "TestStreamTranslator_CustomToolCallInputDelta|TestStreamTranslator_FunctionCall|TestPrepareResponsesBody_(MergesReasoningInclude|DoesNotDuplicateReasoningInclude)" -count=1
```

结果：

```text
ok   github.com/codex2api/proxy
```

```powershell
go test ./proxy ./proxy/wsrelay -count=1
```

结果：

```text
ok   github.com/codex2api/proxy
ok   github.com/codex2api/proxy/wsrelay
```

```powershell
go test ./admin ./api ./auth ./cache ./config ./database ./internal/imageproc ./internal/imagestore ./internal/signedasset ./proxy ./proxy/wsrelay ./security ./security/promptfilter -count=1
```

结果：

```text
ok   github.com/codex2api/admin
ok   github.com/codex2api/api
ok   github.com/codex2api/auth
ok   github.com/codex2api/cache
ok   github.com/codex2api/config
ok   github.com/codex2api/database
ok   github.com/codex2api/internal/imageproc
ok   github.com/codex2api/internal/imagestore
ok   github.com/codex2api/internal/signedasset
ok   github.com/codex2api/proxy
ok   github.com/codex2api/proxy/wsrelay
ok   github.com/codex2api/security
ok   github.com/codex2api/security/promptfilter
```

另外执行：

```powershell
git diff --check
```

结果：无空白错误。Windows 环境下仅出现 Git 换行提示 `LF will be replaced by CRLF the next time Git touches it`。

### 未通过 / 未执行说明

执行 `go test ./...` 时，根包因当前 worktree 缺少前端构建产物失败：

```text
main.go:29:12: pattern frontend/dist/*: no matching files found
```

该失败与本 PR 的 Go 代码修改无关；已用除根包外的全部 Go 子包测试进行覆盖验证。

## 修改总结

本 PR 在不改既有可工作请求头的前提下，补齐了 Codex Responses 请求体 include 合并和 custom tool call SSE 事件兼容能力，提升 Codex 模拟保真度与新版上游事件格式兼容性，并通过定向测试与相关 Go 子包测试验证。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended tool call support to include custom tool calls alongside function calls. Tool inputs are now properly handled and translated in both streaming and non-streaming response modes.

* **Tests**
  * Added test coverage for custom tool call input deltas, streaming behavior, and token estimation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->