### PR TITLE
fix(proxy): 首包前 response.failed 返回真实错误码(含 #318 + 时序修复)

### DIFF
--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -1018,6 +1018,19 @@ func shouldSuppressRetryableResponseFailedBeforeFirstToken(eventType string, ter
 	return responseFailedRetryable(terminalFailurePayload)
 }
 
+// shouldReturnHTTPErrorForResponseFailed 判断:流式请求在首 token 之前收到
+// response.failed(且尚未向下游写任何内容、客户端也未断开)时,应当中止 SSE 转发,
+// 交由循环外按真实 HTTP 错误码返回,而不是把失败包装成 200 + [DONE]。
+//
+// 背景:pending 尚未 flush 时下游 HTTP 200 header 还没发出(见 stream_flush_writer.go),
+// 此时若把 response.failed 写进流并补 [DONE],上游中转层(如 New API 的 pass-through
+// Responses 渠道)会把它当成一次正常完成、按其本地预估的 input token 计费,
+// 造成"上游拒绝(0 输出)却按 input 收费"。#310 已让 context_length_exceeded 等确定性
+// 客户端错误不再换号重试,但流式下游返回仍是 200 + [DONE],本函数补上这一半。
+func shouldReturnHTTPErrorForResponseFailed(eventType string, ttftRecorded, wroteAnyBody, clientGone bool) bool {
+	return eventType == "response.failed" && !ttftRecorded && !wroteAnyBody && !clientGone
+}
+
 func imageGenerationOutputKey(item gjson.Result) string {
 	if key := strings.TrimSpace(item.Get("id").String()); key != "" {
 		return key
@@ -2214,6 +2227,13 @@ func (h *Handler) Responses(c *gin.Context) {
 					return false
 				}
 
+				// 首 token 前的 response.failed 不写进下游流:不可重试(如 context_length_exceeded)
+				// 或已达重试上限时,交由循环外按真实错误码返回,而不是 200 + [DONE] 让中转层误计费。
+				if shouldReturnHTTPErrorForResponseFailed(eventType, ttftRecorded, wroteAnyBody, clientGone) {
+					pendingFirstTokenEvents.Reset()
+					return false
+				}
+
 				if !clientGone {
 					shouldDefer := !ttftRecorded && !gotTerminal && isPreContentLifecycleEvent(eventType)
 					wrote, err := writeDeferredSSEData(streamWriter, &pendingFirstTokenEvents, data, shouldDefer)
@@ -2344,7 +2364,13 @@ func (h *Handler) Responses(c *gin.Context) {
 				}
 			}
 		}
-		if !isStream {
+		if isStream && len(terminalFailurePayload) > 0 && !wroteAnyBody {
+			// 流式:首 token 前上游失败、HTTP 200 尚未发出,返回真实错误码而非静默的成功流,
+			// 避免下游中转/计费方把它当成功并按预估 input token 计费(与回调内 reset 呼应)。
+			c.JSON(logStatusCode, gin.H{
+				"error": gin.H{"message": outcome.failureMessage, "type": "upstream_error"},
+			})
+		} else if !isStream {
 			if len(terminalFailurePayload) > 0 {
 				c.JSON(logStatusCode, gin.H{
 					"error": gin.H{"message": outcome.failureMessage, "type": "upstream_error"},
@@ -3285,6 +3311,13 @@ func (h *Handler) ChatCompletions(c *gin.Context) {
 					return false
 				}
 
+				// 首 token 前的 response.failed 不写进下游流:不可重试(如 context_length_exceeded)
+				// 或已达重试上限时,交由循环外按真实错误码返回,而不是 200 + [DONE] 让中转层误计费。
+				if shouldReturnHTTPErrorForResponseFailed(eventType, ttftRecorded, wroteAnyBody, clientGone) {
+					pendingFirstTokenChunks.Reset()
+					return false
+				}
+
 				if !clientGone && chunk != nil {
 					shouldDefer := !ttftRecorded && !gotTerminal && isPreContentLifecycleEvent(eventType)
 					wrote, err := writeDeferredSSEData(streamWriter, &pendingFirstTokenChunks, chunk, shouldDefer)
@@ -3428,7 +3461,13 @@ func (h *Handler) ChatCompletions(c *gin.Context) {
 				}
 			}
 		}
-		if !isStream {
+		if isStream && len(terminalFailurePayload) > 0 && !wroteAnyBody {
+			// 流式:首 token 前上游失败、HTTP 200 尚未发出,返回真实错误码而非静默的成功流,
+			// 避免下游中转/计费方把它当成功并按预估 input token 计费(与回调内 reset 呼应)。
+			c.JSON(logStatusCode, gin.H{
+				"error": gin.H{"message": outcome.failureMessage, "type": "upstream_error"},
+			})
+		} else if !isStream {
 			if len(terminalFailurePayload) > 0 {
 				c.JSON(logStatusCode, gin.H{
 					"error": gin.H{"message": outcome.failureMessage, "type": "upstream_error"},

--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -1023,10 +1023,13 @@ func shouldSuppressRetryableResponseFailedBeforeFirstToken(eventType string, ter
 // 交由循环外按真实 HTTP 错误码返回,而不是把失败包装成 200 + [DONE]。
 //
 // 背景:pending 尚未 flush 时下游 HTTP 200 header 还没发出(见 stream_flush_writer.go),
-// 此时若把 response.failed 写进流并补 [DONE],上游中转层(如 New API 的 pass-through
-// Responses 渠道)会把它当成一次正常完成、按其本地预估的 input token 计费,
+// 此时若把 response.failed 写进流并补 [DONE],把本服务当上游的计费型中转层
+// 会把它当成一次正常完成、按其本地预估的 input token 计费,
 // 造成"上游拒绝(0 输出)却按 input 收费"。#310 已让 context_length_exceeded 等确定性
 // 客户端错误不再换号重试,但流式下游返回仍是 200 + [DONE],本函数补上这一半。
+//
+// 注意:命中后除了中止转发,循环后的收尾 flush 也必须跳过(见 wroteAnyBody 守卫),
+// 否则空 buffer 的 flusher.Flush 仍会提前提交 200 header,让循环外的 c.JSON(4xx) 失效。
 func shouldReturnHTTPErrorForResponseFailed(eventType string, ttftRecorded, wroteAnyBody, clientGone bool) bool {
 	return eventType == "response.failed" && !ttftRecorded && !wroteAnyBody && !clientGone
 }
@@ -2160,6 +2163,9 @@ func (h *Handler) Responses(c *gin.Context) {
 		var readErr error
 		var writeErr error
 		wroteAnyBody := false
+		// 首 token 前收到不可重试的 response.failed 时置位:中止 SSE 转发、
+		// 不做 transport flush(避免提前提交 200 header),循环外按真实错误码返回 JSON。
+		abortedForHTTPError := false
 		var responseJSON []byte
 		var imageLogInfo imageUsageLogInfo
 		var terminalFailurePayload []byte
@@ -2231,6 +2237,7 @@ func (h *Handler) Responses(c *gin.Context) {
 				// 或已达重试上限时,交由循环外按真实错误码返回,而不是 200 + [DONE] 让中转层误计费。
 				if shouldReturnHTTPErrorForResponseFailed(eventType, ttftRecorded, wroteAnyBody, clientGone) {
 					pendingFirstTokenEvents.Reset()
+					abortedForHTTPError = true
 					return false
 				}
 
@@ -2246,7 +2253,9 @@ func (h *Handler) Responses(c *gin.Context) {
 				}
 				return eventType != "response.completed" && eventType != "response.failed"
 			})
-			if writeErr == nil {
+			// 仅在真的写过 body 时才做收尾 flush:flusher.Flush 会先提交 HTTP 200 header,
+			// 零写入时提前 flush 会让循环外的 c.JSON(4xx) 失效(status 已定型为 200)。
+			if writeErr == nil && wroteAnyBody {
 				writeErr = streamWriter.Flush()
 			}
 		} else {
@@ -2364,9 +2373,11 @@ func (h *Handler) Responses(c *gin.Context) {
 				}
 			}
 		}
-		if isStream && len(terminalFailurePayload) > 0 && !wroteAnyBody {
-			// 流式:首 token 前上游失败、HTTP 200 尚未发出,返回真实错误码而非静默的成功流,
+		if isStream && abortedForHTTPError && !wroteAnyBody {
+			// 流式:首 token 前上游失败、未向下游写过任何内容,HTTP 200 header 尚未提交,
+			// 覆盖预设的 SSE Content-Type 后按真实错误码返回 JSON,
 			// 避免下游中转/计费方把它当成功并按预估 input token 计费(与回调内 reset 呼应)。
+			c.Header("Content-Type", "application/json; charset=utf-8")
 			c.JSON(logStatusCode, gin.H{
 				"error": gin.H{"message": outcome.failureMessage, "type": "upstream_error"},
 			})
@@ -3250,6 +3261,9 @@ func (h *Handler) ChatCompletions(c *gin.Context) {
 		var readErr error
 		var writeErr error
 		wroteAnyBody := false
+		// 首 token 前收到不可重试的 response.failed 时置位:中止 SSE 转发、
+		// 不做 transport flush(避免提前提交 200 header),循环外按真实错误码返回 JSON。
+		abortedForHTTPError := false
 		var compactResult []byte
 		var terminalFailurePayload []byte
 
@@ -3315,6 +3329,7 @@ func (h *Handler) ChatCompletions(c *gin.Context) {
 				// 或已达重试上限时,交由循环外按真实错误码返回,而不是 200 + [DONE] 让中转层误计费。
 				if shouldReturnHTTPErrorForResponseFailed(eventType, ttftRecorded, wroteAnyBody, clientGone) {
 					pendingFirstTokenChunks.Reset()
+					abortedForHTTPError = true
 					return false
 				}
 
@@ -3357,7 +3372,9 @@ func (h *Handler) ChatCompletions(c *gin.Context) {
 				}
 				return true
 			})
-			if writeErr == nil {
+			// 仅在真的写过 body 时才做收尾 flush:flusher.Flush 会先提交 HTTP 200 header,
+			// 零写入时提前 flush 会让循环外的 c.JSON(4xx) 失效(status 已定型为 200)。
+			if writeErr == nil && wroteAnyBody {
 				writeErr = streamWriter.Flush()
 			}
 		} else {
@@ -3461,9 +3478,11 @@ func (h *Handler) ChatCompletions(c *gin.Context) {
 				}
 			}
 		}
-		if isStream && len(terminalFailurePayload) > 0 && !wroteAnyBody {
-			// 流式:首 token 前上游失败、HTTP 200 尚未发出,返回真实错误码而非静默的成功流,
+		if isStream && abortedForHTTPError && !wroteAnyBody {
+			// 流式:首 token 前上游失败、未向下游写过任何内容,HTTP 200 header 尚未提交,
+			// 覆盖预设的 SSE Content-Type 后按真实错误码返回 JSON,
 			// 避免下游中转/计费方把它当成功并按预估 input token 计费(与回调内 reset 呼应)。
+			c.Header("Content-Type", "application/json; charset=utf-8")
 			c.JSON(logStatusCode, gin.H{
 				"error": gin.H{"message": outcome.failureMessage, "type": "upstream_error"},
 			})

--- a/proxy/response_failed_billing_test.go
+++ b/proxy/response_failed_billing_test.go
@@ -1,6 +1,16 @@
 package proxy
 
-import "testing"
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/tidwall/gjson"
+)
 
 // 流式请求在首 token 之前收到 response.failed 时,应中止 SSE 转发、由循环外按真实
 // HTTP 错误码返回,而不是把失败包成 200 + [DONE](后者会被上游中转/计费方误判为
@@ -27,6 +37,127 @@ func TestShouldReturnHTTPErrorForResponseFailed(t *testing.T) {
 			if got != tc.want {
 				t.Errorf("shouldReturnHTTPErrorForResponseFailed(%q, ttft=%v, wrote=%v, gone=%v) = %v, want %v",
 					tc.eventType, tc.ttftRecorded, tc.wroteAnyBody, tc.clientGone, got, tc.want)
+			}
+		})
+	}
+}
+
+// streamEpilogue 复刻 Responses/ChatCompletions 流式路径的收尾时序:
+// 逐事件走 defer/拦截逻辑 → 仅在写过 body 时收尾 flush → 拦截命中时循环外 c.JSON。
+// 用真实 HTTP 连接验证,因为致命点在 gin 层:flusher.Flush 会先 WriteHeaderNow
+// 提交 200,零写入时提前 flush 会让后续 c.JSON(4xx) 的状态码永远无法送达下游。
+func streamEpilogue(t *testing.T, c *gin.Context, events [][]byte) {
+	t.Helper()
+	c.Header("Content-Type", "text/event-stream")
+	c.Header("Cache-Control", "no-cache")
+	flusher, ok := c.Writer.(http.Flusher)
+	if !ok {
+		t.Error("c.Writer 未实现 http.Flusher")
+		return
+	}
+	streamWriter := newStreamFlushWriter(c.Writer, flusher)
+	var pending bytes.Buffer
+	ttftRecorded := false
+	wroteAnyBody := false
+	abortedForHTTPError := false
+	gotTerminal := false
+
+	for _, data := range events {
+		eventType := gjson.GetBytes(data, "type").String()
+		if eventType == "response.output_text.delta" {
+			ttftRecorded = true
+		}
+		if eventType == "response.completed" || eventType == "response.failed" {
+			gotTerminal = true
+		}
+		if shouldReturnHTTPErrorForResponseFailed(eventType, ttftRecorded, wroteAnyBody, false) {
+			pending.Reset()
+			abortedForHTTPError = true
+			break
+		}
+		shouldDefer := !ttftRecorded && !gotTerminal && isPreContentLifecycleEvent(eventType)
+		wrote, err := writeDeferredSSEData(streamWriter, &pending, data, shouldDefer)
+		if err != nil {
+			t.Errorf("writeDeferredSSEData: %v", err)
+			return
+		}
+		if wrote {
+			wroteAnyBody = true
+		}
+	}
+	if wroteAnyBody {
+		_ = streamWriter.Flush()
+	}
+	if abortedForHTTPError && !wroteAnyBody {
+		c.Header("Content-Type", "application/json; charset=utf-8")
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": gin.H{"message": "context_length_exceeded", "type": "upstream_error"},
+		})
+	}
+}
+
+func TestStreamFirstTokenFailureWireBehavior(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	failedEvent := []byte(`{"type":"response.failed","response":{"error":{"code":"context_length_exceeded","message":"input too long"}}}`)
+	cases := []struct {
+		name         string
+		events       [][]byte
+		wantStatus   int
+		wantJSONType bool
+		wantBodyHas  string
+	}{
+		{
+			name: "首 token 前 response.failed → 下游收到真实 4xx JSON",
+			events: [][]byte{
+				[]byte(`{"type":"response.created"}`),
+				[]byte(`{"type":"response.in_progress"}`),
+				failedEvent,
+			},
+			wantStatus:   http.StatusBadRequest,
+			wantJSONType: true,
+			wantBodyHas:  "context_length_exceeded",
+		},
+		{
+			name: "已产出首 token → 维持 200 SSE 流式收尾",
+			events: [][]byte{
+				[]byte(`{"type":"response.created"}`),
+				[]byte(`{"type":"response.output_text.delta","delta":"hi"}`),
+				failedEvent,
+			},
+			wantStatus:   http.StatusOK,
+			wantJSONType: false,
+			wantBodyHas:  "response.output_text.delta",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			router := gin.New()
+			router.GET("/stream", func(c *gin.Context) {
+				streamEpilogue(t, c, tc.events)
+			})
+			srv := httptest.NewServer(router)
+			defer srv.Close()
+
+			resp, err := http.Get(srv.URL + "/stream")
+			if err != nil {
+				t.Fatalf("GET: %v", err)
+			}
+			defer resp.Body.Close()
+			body, _ := io.ReadAll(resp.Body)
+
+			if resp.StatusCode != tc.wantStatus {
+				t.Errorf("status = %d, want %d (body=%q)", resp.StatusCode, tc.wantStatus, body)
+			}
+			ct := resp.Header.Get("Content-Type")
+			if tc.wantJSONType && !strings.Contains(ct, "application/json") {
+				t.Errorf("Content-Type = %q, want application/json", ct)
+			}
+			if !tc.wantJSONType && !strings.Contains(ct, "text/event-stream") {
+				t.Errorf("Content-Type = %q, want text/event-stream", ct)
+			}
+			if !strings.Contains(string(body), tc.wantBodyHas) {
+				t.Errorf("body = %q, want contains %q", body, tc.wantBodyHas)
 			}
 		})
 	}

--- a/proxy/response_failed_billing_test.go
+++ b/proxy/response_failed_billing_test.go
@@ -1,0 +1,33 @@
+package proxy
+
+import "testing"
+
+// 流式请求在首 token 之前收到 response.failed 时,应中止 SSE 转发、由循环外按真实
+// HTTP 错误码返回,而不是把失败包成 200 + [DONE](后者会被上游中转/计费方误判为
+// 成功流并按预估 input token 计费)。见 shouldReturnHTTPErrorForResponseFailed。
+func TestShouldReturnHTTPErrorForResponseFailed(t *testing.T) {
+	cases := []struct {
+		name         string
+		eventType    string
+		ttftRecorded bool
+		wroteAnyBody bool
+		clientGone   bool
+		want         bool
+	}{
+		{"首 token 前的 response.failed 应返回错误码", "response.failed", false, false, false, true},
+		{"response.completed 不拦截", "response.completed", false, false, false, false},
+		{"已产出首 token 不拦截(维持流式收尾)", "response.failed", true, false, false, false},
+		{"已向下游写过 body 不拦截(200 已发出)", "response.failed", false, true, false, false},
+		{"客户端已断开不拦截(继续读上游取 usage)", "response.failed", false, false, true, false},
+		{"普通内容事件不拦截", "response.output_text.delta", false, false, false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := shouldReturnHTTPErrorForResponseFailed(tc.eventType, tc.ttftRecorded, tc.wroteAnyBody, tc.clientGone)
+			if got != tc.want {
+				t.Errorf("shouldReturnHTTPErrorForResponseFailed(%q, ttft=%v, wrote=%v, gone=%v) = %v, want %v",
+					tc.eventType, tc.ttftRecorded, tc.wroteAnyBody, tc.clientGone, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 说明

本 PR 包含 #318 的原始提交(cherry-pick,保留 @JrCx7scC 署名),并在其上修复了一个使原方案在 HTTP 层不生效的时序 bug。合并后关闭 #318。

Closes #318

## #318 的问题

原方案在回调里中止 SSE 转发后,循环外的 `c.JSON(4xx)` 实际不生效:

1. `ReadSSEStream` 返回后紧跟的 `streamWriter.Flush()` 在零写入时也会调用 `flusher.Flush()`;
2. gin 的 `responseWriter.Flush()` 第一行是 `WriteHeaderNow()` —— 200 + `text/event-stream` header 就此定型;
3. 后续 `c.JSON(400)` 只能把 JSON 追加进一个 200 的 event-stream 响应体。

用 gin v1.12.0 + httptest 复刻该调用顺序实测:`STATUS=200 CT="text/event-stream"`,下游中转层照样按 200 计费,且直连 SSE 客户端连原来能收到的 response.failed 事件都没了。

## 修复(第二个 commit)

- 收尾 flush 加 `wroteAnyBody` 守卫:零写入时不触碰 transport flush,header 留到循环外真正响应时再提交(Responses / ChatCompletions 两处);
- 回调命中拦截时置位 `abortedForHTTPError`,外层错误分支改用该标记,避免客户端已断开等零写入场景对死连接误写 JSON;
- `c.JSON` 前覆盖 `Content-Type: application/json; charset=utf-8`(gin 的 JSON render 不覆盖已设置的 Content-Type);
- 新增 wire 级测试:真实 HTTP 连接上断言首包前失败下游收到 4xx JSON、已产出首 token 时维持 200 SSE 收尾。

## 未覆盖(与 #318 保持一致的范围)

`IsOpenAIResponsesAPI()` 直连分支、responses_ws.go 入站 WS、image-generation 强制 HTTP 分支仍保持旧行为,后续单独处理。

## 测试

`go build ./...`、`go test ./...` 全部通过。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming error handling so early upstream failures now return a proper JSON error instead of ending with a misleading successful stream response.
  * Prevented incomplete SSE responses from being sent when no data has reached the client yet, reducing incorrect success outcomes.
  * Preserved normal streaming behavior once output has already started, so completed streams still finish as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->