### PR TITLE
feat: add account custom upstream headers添加自定义请求头给team提供方便

### DIFF
--- a/admin/custom_headers_test.go
+++ b/admin/custom_headers_test.go
@@ -1,0 +1,49 @@
+package admin
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestParseOptionalCustomHeadersFieldNormalizesHeaders(t *testing.T) {
+	raw := json.RawMessage(`{"authorization":"Bearer override","X-Custom-Header":"value"}`)
+
+	parsed, err := parseOptionalCustomHeadersField(raw)
+	if err != nil {
+		t.Fatalf("parseOptionalCustomHeadersField() error = %v", err)
+	}
+	if !parsed.Set {
+		t.Fatal("custom headers should be marked as set")
+	}
+	if got := parsed.Values["Authorization"]; got != "Bearer override" {
+		t.Fatalf("Authorization = %q", got)
+	}
+	if got := parsed.Values["X-Custom-Header"]; got != "value" {
+		t.Fatalf("X-Custom-Header = %q", got)
+	}
+}
+
+func TestParseOptionalCustomHeadersFieldRejectsInvalidValues(t *testing.T) {
+	if _, err := parseOptionalCustomHeadersField(json.RawMessage(`{"Bad Header":"value"}`)); err == nil {
+		t.Fatal("expected invalid header name error")
+	}
+	if _, err := parseOptionalCustomHeadersField(json.RawMessage(`{"X-Test":"line1\nline2"}`)); err == nil {
+		t.Fatal("expected newline value error")
+	}
+}
+
+func TestParseCustomHeadersFormNormalizesHeaders(t *testing.T) {
+	headers, err := parseCustomHeadersForm(`{"authorization":"Bearer override"}`)
+	if err != nil {
+		t.Fatalf("parseCustomHeadersForm() error = %v", err)
+	}
+	if got := headers["Authorization"]; got != "Bearer override" {
+		t.Fatalf("Authorization = %q", got)
+	}
+}
+
+func TestParseCustomHeadersFormRejectsInvalidJSON(t *testing.T) {
+	if _, err := parseCustomHeadersForm(`[]`); err == nil {
+		t.Fatal("expected non-object custom_headers error")
+	}
+}

