### PR TITLE
fix(proxy): 保留 Anthropic 空内容块字段

### DIFF
--- a/proxy/anthropic.go
+++ b/proxy/anthropic.go
@@ -57,6 +57,39 @@ type anthropicContentBlock struct {
 	IsError   bool                  `json:"is_error,omitempty"`
 }
 
+func (b anthropicContentBlock) MarshalJSON() ([]byte, error) {
+	type contentBlock struct {
+		Type      string                `json:"type"`
+		Text      *string               `json:"text,omitempty"`
+		Thinking  *string               `json:"thinking,omitempty"`
+		Source    *anthropicImageSource `json:"source,omitempty"`
+		ID        string                `json:"id,omitempty"`
+		Name      string                `json:"name,omitempty"`
+		Input     json.RawMessage       `json:"input,omitempty"`
+		ToolUseID string                `json:"tool_use_id,omitempty"`
+		Content   json.RawMessage       `json:"content,omitempty"`
+		IsError   bool                  `json:"is_error,omitempty"`
+	}
+
+	out := contentBlock{
+		Type:      b.Type,
+		Source:    b.Source,
+		ID:        b.ID,
+		Name:      b.Name,
+		Input:     b.Input,
+		ToolUseID: b.ToolUseID,
+		Content:   b.Content,
+		IsError:   b.IsError,
+	}
+	if b.Type == "text" || b.Text != "" {
+		out.Text = &b.Text
+	}
+	if b.Type == "thinking" || b.Thinking != "" {
+		out.Thinking = &b.Thinking
+	}
+	return json.Marshal(out)
+}
+
 type anthropicImageSource struct {
 	Type      string `json:"type"`
 	MediaType string `json:"media_type"`

--- a/proxy/anthropic_test.go
+++ b/proxy/anthropic_test.go
@@ -42,6 +42,56 @@ func TestSendAnthropicStreamErrorEscapesJSON(t *testing.T) {
 	}
 }
 
+func TestAnthropicStreamContentBlockStartPreservesEmptyFields(t *testing.T) {
+	tests := []struct {
+		name  string
+		block anthropicContentBlock
+		field string
+	}{
+		{"thinking block", anthropicContentBlock{Type: "thinking"}, "thinking"},
+		{"text block", anthropicContentBlock{Type: "text"}, "text"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			idx := 0
+			data, err := json.Marshal(anthropicStreamEvent{
+				Type:         "content_block_start",
+				Index:        &idx,
+				ContentBlock: &tc.block,
+			})
+			if err != nil {
+				t.Fatalf("marshal content_block_start: %v", err)
+			}
+
+			field := gjson.GetBytes(data, "content_block."+tc.field)
+			if !field.Exists() || field.String() != "" {
+				t.Fatalf("content_block.%s = %q, exists=%v; body=%s", tc.field, field.String(), field.Exists(), data)
+			}
+		})
+	}
+}
+
+func TestAnthropicStreamToolUseStartOmitsTextAndThinkingFields(t *testing.T) {
+	idx := 0
+	data, err := json.Marshal(anthropicStreamEvent{
+		Type:  "content_block_start",
+		Index: &idx,
+		ContentBlock: &anthropicContentBlock{
+			Type:  "tool_use",
+			ID:    "toolu_abc",
+			Name:  "Read",
+			Input: json.RawMessage("{}"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal content_block_start: %v", err)
+	}
+	if gjson.GetBytes(data, "content_block.text").Exists() || gjson.GetBytes(data, "content_block.thinking").Exists() {
+		t.Fatalf("tool_use content_block_start should not include text/thinking fields; body=%s", data)
+	}
+}
+
 func TestTranslateAnthropicToCodex_OutputConfigEffortTakesPrecedence(t *testing.T) {
 	raw := []byte(`{
 		"model":"claude-sonnet-4-5",


### PR DESCRIPTION
## 摘要

修复 Codex 输出转换为 Anthropic 流式响应时的兼容性问题。

OpenCode 对 Anthropic `thinking` 内容块校验较严格，要求 `content_block.thinking` 必须是字符串，即使初始值为空。此前 Go JSON 序列化使用了 `omitempty`，导致 `thinking: ""` 和 `text: ""` 在 `content_block_start` 事件中被移除，从而触发类似错误：

```text
content_block.thinking: Invalid input: expected string, received undefined
```

## 变更
- 为 anthropicContentBlock 添加自定义 JSON 序列化逻辑。
- 当 content_block.type == "thinking" 时保留 thinking: ""。
- 当 content_block.type == "text" 时保留 text: ""。
- 保持 tool_use 内容块不输出无关的 text / thinking 字段。
- 添加回归测试覆盖 Anthropic content_block_start 序列化行为。

## 原因
Anthropic 兼容的流式客户端通常要求 content_block_start 中包含对应类型的空字段，实际内容再通过后续的 thinking_delta 或 text_delta 发送。
如果这些空字段被省略，严格校验的客户端会在收到 delta 之前直接拒绝该流。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JSON handling for streamed Anthropic content blocks so empty values are included or omitted consistently based on block type.
  * Fixed event payloads for tool-use blocks to avoid sending irrelevant text/thinking fields.
* **Tests**
  * Added coverage for stream event output to verify field presence and omission rules for different content block types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->