### PR TITLE
修复远程压缩请求未正确应用模型映射

### DIFF
--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,5 +1,5 @@
 import type { ChangeEvent, ReactNode } from 'react'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { api, resetAdminAuthState, setAdminKey } from '../api'
 import { formatBeijingTime, getTimezone, setTimezone } from '../utils/time'
@@ -329,7 +329,9 @@ function ModelMappingEditor({
   const { t } = useTranslation()
   const [mappings, setMappings] = useState<ModelMappingEntry[]>(() => parseModelMappingEntries(value, fallbackEntries))
   const lastEmittedValueRef = useRef<string | null>(null)
-  const sourceSelectOptions = useMemo(() => {
+  const sourceListId = useId()
+  const targetListId = useId()
+  const sourceSuggestions = useMemo(() => {
     if (!sourceOptions) return []
     const byValue = new Map(sourceOptions.map((option) => [option.value, option]))
     for (const [source] of mappings) {
@@ -340,7 +342,7 @@ function ModelMappingEditor({
     }
     return [...byValue.values()]
   }, [mappings, sourceOptions])
-  const targetSelectOptions = useMemo(() => {
+  const targetSuggestions = useMemo(() => {
     if (!targetOptions) return []
     const byValue = new Map(targetOptions.map((option) => [option.value, option]))
     for (const [, target] of mappings) {
@@ -400,45 +402,25 @@ function ModelMappingEditor({
               <span className="text-[11px] font-semibold text-muted-foreground sm:hidden">
                 {sourceLabel}
               </span>
-              {sourceOptions ? (
-                <Select
-                  compact
-                  value={k.trim()}
-                  options={sourceSelectOptions}
-                  placeholder={sourcePlaceholder}
-                  disabled={sourceSelectOptions.length === 0}
-                  onValueChange={(next) => handleChange(i, 0, next)}
-                />
-              ) : (
-                <Input
-                  className="h-8 px-2 font-mono text-xs"
-                  placeholder={sourcePlaceholder}
-                  value={k}
-                  onChange={(e: ChangeEvent<HTMLInputElement>) => handleChange(i, 0, e.target.value)}
-                />
-              )}
+              <Input
+                className="h-8 px-2 font-mono text-xs"
+                list={sourceOptions ? sourceListId : undefined}
+                placeholder={sourcePlaceholder}
+                value={k}
+                onChange={(e: ChangeEvent<HTMLInputElement>) => handleChange(i, 0, e.target.value)}
+              />
             </div>
             <div className="min-w-0 space-y-1 sm:space-y-0">
               <span className="text-[11px] font-semibold text-muted-foreground sm:hidden">
                 {targetLabel}
               </span>
-              {targetOptions ? (
-                <Select
-                  compact
-                  value={v.trim()}
-                  options={targetSelectOptions}
-                  placeholder={targetPlaceholder}
-                  disabled={targetSelectOptions.length === 0}
-                  onValueChange={(next) => handleChange(i, 1, next)}
-                />
-              ) : (
-                <Input
-                  className="h-8 px-2 font-mono text-xs"
-                  placeholder={targetPlaceholder}
-                  value={v}
-                  onChange={(e: ChangeEvent<HTMLInputElement>) => handleChange(i, 1, e.target.value)}
-                />
-              )}
+              <Input
+                className="h-8 px-2 font-mono text-xs"
+                list={targetOptions ? targetListId : undefined}
+                placeholder={targetPlaceholder}
+                value={v}
+                onChange={(e: ChangeEvent<HTMLInputElement>) => handleChange(i, 1, e.target.value)}
+              />
             </div>
             <button
               type="button"
@@ -451,6 +433,20 @@ function ModelMappingEditor({
           </div>
         ))}
       </div>
+      {sourceOptions ? (
+        <datalist id={sourceListId}>
+          {sourceSuggestions.map((option) => (
+            <option key={option.value} value={option.value} label={option.label} />
+          ))}
+        </datalist>
+      ) : null}
+      {targetOptions ? (
+        <datalist id={targetListId}>
+          {targetSuggestions.map((option) => (
+            <option key={option.value} value={option.value} label={option.label} />
+          ))}
+        </datalist>
+      ) : null}
       <Button type="button" variant="outline" size="sm" className="self-start" onClick={handleAdd}>
         + {t('settings2.addMapping')}
       </Button>

--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -237,7 +237,14 @@ func accountFilterForResponsesModel(model string, allowCodexAccounts bool) auth.
 }
 
 func accountFilterForResponsesModelWithOriginal(originalModel string, effectiveModel string, allowCodexAccounts bool) auth.AccountFilter {
-	originalModel = strings.TrimSpace(originalModel)
+	return accountFilterForResponsesModelCandidates([]string{originalModel, effectiveModel}, effectiveModel, allowCodexAccounts)
+}
+
+func accountFilterForCompactResponsesModelWithOriginal(originalModel string, effectiveModel string, allowCodexAccounts bool) auth.AccountFilter {
+	return accountFilterForResponsesModelCandidates(compactModelMappingCandidates(originalModel, effectiveModel), effectiveModel, allowCodexAccounts)
+}
+
+func accountFilterForResponsesModelCandidates(modelCandidates []string, effectiveModel string, allowCodexAccounts bool) auth.AccountFilter {
 	effectiveModel = strings.TrimSpace(effectiveModel)
 	codexFilter := accountFilterForModel(effectiveModel)
 	return func(account *auth.Account) bool {
@@ -246,7 +253,7 @@ func accountFilterForResponsesModelWithOriginal(originalModel string, effectiveM
 		}
 		if account.IsOpenAIResponsesAPI() {
 			routedModel := effectiveModel
-			if mappedModel, ok := resolveAccountModelMappingForCandidates(account, originalModel, effectiveModel); ok && mappedModel != "" {
+			if mappedModel, ok := resolveAccountModelMappingForCandidates(account, modelCandidates...); ok && mappedModel != "" {
 				routedModel = mappedModel
 			}
 			return account.SupportsOpenAIResponsesModel(routedModel) && (routedModel == "" || !account.IsModelRateLimited(routedModel))
@@ -1640,10 +1647,6 @@ func (h *Handler) Responses(c *gin.Context) {
 		return
 	}
 
-	supportedModels := h.supportedModelIDs(c.Request.Context())
-	rawBody, requestModel, mappedModel, mappingApplied := h.applyConfiguredModelMappingToBody(rawBody, supportedModels)
-	setRawRequestBody(c, rawBody)
-
 	// body-signal compact：较新的 Codex 客户端把会话压缩触发器作为 input item
 	// （type=compaction_trigger）嵌进普通 /responses 请求体，而不调用
 	// /responses/compact。官方 ChatGPT OAuth 账号的原生上游直接接受该形态，
@@ -1653,14 +1656,17 @@ func (h *Handler) Responses(c *gin.Context) {
 	// 处理：池中还有可用官方账号时，把这类请求钉在官方账号上保持原生透传；
 	// 官方账号全不可用（如纯中转部署）时整体提升到 compact 专用链路——
 	// 该链路对两类账号都能正确完成压缩。
-	pinBodySignalToCodexAccounts := false
-	if requestBodyHasCompactionInput(rawBody) {
+	pinBodySignalToCodexAccounts := requestBodyHasCompactionInput(rawBody)
+	if pinBodySignalToCodexAccounts {
 		if !h.storeHasAvailableCodexAccount() {
 			h.ResponsesCompact(c)
 			return
 		}
-		pinBodySignalToCodexAccounts = true
 	}
+
+	supportedModels := h.supportedModelIDs(c.Request.Context())
+	rawBody, requestModel, mappedModel, mappingApplied := h.applyConfiguredModelMappingToBody(rawBody, supportedModels)
+	setRawRequestBody(c, rawBody)
 
 	// Validate request
 	validator := api.NewValidator(rawBody)
@@ -2719,10 +2725,9 @@ func (h *Handler) ResponsesCompact(c *gin.Context) {
 	}
 
 	supportedModels := h.supportedModelIDs(c.Request.Context())
-	// newapi 等聚合网关会给 compact 请求追加 -openai-compact 后缀（如 gpt-5.4-openai-compact）。
-	// 在映射与校验之前剥除后缀，让 newapi 渠道保持该命名，而内部按基础模型 gpt-5.4 处理并转发上游。
-	rawBody, _, _ = stripCompactModelSuffixFromBody(rawBody)
-	rawBody, requestModel, mappedModel, mappingApplied := h.applyConfiguredModelMappingToBody(rawBody, supportedModels)
+	// 先让全局/渠道映射看到客户端原始模型（包括 -openai-compact 别名）；
+	// 没有命中映射时，再按兼容规则剥离后缀。
+	rawBody, requestModel, mappedModel, mappingApplied := h.applyConfiguredCompactModelMappingToBody(rawBody, supportedModels)
 	setRawRequestBody(c, rawBody)
 
 	// Validate request
@@ -2802,7 +2807,7 @@ func (h *Handler) ResponsesCompact(c *gin.Context) {
 	}
 	// compact 同时允许官方 Codex OAuth 账号与中转（OpenAI Responses API）账号：
 	// 中转账号会命中上游自身的 /responses/compact，使仅接入中转的用户也能压缩（issue #174）。
-	accountFilter := accountFilterForResponsesModelWithOriginal(logModel, effectiveModel, modelIDInList(effectiveModel, SupportedModelIDs(c.Request.Context(), h.db)))
+	accountFilter := accountFilterForCompactResponsesModelWithOriginal(logModel, effectiveModel, modelIDInList(effectiveModel, SupportedModelIDs(c.Request.Context(), h.db)))
 	accountFilter = h.withModelCooldownFilter(effectiveModel, accountFilter)
 
 	// compact 走中转账号时需要 OpenAI Responses 形态的请求体
@@ -2850,7 +2855,7 @@ func (h *Handler) ResponsesCompact(c *gin.Context) {
 			baseURL, _ := account.OpenAIResponsesCredentials()
 			upstreamEndpoint := auth.OpenAIResponsesEndpoint(baseURL, "/v1/responses/compact")
 			upstreamBody := openAIResponsesBody
-			if mappedBody, mappedModel, ok := h.applyAccountModelMappingToBodyForModels(upstreamBody, account, logModel, effectiveModel); ok {
+			if mappedBody, mappedModel, ok := h.applyAccountModelMappingToBodyForModels(upstreamBody, account, compactModelMappingCandidates(logModel, effectiveModel)...); ok {
 				upstreamBody = mappedBody
 				attemptEffectiveModel = mappedModel
 				attemptLogEffectiveModel = usageEffectiveModelForMapping(logModel, attemptEffectiveModel, true)

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -228,6 +228,7 @@ func TestResponsesWebSocketForwardsResponsesEvents(t *testing.T) {
 	}
 
 	store := auth.NewStore(nil, nil, &database.SystemSettings{MaxConcurrency: 2, TestConcurrency: 1, TestModel: "gpt-5.4"})
+	store.SetCodexModelMapping(`{"client-ws-alias":"gpt-5.4"}`)
 	store.AddAccount(&auth.Account{DBID: 1, AccessToken: "at", PlanType: "plus", AccountID: "acct-1"})
 	handler := NewHandler(store, nil, &config.Config{AllowAnonymousV1: true}, nil)
 
@@ -246,13 +247,16 @@ func TestResponsesWebSocketForwardsResponsesEvents(t *testing.T) {
 	}
 	defer conn.Close()
 
-	if err := conn.WriteMessage(websocket.TextMessage, []byte(`{"model":"gpt-5.4","previous_response_id":"resp_prev","input":"hello"}`)); err != nil {
+	if err := conn.WriteMessage(websocket.TextMessage, []byte(`{"model":"client-ws-alias","previous_response_id":"resp_prev","input":"hello"}`)); err != nil {
 		t.Fatalf("write request: %v", err)
 	}
 	select {
 	case gotBody := <-bodyCh:
 		if gjson.GetBytes(gotBody, "type").String() != "response.create" {
 			t.Fatalf("upstream type missing: %s", gotBody)
+		}
+		if model := gjson.GetBytes(gotBody, "model").String(); model != "gpt-5.4" {
+			t.Fatalf("upstream model = %q, want mapped gpt-5.4; body=%s", model, gotBody)
 		}
 		if prev := gjson.GetBytes(gotBody, "previous_response_id").String(); prev != "resp_prev" {
 			t.Fatalf("previous_response_id = %q, want resp_prev; body=%s", prev, gotBody)
@@ -875,6 +879,7 @@ func TestResponsesCompactUsesOpenAIResponsesAPIAccount(t *testing.T) {
 		MaxRetries:          0,
 		MaxRateLimitRetries: 0,
 	})
+	store.SetCodexModelMapping(`{"client-compact-alias":"gpt-4.1-direct","gpt-4.1-direct":"gpt-4.1-second"}`)
 	store.AddAccount(&auth.Account{
 		DBID:         1,
 		UpstreamType: auth.UpstreamOpenAIResponses,
@@ -886,7 +891,7 @@ func TestResponsesCompactUsesOpenAIResponsesAPIAccount(t *testing.T) {
 	handler := NewHandler(store, nil, nil, nil)
 
 	body := []byte(`{
-		"model":"gpt-4.1-direct",
+		"model":"client-compact-alias",
 		"input":"hello",
 		"include":["reasoning.encrypted_content"],
 		"store":true,
@@ -919,6 +924,58 @@ func TestResponsesCompactUsesOpenAIResponsesAPIAccount(t *testing.T) {
 	}
 	if id := gjson.GetBytes(recorder.Body.Bytes(), "id").String(); id != "resp_compact_test" {
 		t.Fatalf("response id = %q, want resp_compact_test; body=%s", id, recorder.Body.String())
+	}
+}
+
+func TestResponsesCompactAppliesAccountMappingBeforeSuffixFallback(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	var seenBody []byte
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":"resp_compact_mapped",
+			"object":"response",
+			"model":"gpt-5.5",
+			"output":[],
+			"usage":{"input_tokens":3,"output_tokens":2,"total_tokens":5}
+		}`))
+	}))
+	defer upstream.Close()
+
+	store := auth.NewStore(nil, nil, &database.SystemSettings{
+		MaxConcurrency:      2,
+		MaxRetries:          0,
+		MaxRateLimitRetries: 0,
+	})
+	store.AddAccount(&auth.Account{
+		DBID:         1,
+		UpstreamType: auth.UpstreamOpenAIResponses,
+		BaseURL:      upstream.URL,
+		APIKey:       "sk-direct",
+		Models:       []string{"gpt-5.5"},
+		ModelMapping: `{"gpt-5.6-sol-openai-compact":"gpt-5.5"}`,
+		PlanType:     "api",
+	})
+	handler := NewHandler(store, nil, nil, nil)
+
+	body := []byte(`{"model":"gpt-5.6-sol","input":"hello","stream":true}`)
+	requestCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses/compact", bytes.NewReader(body)).WithContext(requestCtx)
+	req.Header.Set("Content-Type", "application/json")
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Request = req
+
+	handler.ResponsesCompact(ctx)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	if model := gjson.GetBytes(seenBody, "model").String(); model != "gpt-5.5" {
+		t.Fatalf("upstream model = %q, want gpt-5.5; body=%s", model, seenBody)
 	}
 }
 
@@ -2687,6 +2744,7 @@ func TestResponses_BodySignalCompactPromotedOnRelayOnlyPool(t *testing.T) {
 		MaxRetries:          0,
 		MaxRateLimitRetries: 0,
 	})
+	store.SetCodexModelMapping(`{"client-body-signal-alias-openai-compact":"gpt-4.1-direct","gpt-4.1-direct":"gpt-4.1-second"}`)
 	store.AddAccount(&auth.Account{
 		DBID:         1,
 		UpstreamType: auth.UpstreamOpenAIResponses,
@@ -2698,7 +2756,7 @@ func TestResponses_BodySignalCompactPromotedOnRelayOnlyPool(t *testing.T) {
 	handler := NewHandler(store, nil, nil, nil)
 
 	body := []byte(`{
-		"model":"gpt-4.1-direct",
+		"model":"client-body-signal-alias",
 		"stream":true,
 		"client_metadata":{"x-codex-window-id":"w-1","x-codex-installation-id":"i-1"},
 		"input":[
@@ -2727,6 +2785,9 @@ func TestResponses_BodySignalCompactPromotedOnRelayOnlyPool(t *testing.T) {
 	if gjson.GetBytes(seenBody, "client_metadata").Exists() {
 		t.Fatalf("promoted upstream body should not carry client_metadata, got %s", seenBody)
 	}
+	if model := gjson.GetBytes(seenBody, "model").String(); model != "gpt-4.1-direct" {
+		t.Fatalf("promoted compact model = %q, want one-pass mapping to gpt-4.1-direct; body=%s", model, seenBody)
+	}
 	if id := gjson.GetBytes(recorder.Body.Bytes(), "id").String(); id != "resp_compaction_test" {
 		t.Fatalf("response id = %q, want resp_compaction_test; body=%s", id, recorder.Body.String())
 	}
@@ -2737,8 +2798,10 @@ func TestResponses_PlainRequestNotPromotedOnRelayOnlyPool(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	var seenPath string
+	var seenBody []byte
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		seenPath = r.URL.Path
+		seenBody, _ = io.ReadAll(r.Body)
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{
 			"id":"resp_plain_test",
@@ -2756,6 +2819,7 @@ func TestResponses_PlainRequestNotPromotedOnRelayOnlyPool(t *testing.T) {
 		MaxRetries:          0,
 		MaxRateLimitRetries: 0,
 	})
+	store.SetCodexModelMapping(`{"client-response-alias":"gpt-4.1-direct"}`)
 	store.AddAccount(&auth.Account{
 		DBID:         1,
 		UpstreamType: auth.UpstreamOpenAIResponses,
@@ -2766,7 +2830,7 @@ func TestResponses_PlainRequestNotPromotedOnRelayOnlyPool(t *testing.T) {
 	})
 	handler := NewHandler(store, nil, nil, nil)
 
-	body := []byte(`{"model":"gpt-4.1-direct","input":"hello"}`)
+	body := []byte(`{"model":"client-response-alias","input":"hello"}`)
 	req := httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	recorder := httptest.NewRecorder()
@@ -2780,6 +2844,9 @@ func TestResponses_PlainRequestNotPromotedOnRelayOnlyPool(t *testing.T) {
 	}
 	if seenPath != "/v1/responses" {
 		t.Fatalf("upstream path = %q, want /v1/responses (no promotion for plain request)", seenPath)
+	}
+	if model := gjson.GetBytes(seenBody, "model").String(); model != "gpt-4.1-direct" {
+		t.Fatalf("upstream model = %q, want mapped gpt-4.1-direct; body=%s", model, seenBody)
 	}
 }
 

--- a/proxy/model_mapping.go
+++ b/proxy/model_mapping.go
@@ -348,3 +348,70 @@ func stripCompactModelSuffixFromBody(rawBody []byte) ([]byte, string, bool) {
 	}
 	return updated, stripped, true
 }
+
+// compactModelMappingCandidates returns endpoint-qualified aliases before their
+// base names so compact-specific rules override general model rules.
+func compactModelMappingCandidates(models ...string) []string {
+	candidates := make([]string, 0, len(models)*2)
+	seen := make(map[string]struct{}, len(models)*2)
+	add := func(model string) {
+		model = strings.TrimSpace(model)
+		if model == "" {
+			return
+		}
+		key := strings.ToLower(model)
+		if _, ok := seen[key]; ok {
+			return
+		}
+		seen[key] = struct{}{}
+		candidates = append(candidates, model)
+	}
+
+	for _, model := range models {
+		model = strings.TrimSpace(model)
+		if model == "" {
+			continue
+		}
+		if baseModel, stripped := stripCompactModelSuffix(model); stripped {
+			add(model)
+			add(baseModel)
+			continue
+		}
+		add(model + compactOpenAIModelSuffix)
+		add(model)
+	}
+	return candidates
+}
+
+// applyConfiguredCompactModelMappingToBody resolves the endpoint-qualified
+// compact alias before the base model. This lets the same rule work whether a
+// client sends "model" or "model-openai-compact", while preserving the full
+// requested name for per-account routing and usage logs.
+func (h *Handler) applyConfiguredCompactModelMappingToBody(rawBody []byte, supportedModels []string) ([]byte, string, string, bool) {
+	originalModel := strings.TrimSpace(gjson.GetBytes(rawBody, "model").String())
+	if originalModel == "" || !gjson.ValidBytes(rawBody) || h == nil || h.store == nil {
+		return rawBody, originalModel, originalModel, false
+	}
+
+	candidates := compactModelMappingCandidates(originalModel)
+	if len(candidates) > 0 {
+		compactAlias := candidates[0]
+		if mappedModel, ok := resolveConfiguredModelMapping(compactAlias, h.store.GetCodexModelMapping(), supportedModels); ok && mappedModel != "" && !strings.EqualFold(mappedModel, compactAlias) {
+			updatedBody, err := sjson.SetBytes(rawBody, "model", mappedModel)
+			if err == nil {
+				return updatedBody, originalModel, mappedModel, true
+			}
+		}
+	}
+
+	baseBody, baseModel, stripped := stripCompactModelSuffixFromBody(rawBody)
+	if !stripped {
+		baseBody = rawBody
+		baseModel = originalModel
+	}
+	mappedBody, _, effectiveModel, mappingApplied := h.applyConfiguredModelMappingToBody(baseBody, supportedModels)
+	if effectiveModel == "" {
+		effectiveModel = baseModel
+	}
+	return mappedBody, originalModel, effectiveModel, mappingApplied || stripped
+}

--- a/proxy/model_mapping.go
+++ b/proxy/model_mapping.go
@@ -154,6 +154,22 @@ func wildcardModelPatternMatch(pattern string, model string) bool {
 	return true
 }
 
+func applyReasoningEffortModelToBody(rawBody []byte, entry ReasoningEffortModel) ([]byte, error) {
+	updatedBody, err := sjson.SetBytes(rawBody, "model", entry.Model)
+	if err != nil {
+		return rawBody, err
+	}
+	updatedBody, err = sjson.SetBytes(updatedBody, "reasoning_effort", entry.Effort)
+	if err != nil {
+		return rawBody, err
+	}
+	updatedBody, err = sjson.SetBytes(updatedBody, "reasoning.effort", entry.Effort)
+	if err != nil {
+		return rawBody, err
+	}
+	return updatedBody, nil
+}
+
 func (h *Handler) applyConfiguredModelMappingToBody(rawBody []byte, supportedModels []string) ([]byte, string, string, bool) {
 	originalModel := strings.TrimSpace(gjson.GetBytes(rawBody, "model").String())
 	effectiveModel := originalModel
@@ -166,15 +182,7 @@ func (h *Handler) applyConfiguredModelMappingToBody(rawBody []byte, supportedMod
 	mappingApplied := false
 	if entry, ok := resolveReasoningEffortModelAlias(originalModel, h.store.GetReasoningEffortModels(), supportedModels); ok {
 		var err error
-		updatedBody, err = sjson.SetBytes(updatedBody, "model", entry.Model)
-		if err != nil {
-			return rawBody, originalModel, effectiveModel, false
-		}
-		updatedBody, err = sjson.SetBytes(updatedBody, "reasoning_effort", entry.Effort)
-		if err != nil {
-			return rawBody, originalModel, effectiveModel, false
-		}
-		updatedBody, err = sjson.SetBytes(updatedBody, "reasoning.effort", entry.Effort)
+		updatedBody, err = applyReasoningEffortModelToBody(updatedBody, entry)
 		if err != nil {
 			return rawBody, originalModel, effectiveModel, false
 		}
@@ -397,10 +405,19 @@ func (h *Handler) applyConfiguredCompactModelMappingToBody(rawBody []byte, suppo
 	if len(candidates) > 0 {
 		compactAlias := candidates[0]
 		if mappedModel, ok := resolveConfiguredModelMapping(compactAlias, h.store.GetCodexModelMapping(), supportedModels); ok && mappedModel != "" && !strings.EqualFold(mappedModel, compactAlias) {
-			updatedBody, err := sjson.SetBytes(rawBody, "model", mappedModel)
-			if err == nil {
-				return updatedBody, originalModel, mappedModel, true
+			effectiveModel := mappedModel
+			updatedBody := rawBody
+			var err error
+			if entry, ok := resolveReasoningEffortModelAlias(mappedModel, h.store.GetReasoningEffortModels(), supportedModels); ok {
+				updatedBody, err = applyReasoningEffortModelToBody(updatedBody, entry)
+				effectiveModel = entry.Model
+			} else {
+				updatedBody, err = sjson.SetBytes(updatedBody, "model", mappedModel)
 			}
+			if err != nil {
+				return rawBody, originalModel, originalModel, false
+			}
+			return updatedBody, originalModel, effectiveModel, true
 		}
 	}
 

--- a/proxy/model_mapping_test.go
+++ b/proxy/model_mapping_test.go
@@ -227,6 +227,77 @@ func TestApplyConfiguredModelMappingToBodyIgnoresClaudeMappingSetting(t *testing
 	}
 }
 
+func TestApplyConfiguredCompactModelMappingPreservesRequestedAlias(t *testing.T) {
+	tests := []struct {
+		name    string
+		mapping string
+		want    string
+	}{
+		{
+			name:    "full compact alias maps first",
+			mapping: `{"gpt-5.6-sol-openai-compact":"gpt-5.5"}`,
+			want:    "gpt-5.5",
+		},
+		{
+			name:    "base model mapping follows suffix fallback",
+			mapping: `{"gpt-5.6-sol":"gpt-5.5"}`,
+			want:    "gpt-5.5",
+		},
+		{
+			name:    "suffix fallback remains effective without a rule",
+			mapping: `{}`,
+			want:    "gpt-5.6-sol",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := auth.NewStore(nil, nil, nil)
+			store.SetCodexModelMapping(tt.mapping)
+			handler := NewHandler(store, nil, nil, nil)
+
+			body, original, effective, mapped := handler.applyConfiguredCompactModelMappingToBody(
+				[]byte(`{"model":"gpt-5.6-sol-openai-compact","input":"hello"}`),
+				[]string{"gpt-5.6-sol", "gpt-5.5"},
+			)
+
+			if !mapped {
+				t.Fatal("compact alias should be normalized or mapped")
+			}
+			if original != "gpt-5.6-sol-openai-compact" {
+				t.Fatalf("original model = %q, want full client alias", original)
+			}
+			if effective != tt.want {
+				t.Fatalf("effective model = %q, want %q", effective, tt.want)
+			}
+			if got := gjson.GetBytes(body, "model").String(); got != tt.want {
+				t.Fatalf("body model = %q, want %q; body=%s", got, tt.want, body)
+			}
+		})
+	}
+}
+
+func TestApplyConfiguredCompactModelMappingMatchesSyntheticCompactAlias(t *testing.T) {
+	store := auth.NewStore(nil, nil, nil)
+	store.SetCodexModelMapping(`{"gpt-5.6-sol-openai-compact":"gpt-5.5"}`)
+	handler := NewHandler(store, nil, nil, nil)
+
+	body, original, effective, mapped := handler.applyConfiguredCompactModelMappingToBody(
+		[]byte(`{"model":"gpt-5.6-sol","input":"hello"}`),
+		[]string{"gpt-5.6-sol", "gpt-5.5"},
+	)
+
+	if !mapped {
+		t.Fatal("endpoint-qualified compact alias should map a base-model request")
+	}
+	if original != "gpt-5.6-sol" || effective != "gpt-5.5" {
+		t.Fatalf("original/effective = %q/%q, want gpt-5.6-sol/gpt-5.5", original, effective)
+	}
+	if got := gjson.GetBytes(body, "model").String(); got != "gpt-5.5" {
+		t.Fatalf("body model = %q, want gpt-5.5; body=%s", got, body)
+	}
+}
+
 func TestStripCompactModelSuffix(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/proxy/model_mapping_test.go
+++ b/proxy/model_mapping_test.go
@@ -298,6 +298,34 @@ func TestApplyConfiguredCompactModelMappingMatchesSyntheticCompactAlias(t *testi
 	}
 }
 
+func TestApplyConfiguredCompactModelMappingResolvesReasoningEffortTarget(t *testing.T) {
+	store := auth.NewStore(nil, nil, nil)
+	store.SetReasoningEffortModels(`[{"model":"gpt-5.5","effort":"xhigh"}]`)
+	store.SetCodexModelMapping(`{"gpt-5.6-sol-openai-compact":"gpt-5.5(xhigh)"}`)
+	handler := NewHandler(store, nil, nil, nil)
+
+	body, original, effective, mapped := handler.applyConfiguredCompactModelMappingToBody(
+		[]byte(`{"model":"gpt-5.6-sol","input":"hello"}`),
+		[]string{"gpt-5.6-sol", "gpt-5.5", "gpt-5.5(xhigh)"},
+	)
+
+	if !mapped {
+		t.Fatal("compact alias should map to the reasoning-effort target")
+	}
+	if original != "gpt-5.6-sol" || effective != "gpt-5.5" {
+		t.Fatalf("original/effective = %q/%q, want gpt-5.6-sol/gpt-5.5", original, effective)
+	}
+	if got := gjson.GetBytes(body, "model").String(); got != "gpt-5.5" {
+		t.Fatalf("body model = %q, want gpt-5.5; body=%s", got, body)
+	}
+	if got := gjson.GetBytes(body, "reasoning_effort").String(); got != "xhigh" {
+		t.Fatalf("reasoning_effort = %q, want xhigh; body=%s", got, body)
+	}
+	if got := gjson.GetBytes(body, "reasoning.effort").String(); got != "xhigh" {
+		t.Fatalf("reasoning.effort = %q, want xhigh; body=%s", got, body)
+	}
+}
+
 func TestStripCompactModelSuffix(t *testing.T) {
 	tests := []struct {
 		name      string


### PR DESCRIPTION
## 问题

模型映射在普通 Responses 请求中可以生效，但远程压缩请求会使用 `<model>-openai-compact` 形式的模型名。原有流程在映射前处理了压缩后缀，因此无法可靠匹配压缩专用映射，导致 Codex CLI 发起远程压缩时仍请求原模型。

## 修改

- 在移除 `-openai-compact` 后缀前解析端点专用模型映射
- 当客户端发送基础模型名时，同时支持匹配 `<model>-openai-compact` 映射
- 全局与账号级模型映射均支持远程压缩请求
- 保留原始请求模型用于路由与日志，并避免 `compaction_trigger` 路径重复映射
- 保持普通 HTTP 与 WebSocket Responses 请求的模型映射行为
- 将全局模型映射编辑器改为支持自由输入及通配符，并保留候选提示
- 增加普通请求、WebSocket 和远程压缩场景的回归测试

## 示例

将 Codex CLI 的 `gpt-5.5` 请求映射到 `gpt-5.4`：

```json
{"gpt-5.5":"gpt-5.4"}
```

仅映射远程压缩请求：

```json
{"gpt-5.5-openai-compact":"gpt-5.4"}
```

## 验证

- `go test -p 6 ./... -count=1`
- `npm run typecheck`
- `npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved model mapping for compact Responses requests, including compact-specific aliases and improved fallback handling.
  - Added native autocomplete suggestions for model mapping fields.
  - Enhanced model routing behavior for mapped models across HTTP and WebSocket requests.

- **Bug Fixes**
  - Corrected request model selection and forwarding when client aliases are used, including compaction promotion flows.
  - Preserved the originally requested model alias while applying the correct effective upstream mapping.
  - When a mapped target includes reasoning-effort variants, reasoning-effort fields are now updated consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->