### PR TITLE
fix(admin): 修复在线更新后重启旧版本

### DIFF
--- a/admin/system_update.go
+++ b/admin/system_update.go
@@ -46,7 +46,7 @@ type systemUpdater struct {
 	goos               string
 	goarch             string
 	executablePath     func() (string, error)
-	restartProcess     func() error
+	restartProcess     func(string) error
 	restartDelay       time.Duration
 	runningInContainer func() bool
 
@@ -228,12 +228,12 @@ func (u *systemUpdater) PerformUpdate(ctx context.Context) (*systemUpdateResult,
 		return nil, fmt.Errorf("%w: 未找到适配 %s/%s 的发布资产", errSystemUpdateUnsupported, u.goos, u.goarch)
 	}
 
-	backupPath, err := u.applyBinaryUpdate(ctx, inspection)
+	exePath, backupPath, err := u.applyBinaryUpdate(ctx, inspection)
 	if err != nil {
 		return nil, err
 	}
 
-	u.scheduleRestart()
+	u.scheduleRestart(exePath)
 	return &systemUpdateResult{
 		Message:        "更新已应用，服务正在重启",
 		CurrentVersion: inspection.info.CurrentVersion,
@@ -332,23 +332,23 @@ func cloneSystemGitHubRelease(release *systemGitHubRelease) *systemGitHubRelease
 	return &cloned
 }
 
-func (u *systemUpdater) applyBinaryUpdate(ctx context.Context, inspection *systemUpdateInspection) (string, error) {
+func (u *systemUpdater) applyBinaryUpdate(ctx context.Context, inspection *systemUpdateInspection) (string, string, error) {
 	asset := inspection.asset
 	if asset == nil {
-		return "", fmt.Errorf("更新资产为空")
+		return "", "", fmt.Errorf("更新资产为空")
 	}
 	if err := validateSystemUpdateURL(asset.BrowserDownloadURL); err != nil {
-		return "", fmt.Errorf("发布资产 URL 不可信: %w", err)
+		return "", "", fmt.Errorf("发布资产 URL 不可信: %w", err)
 	}
 	if inspection.checksumAsset != nil {
 		if err := validateSystemUpdateURL(inspection.checksumAsset.BrowserDownloadURL); err != nil {
-			return "", fmt.Errorf("校验和 URL 不可信: %w", err)
+			return "", "", fmt.Errorf("校验和 URL 不可信: %w", err)
 		}
 	}
 
 	exePath, err := u.executablePath()
 	if err != nil {
-		return "", fmt.Errorf("获取当前可执行文件路径失败: %w", err)
+		return "", "", fmt.Errorf("获取当前可执行文件路径失败: %w", err)
 	}
 	if resolved, err := filepath.EvalSymlinks(exePath); err == nil {
 		exePath = resolved
@@ -357,34 +357,34 @@ func (u *systemUpdater) applyBinaryUpdate(ctx context.Context, inspection *syste
 
 	tempDir, err := os.MkdirTemp(exeDir, ".codex2api-update-*")
 	if err != nil {
-		return "", fmt.Errorf("创建更新临时目录失败: %w", err)
+		return "", "", fmt.Errorf("创建更新临时目录失败: %w", err)
 	}
 	defer func() { _ = os.RemoveAll(tempDir) }()
 
 	archivePath := filepath.Join(tempDir, filepath.Base(asset.Name))
 	if err := u.client.DownloadFile(ctx, asset.BrowserDownloadURL, archivePath, systemUpdateMaxDownloadBytes); err != nil {
-		return "", fmt.Errorf("下载更新包失败: %w", err)
+		return "", "", fmt.Errorf("下载更新包失败: %w", err)
 	}
 	if err := verifySystemUpdateChecksum(ctx, u.client, archivePath, asset, inspection.checksumAsset); err != nil {
-		return "", err
+		return "", "", err
 	}
 
 	newBinaryPath := filepath.Join(tempDir, systemBinaryName(u.goos))
 	if err := extractSystemUpdateBinary(archivePath, newBinaryPath); err != nil {
-		return "", fmt.Errorf("解压更新包失败: %w", err)
+		return "", "", fmt.Errorf("解压更新包失败: %w", err)
 	}
 	if err := os.Chmod(newBinaryPath, 0755); err != nil {
-		return "", fmt.Errorf("设置新程序执行权限失败: %w", err)
+		return "", "", fmt.Errorf("设置新程序执行权限失败: %w", err)
 	}
 
 	backupPath := exePath + ".backup"
 	if err := replaceExecutable(exePath, newBinaryPath, backupPath); err != nil {
-		return "", err
+		return "", "", err
 	}
-	return backupPath, nil
+	return exePath, backupPath, nil
 }
 
-func (u *systemUpdater) scheduleRestart() {
+func (u *systemUpdater) scheduleRestart(exePath string) {
 	restart := u.restartProcess
 	if restart == nil {
 		return
@@ -395,7 +395,7 @@ func (u *systemUpdater) scheduleRestart() {
 	}
 	go func() {
 		time.Sleep(delay)
-		if err := restart(); err != nil {
+		if err := restart(exePath); err != nil {
 			log.Printf("在线更新后重启失败: %v", err)
 		}
 	}()

--- a/admin/system_update_restart_unix.go
+++ b/admin/system_update_restart_unix.go
@@ -3,14 +3,14 @@
 package admin
 
 import (
+	"fmt"
 	"os"
 	"syscall"
 )
 
-func defaultRestartProcess() error {
-	exePath, err := os.Executable()
-	if err != nil {
-		return err
+func defaultRestartProcess(exePath string) error {
+	if exePath == "" {
+		return fmt.Errorf("restart executable path is empty")
 	}
 	return syscall.Exec(exePath, os.Args, os.Environ())
 }

--- a/admin/system_update_restart_unix_test.go
+++ b/admin/system_update_restart_unix_test.go
@@ -1,0 +1,43 @@
+//go:build unix
+
+package admin
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDefaultRestartProcessExecsProvidedPathAndKeepsEnvironment(t *testing.T) {
+	if os.Getenv("CODEX2API_RESTART_EXEC_HELPER") == "1" {
+		targetPath := os.Getenv("CODEX2API_RESTART_EXEC_TARGET")
+		if err := defaultRestartProcess(targetPath); err != nil {
+			t.Fatalf("defaultRestartProcess(%q) error: %v", targetPath, err)
+		}
+		t.Fatal("defaultRestartProcess returned after successful exec")
+	}
+
+	tempDir := t.TempDir()
+	targetPath := filepath.Join(tempDir, "codex2api-new")
+	targetScript := "#!/bin/sh\nprintf 'target=new env=%s\\n' \"$CODEX2API_RESTART_EXEC_VALUE\"\n"
+	if err := os.WriteFile(targetPath, []byte(targetScript), 0755); err != nil {
+		t.Fatalf("write target script: %v", err)
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestDefaultRestartProcessExecsProvidedPathAndKeepsEnvironment")
+	cmd.Env = append(os.Environ(),
+		"CODEX2API_RESTART_EXEC_HELPER=1",
+		"CODEX2API_RESTART_EXEC_TARGET="+targetPath,
+		"CODEX2API_RESTART_EXEC_VALUE=kept",
+	)
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("restart helper failed: %v\n%s", err, string(output))
+	}
+	if got, want := strings.TrimSpace(string(output)), "target=new env=kept"; got != want {
+		t.Fatalf("restart helper output = %q, want %q", got, want)
+	}
+}

--- a/admin/system_update_restart_unsupported.go
+++ b/admin/system_update_restart_unsupported.go
@@ -4,6 +4,6 @@ package admin
 
 import "fmt"
 
-func defaultRestartProcess() error {
+func defaultRestartProcess(string) error {
 	return fmt.Errorf("online restart is not supported on this platform")
 }

--- a/admin/system_update_restart_windows.go
+++ b/admin/system_update_restart_windows.go
@@ -4,6 +4,6 @@ package admin
 
 import "fmt"
 
-func defaultRestartProcess() error {
+func defaultRestartProcess(string) error {
 	return fmt.Errorf("online restart is not supported on Windows")
 }

--- a/admin/system_update_test.go
+++ b/admin/system_update_test.go
@@ -16,10 +16,10 @@ import (
 )
 
 type fakeSystemReleaseClient struct {
-	release   *systemGitHubRelease
-	files     map[string][]byte
-	fetchErr  error
-	fetches   int
+	release  *systemGitHubRelease
+	files    map[string][]byte
+	fetchErr error
+	fetches  int
 }
 
 func (c *fakeSystemReleaseClient) FetchLatestRelease(context.Context) (*systemGitHubRelease, error) {
@@ -268,7 +268,7 @@ func TestSystemUpdaterPerformUpdateReplacesBinaryAndKeepsBackup(t *testing.T) {
 	archive := buildSystemUpdateTarball(t, "codex2api", []byte("new-binary"))
 	archiveHash := sha256.Sum256(archive)
 	archiveURL := "https://github.com/james-6-23/codex2api/releases/download/v2.4.4/codex2api_2.4.4_linux_amd64.tar.gz"
-	restarted := make(chan struct{}, 1)
+	restarted := make(chan string, 1)
 	client := &fakeSystemReleaseClient{
 		release: &systemGitHubRelease{
 			TagName: "v2.4.4",
@@ -287,8 +287,8 @@ func TestSystemUpdaterPerformUpdateReplacesBinaryAndKeepsBackup(t *testing.T) {
 		goos:           "linux",
 		goarch:         "amd64",
 		executablePath: func() (string, error) { return currentPath, nil },
-		restartProcess: func() error {
-			restarted <- struct{}{}
+		restartProcess: func(path string) error {
+			restarted <- path
 			return nil
 		},
 		restartDelay: 0,
@@ -308,7 +308,10 @@ func TestSystemUpdaterPerformUpdateReplacesBinaryAndKeepsBackup(t *testing.T) {
 		t.Fatalf("backup binary = %q, want old-binary", got)
 	}
 	select {
-	case <-restarted:
+	case path := <-restarted:
+		if path != currentPath {
+			t.Fatalf("restart path = %q, want %q", path, currentPath)
+		}
 	case <-time.After(time.Second):
 		t.Fatal("restart was not scheduled")
 	}
@@ -340,7 +343,7 @@ func TestSystemUpdaterPerformUpdateRejectsChecksumMismatch(t *testing.T) {
 		goos:           "linux",
 		goarch:         "amd64",
 		executablePath: func() (string, error) { return currentPath, nil },
-		restartProcess: func() error { t.Fatal("restart should not be called"); return nil },
+		restartProcess: func(string) error { t.Fatal("restart should not be called"); return nil },
 	}
 
 	_, err := updater.PerformUpdate(context.Background())


### PR DESCRIPTION
## 背景

在线更新会先把当前运行的二进制重命名为 `.backup`，再把新二进制放回原路径。Unix 下如果重启阶段再次调用 `os.Executable()`，该路径会指向已改名的 `.backup`，导致更新后可能重新 exec 旧版本，表现为前端一直等待重启或刷新后仍显示旧版本。

## 改动

- 在替换二进制前解析并保留真实目标路径
- 重启调度时显式传入该目标路径，Unix 端直接 exec 新二进制路径
- 更新测试断言重启使用的是替换后的目标路径而不是备份路径
- 新增 Unix 回归测试，真实调用 `defaultRestartProcess(targetPath)` 并确认 exec 到指定目标且保留环境变量

## 验证

- `go test ./admin -run 'TestDefaultRestartProcessExecsProvidedPathAndKeepsEnvironment|TestSystemUpdaterPerformUpdateReplacesBinaryAndKeepsBackup' -count=1 -v`
- `go test ./admin -run 'TestSystemUpdater|TestHandlerSystemUpdater|TestCompareSystemVersions|TestValidateSystemUpdateURL' -count=1`
- `go test ./...`
- `npm run build`
- `git diff --check`
- 使用 `/tmp` 临时程序模拟自替换 + exec，确认会执行新二进制，验证文件已清理

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved online update restarts to use the updated application path, making restarts more reliable after installing an update.
  * Fixed restart behavior across platforms so unsupported environments continue to fail gracefully.
  * Enhanced Unix restart handling to preserve the current environment when relaunching after an update.
  * Updated update flow checks to ensure the app restarts with the expected version after a successful replacement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->