### PR TITLE
信用账号跳过 5h/7d 用量窗口限流

### DIFF
--- a/auth/premium_rate_limit.go
+++ b/auth/premium_rate_limit.go
@@ -75,6 +75,9 @@ func (a *Account) IsPremium5hPlan() bool {
 }
 
 func (a *Account) premium5hRateLimitedLocked(now time.Time) bool {
+	if a.creditSkipsUsageWindowLocked() {
+		return false
+	}
 	if !isPremium5hPlan(a.PlanType) {
 		return false
 	}

--- a/auth/runtime_status_test.go
+++ b/auth/runtime_status_test.go
@@ -102,6 +102,31 @@ func TestMarkUsage7dRateLimitedUsesActiveResetWindow(t *testing.T) {
 	}
 }
 
+func TestMarkUsage7dRateLimitedSkipsCreditUsageWindow(t *testing.T) {
+	store := NewStore(nil, nil, nil)
+	acc := &Account{
+		DBID:                  1,
+		AccessToken:           "at-test",
+		PlanType:              "team",
+		Status:                StatusReady,
+		HealthTier:            HealthTierHealthy,
+		CreditEnabled:         true,
+		CreditSkipUsageWindow: true,
+	}
+	acc.SetUsagePercent7d(100)
+	acc.SetReset7dAt(time.Now().Add(time.Hour))
+
+	if store.MarkUsage7dRateLimited(acc) {
+		t.Fatal("MarkUsage7dRateLimited() = true, want false for credit account")
+	}
+	if got := acc.RuntimeStatus(); got != "active" {
+		t.Fatalf("RuntimeStatus() = %q, want active for credit account", got)
+	}
+	if !acc.IsAvailable() {
+		t.Fatal("IsAvailable() = false, want true for credit account")
+	}
+}
+
 func TestMarkUsage7dRateLimitedSkipsExpiredResetWindow(t *testing.T) {
 	store := NewStore(nil, nil, nil)
 	acc := &Account{

--- a/auth/store.go
+++ b/auth/store.go
@@ -135,7 +135,7 @@ type Account struct {
 	ScoreBiasOverride       *int64
 	BaseConcurrencyOverride *int64
 	CreditEnabled           bool // 信用账号标记
-	CreditSkipUsageWindow   bool // 跳过用量窗口惩罚
+	CreditSkipUsageWindow   bool // 跳过用量窗口惩罚和本地限流标记
 	SkipWarmTier            bool // 跳过 warm 层级降级
 	AllowedAPIKeyIDs        []int64
 	allowedAPIKeySet        map[int64]struct{}
@@ -1078,9 +1078,23 @@ func resolveEffectiveThreshold(accountThreshold float64, groupIDs []int64, s *St
 	return s.GetGlobalAutoPause7dThreshold()
 }
 
+func (a *Account) creditSkipsUsageWindowLocked() bool {
+	return a.CreditEnabled && a.CreditSkipUsageWindow
+}
+
+// SkipsUsageWindowLimits 判断账号是否应跳过 5h/7d 用量窗口触发的本地限流。
+func (a *Account) SkipsUsageWindowLimits() bool {
+	if a == nil {
+		return false
+	}
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.creditSkipsUsageWindowLocked()
+}
+
 // usageExhaustedLocked 判断 Free 账号 7d 用量是否已耗尽（需持有 mu 读锁）
 func (a *Account) usageExhaustedLocked() bool {
-	if a.CreditEnabled && a.CreditSkipUsageWindow {
+	if a.creditSkipsUsageWindowLocked() {
 		return false
 	}
 	return a.UsagePercent7dValid && strings.EqualFold(a.PlanType, "free") && a.UsagePercent7d >= 100
@@ -1228,6 +1242,9 @@ func (a *Account) GetUsagePercent7d() (float64, bool) {
 // metadata falls back to a full 7d cooldown, while stale reset times are ignored.
 func (s *Store) MarkUsage7dRateLimited(acc *Account) bool {
 	if s == nil || acc == nil || acc.IsBanned() {
+		return false
+	}
+	if acc.SkipsUsageWindowLimits() {
 		return false
 	}
 

--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -3908,7 +3908,7 @@ func SyncCodexUsageState(store *auth.Store, account *auth.Account, resp *http.Re
 	}
 
 	result.UsagePct5h, result.Reset5hAt, result.HasUsage5h = account.GetUsageSnapshot5h()
-	if result.Used5hHeaders && account.IsPremium5hPlan() && result.HasUsage5h && result.UsagePct5h >= 100 {
+	if result.Used5hHeaders && account.IsPremium5hPlan() && result.HasUsage5h && result.UsagePct5h >= 100 && !account.SkipsUsageWindowLimits() {
 		if store != nil {
 			store.MarkPremium5hRateLimited(account, result.Reset5hAt)
 		}

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -2124,6 +2124,64 @@ func TestSyncCodexUsageStateMarks7dUsageLimited(t *testing.T) {
 	}
 }
 
+func TestSyncCodexUsageStateCreditAccountSkips7dUsageLimit(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "codex2api.db")
+	db, err := database.New("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("database.New returned error: %v", err)
+	}
+	defer db.Close()
+
+	id, err := db.InsertAccountWithCredentials(ctx, "credit-7d", map[string]interface{}{
+		"plan_type": "team",
+	}, "")
+	if err != nil {
+		t.Fatalf("InsertAccountWithCredentials returned error: %v", err)
+	}
+
+	store := auth.NewStore(db, nil, &database.SystemSettings{MaxConcurrency: 2, TestConcurrency: 1, TestModel: "gpt-5.5"})
+	account := &auth.Account{
+		DBID:                  id,
+		AccessToken:           "at",
+		PlanType:              "team",
+		Status:                auth.StatusReady,
+		HealthTier:            auth.HealthTierHealthy,
+		CreditEnabled:         true,
+		CreditSkipUsageWindow: true,
+	}
+	resp := &http.Response{Header: make(http.Header)}
+	resp.Header.Set("x-codex-primary-used-percent", "20")
+	resp.Header.Set("x-codex-primary-window-minutes", "300")
+	resp.Header.Set("x-codex-primary-reset-after-seconds", "1200")
+	resp.Header.Set("x-codex-secondary-used-percent", "100")
+	resp.Header.Set("x-codex-secondary-window-minutes", "10080")
+	resp.Header.Set("x-codex-secondary-reset-after-seconds", "3600")
+
+	result := SyncCodexUsageState(store, account, resp)
+
+	if !result.HasUsage7d || result.UsagePct7d != 100 {
+		t.Fatalf("usage sync result = %+v, want 7d snapshot at 100", result)
+	}
+	if result.Usage7dRateLimited {
+		t.Fatalf("Usage7dRateLimited = true, want false for credit account")
+	}
+	if got := account.RuntimeStatus(); got != "active" {
+		t.Fatalf("RuntimeStatus() = %q, want active for credit account", got)
+	}
+	row, err := db.GetAccountByID(ctx, id)
+	if err != nil {
+		t.Fatalf("GetAccountByID returned error: %v", err)
+	}
+	if row.CooldownReason != "" || row.CooldownUntil.Valid {
+		t.Fatalf("persisted cooldown = (%q, %v), want no cooldown", row.CooldownReason, row.CooldownUntil)
+	}
+	pct7d, ok := account.GetUsagePercent7d()
+	if !ok || pct7d != 100 {
+		t.Fatalf("usage_percent_7d = (%v, %v), want 100 with valid snapshot", pct7d, ok)
+	}
+}
+
 func TestAuthMiddlewareSetsAPIKeyContext(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/proxy/premium_rate_limit_test.go
+++ b/proxy/premium_rate_limit_test.go
@@ -129,3 +129,38 @@ func TestSyncCodexUsageStatePremium5hOnlyHeadersMarksRateLimited(t *testing.T) {
 		t.Fatal("account should enter premium 5h rate_limited state from headers alone")
 	}
 }
+
+func TestSyncCodexUsageStateCreditAccountSkipsPremium5hWindowLimit(t *testing.T) {
+	store := newProxyPremiumTestStore()
+	acc := &auth.Account{
+		DBID:                  1,
+		AccessToken:           "token",
+		PlanType:              "team",
+		Status:                auth.StatusReady,
+		CreditEnabled:         true,
+		CreditSkipUsageWindow: true,
+	}
+	resp := &http.Response{Header: make(http.Header)}
+	resp.Header.Set("x-codex-primary-used-percent", "100")
+	resp.Header.Set("x-codex-primary-window-minutes", "300")
+	resp.Header.Set("x-codex-primary-reset-after-seconds", "900")
+
+	result := SyncCodexUsageState(store, acc, resp)
+
+	if !result.HasUsage5h {
+		t.Fatal("HasUsage5h = false, want true")
+	}
+	if !result.Persisted5hOnly {
+		t.Fatal("Persisted5hOnly = false, want true")
+	}
+	if result.Premium5hRateLimited {
+		t.Fatal("Premium5hRateLimited = true, want false for credit account")
+	}
+	if acc.IsPremium5hRateLimited() {
+		t.Fatal("credit account should not enter premium 5h rate_limited state from usage-window headers")
+	}
+	pct5h, _, ok := acc.GetUsageSnapshot5h()
+	if !ok || pct5h != 100 {
+		t.Fatalf("5h snapshot = (%v, %v), want 100 with valid snapshot", pct5h, ok)
+	}
+}

--- a/proxy/usage_wham.go
+++ b/proxy/usage_wham.go
@@ -349,7 +349,7 @@ func ApplyWhamUsage(store *auth.Store, account *auth.Account, usage *WhamUsage) 
 	}
 
 	// premium 5h 限流标记
-	if result.Used5hHeaders && account.IsPremium5hPlan() && result.HasUsage5h && result.UsagePct5h >= 100 {
+	if result.Used5hHeaders && account.IsPremium5hPlan() && result.HasUsage5h && result.UsagePct5h >= 100 && !account.SkipsUsageWindowLimits() {
 		if store != nil {
 			store.MarkPremium5hRateLimited(account, result.Reset5hAt)
 		}

--- a/proxy/usage_wham_test.go
+++ b/proxy/usage_wham_test.go
@@ -432,6 +432,34 @@ func TestApplyWhamUsage_MarksPremium5hLimitedAt100Percent(t *testing.T) {
 	}
 }
 
+func TestApplyWhamUsage_CreditAccountSkipsPremium5hWindowLimit(t *testing.T) {
+	store := auth.NewStore(nil, nil, &database.SystemSettings{MaxConcurrency: 2, TestConcurrency: 1, TestModel: "gpt-5.5"})
+	account := &auth.Account{
+		DBID:                  1,
+		AccessToken:           "at",
+		PlanType:              "plus",
+		Status:                auth.StatusReady,
+		CreditEnabled:         true,
+		CreditSkipUsageWindow: true,
+	}
+
+	now := time.Now()
+	usage := &WhamUsage{PlanType: "plus"}
+	usage.RateLimit.PrimaryWindow = &WhamUsageWindow{UsedPercent: 100, LimitWindowSeconds: 18000, ResetAt: now.Add(2 * time.Hour).Unix()}
+
+	result := ApplyWhamUsage(store, account, usage)
+	if result.Premium5hRateLimited {
+		t.Fatalf("Premium5hRateLimited = true, want false for credit account")
+	}
+	if account.IsPremium5hRateLimited() {
+		t.Fatal("credit account should not be in premium 5h rate-limited state after ApplyWhamUsage")
+	}
+	pct5h, _, ok := account.GetUsageSnapshot5h()
+	if !ok || pct5h != 100 {
+		t.Fatalf("5h snapshot = (%v, %v), want 100 with valid snapshot", pct5h, ok)
+	}
+}
+
 func TestApplyWhamUsage_Marks7dLimitedAt100Percent(t *testing.T) {
 	store := auth.NewStore(nil, nil, &database.SystemSettings{MaxConcurrency: 2, TestConcurrency: 1, TestModel: "gpt-5.4"})
 	account := &auth.Account{DBID: 1, AccessToken: "at", PlanType: "team", Status: auth.StatusReady, HealthTier: auth.HealthTierHealthy}
@@ -447,6 +475,36 @@ func TestApplyWhamUsage_Marks7dLimitedAt100Percent(t *testing.T) {
 	}
 	if got := account.RuntimeStatus(); got != "rate_limited" {
 		t.Fatalf("RuntimeStatus() = %q, want rate_limited", got)
+	}
+}
+
+func TestApplyWhamUsage_CreditAccountSkips7dWindowLimit(t *testing.T) {
+	store := auth.NewStore(nil, nil, &database.SystemSettings{MaxConcurrency: 2, TestConcurrency: 1, TestModel: "gpt-5.5"})
+	account := &auth.Account{
+		DBID:                  1,
+		AccessToken:           "at",
+		PlanType:              "team",
+		Status:                auth.StatusReady,
+		HealthTier:            auth.HealthTierHealthy,
+		CreditEnabled:         true,
+		CreditSkipUsageWindow: true,
+	}
+
+	now := time.Now()
+	usage := &WhamUsage{PlanType: "team"}
+	usage.RateLimit.PrimaryWindow = &WhamUsageWindow{UsedPercent: 20, LimitWindowSeconds: 18000, ResetAt: now.Add(2 * time.Hour).Unix()}
+	usage.RateLimit.SecondaryWindow = &WhamUsageWindow{UsedPercent: 100, LimitWindowSeconds: 604800, ResetAt: now.Add(5 * 24 * time.Hour).Unix()}
+
+	result := ApplyWhamUsage(store, account, usage)
+	if result.Usage7dRateLimited {
+		t.Fatalf("Usage7dRateLimited = true, want false for credit account")
+	}
+	if got := account.RuntimeStatus(); got != "active" {
+		t.Fatalf("RuntimeStatus() = %q, want active for credit account", got)
+	}
+	pct7d, ok := account.GetUsagePercent7d()
+	if !ok || pct7d != 100 {
+		t.Fatalf("7d snapshot = (%v, %v), want 100 with valid snapshot", pct7d, ok)
 	}
 }
 


### PR DESCRIPTION
## 背景

`credit_enabled + credit_skip_usage_window` 的含义是信用账号跳过 5h/7d 用量窗口限制。当前实现已经跳过了调度评分里的 7d 用量惩罚，也会让 free 账号的 `usage_exhausted` 判定失效；但响应头同步和 WHAM 用量探针在看到 7d 或 5h 用量达到 100% 时，仍会把账号写入 `rate_limited` 冷却状态。

这会导致信用账号虽然配置了 `credit_skip_usage_window`，但只要上游返回 5h/7d 用量窗口为 100%，仍然会被本地调度排除。

## 改动

- 增加账号级 `SkipsUsageWindowLimits()` 判断，统一表达信用账号跳过用量窗口本地限流的语义。
- 7d 用量窗口达到 100% 时，信用账号仍记录用量快照，但不再调用本地 `MarkUsage7dRateLimited`。
- 5h 用量窗口达到 100% 时，响应头同步和 WHAM 探针仍记录 5h 快照，但不再把信用账号判定为 premium 5h 限流。
- 保留真实冷却/错误路径：401、已有 cooldown、真实上游失败等路径没有被改成可用。

## 验证

- `go test ./auth ./proxy -run 'TestMarkUsage7dRateLimited|TestSyncCodexUsageState|TestApplyWhamUsage'`
- `mkdir -p frontend/dist && touch frontend/dist/placeholder && go test ./...`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Credit-enabled accounts that skip usage-window limits are no longer incorrectly marked as rate-limited when usage reaches 100%.
  * Premium 5h and 7d usage snapshots still record normally, but the account remains active and available.
  * Cooldown/rate-limit state is no longer persisted for accounts configured to bypass these limits.

* **Tests**
  * Added coverage for credit accounts skipping both premium 5h and 7d usage-window limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->