### PR TITLE
fix(update): 仅缓存远端最新版本信息

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -74,7 +74,7 @@ export default function Layout({ children }: PropsWithChildren) {
   const releaseURL = updateInfo?.release_url || (latestVersion
     ? `https://github.com/james-6-23/codex2api/releases/tag/${encodeURIComponent(latestVersion)}`
     : undefined)
-  const canApplyUpdate = hasUpdate && updateInfo?.supported !== false
+  const canApplyUpdate = hasUpdate && Boolean(updateInfo) && updateInfo?.supported !== false
   const updateUnavailableReason = updateInfo?.unsupported_reason
 
   const stopRestartPolling = useCallback(() => {
@@ -139,6 +139,12 @@ export default function Layout({ children }: PropsWithChildren) {
       setUpdatingVersion(false)
     }
   }
+
+  useEffect(() => {
+    if (showVersionPopover && hasUpdate && !updateInfo) {
+      void refreshVersion(true)
+    }
+  }, [showVersionPopover, hasUpdate, updateInfo, refreshVersion])
 
   useEffect(() => {
     if (!showVersionPopover) return

--- a/frontend/src/hooks/useVersionCheck.ts
+++ b/frontend/src/hooks/useVersionCheck.ts
@@ -2,12 +2,18 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { api } from '../api'
 import type { SystemUpdateInfo } from '../types'
 
-const CACHE_KEY = 'codex2api_latest_version'
+const REMOTE_RELEASE_CACHE_KEY = 'codex2api_latest_release'
+const LEGACY_UPDATE_CACHE_KEY = 'codex2api_latest_version'
 const CACHE_TTL = 10 * 60 * 1000
 const POLL_INTERVAL = 30 * 60 * 1000
 
-interface CachedUpdateInfo {
-  info: SystemUpdateInfo
+interface RemoteReleaseInfo {
+  latest_version: string
+  release_url?: string
+  published_at?: string
+}
+
+interface CachedRemoteReleaseInfo extends RemoteReleaseInfo {
   checkedAt: number
 }
 
@@ -16,40 +22,106 @@ function versionLabel(version?: string | null): string | null {
   return version.startsWith('v') || version.startsWith('V') ? version : `v${version}`
 }
 
-function readCachedInfo(ignoreTTL = false): SystemUpdateInfo | null {
+function normalizeVersion(version?: string | null): string {
+  return (version || '')
+    .trim()
+    .replace(/^refs\/tags\//i, '')
+    .replace(/^v/i, '')
+}
+
+function parseVersion(version: string): [number, number, number] | null {
+  const normalized = normalizeVersion(version).split(/[+-]/, 1)[0]
+  if (!normalized) return null
+  const parts = normalized.split('.')
+  if (parts.length === 0 || parts.length > 3) return null
+
+  const parsed: [number, number, number] = [0, 0, 0]
+  for (let i = 0; i < parts.length; i += 1) {
+    if (!/^\d+$/.test(parts[i])) return null
+    parsed[i] = Number(parts[i])
+  }
+  return parsed
+}
+
+function compareVersions(a: string, b: string): number {
+  const parsedA = parseVersion(a)
+  const parsedB = parseVersion(b)
+  if (!parsedA && !parsedB) return normalizeVersion(a).localeCompare(normalizeVersion(b))
+  if (!parsedA) return -1
+  if (!parsedB) return 1
+
+  for (let i = 0; i < 3; i += 1) {
+    if (parsedA[i] < parsedB[i]) return -1
+    if (parsedA[i] > parsedB[i]) return 1
+  }
+  return 0
+}
+
+function hasRemoteUpdate(latestVersion?: string | null): boolean {
+  if (!latestVersion || __APP_VERSION__ === 'dev') return false
+  return compareVersions(__APP_VERSION__, latestVersion) < 0
+}
+
+function remoteReleaseFromInfo(info: Pick<SystemUpdateInfo, 'latest_version' | 'release_url' | 'published_at'>): RemoteReleaseInfo {
+  return {
+    latest_version: info.latest_version,
+    release_url: info.release_url,
+    published_at: info.published_at,
+  }
+}
+
+function clearLegacyUpdateCache() {
   try {
-    const raw = localStorage.getItem(CACHE_KEY)
+    localStorage.removeItem(LEGACY_UPDATE_CACHE_KEY)
+  } catch {
+    // ignore localStorage failures
+  }
+}
+
+function readCachedRemoteRelease(ignoreTTL = false): RemoteReleaseInfo | null {
+  clearLegacyUpdateCache()
+  try {
+    const raw = localStorage.getItem(REMOTE_RELEASE_CACHE_KEY)
     if (!raw) return null
-    const cached = JSON.parse(raw) as Partial<CachedUpdateInfo>
-    if (!ignoreTTL && typeof cached.checkedAt === 'number' && Date.now() - cached.checkedAt >= CACHE_TTL) {
-      return null
+
+    const cached = JSON.parse(raw) as Partial<CachedRemoteReleaseInfo>
+    if (typeof cached.latest_version !== 'string' || !cached.latest_version.trim()) return null
+    if (typeof cached.checkedAt !== 'number') return null
+    if (!ignoreTTL && Date.now() - cached.checkedAt >= CACHE_TTL) return null
+
+    return {
+      latest_version: cached.latest_version.trim(),
+      release_url: typeof cached.release_url === 'string' ? cached.release_url : undefined,
+      published_at: typeof cached.published_at === 'string' ? cached.published_at : undefined,
     }
-    return cached.info?.latest_version ? cached.info : null
   } catch {
     return null
   }
 }
 
-function writeCachedInfo(info: SystemUpdateInfo) {
+function writeCachedRemoteRelease(remote: RemoteReleaseInfo) {
+  clearLegacyUpdateCache()
   try {
-    localStorage.setItem(CACHE_KEY, JSON.stringify({ info, checkedAt: Date.now() }))
+    localStorage.setItem(REMOTE_RELEASE_CACHE_KEY, JSON.stringify({ ...remote, checkedAt: Date.now() }))
   } catch {
-    // ignore localStorage write failures
+    // ignore localStorage failures
   }
 }
 
-async function fetchUpdateInfo(forceNetwork = false): Promise<SystemUpdateInfo | null> {
+async function fetchUpdateInfo(forceNetwork = false): Promise<{ remote: RemoteReleaseInfo; info: SystemUpdateInfo | null } | null> {
   if (!forceNetwork) {
-    const cached = readCachedInfo()
-    if (cached) return cached
+    const cached = readCachedRemoteRelease()
+    if (cached) return { remote: cached, info: null }
   }
 
   try {
     const info = await api.getSystemUpdate()
-    writeCachedInfo(info)
-    return info
+    const remote = remoteReleaseFromInfo(info)
+    writeCachedRemoteRelease(remote)
+    return { remote, info }
   } catch {
-    return readCachedInfo(true)
+    const cached = readCachedRemoteRelease(true)
+    return cached ? { remote: cached, info: null } : null
   }
 }
 
@@ -62,12 +134,24 @@ export function useVersionCheck(triggerKey?: string) {
   const check = useCallback(async (forceNetwork = false) => {
     if (__APP_VERSION__ === 'dev') return
 
-    const info = await fetchUpdateInfo(forceNetwork)
-    if (!info) return
+    const result = await fetchUpdateInfo(forceNetwork)
+    if (!result) {
+      setUpdateInfo(null)
+      setLatestVersion(null)
+      setHasUpdate(false)
+      return
+    }
 
-    setUpdateInfo(info)
-    setLatestVersion(versionLabel(info.latest_version))
-    setHasUpdate(Boolean(info.has_update))
+    const remoteLatestVersion = result.remote.latest_version
+    setUpdateInfo((current) => {
+      if (result.info) return result.info
+      if (current && normalizeVersion(current.latest_version) === normalizeVersion(remoteLatestVersion)) {
+        return current
+      }
+      return null
+    })
+    setLatestVersion(versionLabel(remoteLatestVersion))
+    setHasUpdate(hasRemoteUpdate(remoteLatestVersion))
   }, [])
 
   useEffect(() => {


### PR DESCRIPTION
## 背景

在线更新前端原先把 `/system/update` 返回的完整 `SystemUpdateInfo` 写入 localStorage，其中包含 `current_version` 和 `has_update`。当用户从旧版本更新到最新版本后，前端 bundle 中的 `__APP_VERSION__` 已经变成新版本，但 localStorage 里旧的 `has_update=true` 仍可能被复用，导致出现“当前版本和最新版本相同，但仍提示新版本可用”的假阳性。

## 改动

- 移除完整 `SystemUpdateInfo` 缓存逻辑
- 新增仅包含远端 release 字段的缓存：`latest_version` / `release_url` / `published_at`
- 启动时清理旧的 `codex2api_latest_version` 缓存 key，避免历史脏缓存继续影响
- `hasUpdate` 改为每次基于当前 bundle 的 `__APP_VERSION__` 与远端 latest 版本实时计算
- `updateInfo` 只保留后端实时返回的数据，不再由缓存伪造本地运行状态

## 验证

- `npm run build`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved update checking using a dedicated cached remote release payload and more reliable semantic version comparison.
  * Enhanced offline behavior by preferring cached remote release data and safely falling back when network checks fail.
  * Updated update-check UI behavior to reset when update details can’t be retrieved.
  * Tightened update actions to enable only when full update details are available; missing details are fetched automatically when opening the version popover.
  * Remote update detection remains disabled for development builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->