--- a/admin/handler.go
+++ b/admin/handler.go
@@ -644,6 +644,7 @@ type accountResponse struct {
 	OpenAIResponsesAPI       bool                       `json:"openai_responses_api,omitempty"`
 	BaseURL                  string                     `json:"base_url,omitempty"`
 	Models                   []string                   `json:"models,omitempty"`
+	CustomHeaders            map[string]string          `json:"custom_headers,omitempty"`
 	HealthTier               string                     `json:"health_tier"`
 	SchedulerScore           float64                    `json:"scheduler_score"`
 	DispatchScore            float64                    `json:"dispatch_score"`
@@ -811,6 +812,7 @@ func (h *Handler) ListAccounts(c *gin.Context) {
 			OpenAIResponsesAPI:       isOpenAIResponsesAccount,
 			BaseURL:                  baseURL,
 			Models:                   row.GetCredentialStringSlice("models"),
+			CustomHeaders:            row.GetCredentialStringMap("custom_headers"),
 			ProxyURL:                 row.ProxyURL,
 			Enabled:                  row.Enabled,
 			Locked:                   row.Locked,
@@ -1001,6 +1003,7 @@ type updateAccountSchedulerReq struct {
 	AutoPause7dDisabled     json.RawMessage `json:"auto_pause_7d_disabled"`
 	DispatchCountLimit      json.RawMessage `json:"dispatch_count_limit"`
 	ProxyURL                json.RawMessage `json:"proxy_url"`
+	CustomHeaders           json.RawMessage `json:"custom_headers"`
 }
 
 type accountSchedulerUpdate struct {
@@ -1016,6 +1019,7 @@ type accountSchedulerUpdate struct {
 	AutoPause7dDisabled     database.OptionalBool
 	DispatchCountLimit      database.OptionalNullInt64
 	ProxyURL                database.OptionalString
+	CustomHeaders           optionalCustomHeaders
 	CredentialUpdates       map[string]interface{}
 }
 
@@ -1069,7 +1073,14 @@ func parseAccountSchedulerUpdate(req updateAccountSchedulerReq) (accountSchedule
 	if err != nil {
 		return accountSchedulerUpdate{}, err
 	}
+	customHeaders, err := parseOptionalCustomHeadersField(req.CustomHeaders)
+	if err != nil {
+		return accountSchedulerUpdate{}, err
+	}
 	credentialUpdates := make(map[string]interface{})
+	if customHeaders.Set {
+		credentialUpdates["custom_headers"] = cloneCustomHeaders(customHeaders.Values)
+	}
 	if autoPause5hThreshold.Set {
 		credentialUpdates["auto_pause_5h_threshold"] = autoPause5hThreshold.Value
 	}
@@ -1106,6 +1117,7 @@ func parseAccountSchedulerUpdate(req updateAccountSchedulerReq) (accountSchedule
 		AutoPause7dDisabled:     autoPause7dDisabled,
 		DispatchCountLimit:      dispatchCountLimit,
 		ProxyURL:                proxyURL,
+		CustomHeaders:           customHeaders,
 		CredentialUpdates:       credentialUpdates,
 	}, nil
 }
@@ -1278,6 +1290,90 @@ func (h *Handler) applyAccountSchedulerRuntimeUpdate(id int64, update accountSch
 	if update.ProxyURL.Set {
 		h.store.ApplyAccountProxyURL(id, update.ProxyURL.Value)
 	}
+	if update.CustomHeaders.Set {
+		h.store.ApplyAccountCustomHeaders(id, update.CustomHeaders.Values)
+	}
+}
+
+type optionalCustomHeaders struct {
+	Set    bool
+	Values map[string]string
+}
+
+func parseOptionalCustomHeadersField(raw json.RawMessage) (optionalCustomHeaders, error) {
+	if len(raw) == 0 {
+		return optionalCustomHeaders{}, nil
+	}
+	if string(raw) == "null" {
+		return optionalCustomHeaders{Set: true}, nil
+	}
+	var headers map[string]string
+	if err := json.Unmarshal(raw, &headers); err != nil {
+		return optionalCustomHeaders{}, fmt.Errorf("custom_headers 必须是对象或 null")
+	}
+	normalized, err := normalizeCustomHeaders(headers)
+	if err != nil {
+		return optionalCustomHeaders{}, err
+	}
+	return optionalCustomHeaders{Set: true, Values: normalized}, nil
+}
+
+func normalizeCustomHeaders(headers map[string]string) (map[string]string, error) {
+	if len(headers) == 0 {
+		return nil, nil
+	}
+	if len(headers) > 64 {
+		return nil, fmt.Errorf("custom_headers 最多支持 64 个请求头")
+	}
+	out := make(map[string]string, len(headers))
+	for rawName, rawValue := range headers {
+		name := strings.TrimSpace(rawName)
+		if name == "" {
+			continue
+		}
+		if len(name) > 128 || !isValidHeaderName(name) {
+			return nil, fmt.Errorf("custom_headers 包含无效请求头名称: %s", name)
+		}
+		value := strings.TrimSpace(rawValue)
+		if strings.ContainsAny(value, "\r\n") {
+			return nil, fmt.Errorf("custom_headers.%s 不能包含换行符", name)
+		}
+		if len(value) > 8192 {
+			return nil, fmt.Errorf("custom_headers.%s 不能超过 8192 字符", name)
+		}
+		out[http.CanonicalHeaderKey(name)] = value
+	}
+	if len(out) == 0 {
+		return nil, nil
+	}
+	return out, nil
+}
+
+func isValidHeaderName(name string) bool {
+	for i := 0; i < len(name); i++ {
+		c := name[i]
+		if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') {
+			continue
+		}
+		switch c {
+		case '!', '#', '$', '%', '&', '\'', '*', '+', '-', '.', '^', '_', '`', '|', '~':
+			continue
+		default:
+			return false
+		}
+	}
+	return name != ""
+}
+
+func cloneCustomHeaders(headers map[string]string) map[string]string {
+	if len(headers) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(headers))
+	for name, value := range headers {
+		out[name] = value
+	}
+	return out
 }
 
 type optionalStringSlice struct {
@@ -1636,11 +1732,12 @@ func (h *Handler) getAccountUsageWindows(ctx context.Context) (map[int64]*databa
 }
 
 type addAccountReq struct {
-	Name           string `json:"name"`
-	RefreshToken   string `json:"refresh_token"`
-	SessionToken   string `json:"session_token"`
-	ProxyURL       string `json:"proxy_url"`
-	AllowDuplicate bool   `json:"allow_duplicate"`
+	Name           string            `json:"name"`
+	RefreshToken   string            `json:"refresh_token"`
+	SessionToken   string            `json:"session_token"`
+	ProxyURL       string            `json:"proxy_url"`
+	CustomHeaders  map[string]string `json:"custom_headers"`
+	AllowDuplicate bool              `json:"allow_duplicate"`
 }
 
 func splitAccountCredentialLines(raw string, sanitize bool) []string {
@@ -1740,6 +1837,12 @@ func (h *Handler) AddAccount(c *gin.Context) {
 		writeError(c, http.StatusBadRequest, "代理URL无效")
 		return
 	}
+	customHeaders, err := normalizeCustomHeaders(req.CustomHeaders)
+	if err != nil {
+		writeError(c, http.StatusBadRequest, err.Error())
+		return
+	}
+	req.CustomHeaders = customHeaders
 
 	// 按行分割，支持批量添加。refresh_token 与 session_token 同时填写时，
 	// session_token 可填写一行应用到所有 RT，也可与 RT 行数一一对应。
@@ -1756,7 +1859,7 @@ func (h *Handler) AddAccount(c *gin.Context) {
 
 	var seeds []tokenCredentialSeed
 	for i := 0; i < total; i++ {
-		seed := tokenCredentialSeed{allowDuplicate: req.AllowDuplicate}
+		seed := tokenCredentialSeed{allowDuplicate: req.AllowDuplicate, customHeaders: customHeaders}
 		if len(refreshTokens) > 0 {
 			seed.refreshToken = refreshTokens[i]
 		}
@@ -1926,10 +2029,11 @@ func (h *Handler) streamAddAccounts(c *gin.Context, req addAccountReq, seeds []t
 
 // addATAccountReq AT 模式添加账号请求
 type addATAccountReq struct {
-	Name           string `json:"name"`
-	AccessToken    string `json:"access_token"`
-	ProxyURL       string `json:"proxy_url"`
-	AllowDuplicate bool   `json:"allow_duplicate"`
+	Name           string            `json:"name"`
+	AccessToken    string            `json:"access_token"`
+	ProxyURL       string            `json:"proxy_url"`
+	CustomHeaders  map[string]string `json:"custom_headers"`
+	AllowDuplicate bool              `json:"allow_duplicate"`
 }
 
 // AddATAccount 添加 AT-only 账号（支持批量：access_token 按行分割）
@@ -1962,6 +2066,12 @@ func (h *Handler) AddATAccount(c *gin.Context) {
 		writeError(c, http.StatusBadRequest, "代理URL无效")
 		return
 	}
+	customHeaders, err := normalizeCustomHeaders(req.CustomHeaders)
+	if err != nil {
+		writeError(c, http.StatusBadRequest, err.Error())
+		return
+	}
+	req.CustomHeaders = customHeaders
 
 	// 按行分割，支持批量添加
 	lines := strings.Split(req.AccessToken, "\n")
@@ -2021,6 +2131,7 @@ func (h *Handler) AddATAccount(c *gin.Context) {
 		seed := normalizeTokenCredentialSeed(tokenCredentialSeed{
 			accessToken:    at,
 			allowDuplicate: req.AllowDuplicate,
+			customHeaders:  customHeaders,
 		})
 		if !req.AllowDuplicate && seed.email != "" && (seed.accountID != "" || seed.userID != "") {
 			id, updated, err := h.upsertOAuthIdentityAccount(ctx, name, req.ProxyURL, seed, "manual_at")
@@ -2140,7 +2251,7 @@ func (h *Handler) streamAddATAccounts(c *gin.Context, req addATAccountReq, token
 			name = fmt.Sprintf("%s-%d", req.Name, i+1)
 		}
 
-		seed := normalizeTokenCredentialSeed(tokenCredentialSeed{accessToken: at, allowDuplicate: req.AllowDuplicate})
+		seed := normalizeTokenCredentialSeed(tokenCredentialSeed{accessToken: at, allowDuplicate: req.AllowDuplicate, customHeaders: req.CustomHeaders})
 		if !req.AllowDuplicate && seed.email != "" && (seed.accountID != "" || seed.userID != "") {
 			id, updated, err := h.upsertOAuthIdentityAccount(ctx, name, req.ProxyURL, seed, "manual_at")
 			if err != nil {
@@ -2197,11 +2308,12 @@ func (h *Handler) streamAddATAccounts(c *gin.Context, req addATAccountReq, token
 }
 
 type addOpenAIResponsesAccountReq struct {
-	Name     string   `json:"name"`
-	BaseURL  string   `json:"base_url"`
-	APIKey   string   `json:"api_key"`
-	Models   []string `json:"models"`
-	ProxyURL string   `json:"proxy_url"`
+	Name          string            `json:"name"`
+	BaseURL       string            `json:"base_url"`
+	APIKey        string            `json:"api_key"`
+	Models        []string          `json:"models"`
+	ProxyURL      string            `json:"proxy_url"`
+	CustomHeaders map[string]string `json:"custom_headers"`
 }
 
 type fetchOpenAIResponsesModelsReq struct {
@@ -2248,6 +2360,11 @@ func (h *Handler) AddOpenAIResponsesAccount(c *gin.Context) {
 		writeError(c, http.StatusBadRequest, "代理URL无效")
 		return
 	}
+	customHeaders, err := normalizeCustomHeaders(req.CustomHeaders)
+	if err != nil {
+		writeError(c, http.StatusBadRequest, err.Error())
+		return
+	}
 	for _, model := range models {
 		if err := security.ValidateModelName(model); err != nil {
 			writeError(c, http.StatusBadRequest, fmt.Sprintf("模型名称无效: %s", model))
@@ -2280,6 +2397,9 @@ func (h *Handler) AddOpenAIResponsesAccount(c *gin.Context) {
 		"plan_type":     "api",
 		"email":         baseURL,
 	}
+	if len(customHeaders) > 0 {
+		credentials["custom_headers"] = cloneCustomHeaders(customHeaders)
+	}
 	id, err := h.db.InsertOpenAIResponsesAccount(ctx, name, credentials, req.ProxyURL)
 	if err != nil {
 		writeInternalError(c, err)
@@ -2288,15 +2408,16 @@ func (h *Handler) AddOpenAIResponsesAccount(c *gin.Context) {
 	h.db.InsertAccountEventAsync(id, "added", "manual_openai_responses")
 
 	h.store.AddAccount(&auth.Account{
-		DBID:         id,
-		ProxyURL:     req.ProxyURL,
-		HealthTier:   auth.HealthTierHealthy,
-		UpstreamType: auth.UpstreamOpenAIResponses,
-		BaseURL:      baseURL,
-		APIKey:       req.APIKey,
-		Models:       models,
-		Email:        baseURL,
-		PlanType:     "api",
+		DBID:          id,
+		ProxyURL:      req.ProxyURL,
+		HealthTier:    auth.HealthTierHealthy,
+		UpstreamType:  auth.UpstreamOpenAIResponses,
+		BaseURL:       baseURL,
+		APIKey:        req.APIKey,
+		Models:        models,
+		CustomHeaders: customHeaders,
+		Email:         baseURL,
+		PlanType:      "api",
 	})
 
 	security.SecurityAuditLog("OPENAI_RESPONSES_ACCOUNT_ADDED", fmt.Sprintf("account_id=%d models=%d ip=%s", id, len(models), c.ClientIP()))
@@ -2418,6 +2539,11 @@ func (h *Handler) UpdateOpenAIResponsesAccount(c *gin.Context) {
 		writeError(c, http.StatusBadRequest, "代理URL无效")
 		return
 	}
+	customHeaders, err := normalizeCustomHeaders(req.CustomHeaders)
+	if err != nil {
+		writeError(c, http.StatusBadRequest, err.Error())
+		return
+	}
 	for _, model := range models {
 		if err := security.ValidateModelName(model); err != nil {
 			writeError(c, http.StatusBadRequest, fmt.Sprintf("模型名称无效: %s", model))
@@ -2434,11 +2560,12 @@ func (h *Handler) UpdateOpenAIResponsesAccount(c *gin.Context) {
 	}
 
 	credentials := map[string]interface{}{
-		"upstream_type": auth.UpstreamOpenAIResponses,
-		"base_url":      baseURL,
-		"models":        models,
-		"plan_type":     "api",
-		"email":         baseURL,
+		"upstream_type":  auth.UpstreamOpenAIResponses,
+		"base_url":       baseURL,
+		"models":         models,
+		"plan_type":      "api",
+		"email":          baseURL,
+		"custom_headers": cloneCustomHeaders(customHeaders),
 	}
 	if req.APIKey != "" {
 		credentials["api_key"] = req.APIKey
@@ -2458,6 +2585,7 @@ func (h *Handler) UpdateOpenAIResponsesAccount(c *gin.Context) {
 	}
 	if h.store != nil {
 		h.store.ApplyOpenAIResponsesConfig(id, baseURL, req.APIKey, models, req.ProxyURL)
+		h.store.ApplyAccountCustomHeaders(id, customHeaders)
 	}
 	h.db.InsertAccountEventAsync(id, "updated", "manual_openai_responses")
 
@@ -2885,16 +3013,21 @@ func (h *Handler) ImportAccounts(c *gin.Context) {
 	format := c.DefaultPostForm("format", "txt")
 	proxyURL := c.PostForm("proxy_url")
 	allowDuplicate := parseBoolForm(c.PostForm("allow_duplicate"))
+	customHeaders, err := parseCustomHeadersForm(c.PostForm("custom_headers"))
+	if err != nil {
+		writeError(c, http.StatusBadRequest, err.Error())
+		return
+	}
 
 	switch format {
 	case "json":
-		h.importAccountsJSON(c, proxyURL, allowDuplicate)
+		h.importAccountsJSON(c, proxyURL, allowDuplicate, customHeaders)
 	case "json_at":
-		h.importAccountsJSONPreferAT(c, proxyURL, allowDuplicate)
+		h.importAccountsJSONPreferAT(c, proxyURL, allowDuplicate, customHeaders)
 	case "at_txt":
-		h.importAccountsATTXT(c, proxyURL, allowDuplicate)
+		h.importAccountsATTXT(c, proxyURL, allowDuplicate, customHeaders)
 	default:
-		h.importAccountsTXT(c, proxyURL, allowDuplicate)
+		h.importAccountsTXT(c, proxyURL, allowDuplicate, customHeaders)
 	}
 }
 
@@ -2906,6 +3039,18 @@ func parseBoolForm(v string) bool {
 	default:
 		return false
 	}
+}
+
+func parseCustomHeadersForm(raw string) (map[string]string, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return nil, nil
+	}
+	var headers map[string]string
+	if err := json.Unmarshal([]byte(trimmed), &headers); err != nil {
+		return nil, fmt.Errorf("custom_headers 必须是 JSON 对象")
+	}
+	return normalizeCustomHeaders(headers)
 }
 
 type uploadedImportFile struct {
@@ -2964,7 +3109,7 @@ func importTokensFromTextFiles(files []uploadedImportFile, makeToken func(string
 }
 
 // importAccountsTXT 通过 TXT 文件导入（每行一个 RT）
-func (h *Handler) importAccountsTXT(c *gin.Context, proxyURL string, allowDuplicate bool) {
+func (h *Handler) importAccountsTXT(c *gin.Context, proxyURL string, allowDuplicate bool, customHeaders ...map[string]string) {
 	files, err := readUploadedImportFiles(c)
 	if err != nil {
 		writeError(c, http.StatusBadRequest, err.Error())
@@ -2979,11 +3124,11 @@ func (h *Handler) importAccountsTXT(c *gin.Context, proxyURL string, allowDuplic
 		return
 	}
 
-	h.importAccountsCommon(c, tokens, proxyURL, allowDuplicate)
+	h.importAccountsCommon(c, tokens, proxyURL, allowDuplicate, firstCustomHeaders(customHeaders))
 }
 
 // importAccountsJSON 通过 JSON 文件导入（兼容 CLIProxyAPI 凭证格式）
-func (h *Handler) importAccountsJSON(c *gin.Context, proxyURL string, allowDuplicate bool) {
+func (h *Handler) importAccountsJSON(c *gin.Context, proxyURL string, allowDuplicate bool, customHeaders ...map[string]string) {
 	if err := c.Request.ParseMultipartForm(32 << 20); err != nil {
 		writeError(c, http.StatusBadRequest, "解析表单失败")
 		return
@@ -3029,12 +3174,12 @@ func (h *Handler) importAccountsJSON(c *gin.Context, proxyURL string, allowDupli
 		return
 	}
 
-	h.importAccountsCommon(c, allTokens, proxyURL, allowDuplicate)
+	h.importAccountsCommon(c, allTokens, proxyURL, allowDuplicate, firstCustomHeaders(customHeaders))
 }
 
 // importAccountsJSONPreferAT 通过 JSON 文件导入，但只信任 access_token，
 // 用于一些导出工具中 refresh_token / session_token 是占位/重复值的场景。
-func (h *Handler) importAccountsJSONPreferAT(c *gin.Context, proxyURL string, allowDuplicate bool) {
+func (h *Handler) importAccountsJSONPreferAT(c *gin.Context, proxyURL string, allowDuplicate bool, customHeaders ...map[string]string) {
 	if err := c.Request.ParseMultipartForm(32 << 20); err != nil {
 		writeError(c, http.StatusBadRequest, "解析表单失败")
 		return
@@ -3087,7 +3232,14 @@ func (h *Handler) importAccountsJSONPreferAT(c *gin.Context, proxyURL string, al
 		return
 	}
 
-	h.importAccountsCommon(c, allTokens, proxyURL, allowDuplicate)
+	h.importAccountsCommon(c, allTokens, proxyURL, allowDuplicate, firstCustomHeaders(customHeaders))
+}
+
+func firstCustomHeaders(headers []map[string]string) map[string]string {
+	if len(headers) == 0 {
+		return nil
+	}
+	return headers[0]
 }
 
 // importEvent SSE 导入进度事件
@@ -3127,7 +3279,8 @@ func sendSSEJSON(c *gin.Context, event any) {
 }
 
 // importAccountsCommon 公共的去重、并发插入、SSE 进度推送逻辑（支持 RT 和 AT-only 混合导入）
-func (h *Handler) importAccountsCommon(c *gin.Context, tokens []importToken, proxyURL string, allowDuplicate bool) {
+func (h *Handler) importAccountsCommon(c *gin.Context, tokens []importToken, proxyURL string, allowDuplicate bool, customHeaders ...map[string]string) {
+	importCustomHeaders := firstCustomHeaders(customHeaders)
 	// 文件内去重：
 	// 1) 当条目可解析出 email + account_id 时，以它作为 OAuth 身份键；
 	//    同身份同 RT/ST/AT 折叠，同身份不同 RT/ST/AT 整组跳过，避免任选一个覆盖。
@@ -3366,6 +3519,7 @@ func (h *Handler) importAccountsCommon(c *gin.Context, tokens []importToken, pro
 
 			seed := importTokenSeed(tok, conflictingChatGPTIDs)
 			seed.allowDuplicate = allowDuplicate
+			seed.customHeaders = cloneCustomHeaders(importCustomHeaders)
 			importSource := "import"
 			if tok.accessToken != "" && tok.refreshToken == "" {
 				importSource = "import_at"
@@ -3503,7 +3657,7 @@ func (h *Handler) importAccountsCommon(c *gin.Context, tokens []importToken, pro
 }
 
 // importAccountsATTXT 通过 TXT 文件导入 AT-only 账号（每行一个 Access Token）
-func (h *Handler) importAccountsATTXT(c *gin.Context, proxyURL string, allowDuplicate bool) {
+func (h *Handler) importAccountsATTXT(c *gin.Context, proxyURL string, allowDuplicate bool, customHeaders ...map[string]string) {
 	files, err := readUploadedImportFiles(c)
 	if err != nil {
 		writeError(c, http.StatusBadRequest, err.Error())
@@ -3518,7 +3672,7 @@ func (h *Handler) importAccountsATTXT(c *gin.Context, proxyURL string, allowDupl
 		return
 	}
 
-	h.importAccountsCommon(c, tokens, proxyURL, allowDuplicate)
+	h.importAccountsCommon(c, tokens, proxyURL, allowDuplicate, firstCustomHeaders(customHeaders))
 }
 
 // GetAccountUsage 查询单个账号的用量统计

--- a/admin/token_credentials.go
+++ b/admin/token_credentials.go
@@ -34,6 +34,7 @@ type tokenCredentialSeed struct {
 	codex5HResetAt        string
 	codex5HUsageUpdatedAt string
 	codexUsageUpdatedAt   string
+	customHeaders         map[string]string
 }
 
 func normalizeTokenCredentialSeed(seed tokenCredentialSeed) tokenCredentialSeed {
@@ -188,6 +189,9 @@ func tokenCredentialMap(seed tokenCredentialSeed) map[string]interface{} {
 	if seed.codexUsageUpdatedAt != "" {
 		credentials["codex_usage_updated_at"] = seed.codexUsageUpdatedAt
 	}
+	if len(seed.customHeaders) > 0 {
+		credentials["custom_headers"] = cloneCustomHeaders(seed.customHeaders)
+	}
 	return credentials
 }
 
@@ -203,6 +207,7 @@ func accountFromCredentialSeed(id int64, proxyURL string, seed tokenCredentialSe
 		Email:                 seed.email,
 		PlanType:              seed.planType,
 		ProxyURL:              proxyURL,
+		CustomHeaders:         cloneCustomHeaders(seed.customHeaders),
 		Status:                auth.StatusReady,
 		SubscriptionExpiresAt: seed.subscriptionExpiresAt,
 	}

--- a/auth/store.go
+++ b/auth/store.go
@@ -55,6 +55,7 @@ type Account struct {
 	Email          string
 	PlanType       string
 	ProxyURL       string
+	CustomHeaders  map[string]string
 	UpstreamType   string
 	BaseURL        string
 	APIKey         string
@@ -87,8 +88,8 @@ type Account struct {
 	usageProbeInFlight          bool
 	recoveryProbeInFlight       bool
 	lastAuthVerifyAt            time.Time // WS 上游异常关闭后触发的鉴权验证探针节流时间戳
-	AutoPause5hThreshold        float64 // 0..1, 0 = disabled
-	AutoPause7dThreshold        float64 // 0..1, 0 = disabled
+	AutoPause5hThreshold        float64   // 0..1, 0 = disabled
+	AutoPause7dThreshold        float64   // 0..1, 0 = disabled
 	AutoPause5hDisabled         bool
 	AutoPause7dDisabled         bool
 	effectiveAutoPause5h        float64 // resolved: account > group > global
@@ -318,6 +319,15 @@ func (a *Account) GetAccessToken() string {
 	return strings.TrimSpace(a.AccessToken)
 }
 
+func (a *Account) GetCustomHeaders() map[string]string {
+	if a == nil {
+		return nil
+	}
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return cloneStringMap(a.CustomHeaders)
+}
+
 func clampInt(value, minValue, maxValue int) int {
 	if value < minValue {
 		return minValue
@@ -351,6 +361,17 @@ func cloneStringSlice(values []string) []string {
 	}
 	cloned := make([]string, len(values))
 	copy(cloned, values)
+	return cloned
+}
+
+func cloneStringMap(values map[string]string) map[string]string {
+	if len(values) == 0 {
+		return nil
+	}
+	cloned := make(map[string]string, len(values))
+	for key, value := range values {
+		cloned[key] = value
+	}
 	return cloned
 }
 
@@ -3075,16 +3096,17 @@ func (s *Store) buildAccountFromRow(ctx context.Context, row *database.AccountRo
 	}
 
 	account := &Account{
-		DBID:         row.ID,
-		RefreshToken: rt,
-		SessionToken: st,
-		ProxyURL:     strings.TrimSpace(row.ProxyURL),
-		HealthTier:   HealthTierWarm,
-		AddedAt:      row.CreatedAt.UnixNano(),
-		UpstreamType: upstreamType,
-		BaseURL:      strings.TrimRight(strings.TrimSpace(baseURL), "/"),
-		APIKey:       strings.TrimSpace(apiKey),
-		Models:       models,
+		DBID:          row.ID,
+		RefreshToken:  rt,
+		SessionToken:  st,
+		ProxyURL:      strings.TrimSpace(row.ProxyURL),
+		CustomHeaders: row.GetCredentialStringMap("custom_headers"),
+		HealthTier:    HealthTierWarm,
+		AddedAt:       row.CreatedAt.UnixNano(),
+		UpstreamType:  upstreamType,
+		BaseURL:       strings.TrimRight(strings.TrimSpace(baseURL), "/"),
+		APIKey:        strings.TrimSpace(apiKey),
+		Models:        models,
 	}
 	if isOpenAIResponsesAccount {
 		account.HealthTier = HealthTierHealthy
@@ -4848,6 +4870,17 @@ func (s *Store) ApplyAccountProxyURL(dbID int64, proxyURL string) bool {
 	}
 	acc.mu.Lock()
 	acc.ProxyURL = strings.TrimSpace(proxyURL)
+	acc.mu.Unlock()
+	return true
+}
+
+func (s *Store) ApplyAccountCustomHeaders(dbID int64, headers map[string]string) bool {
+	acc := s.FindByID(dbID)
+	if acc == nil {
+		return false
+	}
+	acc.mu.Lock()
+	acc.CustomHeaders = cloneStringMap(headers)
 	acc.mu.Unlock()
 	return true
 }

--- a/database/credentials_accessors.go
+++ b/database/credentials_accessors.go
@@ -1,6 +1,10 @@
 package database
 
-import "strconv"
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
 
 func (a *AccountRow) GetCredentialFloat64(key string) (float64, bool) {
 	if a == nil || a.Credentials == nil {
@@ -47,4 +51,51 @@ func (a *AccountRow) GetCredentialBool(key string) bool {
 	default:
 		return false
 	}
+}
+
+func (a *AccountRow) GetCredentialStringMap(key string) map[string]string {
+	if a == nil || a.Credentials == nil {
+		return nil
+	}
+	v, ok := a.Credentials[key]
+	if !ok || v == nil {
+		return nil
+	}
+	switch val := v.(type) {
+	case map[string]string:
+		return cloneTrimmedStringMap(val)
+	case map[string]interface{}:
+		out := make(map[string]string, len(val))
+		for key, raw := range val {
+			name := strings.TrimSpace(key)
+			if name == "" || raw == nil {
+				continue
+			}
+			out[name] = strings.TrimSpace(fmt.Sprint(raw))
+		}
+		if len(out) == 0 {
+			return nil
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+func cloneTrimmedStringMap(values map[string]string) map[string]string {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(values))
+	for key, value := range values {
+		name := strings.TrimSpace(key)
+		if name == "" {
+			continue
+		}
+		out[name] = strings.TrimSpace(value)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }

--- a/frontend/src/pages/Accounts.tsx
+++ b/frontend/src/pages/Accounts.tsx
@@ -133,7 +133,14 @@ const ACCOUNT_GROUP_COLORS = [
   "#0891b2",
   "#64748b",
 ] as const;
+const CUSTOM_HEADERS_PLACEHOLDER = `{
+  "Authorization": "Bearer upstream-token",
+  "X-Custom-Header": "value"
+}`;
 type AccountTableColumn = (typeof ACCOUNT_TABLE_COLUMNS)[number];
+type CustomHeadersParseResult =
+  | { ok: true; value: Record<string, string> | null }
+  | { ok: false };
 type AccountGroupDraft = {
   id: number | null;
   name: string;
@@ -310,6 +317,39 @@ function parseModelTokens(value: string): string[] {
       seen.add(key);
       return true;
     });
+}
+
+function formatCustomHeadersText(
+  headers?: Record<string, string> | null,
+): string {
+  if (!headers || Object.keys(headers).length === 0) return "";
+  return JSON.stringify(headers, null, 2);
+}
+
+function parseCustomHeadersText(value: string): CustomHeadersParseResult {
+  const trimmed = value.trim();
+  if (!trimmed) return { ok: true, value: null };
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return { ok: false };
+  }
+
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return { ok: false };
+  }
+
+  const entries = Object.entries(parsed as Record<string, unknown>);
+  if (entries.some(([, headerValue]) => typeof headerValue !== "string")) {
+    return { ok: false };
+  }
+
+  return {
+    ok: true,
+    value: Object.fromEntries(entries) as Record<string, string>,
+  };
 }
 
 function mergeModelLists(current: string[], incoming: string[]): string[] {
@@ -545,6 +585,7 @@ export default function Accounts() {
     session_token: "",
     proxy_url: "",
   });
+  const [addCustomHeadersText, setAddCustomHeadersText] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [selected, setSelected] = useState<Set<number>>(new Set());
   const [refreshingIds, setRefreshingIds] = useState<Set<number>>(new Set());
@@ -599,6 +640,7 @@ export default function Accounts() {
     number[]
   >([]);
   const [editProxyUrl, setEditProxyUrl] = useState("");
+  const [editCustomHeadersText, setEditCustomHeadersText] = useState("");
   const [testingProxyKey, setTestingProxyKey] = useState<string | null>(null);
   const [editOpenAIForm, setEditOpenAIForm] =
     useState<UpdateOpenAIResponsesAccountRequest>({
@@ -614,6 +656,7 @@ export default function Accounts() {
   const [importing, setImporting] = useState(false);
   const [showImportPicker, setShowImportPicker] = useState(false);
   const [importProxyUrl, setImportProxyUrl] = useState("");
+  const [importCustomHeadersText, setImportCustomHeadersText] = useState("");
   const [showSub2APIImport, setShowSub2APIImport] = useState(false);
   const [showPasteImport, setShowPasteImport] = useState(false);
   const [pasteImportText, setPasteImportText] = useState("");
@@ -841,6 +884,43 @@ export default function Accounts() {
       </div>
     );
   };
+
+  const renderCustomHeadersTextarea = ({
+    value,
+    onChange,
+  }: {
+    value: string;
+    onChange: (value: string) => void;
+  }) => (
+    <div>
+      <div className="flex items-center justify-between mb-2">
+        <label className="block text-sm font-semibold text-muted-foreground">
+          上游自定义请求头 JSON
+        </label>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => onChange(CUSTOM_HEADERS_PLACEHOLDER)}
+        >
+          插入模板
+        </Button>
+      </div>
+      <textarea
+        className="w-full min-h-[140px] p-3 border border-input rounded-xl bg-background text-sm resize-y font-mono focus:outline-none focus:ring-2 focus:ring-ring"
+        placeholder={CUSTOM_HEADERS_PLACEHOLDER}
+        value={value}
+        onChange={(event: ChangeEvent<HTMLTextAreaElement>) =>
+          onChange(event.target.value)
+        }
+        rows={6}
+        spellCheck={false}
+      />
+      <p className="mt-1.5 text-xs text-muted-foreground">
+        留空表示不设置；JSON 必须是对象，所有请求头值都必须是字符串。
+      </p>
+    </div>
+  );
 
   useEffect(() => {
     return () => {
@@ -1401,10 +1481,25 @@ export default function Accounts() {
   }, [allPageSelected, pagedAccountIds]);
 
   const handleAdd = async (credential: "rt" | "st" = "rt") => {
+    const parsedCustomHeaders = parseCustomHeadersText(addCustomHeadersText);
+    if (!parsedCustomHeaders.ok) {
+      showToast("自定义请求头必须是 JSON 对象，且所有值必须是字符串", "error");
+      return;
+    }
     const payload: AddAccountRequest =
       credential === "st"
-        ? { ...addForm, refresh_token: "", allow_duplicate: allowDuplicate }
-        : { ...addForm, session_token: "", allow_duplicate: allowDuplicate };
+        ? {
+            ...addForm,
+            refresh_token: "",
+            allow_duplicate: allowDuplicate,
+            custom_headers: parsedCustomHeaders.value,
+          }
+        : {
+            ...addForm,
+            session_token: "",
+            allow_duplicate: allowDuplicate,
+            custom_headers: parsedCustomHeaders.value,
+          };
     if (
       !payload.refresh_token?.trim() &&
       !payload.session_token?.trim()
@@ -1426,6 +1521,7 @@ export default function Accounts() {
         await readImportSSE(res);
         showToast(t("accounts.addSuccess"));
         setAddForm({ refresh_token: "", session_token: "", proxy_url: "" });
+        setAddCustomHeadersText("");
         return;
       }
 
@@ -1433,6 +1529,7 @@ export default function Accounts() {
       showToast(t("accounts.addSuccess"));
       setShowAdd(false);
       setAddForm({ refresh_token: "", session_token: "", proxy_url: "" });
+      setAddCustomHeadersText("");
       void reload();
     } catch (error) {
       showToast(
@@ -1446,6 +1543,11 @@ export default function Accounts() {
 
   const handleAddAT = async () => {
     if (!atForm.access_token.trim()) return;
+    const parsedCustomHeaders = parseCustomHeadersText(addCustomHeadersText);
+    if (!parsedCustomHeaders.ok) {
+      showToast("自定义请求头必须是 JSON 对象，且所有值必须是字符串", "error");
+      return;
+    }
     setSubmitting(true);
     try {
       // 始终走流式：即使只添加一个 access_token 也展示进度条，并能反映
@@ -1453,11 +1555,13 @@ export default function Accounts() {
       const res = await postAdminSSE("/accounts/at?stream=true", {
         ...atForm,
         allow_duplicate: allowDuplicate,
+        custom_headers: parsedCustomHeaders.value,
       });
       setShowAdd(false);
       await readImportSSE(res);
       showToast(t("accounts.addSuccess"));
       setAtForm({ access_token: "", proxy_url: "" });
+      setAddCustomHeadersText("");
     } catch (error) {
       showToast(
         t("accounts.addFailed", { error: getErrorMessage(error) }),
@@ -1543,9 +1647,10 @@ export default function Accounts() {
       const items = Array.isArray(parsed) ? parsed : [parsed];
       const blob = new Blob([JSON.stringify(items)], { type: "application/json" });
       const file = new File([blob], "session.json", { type: "application/json" });
-      await importFiles([file], "json", sessionProxyUrl);
+      await importFiles([file], "json", sessionProxyUrl, addCustomHeadersText);
       setShowAdd(false);
       setSessionJson("");
+      setAddCustomHeadersText("");
     } catch (error) {
       if (error instanceof SyntaxError) {
         showToast(t("accounts.sessionJsonInvalid"), "error");
@@ -1562,9 +1667,18 @@ export default function Accounts() {
   const handleAddOpenAIResponses = async () => {
     const models = openAIForm.models;
     if (!openAIForm.api_key.trim() || models.length === 0) return;
+    const parsedCustomHeaders = parseCustomHeadersText(addCustomHeadersText);
+    if (!parsedCustomHeaders.ok) {
+      showToast("自定义请求头必须是 JSON 对象，且所有值必须是字符串", "error");
+      return;
+    }
     setSubmitting(true);
     try {
-      await api.addOpenAIResponsesAccount({ ...openAIForm, models });
+      await api.addOpenAIResponsesAccount({
+        ...openAIForm,
+        models,
+        custom_headers: parsedCustomHeaders.value,
+      });
       showToast(t("accounts.addSuccess"));
       setShowAdd(false);
       setOpenAIForm({
@@ -1574,6 +1688,7 @@ export default function Accounts() {
         proxy_url: "",
       });
       setOpenAIModelDraft("");
+      setAddCustomHeadersText("");
       void reload();
     } catch (error) {
       showToast(
@@ -1622,11 +1737,17 @@ export default function Accounts() {
       showToast(t("accounts.openaiAccountInvalid"), "error");
       return;
     }
+    const parsedCustomHeaders = parseCustomHeadersText(editCustomHeadersText);
+    if (!parsedCustomHeaders.ok) {
+      showToast("自定义请求头必须是 JSON 对象，且所有值必须是字符串", "error");
+      return;
+    }
     setEditSubmitting(true);
     try {
       await api.updateOpenAIResponsesAccount(editingAccount.id, {
         ...editOpenAIForm,
         api_key: editOpenAIForm.api_key?.trim() || undefined,
+        custom_headers: parsedCustomHeaders.value,
       });
       showToast(t("accounts.openaiAccountSaveSuccess"));
       await reload();
@@ -1719,6 +1840,7 @@ export default function Accounts() {
       setOauthSession(null);
       setOauthCallbackUrl("");
       setOauthName("");
+      setAddCustomHeadersText("");
       void reload();
     } catch (error) {
       showToast(
@@ -1878,7 +2000,13 @@ export default function Accounts() {
     files: File[],
     format: "txt" | "json" | "json_at" | "at_txt",
     proxyOverride?: string,
+    customHeadersText?: string,
   ) => {
+    const parsedCustomHeaders = parseCustomHeadersText(customHeadersText ?? "");
+    if (!parsedCustomHeaders.ok) {
+      showToast("自定义请求头必须是 JSON 对象，且所有值必须是字符串", "error");
+      return;
+    }
     setImporting(true);
     setImportProgress({
       show: true,
@@ -1895,6 +2023,12 @@ export default function Accounts() {
       if (format !== "txt") formData.append("format", format);
       const trimmedImportProxy = (proxyOverride ?? importProxyUrl).trim();
       if (trimmedImportProxy) formData.append("proxy_url", trimmedImportProxy);
+      if (parsedCustomHeaders.value) {
+        formData.append(
+          "custom_headers",
+          JSON.stringify(parsedCustomHeaders.value),
+        );
+      }
       if (allowDuplicate) formData.append("allow_duplicate", "true");
       for (const f of files) formData.append("file", f);
       const res = await fetch("/api/admin/accounts/import", {
@@ -2088,7 +2222,7 @@ export default function Accounts() {
       return;
     }
     setShowImportPicker(false);
-    await importFiles(files, "txt");
+    await importFiles(files, "txt", undefined, importCustomHeadersText);
     if (fileInputRef.current) fileInputRef.current.value = "";
   };
 
@@ -2096,7 +2230,12 @@ export default function Accounts() {
     const files = event.target.files;
     if (!files || files.length === 0) return;
     setShowImportPicker(false);
-    await importFiles(Array.from(files), "json");
+    await importFiles(
+      Array.from(files),
+      "json",
+      undefined,
+      importCustomHeadersText,
+    );
     if (jsonInputRef.current) jsonInputRef.current.value = "";
   };
 
@@ -2104,7 +2243,12 @@ export default function Accounts() {
     const files = event.target.files;
     if (!files || files.length === 0) return;
     setShowImportPicker(false);
-    await importFiles(Array.from(files), "json_at");
+    await importFiles(
+      Array.from(files),
+      "json_at",
+      undefined,
+      importCustomHeadersText,
+    );
     if (jsonAtInputRef.current) jsonAtInputRef.current.value = "";
   };
 
@@ -2116,7 +2260,7 @@ export default function Accounts() {
       return;
     }
     setShowImportPicker(false);
-    await importFiles(files, "at_txt");
+    await importFiles(files, "at_txt", undefined, importCustomHeadersText);
     if (atFileInputRef.current) atFileInputRef.current.value = "";
   };
 
@@ -2144,10 +2288,10 @@ export default function Accounts() {
     );
 
     if (jsonFiles.length > 0) {
-      await importFiles(jsonFiles, "json");
+      await importFiles(jsonFiles, "json", undefined, importCustomHeadersText);
     }
     if (txtFiles.length > 0) {
-      await importFiles(txtFiles, "txt");
+      await importFiles(txtFiles, "txt", undefined, importCustomHeadersText);
     }
 
     if (folderInputRef.current) folderInputRef.current.value = "";
@@ -2166,7 +2310,7 @@ export default function Accounts() {
     }
     const blob = new Blob([JSON.stringify(items)], { type: "application/json" });
     const file = new File([blob], "paste.json", { type: "application/json" });
-    await importFiles([file], "json");
+    await importFiles([file], "json", undefined, importCustomHeadersText);
     setShowPasteImport(false);
     setPasteImportText("");
   };
@@ -2807,6 +2951,7 @@ export default function Accounts() {
       filterExistingAPIKeyIDs(account.allowed_api_key_ids ?? [], apiKeys),
     );
     setEditProxyUrl(account.proxy_url ?? "");
+    setEditCustomHeadersText(formatCustomHeadersText(account.custom_headers));
     setEditTags(account.tags ?? []);
     setEditGroupIds(account.group_ids ?? []);
     setEditOpenAIForm({
@@ -2841,6 +2986,7 @@ export default function Accounts() {
     setEditDispatchCountLimitInput("");
     setAllowedAPIKeySelection([]);
     setEditProxyUrl("");
+    setEditCustomHeadersText("");
     setEditTags([]);
     setEditGroupIds([]);
     setEditOpenAIForm({
@@ -2953,6 +3099,11 @@ export default function Accounts() {
       showToast(t("accounts.schedulerInvalidInput"), "error");
       return;
     }
+    const parsedCustomHeaders = parseCustomHeadersText(editCustomHeadersText);
+    if (!parsedCustomHeaders.ok) {
+      showToast("自定义请求头必须是 JSON 对象，且所有值必须是字符串", "error");
+      return;
+    }
 
     setEditSubmitting(true);
     try {
@@ -2976,6 +3127,7 @@ export default function Accounts() {
         dispatch_count_limit: dispatchCountLimitInputToValue(
           editDispatchCountLimitInput,
         ),
+        custom_headers: parsedCustomHeaders.value,
       };
       await api.updateAccountScheduler(editingAccount.id, payload);
       showToast(t("accounts.schedulerSaveSuccess"));
@@ -4463,6 +4615,7 @@ export default function Accounts() {
               setOpenAIModelDraft("");
               setSessionJson("");
               setSessionProxyUrl("");
+              setAddCustomHeadersText("");
             }}
             footer={
               <>
@@ -4499,6 +4652,7 @@ export default function Accounts() {
                     setOpenAIModelDraft("");
                     setSessionJson("");
                     setSessionProxyUrl("");
+                    setAddCustomHeadersText("");
                   }}
                 >
                   {t("common.cancel")}
@@ -4667,6 +4821,10 @@ export default function Accounts() {
                       proxy_url: value,
                     })),
                 })}
+                {renderCustomHeadersTextarea({
+                  value: addCustomHeadersText,
+                  onChange: setAddCustomHeadersText,
+                })}
               </div>
             ) : addMethod === "st" ? (
               <div className="space-y-4">
@@ -4695,6 +4853,10 @@ export default function Accounts() {
                       ...form,
                       proxy_url: value,
                     })),
+                })}
+                {renderCustomHeadersTextarea({
+                  value: addCustomHeadersText,
+                  onChange: setAddCustomHeadersText,
                 })}
               </div>
             ) : addMethod === "at" ? (
@@ -4728,6 +4890,10 @@ export default function Accounts() {
                       proxy_url: value,
                     })),
                 })}
+                {renderCustomHeadersTextarea({
+                  value: addCustomHeadersText,
+                  onChange: setAddCustomHeadersText,
+                })}
               </div>
             ) : addMethod === "session" ? (
               <div className="space-y-4">
@@ -4753,6 +4919,10 @@ export default function Accounts() {
                   testKey: "add-session-json",
                   label: t("accounts.importProxyLabel"),
                   onChange: setSessionProxyUrl,
+                })}
+                {renderCustomHeadersTextarea({
+                  value: addCustomHeadersText,
+                  onChange: setAddCustomHeadersText,
                 })}
               </div>
             ) : addMethod === "openai" ? (
@@ -4882,6 +5052,10 @@ export default function Accounts() {
                       proxy_url: value,
                     })),
                 })}
+                {renderCustomHeadersTextarea({
+                  value: addCustomHeadersText,
+                  onChange: setAddCustomHeadersText,
+                })}
               </div>
             ) : (
               <div className="space-y-5">
@@ -5002,6 +5176,10 @@ export default function Accounts() {
               <p className="text-[11px] text-muted-foreground">
                 {t("accounts.importProxyHint")}
               </p>
+              {renderCustomHeadersTextarea({
+                value: importCustomHeadersText,
+                onChange: setImportCustomHeadersText,
+              })}
               <label className="flex cursor-pointer items-center gap-2 pt-1 text-xs text-muted-foreground">
                 <input
                   type="checkbox"
@@ -5596,6 +5774,10 @@ export default function Accounts() {
                           proxy_url: value,
                         })),
                     })}
+                    {renderCustomHeadersTextarea({
+                      value: editCustomHeadersText,
+                      onChange: setEditCustomHeadersText,
+                    })}
                   </div>
                 ) : editTab === "account" && isOAuthAccount(editingAccount) ? (
                   <div className="space-y-4">
@@ -5959,6 +6141,13 @@ export default function Accounts() {
                           value: editProxyUrl,
                           testKey: "edit-account-proxy",
                           onChange: setEditProxyUrl,
+                        })}
+                      </div>
+
+                      <div className="rounded-xl border border-border p-4 md:col-span-2">
+                        {renderCustomHeadersTextarea({
+                          value: editCustomHeadersText,
+                          onChange: setEditCustomHeadersText,
                         })}
                       </div>
                     </div>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -39,6 +39,7 @@ export interface AccountRow {
   openai_responses_api?: boolean
   base_url?: string
   models?: string[]
+  custom_headers?: Record<string, string> | null
   health_tier?: string
   scheduler_score?: number
   dispatch_score?: number
@@ -177,6 +178,7 @@ export interface AddAccountRequest {
   session_token?: string
   proxy_url: string
   allow_duplicate?: boolean
+  custom_headers?: Record<string, string> | null
 }
 
 export interface AddATAccountRequest {
@@ -184,6 +186,7 @@ export interface AddATAccountRequest {
   access_token: string
   proxy_url: string
   allow_duplicate?: boolean
+  custom_headers?: Record<string, string> | null
 }
 
 export interface AddOpenAIResponsesAccountRequest {
@@ -192,6 +195,7 @@ export interface AddOpenAIResponsesAccountRequest {
   api_key: string
   models: string[]
   proxy_url: string
+  custom_headers?: Record<string, string> | null
 }
 
 export interface UpdateOpenAIResponsesAccountRequest {
@@ -200,6 +204,7 @@ export interface UpdateOpenAIResponsesAccountRequest {
   api_key?: string
   models: string[]
   proxy_url: string
+  custom_headers?: Record<string, string> | null
 }
 
 export interface FetchOpenAIResponsesModelsRequest {
@@ -227,6 +232,7 @@ export interface UpdateAccountSchedulerRequest {
   auto_pause_5h_disabled?: boolean
   auto_pause_7d_disabled?: boolean
   dispatch_count_limit?: number | null
+  custom_headers?: Record<string, string> | null
 }
 
 export interface BatchUpdateAccountsRequest extends UpdateAccountSchedulerRequest {

--- a/proxy/executor.go
+++ b/proxy/executor.go
@@ -655,6 +655,19 @@ func applyCodexAllowedForwardHeaders(req *http.Request, downstreamHeaders http.H
 	}
 }
 
+func applyAccountCustomHeaders(req *http.Request, account *auth.Account) {
+	if req == nil || account == nil {
+		return
+	}
+	for name, value := range account.GetCustomHeaders() {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		req.Header.Set(name, value)
+	}
+}
+
 func applyCodexRequestHeaders(req *http.Request, account *auth.Account, accessToken, cacheKey, apiKey string, deviceCfg *DeviceProfileConfig, downstreamHeaders http.Header) {
 	if req == nil {
 		return
@@ -690,6 +703,7 @@ func applyCodexRequestHeaders(req *http.Request, account *auth.Account, accessTo
 		req.Header.Set("Session_id", cacheKey)
 		req.Header.Del("Conversation_id")
 	}
+	applyAccountCustomHeaders(req, account)
 }
 
 func applyOpenAIResponsesRequestHeaders(req *http.Request, account *auth.Account, apiKey string, headers http.Header) {
@@ -711,6 +725,7 @@ func applyOpenAIResponsesRequestHeaders(req *http.Request, account *auth.Account
 			}
 		}
 	}
+	applyAccountCustomHeaders(req, account)
 }
 
 // ResolveSessionID 从下游请求提取或生成 session ID

--- a/proxy/executor_test.go
+++ b/proxy/executor_test.go
@@ -318,6 +318,60 @@ func TestApplyCodexRequestHeadersUsesSessionIDWithoutConversationID(t *testing.T
 	}
 }
 
+func TestApplyCodexRequestHeadersAppliesAccountCustomHeadersLast(t *testing.T) {
+	req, err := http.NewRequest(http.MethodPost, "https://example.com/v1/responses", nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest() error = %v", err)
+	}
+
+	acc := &auth.Account{
+		DBID:      42,
+		AccountID: "acct-default",
+		CustomHeaders: map[string]string{
+			"Authorization":      "Bearer upstream-override",
+			"Chatgpt-Account-Id": "acct-override",
+			"X-Custom-Header":    "custom-value",
+		},
+	}
+
+	applyCodexRequestHeaders(req, acc, "token-123", "cache-key-1", "api-key-1", nil, http.Header{})
+
+	if got := req.Header.Get("Authorization"); got != "Bearer upstream-override" {
+		t.Fatalf("Authorization = %q", got)
+	}
+	if got := req.Header.Get("Chatgpt-Account-Id"); got != "acct-override" {
+		t.Fatalf("Chatgpt-Account-Id = %q", got)
+	}
+	if got := req.Header.Get("X-Custom-Header"); got != "custom-value" {
+		t.Fatalf("X-Custom-Header = %q", got)
+	}
+}
+
+func TestApplyOpenAIResponsesRequestHeadersAppliesAccountCustomHeadersLast(t *testing.T) {
+	req, err := http.NewRequest(http.MethodPost, "https://example.com/v1/responses", nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest() error = %v", err)
+	}
+
+	acc := &auth.Account{
+		DBID: 42,
+		CustomHeaders: map[string]string{
+			"Authorization":       "Bearer upstream-override",
+			"OpenAI-Organization": "org-override",
+		},
+	}
+	downstreamHeaders := http.Header{"OpenAI-Organization": []string{"org-downstream"}}
+
+	applyOpenAIResponsesRequestHeaders(req, acc, "api-key-1", downstreamHeaders)
+
+	if got := req.Header.Get("Authorization"); got != "Bearer upstream-override" {
+		t.Fatalf("Authorization = %q", got)
+	}
+	if got := req.Header.Get("OpenAI-Organization"); got != "org-override" {
+		t.Fatalf("OpenAI-Organization = %q", got)
+	}
+}
+
 func TestApplyCodexRequestHeadersUsesMinimalFallbackByDefault(t *testing.T) {
 	req, err := http.NewRequest(http.MethodPost, "https://example.com/v1/responses", nil)
 	if err != nil {

--- a/proxy/wsrelay/executor.go
+++ b/proxy/wsrelay/executor.go
@@ -270,6 +270,13 @@ func (e *Executor) prepareWebsocketHeaders(accessToken string, account *auth.Acc
 		headers.Set("Session_id", sessionID)
 		headers.Set("Conversation_id", sessionID)
 	}
+	for name, value := range account.GetCustomHeaders() {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		headers.Set(name, value)
+	}
 
 	return headers
 }

--- a/proxy/wsrelay/executor_test.go
+++ b/proxy/wsrelay/executor_test.go
@@ -68,6 +68,31 @@ func TestPrepareWebsocketHeadersUsesConfiguredDefaultsAndBetaFeatures(t *testing
 	}
 }
 
+func TestPrepareWebsocketHeadersAppliesAccountCustomHeadersLast(t *testing.T) {
+	exec := NewExecutor()
+	account := &auth.Account{
+		DBID:      42,
+		AccountID: "42",
+		CustomHeaders: map[string]string{
+			"Authorization":      "Bearer websocket-override",
+			"Chatgpt-Account-Id": "acct-override",
+			"X-Custom-Header":    "custom-value",
+		},
+	}
+
+	headers := exec.prepareWebsocketHeaders("token-123", account, "42", "session-123", "api-key-1", nil, http.Header{})
+
+	if got := headers.Get("Authorization"); got != "Bearer websocket-override" {
+		t.Fatalf("Authorization = %q", got)
+	}
+	if got := headers.Get("Chatgpt-Account-Id"); got != "acct-override" {
+		t.Fatalf("Chatgpt-Account-Id = %q", got)
+	}
+	if got := headers.Get("X-Custom-Header"); got != "custom-value" {
+		t.Fatalf("X-Custom-Header = %q", got)
+	}
+}
+
 func TestPrepareWebsocketHeadersSendsUserAgentByDefault(t *testing.T) {
 	t.Setenv("CODEX_WS_SEND_USER_AGENT", "")
 	exec := NewExecutor()


### PR DESCRIPTION
添加自定义请求头，可以给team使用，还增加了插入模板功能

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for per-account custom request headers across account creation, editing, import, and scheduler flows.
  * Custom headers are now applied to outgoing upstream and WebSocket requests.

* **Bug Fixes**
  * Header names are normalized consistently.
  * Invalid JSON, invalid header names, and unsafe header values are rejected.
  * Account-level headers now override conflicting upstream headers as expected.

* **Tests**
  * Added coverage for custom header parsing, validation, and request-header application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->