### PR TITLE
fix(proxy): 首包前 response.failed 返回真实错误码,避免下游中转按 input 误计费

### DIFF
--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -962,6 +962,19 @@ func shouldSuppressRetryableResponseFailedBeforeFirstToken(eventType string, ter
 	return responseFailedRetryable(terminalFailurePayload)
 }
 
+// shouldReturnHTTPErrorForResponseFailed 判断:流式请求在首 token 之前收到
+// response.failed(且尚未向下游写任何内容、客户端也未断开)时,应当中止 SSE 转发,
+// 交由循环外按真实 HTTP 错误码返回,而不是把失败包装成 200 + [DONE]。
+//
+// 背景:pending 尚未 flush 时下游 HTTP 200 header 还没发出(见 stream_flush_writer.go),
+// 此时若把 response.failed 写进流并补 [DONE],上游中转层(如 New API 的 pass-through
+// Responses 渠道)会把它当成一次正常完成、按其本地预估的 input token 计费,
+// 造成"上游拒绝(0 输出)却按 input 收费"。#310 已让 context_length_exceeded 等确定性
+// 客户端错误不再换号重试,但流式下游返回仍是 200 + [DONE],本函数补上这一半。
+func shouldReturnHTTPErrorForResponseFailed(eventType string, ttftRecorded, wroteAnyBody, clientGone bool) bool {
+	return eventType == "response.failed" && !ttftRecorded && !wroteAnyBody && !clientGone
+}
+
 func imageGenerationOutputKey(item gjson.Result) string {
 	if key := strings.TrimSpace(item.Get("id").String()); key != "" {
 		return key
@@ -2141,6 +2154,13 @@ func (h *Handler) Responses(c *gin.Context) {
 					return false
 				}
 
+				// 首 token 前的 response.failed 不写进下游流:不可重试(如 context_length_exceeded)
+				// 或已达重试上限时,交由循环外按真实错误码返回,而不是 200 + [DONE] 让中转层误计费。
+				if shouldReturnHTTPErrorForResponseFailed(eventType, ttftRecorded, wroteAnyBody, clientGone) {
+					pendingFirstTokenEvents.Reset()
+					return false
+				}
+
 				if !clientGone {
 					shouldDefer := !ttftRecorded && !gotTerminal && isPreContentLifecycleEvent(eventType)
 					wrote, err := writeDeferredSSEData(streamWriter, &pendingFirstTokenEvents, data, shouldDefer)
@@ -2271,7 +2291,13 @@ func (h *Handler) Responses(c *gin.Context) {
 				}
 			}
 		}
-		if !isStream {
+		if isStream && len(terminalFailurePayload) > 0 && !wroteAnyBody {
+			// 流式:首 token 前上游失败、HTTP 200 尚未发出,返回真实错误码而非静默的成功流,
+			// 避免下游中转/计费方把它当成功并按预估 input token 计费(与回调内 reset 呼应)。
+			c.JSON(logStatusCode, gin.H{
+				"error": gin.H{"message": outcome.failureMessage, "type": "upstream_error"},
+			})
+		} else if !isStream {
 			if len(terminalFailurePayload) > 0 {
 				c.JSON(logStatusCode, gin.H{
 					"error": gin.H{"message": outcome.failureMessage, "type": "upstream_error"},
@@ -3196,6 +3222,13 @@ func (h *Handler) ChatCompletions(c *gin.Context) {
 					return false
 				}
 
+				// 首 token 前的 response.failed 不写进下游流:不可重试(如 context_length_exceeded)
+				// 或已达重试上限时,交由循环外按真实错误码返回,而不是 200 + [DONE] 让中转层误计费。
+				if shouldReturnHTTPErrorForResponseFailed(eventType, ttftRecorded, wroteAnyBody, clientGone) {
+					pendingFirstTokenChunks.Reset()
+					return false
+				}
+
 				if !clientGone && chunk != nil {
 					shouldDefer := !ttftRecorded && !gotTerminal && isPreContentLifecycleEvent(eventType)
 					wrote, err := writeDeferredSSEData(streamWriter, &pendingFirstTokenChunks, chunk, shouldDefer)
@@ -3339,7 +3372,13 @@ func (h *Handler) ChatCompletions(c *gin.Context) {
 				}
 			}
 		}
-		if !isStream {
+		if isStream && len(terminalFailurePayload) > 0 && !wroteAnyBody {
+			// 流式:首 token 前上游失败、HTTP 200 尚未发出,返回真实错误码而非静默的成功流,
+			// 避免下游中转/计费方把它当成功并按预估 input token 计费(与回调内 reset 呼应)。
+			c.JSON(logStatusCode, gin.H{
+				"error": gin.H{"message": outcome.failureMessage, "type": "upstream_error"},
+			})
+		} else if !isStream {
 			if len(terminalFailurePayload) > 0 {
 				c.JSON(logStatusCode, gin.H{
 					"error": gin.H{"message": outcome.failureMessage, "type": "upstream_error"},

--- a/proxy/response_failed_billing_test.go
+++ b/proxy/response_failed_billing_test.go
@@ -1,0 +1,33 @@
+package proxy
+
+import "testing"
+
+// 流式请求在首 token 之前收到 response.failed 时,应中止 SSE 转发、由循环外按真实
+// HTTP 错误码返回,而不是把失败包成 200 + [DONE](后者会被上游中转/计费方误判为
+// 成功流并按预估 input token 计费)。见 shouldReturnHTTPErrorForResponseFailed。
+func TestShouldReturnHTTPErrorForResponseFailed(t *testing.T) {
+	cases := []struct {
+		name         string
+		eventType    string
+		ttftRecorded bool
+		wroteAnyBody bool
+		clientGone   bool
+		want         bool
+	}{
+		{"首 token 前的 response.failed 应返回错误码", "response.failed", false, false, false, true},
+		{"response.completed 不拦截", "response.completed", false, false, false, false},
+		{"已产出首 token 不拦截(维持流式收尾)", "response.failed", true, false, false, false},
+		{"已向下游写过 body 不拦截(200 已发出)", "response.failed", false, true, false, false},
+		{"客户端已断开不拦截(继续读上游取 usage)", "response.failed", false, false, true, false},
+		{"普通内容事件不拦截", "response.output_text.delta", false, false, false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := shouldReturnHTTPErrorForResponseFailed(tc.eventType, tc.ttftRecorded, tc.wroteAnyBody, tc.clientGone)
+			if got != tc.want {
+				t.Errorf("shouldReturnHTTPErrorForResponseFailed(%q, ttft=%v, wrote=%v, gone=%v) = %v, want %v",
+					tc.eventType, tc.ttftRecorded, tc.wroteAnyBody, tc.clientGone, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 问题

流式 `/v1/responses` 与 `/v1/chat/completions` 请求,当输入超过模型上下文窗口时,上游以 `response.failed`(`context_length_exceeded`)在**首 token 之前**终止。当前代码把该失败事件写进下游 SSE 流并补 `[DONE]`,HTTP 状态码停在 **200**。

- 对直接消费的客户端,这表现为"200 但空内容";
- 但对**把 codex2api 当上游的中转层**(例如 New API 的 pass-through Responses 渠道),它拿不到 usage、又看到一个正常结束的 200 流,于是按**自己预估的 input token** 计费 —— 结果是"上游 0 输出、用户却被按 input(可达数十万 token)收费"。

实测中该现象逐笔可复现:codex2api 日志 `流异常结束 (... status ...): context_length_exceeded ... 已转发约 0 字符`,与下游中转的计费记录**秒级对齐**。

## 根因

`stream_flush_writer.go` 的 pending 机制会把首 token 前的生命周期事件缓存,**首 token 之前下游 HTTP 200 header 其实还没发出** —— 本可以返回真实的 4xx/5xx。但回调对 `response.failed` 走了 `writeDeferredSSEData`(flush pending + 写入),触发 200 并补 `[DONE]`,而非像非流式路径那样返回真实错误码。

#310 已让 `context_length_exceeded` 等确定性客户端错误不再换号重试,但流式下游返回仍是 200 + `[DONE]`。本 PR 补上另一半。

## 改动

- 新增可单测的 `shouldReturnHTTPErrorForResponseFailed(eventType, ttftRecorded, wroteAnyBody, clientGone)`:首 token 前、尚未向下游写任何内容、客户端未断开的 `response.failed` → 中止 SSE 转发。
- `Responses` / `ChatCompletions` 两条主流式路径:回调命中即 `pending.Reset(); return false`;循环外当 `isStream && terminalFailurePayload != nil && !wroteAnyBody` 时,按 `outcome.logStatusCode` 返回 JSON 错误(与非流式路径一致)。
- 新增单元测试。

`wroteAnyBody == false` 保证 HTTP 200 尚未发出,`c.JSON` 能正常返回 4xx/5xx;可重试的失败仍走既有的首包前换号重试,不受影响。

## 未覆盖(想听维护者意见)

同一模式也存在于 image-generation 强制 HTTP 分支,以及 WebSocket 路径(`responses_ws.go`)。这两处结构略有差异、我暂无稳定复现,故本 PR 未改,想先确认方向再决定是否一并处理。

## 测试

`go build ./...` 与 `go test ./proxy/` 通过。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming error handling so requests can return a proper HTTP error when an upstream failure happens before any response content is sent.
  * Prevented certain failed streaming responses from being treated as successful completions, reducing incorrect downstream status and usage reporting.
  * Applied the fix across both supported streaming response paths for more consistent behavior.

* **Tests**
  * Added coverage for multiple streaming failure scenarios to verify the new error-handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->