### PR TITLE
fix(wsrelay): keep a permanent reader per connection

### DIFF
--- a/proxy/wsrelay/discard_on_error_test.go
+++ b/proxy/wsrelay/discard_on_error_test.go
@@ -37,6 +37,9 @@ func TestDiscardConnectionClosesAndRemovesFromPool(t *testing.T) {
 	if wc.IsConnected() {
 		t.Fatal("expected discarded connection to be closed (state != connected)")
 	}
+	if session.IsConnected() {
+		t.Fatal("expected discarded session heartbeat to be stopped")
+	}
 }
 
 // TestDiscardConnectionKeepsReplacedConnection 验证 DiscardConnection 使用
@@ -68,6 +71,24 @@ func TestDiscardConnectionKeepsReplacedConnection(t *testing.T) {
 	}
 	if v, ok := manager.sessions.Load(key); !ok || v.(*Session) != newSession {
 		t.Fatal("DiscardConnection must not remove the replaced session under the same key")
+	}
+}
+
+func TestStartHeartbeatSkipsRetiredConnection(t *testing.T) {
+	manager := NewManager()
+	t.Cleanup(manager.Stop)
+
+	session := NewSession(1, manager)
+	session.SetConnected(false)
+	wc := &WsConnection{session: session}
+	wc.SetState(StateDisconnected)
+
+	manager.StartHeartbeat(wc)
+	session.mu.Lock()
+	timer := session.heartbeatTimer
+	session.mu.Unlock()
+	if timer != nil {
+		t.Fatal("retired connection created a new heartbeat timer")
 	}
 }
 

--- a/proxy/wsrelay/executor.go
+++ b/proxy/wsrelay/executor.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -195,7 +196,7 @@ func (e *Executor) ExecuteRequestViaWebsocket(
 	// 用 DiscardConnection 按连接指针精确清理：续链亲和取回的连接其 PoolKey
 	// 可能与当前请求的 proxy 组合不同，按参数重算 key 会漏删。
 	sendErr := e.sendRequest(wc, wsBody, pr.RequestID)
-	for retries := 0; sendErr != nil && retries < 2; retries++ {
+	for retries := 0; shouldRetryWebsocketSendError(sendErr) && retries < 2; retries++ {
 		wc.session.RemovePendingRequest(pr.RequestID)
 		e.manager.DiscardConnection(wc)
 
@@ -229,6 +230,14 @@ func (e *Executor) ExecuteRequestViaWebsocket(
 		apiKey:      apiKey,
 		readErrChan: make(chan error, 1),
 	}, nil
+}
+
+func shouldRetryWebsocketSendError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var closeErr *websocket.CloseError
+	return !errors.As(err, &closeErr) || closeErr.Code != websocket.CloseMessageTooBig
 }
 
 // prepareWebsocketBody 准备 WebSocket 请求体
@@ -332,6 +341,9 @@ func (e *Executor) sendRequest(wc *WsConnection, body []byte, requestID string) 
 	if !wc.IsConnected() {
 		return fmt.Errorf("websocket connection is not connected")
 	}
+	if err := wc.ensureReadLeaseForSend(requestID); err != nil {
+		return err
+	}
 	return wc.WriteMessage(websocket.TextMessage, body)
 }
 
@@ -361,19 +373,21 @@ type WsResponse struct {
 
 // ReadStream 读取 SSE 流
 func (r *WsResponse) ReadStream(callback func(data []byte) bool) error {
-	if r.conn == nil || !r.conn.IsConnected() {
+	if r.conn == nil {
 		return fmt.Errorf("websocket connection is not available")
+	}
+	if r.pendingReq != nil {
+		if err := r.conn.ensureReadLeaseForResponse(r.pendingReq.RequestID); err != nil {
+			return fmt.Errorf("websocket connection is not available: %w", err)
+		}
 	}
 
 	for {
 		msgType, payload, err := r.conn.ReadMessage()
 		if err != nil {
-			// 检查是否是正常关闭
-			if websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
-				return nil
-			}
-			// 非正常关闭(close 1006/1009/1011、broken pipe、unexpected EOF、读超时等)：
-			// 连接已不可靠，标记为坏连接，Close() 时销毁并移出连接池，避免复用与 CLOSE_WAIT 滞留。
+			// ReadStream only returns successfully after consuming an explicit
+			// response terminal frame. Any socket close here, including 1000/1001,
+			// is premature and must preserve the real close error for the consumer.
 			r.markConnBroken()
 			return fmt.Errorf("websocket read error: %w", err)
 		}
@@ -556,7 +570,7 @@ func (r *WsResponse) Close() error {
 	r.closed = true
 
 	// 移除等待请求
-	if r.conn != nil && r.conn.session != nil {
+	if r.conn != nil && r.conn.session != nil && r.pendingReq != nil {
 		r.conn.session.RemovePendingRequest(r.pendingReq.RequestID)
 	}
 

--- a/proxy/wsrelay/executor_test.go
+++ b/proxy/wsrelay/executor_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/sha1"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -485,5 +486,28 @@ func TestStatelessOneShotEnabled(t *testing.T) {
 	t.Setenv("CODEX_WS_STATELESS_ONESHOT", "1")
 	if !statelessOneShotEnabled() {
 		t.Fatal("CODEX_WS_STATELESS_ONESHOT=1 must disable slot reuse")
+	}
+}
+
+func TestShouldRetryWebsocketSendError(t *testing.T) {
+	messageTooBig := fmt.Errorf("send interrupted: %w", &websocket.CloseError{
+		Code: websocket.CloseMessageTooBig,
+		Text: "message too big",
+	})
+	if shouldRetryWebsocketSendError(messageTooBig) {
+		t.Fatal("close 1009 must return to the handler for HTTP fallback without rebuilding WebSocket connections")
+	}
+
+	if !shouldRetryWebsocketSendError(errors.New("temporary write failure")) {
+		t.Fatal("ordinary transport write failures should retain the bounded reconnect retry")
+	}
+	if !shouldRetryWebsocketSendError(fmt.Errorf("send interrupted: %w", &websocket.CloseError{
+		Code: websocket.CloseInternalServerErr,
+		Text: "temporary upstream failure",
+	})) {
+		t.Fatal("retryable peer closes other than 1009 should retain the bounded reconnect retry")
+	}
+	if shouldRetryWebsocketSendError(nil) {
+		t.Fatal("nil is not a retryable send error")
 	}
 }

--- a/proxy/wsrelay/manager.go
+++ b/proxy/wsrelay/manager.go
@@ -56,11 +56,34 @@ type WsConnection struct {
 	// 写操作锁
 	writeMu sync.Mutex
 
+	// 永久 reader、业务帧 lease 与探活状态。读取状态按需初始化，兼容测试中
+	// 通过字面量构造且没有底层 socket 的 WsConnection。
+	readStateOnce       sync.Once
+	readPumpOnce        sync.Once
+	readFailureOnce     sync.Once
+	controlHandlersOnce sync.Once
+	readState           *wsReadState
+
+	probeGateOnce sync.Once
+	probeGate     chan struct{}
+	probeStateMu  sync.Mutex
+	probePayload  string
+	probeResult   chan struct{}
+
+	// 底层 socket 与断开回调只关闭/调用一次。
+	closeOnce          sync.Once
+	closeErr           error
+	disconnectNotified atomic.Bool
+
 	// HTTP 握手响应
 	httpResp *http.Response
 
 	// 连接关闭回调
 	onDisconnected func(accountID int64)
+
+	// 永久 reader 失败回调。Manager 使用指针级 CompareAndDelete 精确移除
+	// 当前连接，避免误删同 PoolKey 下已经重建的连接。
+	onReadFailure func(wc *WsConnection)
 }
 
 func effectiveProxyURL(account *auth.Account, proxyOverride string) string {
@@ -117,18 +140,20 @@ func (wc *WsConnection) IsConnected() bool {
 
 // Close 安全关闭连接
 func (wc *WsConnection) Close() error {
-	if wc.state.CompareAndSwap(int32(StateConnected), int32(StateClosing)) ||
-		wc.state.CompareAndSwap(int32(StateConnecting), int32(StateClosing)) {
-		// 调用断开回调
-		if wc.onDisconnected != nil && wc.session != nil {
-			wc.onDisconnected(wc.session.AccountID)
-		}
-		if wc.conn != nil {
-			return wc.conn.Close()
-		}
+	if wc == nil {
 		return nil
 	}
-	return nil
+	wc.closeOnce.Do(func() {
+		wc.state.Store(int32(StateClosing))
+		if wc.conn != nil {
+			wc.closeErr = wc.conn.Close()
+		}
+		wc.state.Store(int32(StateDisconnected))
+	})
+	if wc.onDisconnected != nil && wc.session != nil && wc.disconnectNotified.CompareAndSwap(false, true) {
+		wc.onDisconnected(wc.session.AccountID)
+	}
+	return wc.closeErr
 }
 
 // SetState 设置连接状态
@@ -141,26 +166,22 @@ func (wc *WsConnection) WriteMessage(messageType int, data []byte) error {
 	wc.writeMu.Lock()
 	defer wc.writeMu.Unlock()
 
-	if !wc.IsConnected() {
+	if !wc.IsConnected() || wc.conn == nil {
 		return fmt.Errorf("websocket connection is not connected")
+	}
+	leaseID, tracksLease, err := wc.beginReadLeaseWrite(messageType)
+	if err != nil {
+		return err
 	}
 
 	wc.conn.SetWriteDeadline(time.Now().Add(WriteTimeout))
 	defer wc.conn.SetWriteDeadline(time.Time{})
 
-	return wc.conn.WriteMessage(messageType, data)
-}
-
-// ReadMessage 读取消息（带超时）
-func (wc *WsConnection) ReadMessage() (int, []byte, error) {
-	wc.conn.SetReadDeadline(time.Now().Add(ReadTimeout))
-	defer wc.conn.SetReadDeadline(time.Time{})
-
-	msgType, data, err := wc.conn.ReadMessage()
-	if err == nil {
-		wc.Touch()
+	writeErr := wc.conn.WriteMessage(messageType, data)
+	if tracksLease {
+		return wc.completeReadLeaseWrite(leaseID, writeErr)
 	}
-	return msgType, data, err
+	return writeErr
 }
 
 // HTTPResponse 返回 HTTP 握手响应
@@ -372,6 +393,7 @@ func (m *Manager) AcquireConnection(
 	lock := m.keyLock(key)
 	wait := AcquireInitialBackoff
 	var waited time.Duration
+	var createLeaseFailures int
 
 	for {
 		lock.Lock()
@@ -380,19 +402,22 @@ func (m *Manager) AcquireConnection(
 			if canReuseConnection(wc) {
 				// 发送 Ping 探活，确认连接真正存活
 				if m.probe(wc) {
-					pr := wc.session.AddPendingRequest(sessionKey)
-					wc.Touch()
+					pr, leaseErr := m.addPendingAndBeginReadLease(wc, sessionKey)
+					if leaseErr == nil {
+						wc.Touch()
+						lock.Unlock()
+						return wc, pr, nil
+					}
+					m.DiscardConnection(wc)
 					lock.Unlock()
-					return wc, pr, nil
+					continue
 				}
 				// 探活失败，清理死连接
-				m.connections.Delete(key)
-				m.sessions.Delete(key)
-				wc.Close()
+				m.DiscardConnection(wc)
 				lock.Unlock()
 				continue
 			}
-			if wc.IsConnected() && !wc.IsExpired() && wc.session != nil && !isRotatableOverAge(wc) {
+			if wc.IsConnected() && !wc.IsExpired() && wc.session != nil && wc.session.PendingCount() > 0 && !isRotatableOverAge(wc) {
 				lock.Unlock()
 				// 连接被同 session 的前一个请求占用：指数退避轮询等待其空闲，
 				// 累计等待超过上限则返回错误，避免无界阻塞与固定间隔空转抢锁。
@@ -414,9 +439,7 @@ func (m *Manager) AcquireConnection(
 				}
 				continue
 			}
-			m.connections.Delete(key)
-			m.sessions.Delete(key)
-			wc.Close()
+			m.DiscardConnection(wc)
 		}
 
 		wc, err := m.createConnection(ctx, account, wsURL, sessionKey, headers, proxyOverride)
@@ -427,7 +450,30 @@ func (m *Manager) AcquireConnection(
 
 		// 存储新连接并立即占位 pending request，避免返回后才记账产生竞态
 		m.connections.Store(key, wc)
-		pr := wc.session.AddPendingRequest(sessionKey)
+		pr, leaseErr := m.addPendingAndBeginReadLease(wc, sessionKey)
+		if leaseErr == nil {
+			if earlyErr := wc.waitForEarlyReadFailure(ctx, newConnectionReadFailureGrace); earlyErr != nil {
+				wc.session.RemovePendingRequest(pr.RequestID)
+				leaseErr = earlyErr
+			}
+		}
+		if leaseErr != nil {
+			m.DiscardConnection(wc)
+			lock.Unlock()
+			if ctx.Err() != nil {
+				return nil, nil, ctx.Err()
+			}
+			createLeaseFailures++
+			if createLeaseFailures >= maxCreateLeaseAttempts {
+				return nil, nil, fmt.Errorf("reserve new websocket connection after %d attempts: %w", createLeaseFailures, leaseErr)
+			}
+			select {
+			case <-ctx.Done():
+				return nil, nil, ctx.Err()
+			default:
+			}
+			continue
+		}
 		lock.Unlock()
 
 		if fn := m.getOnConnected(); fn != nil {
@@ -442,6 +488,15 @@ func (m *Manager) AcquireConnection(
 // 复用的持久连接槽位数。槽位内空闲连接直接复用,避免每个请求都重新握手——
 // 持续高 RPM 下逐请求握手会触发上游 WS 握手限流（bad handshake → 503）。
 const StatelessConnectionSlots = 8
+
+// maxCreateLeaseAttempts bounds retries when a freshly completed handshake is
+// already rejected by its permanent reader before the first request lease can
+// be reserved (for example, an immediately queued peer Close frame).
+const maxCreateLeaseAttempts = 3
+
+// Give the permanent reader a small, bounded window to surface a Close/error
+// already queued with the handshake before returning a newly reserved lease.
+const newConnectionReadFailureGrace = 5 * time.Millisecond
 
 // AcquireReusableConnection 在固定槽位内复用或创建连接，返回实际使用的 session key。
 // 第一遍只复用已存在且空闲的连接；第二遍在空槽位新建持久连接；槽位全忙时回退到
@@ -467,18 +522,19 @@ func (m *Manager) AcquireReusableConnection(
 			wc := v.(*WsConnection)
 			if canReuseConnection(wc) {
 				if m.probe(wc) {
-					pr := wc.session.AddPendingRequest(slotSession)
-					wc.Touch()
+					pr, leaseErr := m.addPendingAndBeginReadLease(wc, slotSession)
+					if leaseErr == nil {
+						wc.Touch()
+						lock.Unlock()
+						return wc, pr, slotSession, nil
+					}
+					m.DiscardConnection(wc)
 					lock.Unlock()
-					return wc, pr, slotSession, nil
+					continue
 				}
-				m.connections.Delete(key)
-				m.sessions.Delete(key)
-				wc.Close()
-			} else if !wc.IsConnected() || wc.IsExpired() || isRotatableOverAge(wc) {
-				m.connections.Delete(key)
-				m.sessions.Delete(key)
-				wc.Close()
+				m.DiscardConnection(wc)
+			} else if !wc.IsConnected() || wc.IsExpired() || isRotatableOverAge(wc) || wc.session == nil || wc.session.PendingCount() == 0 {
+				m.DiscardConnection(wc)
 			}
 		}
 		lock.Unlock()
@@ -499,7 +555,21 @@ func (m *Manager) AcquireReusableConnection(
 			return nil, nil, "", err
 		}
 		m.connections.Store(key, wc)
-		pr := wc.session.AddPendingRequest(slotSession)
+		pr, leaseErr := m.addPendingAndBeginReadLease(wc, slotSession)
+		if leaseErr == nil {
+			if earlyErr := wc.waitForEarlyReadFailure(ctx, newConnectionReadFailureGrace); earlyErr != nil {
+				wc.session.RemovePendingRequest(pr.RequestID)
+				leaseErr = earlyErr
+			}
+		}
+		if leaseErr != nil {
+			m.DiscardConnection(wc)
+			lock.Unlock()
+			if ctx.Err() != nil {
+				return nil, nil, "", ctx.Err()
+			}
+			continue
+		}
 		lock.Unlock()
 		if fn := m.getOnConnected(); fn != nil {
 			fn(account.ID(), wc.session)
@@ -509,6 +579,22 @@ func (m *Manager) AcquireReusableConnection(
 	// 槽位全忙：回退一次性连接
 	wc, pr, err := m.AcquireConnection(ctx, account, wsURL, fallbackKey, headers, proxyOverride)
 	return wc, pr, fallbackKey, err
+}
+
+// addPendingAndBeginReadLease keeps the Session reservation and the pump lease
+// atomic from an acquire caller's perspective. On failure it rolls the pending
+// request back; the caller discards the unusable connection while holding its
+// pool-key acquisition lock.
+func (m *Manager) addPendingAndBeginReadLease(wc *WsConnection, sessionKey string) (*PendingRequest, error) {
+	if wc == nil || wc.session == nil {
+		return nil, fmt.Errorf("begin websocket read lease: connection has no session")
+	}
+	pr := wc.session.AddPendingRequest(sessionKey)
+	if err := wc.BeginReadLease(pr.RequestID); err != nil {
+		wc.session.RemovePendingRequest(pr.RequestID)
+		return nil, fmt.Errorf("reserve websocket connection: %w", err)
+	}
+	return pr, nil
 }
 
 func canReuseConnection(wc *WsConnection) bool {
@@ -521,7 +607,7 @@ func canReuseConnection(wc *WsConnection) bool {
 	if wc.session == nil {
 		return false
 	}
-	return wc.session.PendingCount() == 0
+	return wc.session.PendingCount() == 0 && wc.readPumpReusable()
 }
 
 // isRotatableOverAge 连接已到龄且当前无在途请求，可安全轮转（销毁重建）。
@@ -536,15 +622,7 @@ func isRotatableOverAge(wc *WsConnection) bool {
 
 // probeConnection 发送 Ping 检测连接是否真正存活
 func probeConnection(wc *WsConnection) bool {
-	wc.writeMu.Lock()
-	defer wc.writeMu.Unlock()
-
-	if !wc.IsConnected() || wc.conn == nil {
-		return false
-	}
-	deadline := time.Now().Add(5 * time.Second)
-	err := wc.conn.WriteControl(websocket.PingMessage, []byte{}, deadline)
-	return err == nil
+	return probeConnectionWithTimeout(wc, defaultProbeTimeout)
 }
 
 // probe 调用探活函数���支持测试替换）
@@ -610,14 +688,12 @@ func (m *Manager) createConnection(
 	wc.PoolKey = poolKey
 	wc.httpResp = resp
 	wc.onDisconnected = m.getOnDisconnected()
+	wc.onReadFailure = m.DiscardConnection
 	session.SetConnected(true)
 
-	// 设置 Pong 处理器
-	conn.SetPongHandler(func(appData string) error {
-		session.HandlePong()
-		wc.Touch()
-		return nil
-	})
+	// 控制帧处理器必须在唯一永久 reader 启动前安装。
+	wc.installControlHandlers()
+	wc.StartReadPump()
 
 	return wc, nil
 }
@@ -649,13 +725,17 @@ func (m *Manager) DiscardConnection(wc *WsConnection) {
 	if wc == nil {
 		return
 	}
-	wc.Close()
 	if wc.PoolKey != "" {
 		m.connections.CompareAndDelete(wc.PoolKey, wc)
 		if wc.session != nil {
 			m.sessions.CompareAndDelete(wc.PoolKey, wc.session)
 		}
 	}
+	if wc.session != nil {
+		wc.session.StopHeartbeat()
+		wc.session.SetConnected(false)
+	}
+	_ = wc.Close()
 }
 
 // BindResponseConn 记录 response_id 由哪条连接产出（续链亲和）。
@@ -737,15 +817,20 @@ func (m *Manager) AcquirePreferredConnection(responseID string, accountID int64,
 		return nil, nil, ""
 	}
 	if !canReuseConnection(wc) {
+		if wc.session == nil || wc.session.PendingCount() == 0 {
+			m.DiscardConnection(wc)
+		}
 		return nil, nil, ""
 	}
 	if !m.probe(wc) {
-		m.connections.Delete(wc.PoolKey)
-		m.sessions.Delete(wc.PoolKey)
-		wc.Close()
+		m.DiscardConnection(wc)
 		return nil, nil, ""
 	}
-	pr := wc.session.AddPendingRequest(sessionKey)
+	pr, err := m.addPendingAndBeginReadLease(wc, sessionKey)
+	if err != nil {
+		m.DiscardConnection(wc)
+		return nil, nil, ""
+	}
 	wc.Touch()
 	return wc, pr, sessionKey
 }
@@ -812,11 +897,7 @@ func (m *Manager) SendHeartbeat(wc *WsConnection) error {
 	err := wc.conn.WriteControl(websocket.PingMessage, []byte{}, deadline)
 	if err != nil {
 		log.Printf("WebSocket Ping 失败 (account %d): %v", wc.session.AccountID, err)
-		wc.Close()
-		if wc.PoolKey != "" {
-			m.connections.Delete(wc.PoolKey)
-			m.sessions.Delete(wc.PoolKey)
-		}
+		m.DiscardConnection(wc)
 		return err
 	}
 	return nil
@@ -824,6 +905,9 @@ func (m *Manager) SendHeartbeat(wc *WsConnection) error {
 
 // StartHeartbeat 启动连接心跳
 func (m *Manager) StartHeartbeat(wc *WsConnection) {
+	if wc == nil || wc.session == nil || !wc.IsConnected() || !wc.session.IsConnected() {
+		return
+	}
 	wc.session.StartHeartbeat(func() error {
 		return m.SendHeartbeat(wc)
 	})

--- a/proxy/wsrelay/read_pump.go
+++ b/proxy/wsrelay/read_pump.go
@@ -1,0 +1,797 @@
+package wsrelay
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/tidwall/gjson"
+)
+
+const (
+	readPumpMaxQueuedPayload = 16 * 1024 * 1024
+	readPumpMaxQueuedItems   = 4096
+	defaultProbeTimeout      = 2 * time.Second
+	readPumpCloseCauseWait   = 100 * time.Millisecond
+)
+
+var (
+	errReadPumpQueueOverflow = errors.New("websocket read pump queue exceeds its payload or item limit")
+	errReadPumpIdleFrame     = errors.New("websocket read pump received a business frame without an active lease")
+	errReadPumpUncommitted   = errors.New("websocket read pump received a business frame before request write committed")
+	errReadPumpStopped       = errors.New("websocket read pump stopped")
+	probeSequence            atomic.Uint64
+)
+
+type readLeasePhase uint8
+
+const (
+	readLeaseIdle readLeasePhase = iota
+	readLeaseReserved
+	readLeaseWriting
+	readLeaseCommitted
+)
+
+type readPumpItem struct {
+	messageType int
+	payload     []byte
+	err         error
+	leaseID     string
+	captured    capturedReadLease
+}
+
+type capturedReadLease struct {
+	leaseID string
+	write   *readLeaseWriteResult
+}
+
+type readLeaseWriteResult struct {
+	done      chan struct{}
+	resolved  bool
+	committed bool
+	err       error
+}
+
+type wsReadState struct {
+	mu sync.Mutex
+
+	queue               []readPumpItem
+	queuedPayload       int
+	activeLease         string
+	leasePhase          readLeasePhase
+	leaseWrite          *readLeaseWriteResult
+	leaseTerminalQueued bool
+	pumpStarted         bool
+	readerErr           error
+	readerStopped       bool
+
+	notify     chan struct{}
+	readerDone chan struct{}
+	doneOnce   sync.Once
+}
+
+func (wc *WsConnection) ensureReadState() *wsReadState {
+	wc.readStateOnce.Do(func() {
+		wc.readState = &wsReadState{
+			notify:     make(chan struct{}, 1),
+			readerDone: make(chan struct{}),
+		}
+	})
+	return wc.readState
+}
+
+func (state *wsReadState) notifyReaderLocked() {
+	select {
+	case state.notify <- struct{}{}:
+	default:
+	}
+}
+
+func (state *wsReadState) resolveLeaseWriteLocked(committed bool, writeErr error) {
+	result := state.leaseWrite
+	if result == nil || result.resolved {
+		return
+	}
+	result.committed = committed
+	result.err = writeErr
+	result.resolved = true
+	close(result.done)
+	state.leaseWrite = nil
+}
+
+func (wc *WsConnection) installControlHandlers() {
+	wc.controlHandlersOnce.Do(func() {
+		if wc.conn == nil {
+			return
+		}
+		wc.conn.SetPingHandler(func(appData string) error {
+			return wc.conn.WriteControl(
+				websocket.PongMessage,
+				[]byte(appData),
+				time.Now().Add(WriteTimeout),
+			)
+		})
+		wc.conn.SetPongHandler(func(appData string) error {
+			if wc.session != nil {
+				wc.session.HandlePong()
+			}
+			wc.Touch()
+			wc.notifyProbePong(appData)
+			return nil
+		})
+	})
+}
+
+// StartReadPump starts the connection's sole underlying WebSocket reader.
+// It is safe to call repeatedly; WsConnection.ReadMessage consumes this pump's
+// queue and never reads the Gorilla connection directly.
+func (wc *WsConnection) StartReadPump() {
+	if wc == nil {
+		return
+	}
+	wc.ensureReadState()
+	wc.installControlHandlers()
+	wc.readPumpOnce.Do(func() {
+		if wc.conn == nil {
+			wc.finishReadPump(fmt.Errorf("websocket connection is nil"), true)
+			return
+		}
+		if !wc.IsConnected() {
+			wc.finishReadPump(fmt.Errorf("websocket connection is not connected"), true)
+			return
+		}
+		state := wc.ensureReadState()
+		state.mu.Lock()
+		state.pumpStarted = true
+		state.mu.Unlock()
+		wc.conn.SetReadLimit(readPumpMaxQueuedPayload)
+		go wc.runReadPump()
+	})
+}
+
+func (wc *WsConnection) runReadPump() {
+	for {
+		messageType, reader, err := wc.conn.NextReader()
+		if err != nil {
+			wc.finishReadPump(err, true)
+			return
+		}
+		if messageType != websocket.TextMessage && messageType != websocket.BinaryMessage {
+			_, _ = io.Copy(io.Discard, reader)
+			continue
+		}
+
+		// Capture the lease at the first data frame, before reading the rest of a
+		// possibly fragmented message. A later BeginReadLease must never claim a
+		// message that started while idle or while the request write was in flight.
+		captured, err := wc.captureReadLease()
+		if err != nil {
+			return
+		}
+		payload, err := io.ReadAll(reader)
+		if err != nil {
+			wc.finishReadPumpForLease(err, captured.leaseID)
+			return
+		}
+		// Never wait for the request writer in the sole raw reader. A response can
+		// arrive just before WriteMessage returns; queue it with the captured
+		// commit result so Ping/Pong/Close frames behind it are still processed.
+		wc.Touch()
+		if err := wc.enqueueBusinessFrameForCapturedLease(messageType, payload, captured); err != nil {
+			wc.finishReadPumpForLease(err, captured.leaseID)
+			return
+		}
+	}
+}
+
+func (wc *WsConnection) captureReadLease() (capturedReadLease, error) {
+	state := wc.ensureReadState()
+	state.mu.Lock()
+	leaseID := state.activeLease
+	if state.activeLease == "" {
+		wc.recordReadPumpFailureLocked(state, errReadPumpIdleFrame, "")
+		state.mu.Unlock()
+		wc.finalizeReadPumpFailure(state)
+		return capturedReadLease{}, errReadPumpIdleFrame
+	}
+	if state.leaseTerminalQueued {
+		err := fmt.Errorf("websocket read pump received a business frame after the terminal frame for request %q", leaseID)
+		wc.recordReadPumpFailureLocked(state, err, leaseID)
+		state.mu.Unlock()
+		wc.finalizeReadPumpFailure(state)
+		return capturedReadLease{}, err
+	}
+	if state.leasePhase == readLeaseWriting && state.leaseWrite != nil {
+		captured := capturedReadLease{leaseID: leaseID, write: state.leaseWrite}
+		state.mu.Unlock()
+		return captured, nil
+	}
+	if state.leasePhase != readLeaseCommitted {
+		err := fmt.Errorf("%w: request %q phase %d", errReadPumpUncommitted, leaseID, state.leasePhase)
+		wc.recordReadPumpFailureLocked(state, err, leaseID)
+		state.mu.Unlock()
+		wc.finalizeReadPumpFailure(state)
+		return capturedReadLease{}, err
+	}
+	state.mu.Unlock()
+	return capturedReadLease{leaseID: leaseID}, nil
+}
+
+func (wc *WsConnection) awaitCapturedReadLease(captured capturedReadLease) error {
+	if captured.write == nil {
+		return nil
+	}
+	<-captured.write.done
+
+	state := wc.ensureReadState()
+	state.mu.Lock()
+	committed := captured.write.committed
+	writeErr := captured.write.err
+	resolved := captured.write.resolved
+	state.mu.Unlock()
+	if resolved && committed {
+		return nil
+	}
+	if writeErr != nil {
+		return writeErr
+	}
+	return fmt.Errorf("%w: request %q did not commit after its write completed", errReadPumpUncommitted, captured.leaseID)
+}
+
+func (wc *WsConnection) enqueueBusinessFrameForLease(messageType int, payload []byte, leaseID string) error {
+	return wc.enqueueBusinessFrameForCapturedLease(messageType, payload, capturedReadLease{leaseID: leaseID})
+}
+
+func (wc *WsConnection) enqueueBusinessFrameForCapturedLease(messageType int, payload []byte, captured capturedReadLease) error {
+	state := wc.ensureReadState()
+	state.mu.Lock()
+	defer state.mu.Unlock()
+
+	leaseID := captured.leaseID
+	if leaseID == "" || state.activeLease != leaseID || state.leasePhase != readLeaseCommitted {
+		if captured.write == nil || state.activeLease != leaseID {
+			return fmt.Errorf("websocket read pump lease changed while reading message for request %q", leaseID)
+		}
+		if captured.write.resolved {
+			if !captured.write.committed {
+				if captured.write.err != nil {
+					return captured.write.err
+				}
+				return fmt.Errorf("%w: request %q write did not commit", errReadPumpUncommitted, leaseID)
+			}
+			if state.leasePhase != readLeaseCommitted {
+				return fmt.Errorf("websocket read pump lease changed after request %q committed", leaseID)
+			}
+		} else if state.leasePhase != readLeaseWriting || state.leaseWrite != captured.write {
+			return fmt.Errorf("websocket read pump write changed while reading message for request %q", leaseID)
+		}
+	}
+	if len(state.queue) >= readPumpMaxQueuedItems || len(payload) > readPumpMaxQueuedPayload-state.queuedPayload {
+		return errReadPumpQueueOverflow
+	}
+
+	state.queue = append(state.queue, readPumpItem{
+		messageType: messageType,
+		payload:     payload,
+		leaseID:     leaseID,
+		captured:    captured,
+	})
+	state.queuedPayload += len(payload)
+	if isReadLeaseTerminal(payload) {
+		if captured.write != nil && !captured.write.resolved {
+			state.leaseTerminalQueued = true
+		} else {
+			state.activeLease = ""
+			state.leasePhase = readLeaseIdle
+			state.leaseTerminalQueued = false
+		}
+	}
+	state.notifyReaderLocked()
+	return nil
+}
+
+func isReadLeaseTerminal(payload []byte) bool {
+	switch gjson.GetBytes(payload, "type").String() {
+	case "response.completed", "response.failed", "response.done", "error":
+		return true
+	default:
+		return false
+	}
+}
+
+func (wc *WsConnection) finishReadPump(readErr error, enqueueForActiveLease bool) {
+	if readErr == nil {
+		readErr = errReadPumpStopped
+	}
+	state := wc.ensureReadState()
+	state.mu.Lock()
+	leaseID := ""
+	if enqueueForActiveLease {
+		leaseID = state.activeLease
+	}
+	wc.recordReadPumpFailureLocked(state, readErr, leaseID)
+	state.mu.Unlock()
+	wc.finalizeReadPumpFailure(state)
+}
+
+func (wc *WsConnection) finishReadPumpForLease(readErr error, leaseID string) {
+	if readErr == nil {
+		readErr = errReadPumpStopped
+	}
+	state := wc.ensureReadState()
+	state.mu.Lock()
+	wc.recordReadPumpFailureLocked(state, readErr, leaseID)
+	state.mu.Unlock()
+	wc.finalizeReadPumpFailure(state)
+}
+
+// recordReadPumpFailureLocked seals the reader and optionally queues the
+// failure for the lease captured when the failing message began. The caller
+// holds state.mu, so BeginReadLease cannot slip into the failure boundary.
+func (wc *WsConnection) recordReadPumpFailureLocked(state *wsReadState, readErr error, leaseID string) {
+	readErr = normalizeReadPumpError(readErr)
+	if state.readerStopped {
+		return
+	}
+	deferTerminalCommit := state.leaseTerminalQueued &&
+		state.leasePhase == readLeaseWriting &&
+		state.leaseWrite != nil &&
+		isNormalPeerClose(readErr)
+	if leaseID != "" && state.activeLease == leaseID && len(state.queue) < readPumpMaxQueuedItems {
+		state.queue = append(state.queue, readPumpItem{err: readErr, leaseID: leaseID})
+	}
+	if !deferTerminalCommit {
+		state.resolveLeaseWriteLocked(false, readErr)
+		state.activeLease = ""
+		state.leasePhase = readLeaseIdle
+		state.leaseTerminalQueued = false
+	}
+	state.readerErr = readErr
+	state.readerStopped = true
+	state.notifyReaderLocked()
+}
+
+func normalizeReadPumpError(readErr error) error {
+	if errors.Is(readErr, websocket.ErrReadLimit) {
+		return fmt.Errorf("%w: %w", &websocket.CloseError{
+			Code: websocket.CloseMessageTooBig,
+			Text: "message too big",
+		}, readErr)
+	}
+	return readErr
+}
+
+func isNormalPeerClose(readErr error) bool {
+	var closeErr *websocket.CloseError
+	if !errors.As(readErr, &closeErr) {
+		return false
+	}
+	return closeErr.Code == websocket.CloseNormalClosure || closeErr.Code == websocket.CloseGoingAway
+}
+
+func (wc *WsConnection) finalizeReadPumpFailure(state *wsReadState) {
+	wc.readFailureOnce.Do(func() {
+		// Make the connection non-reusable only after the real read error has
+		// been queued for an active consumer.
+		wc.state.Store(int32(StateClosing))
+		state.doneOnce.Do(func() { close(state.readerDone) })
+		if wc.onReadFailure != nil {
+			wc.onReadFailure(wc)
+		}
+		_ = wc.Close()
+		wc.state.Store(int32(StateDisconnected))
+	})
+}
+
+// BeginReadLease reserves the pump's business-frame boundary for one request.
+func (wc *WsConnection) BeginReadLease(requestID string) error {
+	if wc == nil {
+		return fmt.Errorf("begin websocket read lease: nil connection")
+	}
+	if requestID == "" {
+		return fmt.Errorf("begin websocket read lease: empty request ID")
+	}
+	if !wc.IsConnected() {
+		return fmt.Errorf("begin websocket read lease: connection is not connected")
+	}
+
+	state := wc.ensureReadState()
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	if !wc.IsConnected() {
+		return fmt.Errorf("begin websocket read lease: connection is not connected")
+	}
+	if state.readerStopped {
+		return fmt.Errorf("begin websocket read lease: reader stopped: %w", state.readerErr)
+	}
+	if state.activeLease != "" {
+		return fmt.Errorf("begin websocket read lease: request %q is already active", state.activeLease)
+	}
+	if len(state.queue) != 0 {
+		return fmt.Errorf("begin websocket read lease: %d unread item(s) remain", len(state.queue))
+	}
+	state.activeLease = requestID
+	state.leasePhase = readLeaseReserved
+	state.leaseTerminalQueued = false
+	return nil
+}
+
+func (wc *WsConnection) beginReadLeaseWrite(messageType int) (string, bool, error) {
+	if messageType != websocket.TextMessage && messageType != websocket.BinaryMessage {
+		return "", false, nil
+	}
+	state := wc.ensureReadState()
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	if state.readerStopped {
+		return "", false, fmt.Errorf("write websocket request: reader stopped: %w", state.readerErr)
+	}
+	if state.activeLease == "" {
+		return "", false, fmt.Errorf("write websocket request: no active read lease")
+	}
+	if state.leasePhase != readLeaseReserved {
+		return "", false, fmt.Errorf("write websocket request: lease %q phase %d is not reserved", state.activeLease, state.leasePhase)
+	}
+	if state.leaseWrite != nil {
+		return "", false, fmt.Errorf("write websocket request: lease %q already has an active write", state.activeLease)
+	}
+	state.leaseWrite = &readLeaseWriteResult{done: make(chan struct{})}
+	state.leasePhase = readLeaseWriting
+	return state.activeLease, true, nil
+}
+
+func (wc *WsConnection) ensureReadLeaseForSend(requestID string) error {
+	state := wc.ensureReadState()
+	state.mu.Lock()
+	if state.activeLease == requestID && state.leasePhase == readLeaseReserved {
+		state.mu.Unlock()
+		return nil
+	}
+	if state.activeLease != "" {
+		activeLease := state.activeLease
+		phase := state.leasePhase
+		state.mu.Unlock()
+		return fmt.Errorf("send websocket request: lease %q is active in phase %d", activeLease, phase)
+	}
+	if state.readerStopped {
+		err := state.readerErr
+		state.mu.Unlock()
+		return fmt.Errorf("send websocket request: reader stopped: %w", err)
+	}
+	if len(state.queue) != 0 {
+		queued := len(state.queue)
+		state.mu.Unlock()
+		return fmt.Errorf("send websocket request: %d unread item(s) remain", queued)
+	}
+	state.mu.Unlock()
+	return wc.BeginReadLease(requestID)
+}
+
+func (wc *WsConnection) completeReadLeaseWrite(leaseID string, writeErr error) error {
+	if writeErr != nil {
+		state := wc.ensureReadState()
+		state.mu.Lock()
+		wc.state.Store(int32(StateClosing))
+		state.mu.Unlock()
+
+		resolvedErr := wc.preservePeerCloseCause(writeErr)
+		state.mu.Lock()
+		if state.readerStopped {
+			state.resolveLeaseWriteLocked(false, resolvedErr)
+			state.activeLease = ""
+			state.leasePhase = readLeaseIdle
+			state.leaseTerminalQueued = false
+		} else {
+			wc.recordReadPumpFailureLocked(state, resolvedErr, leaseID)
+		}
+		state.mu.Unlock()
+		wc.finalizeReadPumpFailure(state)
+		return resolvedErr
+	}
+	state := wc.ensureReadState()
+	state.mu.Lock()
+	if state.readerStopped || !wc.IsConnected() {
+		if state.readerStopped &&
+			state.activeLease == leaseID &&
+			state.leasePhase == readLeaseWriting &&
+			state.leaseWrite != nil &&
+			state.leaseTerminalQueued &&
+			isNormalPeerClose(state.readerErr) {
+			state.activeLease = ""
+			state.leasePhase = readLeaseIdle
+			state.leaseTerminalQueued = false
+			state.resolveLeaseWriteLocked(true, nil)
+			state.mu.Unlock()
+			return nil
+		}
+		var err error
+		if state.readerErr != nil {
+			err = fmt.Errorf("write websocket request: connection failed before lease %q committed: %w", leaseID, state.readerErr)
+		} else {
+			err = fmt.Errorf("write websocket request: connection failed before lease %q committed", leaseID)
+		}
+		wc.recordReadPumpFailureLocked(state, err, leaseID)
+		state.mu.Unlock()
+		wc.finalizeReadPumpFailure(state)
+		return err
+	}
+	if state.activeLease != leaseID || state.leasePhase != readLeaseWriting {
+		err := fmt.Errorf("write websocket request: lease %q changed before commit", leaseID)
+		wc.state.Store(int32(StateClosing))
+		wc.recordReadPumpFailureLocked(state, err, leaseID)
+		state.mu.Unlock()
+		wc.finalizeReadPumpFailure(state)
+		return err
+	}
+	state.leasePhase = readLeaseCommitted
+	if state.leaseTerminalQueued {
+		state.activeLease = ""
+		state.leasePhase = readLeaseIdle
+		state.leaseTerminalQueued = false
+	}
+	state.resolveLeaseWriteLocked(true, nil)
+	state.mu.Unlock()
+	return nil
+}
+
+// A peer Close can race a data write and surface as ErrCloseSent, broken pipe,
+// or connection reset on the writer. Give the sole reader a short,
+// error-path-only window to publish the protocol-level close code/reason so
+// callers can still distinguish close 1009 and fall back to HTTP.
+func (wc *WsConnection) preservePeerCloseCause(writeErr error) error {
+	state := wc.ensureReadState()
+	readCause := func() (error, bool) {
+		state.mu.Lock()
+		defer state.mu.Unlock()
+		return state.readerErr, state.readerStopped
+	}
+	if err, stopped := readCause(); stopped {
+		if err != nil {
+			return fmt.Errorf("websocket write interrupted by peer close: %w", err)
+		}
+		return writeErr
+	}
+
+	state.mu.Lock()
+	pumpStarted := state.pumpStarted
+	readerDone := state.readerDone
+	state.mu.Unlock()
+	if !pumpStarted || readerDone == nil {
+		return writeErr
+	}
+
+	timer := time.NewTimer(readPumpCloseCauseWait)
+	defer timer.Stop()
+	select {
+	case <-readerDone:
+		if err, _ := readCause(); err != nil {
+			return fmt.Errorf("websocket write interrupted by peer close: %w", err)
+		}
+	case <-timer.C:
+	}
+	return writeErr
+}
+
+// ensureReadLeaseForResponse preserves compatibility with tests and callers
+// that manually construct WsConnection/WsResponse rather than acquiring them
+// through Manager. Manager-owned production paths begin the lease before send.
+func (wc *WsConnection) ensureReadLeaseForResponse(requestID string) error {
+	state := wc.ensureReadState()
+	state.mu.Lock()
+	if state.activeLease == requestID {
+		// Compatibility for tests/callers that manually construct a WsResponse
+		// after writing directly to the underlying socket. Manager/Executor paths
+		// have already committed the lease in WsConnection.WriteMessage.
+		if state.leasePhase == readLeaseReserved && !state.pumpStarted {
+			state.leasePhase = readLeaseCommitted
+		}
+		if state.leasePhase != readLeaseCommitted {
+			phase := state.leasePhase
+			state.mu.Unlock()
+			return fmt.Errorf("websocket read lease %q is not committed (phase %d)", requestID, phase)
+		}
+		state.mu.Unlock()
+		return nil
+	}
+	if state.activeLease != "" {
+		active := state.activeLease
+		state.mu.Unlock()
+		return fmt.Errorf("websocket read lease belongs to request %q", active)
+	}
+	if len(state.queue) != 0 {
+		leaseID := state.queue[0].leaseID
+		state.mu.Unlock()
+		if leaseID == requestID {
+			return nil
+		}
+		return fmt.Errorf("websocket read queue belongs to request %q", leaseID)
+	}
+	legacyManualConnection := !state.pumpStarted
+	state.mu.Unlock()
+	if !legacyManualConnection {
+		return fmt.Errorf("websocket read lease %q was not reserved before the reader started", requestID)
+	}
+	if err := wc.BeginReadLease(requestID); err != nil {
+		return err
+	}
+	state.mu.Lock()
+	if state.activeLease == requestID && state.leasePhase == readLeaseReserved {
+		state.leasePhase = readLeaseCommitted
+	}
+	state.mu.Unlock()
+	return nil
+}
+
+func (wc *WsConnection) readPumpReusable() bool {
+	if wc == nil {
+		return false
+	}
+	state := wc.ensureReadState()
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	return !state.readerStopped && state.activeLease == "" && state.leasePhase == readLeaseIdle && state.leaseWrite == nil && !state.leaseTerminalQueued && len(state.queue) == 0
+}
+
+func (wc *WsConnection) waitForEarlyReadFailure(ctx context.Context, grace time.Duration) error {
+	state := wc.ensureReadState()
+	state.mu.Lock()
+	if state.readerStopped {
+		err := state.readerErr
+		state.mu.Unlock()
+		return fmt.Errorf("new websocket reader stopped: %w", err)
+	}
+	state.mu.Unlock()
+
+	timer := time.NewTimer(grace)
+	defer timer.Stop()
+	select {
+	case <-state.readerDone:
+		state.mu.Lock()
+		err := state.readerErr
+		state.mu.Unlock()
+		return fmt.Errorf("new websocket reader stopped: %w", err)
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+// ReadMessage consumes the permanent reader's bounded ordered queue. The
+// timeout is applied to this consumer wait, never to Gorilla's permanent read.
+func (wc *WsConnection) ReadMessage() (int, []byte, error) {
+	if wc == nil {
+		return 0, nil, fmt.Errorf("websocket connection is nil")
+	}
+	state := wc.ensureReadState()
+	wc.StartReadPump()
+
+	timer := time.NewTimer(ReadTimeout)
+	defer timer.Stop()
+	for {
+		state.mu.Lock()
+		if len(state.queue) != 0 {
+			item := state.queue[0]
+			state.queue[0] = readPumpItem{}
+			state.queue = state.queue[1:]
+			state.queuedPayload -= len(item.payload)
+			if len(state.queue) == 0 {
+				state.queue = nil
+			}
+			state.mu.Unlock()
+			if item.err != nil {
+				return item.messageType, item.payload, item.err
+			}
+			if err := wc.awaitCapturedReadLease(item.captured); err != nil {
+				return item.messageType, item.payload, err
+			}
+			wc.Touch()
+			return item.messageType, item.payload, nil
+		}
+		readerStopped := state.readerStopped
+		readerErr := state.readerErr
+		state.mu.Unlock()
+
+		if readerStopped {
+			if readerErr == nil {
+				readerErr = errReadPumpStopped
+			}
+			return 0, nil, readerErr
+		}
+
+		select {
+		case <-state.notify:
+		case <-state.readerDone:
+		case <-timer.C:
+			return 0, nil, fmt.Errorf("websocket read timeout after %s", ReadTimeout)
+		}
+	}
+}
+
+func (wc *WsConnection) notifyProbePong(payload string) {
+	wc.probeStateMu.Lock()
+	if wc.probePayload == payload && wc.probeResult != nil {
+		select {
+		case wc.probeResult <- struct{}{}:
+		default:
+		}
+	}
+	wc.probeStateMu.Unlock()
+}
+
+func (wc *WsConnection) acquireProbeGate(state *wsReadState, deadline time.Time) bool {
+	wc.probeGateOnce.Do(func() {
+		wc.probeGate = make(chan struct{}, 1)
+	})
+	remaining := time.Until(deadline)
+	if remaining <= 0 {
+		return false
+	}
+	timer := time.NewTimer(remaining)
+	defer timer.Stop()
+	select {
+	case wc.probeGate <- struct{}{}:
+		return true
+	case <-state.readerDone:
+		return false
+	case <-timer.C:
+		return false
+	}
+}
+
+func probeConnectionWithTimeout(wc *WsConnection, timeout time.Duration) bool {
+	if wc == nil || timeout <= 0 || !wc.IsConnected() || wc.conn == nil {
+		return false
+	}
+	deadline := time.Now().Add(timeout)
+	wc.StartReadPump()
+	state := wc.ensureReadState()
+
+	if !wc.acquireProbeGate(state, deadline) {
+		return false
+	}
+	defer func() { <-wc.probeGate }()
+	if !wc.IsConnected() {
+		return false
+	}
+
+	payload := fmt.Sprintf("probe-%d-%d", time.Now().UnixNano(), probeSequence.Add(1))
+	result := make(chan struct{}, 1)
+	wc.probeStateMu.Lock()
+	wc.probePayload = payload
+	wc.probeResult = result
+	wc.probeStateMu.Unlock()
+	defer func() {
+		wc.probeStateMu.Lock()
+		if wc.probeResult == result {
+			wc.probePayload = ""
+			wc.probeResult = nil
+		}
+		wc.probeStateMu.Unlock()
+	}()
+
+	err := wc.conn.WriteControl(websocket.PingMessage, []byte(payload), deadline)
+	if err != nil {
+		return false
+	}
+
+	remaining := time.Until(deadline)
+	if remaining <= 0 {
+		return false
+	}
+	timer := time.NewTimer(remaining)
+	defer timer.Stop()
+	select {
+	case <-result:
+		return wc.IsConnected()
+	case <-state.readerDone:
+		return false
+	case <-timer.C:
+		return false
+	}
+}

--- a/proxy/wsrelay/read_pump_test.go
+++ b/proxy/wsrelay/read_pump_test.go
@@ -1,0 +1,1272 @@
+package wsrelay
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/codex2api/auth"
+	"github.com/gorilla/websocket"
+)
+
+const readPumpTestTimeout = 2 * time.Second
+
+type readPumpMessageResult struct {
+	messageType int
+	payload     []byte
+	err         error
+}
+
+func newReadPumpTestConnection(t *testing.T, serve func(*websocket.Conn)) (*Manager, *WsConnection) {
+	t.Helper()
+	return newReadPumpTestConnectionWithUpgrader(t, websocket.Upgrader{}, serve)
+}
+
+func newReadPumpTestConnectionWithUpgrader(t *testing.T, upgrader websocket.Upgrader, serve func(*websocket.Conn)) (*Manager, *WsConnection) {
+	t.Helper()
+
+	ready := make(chan struct{})
+	upgrader.CheckOrigin = func(*http.Request) bool { return true }
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade websocket: %v", err)
+			return
+		}
+		defer conn.Close()
+		<-ready
+		serve(conn)
+	}))
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		server.Close()
+		t.Fatalf("dial websocket: %v", err)
+	}
+
+	manager := NewManager()
+	key := manager.poolKey(1, wsURL, "read-pump-test", "")
+	session := NewSession(1, manager)
+	session.SetConnected(true)
+	wc := NewWsConnection(conn, session, wsURL)
+	wc.PoolKey = key
+	wc.onReadFailure = manager.DiscardConnection
+	wc.installControlHandlers()
+	manager.connections.Store(key, wc)
+	manager.sessions.Store(key, session)
+	wc.StartReadPump()
+	close(ready)
+
+	t.Cleanup(func() {
+		_ = wc.Close()
+		manager.Stop()
+		server.Close()
+	})
+	return manager, wc
+}
+
+func readPumpMessage(t *testing.T, wc *WsConnection) (int, []byte, error) {
+	t.Helper()
+	resultCh := make(chan readPumpMessageResult, 1)
+	go func() {
+		messageType, payload, err := wc.ReadMessage()
+		resultCh <- readPumpMessageResult{messageType: messageType, payload: payload, err: err}
+	}()
+
+	select {
+	case result := <-resultCh:
+		return result.messageType, result.payload, result.err
+	case <-time.After(readPumpTestTimeout):
+		t.Fatal("timed out waiting for read-pump message")
+		return 0, nil, nil
+	}
+}
+
+func waitForReadPumpCondition(t *testing.T, condition func() bool, message string) {
+	t.Helper()
+	deadline := time.Now().Add(readPumpTestTimeout)
+	for time.Now().Before(deadline) {
+		if condition() {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatal(message)
+}
+
+func TestReadPumpProcessesPingWhileIdle(t *testing.T) {
+	pongPayload := make(chan string, 1)
+	_, wc := newReadPumpTestConnection(t, func(conn *websocket.Conn) {
+		conn.SetPongHandler(func(appData string) error {
+			pongPayload <- appData
+			return nil
+		})
+		if err := conn.WriteControl(websocket.PingMessage, []byte("idle-ping"), time.Now().Add(time.Second)); err != nil {
+			t.Errorf("write ping: %v", err)
+			return
+		}
+		_, _, _ = conn.ReadMessage()
+	})
+
+	select {
+	case got := <-pongPayload:
+		if got != "idle-ping" {
+			t.Fatalf("pong payload = %q, want %q", got, "idle-ping")
+		}
+	case <-time.After(readPumpTestTimeout):
+		t.Fatal("idle connection did not process peer ping")
+	}
+	if !wc.IsConnected() {
+		t.Fatal("processing an idle ping must not disconnect the connection")
+	}
+}
+
+func TestReadPumpRejectsQueuedPeerClose(t *testing.T) {
+	holdOpen := make(chan struct{})
+	t.Cleanup(func() { close(holdOpen) })
+
+	manager, wc := newReadPumpTestConnection(t, func(conn *websocket.Conn) {
+		if err := conn.WriteControl(
+			websocket.CloseMessage,
+			websocket.FormatCloseMessage(websocket.CloseInternalServerErr, "queued close"),
+			time.Now().Add(time.Second),
+		); err != nil {
+			t.Errorf("write close: %v", err)
+			return
+		}
+		<-holdOpen
+	})
+
+	waitForReadPumpCondition(t, func() bool {
+		_, connectionExists := manager.connections.Load(wc.PoolKey)
+		_, sessionExists := manager.sessions.Load(wc.PoolKey)
+		return !wc.IsConnected() && !connectionExists && !sessionExists
+	}, "peer close did not mark and remove the connection")
+	if _, ok := manager.connections.Load(wc.PoolKey); ok {
+		t.Fatal("peer close left the exact connection in Manager")
+	}
+	if _, ok := manager.sessions.Load(wc.PoolKey); ok {
+		t.Fatal("peer close left the exact session in Manager")
+	}
+	if err := wc.BeginReadLease("next-request"); err == nil {
+		t.Fatal("reader terminated by queued close must reject a new lease")
+	}
+}
+
+func TestProbeRequiresMatchingPong(t *testing.T) {
+	pingPayload := make(chan string, 1)
+	_, wc := newReadPumpTestConnection(t, func(conn *websocket.Conn) {
+		conn.SetPingHandler(func(appData string) error {
+			pingPayload <- appData
+			return conn.WriteControl(websocket.PongMessage, []byte("not-"+appData), time.Now().Add(time.Second))
+		})
+		_, _, _ = conn.ReadMessage()
+	})
+
+	if probeConnectionWithTimeout(wc, 100*time.Millisecond) {
+		t.Fatal("probe succeeded without a matching pong")
+	}
+	select {
+	case payload := <-pingPayload:
+		if payload == "" {
+			t.Fatal("probe ping payload must be unique and non-empty")
+		}
+	case <-time.After(readPumpTestTimeout):
+		t.Fatal("server never received the probe ping")
+	}
+}
+
+func TestReadPumpProbeAcceptsMatchingPong(t *testing.T) {
+	pingSeen := make(chan struct{}, 1)
+	_, wc := newReadPumpTestConnection(t, func(conn *websocket.Conn) {
+		defaultPingHandler := conn.PingHandler()
+		conn.SetPingHandler(func(appData string) error {
+			pingSeen <- struct{}{}
+			return defaultPingHandler(appData)
+		})
+		_, _, _ = conn.ReadMessage()
+	})
+
+	if !probeConnectionWithTimeout(wc, time.Second) {
+		t.Fatal("probe rejected the matching pong")
+	}
+	select {
+	case <-pingSeen:
+	case <-time.After(readPumpTestTimeout):
+		t.Fatal("server never received the successful probe ping")
+	}
+}
+
+func TestReadPumpProbeUsesSingleAbsoluteDeadline(t *testing.T) {
+	_, wc := newReadPumpTestConnection(t, func(conn *websocket.Conn) {
+		conn.SetPingHandler(func(appData string) error {
+			return conn.WriteControl(websocket.PongMessage, []byte("not-"+appData), time.Now().Add(time.Second))
+		})
+		_, _, _ = conn.ReadMessage()
+	})
+
+	const (
+		probeTimeout = 150 * time.Millisecond
+		writeDelay   = 100 * time.Millisecond
+		maxElapsed   = 200 * time.Millisecond
+	)
+	wc.writeMu.Lock()
+	started := time.Now()
+	resultCh := make(chan bool, 1)
+	go func() { resultCh <- probeConnectionWithTimeout(wc, probeTimeout) }()
+
+	waitForReadPumpCondition(t, func() bool {
+		wc.probeStateMu.Lock()
+		registered := wc.probeResult != nil
+		wc.probeStateMu.Unlock()
+		return registered
+	}, "probe did not register its pong waiter")
+	time.Sleep(writeDelay)
+	wc.writeMu.Unlock()
+
+	select {
+	case alive := <-resultCh:
+		if alive {
+			t.Fatal("probe succeeded without a matching pong")
+		}
+		if elapsed := time.Since(started); elapsed > maxElapsed {
+			t.Fatalf("probe elapsed %s, want a single %s deadline", elapsed, probeTimeout)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("probe did not honor its timeout")
+	}
+}
+
+func TestReadPumpProbeSerializationHonorsDeadline(t *testing.T) {
+	pingPayloads := make(chan string, 2)
+	_, wc := newReadPumpTestConnection(t, func(conn *websocket.Conn) {
+		conn.SetPingHandler(func(appData string) error {
+			pingPayloads <- appData
+			return nil
+		})
+		_, _, _ = conn.ReadMessage()
+	})
+
+	longResult := make(chan bool, 1)
+	go func() { longResult <- probeConnectionWithTimeout(wc, 300*time.Millisecond) }()
+	select {
+	case payload := <-pingPayloads:
+		if payload == "" {
+			t.Fatal("long probe sent an empty payload")
+		}
+	case <-time.After(readPumpTestTimeout):
+		t.Fatal("long probe never acquired the serialization gate")
+	}
+
+	started := time.Now()
+	if probeConnectionWithTimeout(wc, 50*time.Millisecond) {
+		t.Fatal("short probe succeeded without a pong")
+	}
+	if elapsed := time.Since(started); elapsed > 150*time.Millisecond {
+		t.Fatalf("serialized short probe elapsed %s, want its 50ms total budget", elapsed)
+	}
+	select {
+	case alive := <-longResult:
+		if alive {
+			t.Fatal("long probe succeeded without a pong")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("long probe did not finish")
+	}
+}
+
+func TestReadPumpProbeDoesNotWaitForDataWriteLock(t *testing.T) {
+	pingSeen := make(chan struct{}, 1)
+	_, wc := newReadPumpTestConnection(t, func(conn *websocket.Conn) {
+		defaultPingHandler := conn.PingHandler()
+		conn.SetPingHandler(func(appData string) error {
+			pingSeen <- struct{}{}
+			return defaultPingHandler(appData)
+		})
+		_, _, _ = conn.ReadMessage()
+	})
+
+	wc.writeMu.Lock()
+	locked := true
+	defer func() {
+		if locked {
+			wc.writeMu.Unlock()
+		}
+	}()
+	resultCh := make(chan bool, 1)
+	go func() { resultCh <- probeConnectionWithTimeout(wc, 100*time.Millisecond) }()
+
+	select {
+	case <-pingSeen:
+	case <-time.After(200 * time.Millisecond):
+		wc.writeMu.Unlock()
+		locked = false
+		<-resultCh
+		t.Fatal("probe Ping was blocked by the data-message write lock")
+	}
+	select {
+	case alive := <-resultCh:
+		if !alive {
+			t.Fatal("matching Pong was not observed while the data write lock was held")
+		}
+	case <-time.After(200 * time.Millisecond):
+		wc.writeMu.Unlock()
+		locked = false
+		t.Fatal("probe did not finish while the data write lock was held")
+	}
+	wc.writeMu.Unlock()
+	locked = false
+}
+
+func TestReadPumpRejectsFragmentedMessageStartedWhileIdle(t *testing.T) {
+	firstFragmentFlushed := make(chan struct{})
+	finishMessage := make(chan struct{})
+	pongSeen := make(chan struct{}, 1)
+
+	manager, wc := newReadPumpTestConnectionWithUpgrader(t, websocket.Upgrader{WriteBufferSize: 64}, func(conn *websocket.Conn) {
+		conn.SetPongHandler(func(string) error {
+			select {
+			case pongSeen <- struct{}{}:
+			default:
+			}
+			return nil
+		})
+		go func() { _, _, _ = conn.ReadMessage() }()
+
+		writer, err := conn.NextWriter(websocket.TextMessage)
+		if err != nil {
+			t.Errorf("NextWriter: %v", err)
+			return
+		}
+		payload := `{"type":"response.output_text.delta","delta":"` + strings.Repeat("stale", 2048) + `"}`
+		if _, err := writer.Write([]byte(payload)); err != nil {
+			t.Errorf("write first fragmented payload: %v", err)
+			return
+		}
+		if err := conn.WriteControl(websocket.PingMessage, []byte("between-fragments"), time.Now().Add(time.Second)); err != nil {
+			t.Errorf("write interleaved ping: %v", err)
+			return
+		}
+		close(firstFragmentFlushed)
+		<-finishMessage
+		_ = writer.Close()
+	})
+
+	<-firstFragmentFlushed
+	waitForReadPumpCondition(t, func() bool {
+		select {
+		case <-pongSeen:
+			return true
+		default:
+			return !wc.IsConnected()
+		}
+	}, "fragmented message was not observed by the client reader")
+
+	beginErr := wc.BeginReadLease("new-request")
+	close(finishMessage)
+	if beginErr == nil {
+		_, payload, readErr := readPumpMessage(t, wc)
+		if readErr == nil && strings.Contains(string(payload), "stale") {
+			t.Fatal("message that started while idle was attributed to a later lease")
+		}
+		t.Fatal("connection accepted a lease after an idle fragmented message had started")
+	}
+	waitForReadPumpCondition(t, func() bool {
+		_, exists := manager.connections.Load(wc.PoolKey)
+		return !wc.IsConnected() && !exists
+	}, "idle fragmented message did not discard the connection")
+}
+
+func TestReadPumpRejectsFrameBeforeRequestCommit(t *testing.T) {
+	sendStale := make(chan struct{})
+	holdOpen := make(chan struct{})
+	t.Cleanup(func() { close(holdOpen) })
+
+	manager, wc := newReadPumpTestConnection(t, func(conn *websocket.Conn) {
+		<-sendStale
+		if err := conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.output_text.delta","delta":"stale-before-write"}`)); err != nil {
+			t.Errorf("write stale frame: %v", err)
+			return
+		}
+		<-holdOpen
+	})
+
+	if err := wc.BeginReadLease("reserved-request"); err != nil {
+		t.Fatalf("BeginReadLease: %v", err)
+	}
+	close(sendStale)
+	if _, payload, err := readPumpMessage(t, wc); err == nil {
+		t.Fatalf("frame received before request commit was accepted: %s", payload)
+	}
+	waitForReadPumpCondition(t, func() bool {
+		_, exists := manager.connections.Load(wc.PoolKey)
+		return !wc.IsConnected() && !exists
+	}, "pre-commit frame did not discard the connection")
+}
+
+func TestCaptureLeaseWaitsForSuccessfulInFlightWrite(t *testing.T) {
+	wc := &WsConnection{}
+	wc.state.Store(int32(StateConnected))
+	if err := wc.BeginReadLease("fast-response"); err != nil {
+		t.Fatalf("BeginReadLease: %v", err)
+	}
+	leaseID, tracksLease, err := wc.beginReadLeaseWrite(websocket.TextMessage)
+	if err != nil {
+		t.Fatalf("beginReadLeaseWrite: %v", err)
+	}
+	if !tracksLease {
+		t.Fatal("text request did not start a tracked lease write")
+	}
+
+	captured, err := wc.captureReadLease()
+	if err != nil {
+		t.Fatalf("captureReadLease: %v", err)
+	}
+	if captured.leaseID != leaseID || captured.write == nil {
+		t.Fatalf("captured lease = %#v, want writing lease %q with barrier", captured, leaseID)
+	}
+
+	resultCh := make(chan error, 1)
+	go func() { resultCh <- wc.awaitCapturedReadLease(captured) }()
+	select {
+	case awaitErr := <-resultCh:
+		t.Fatalf("await returned before the in-flight write completed: %v", awaitErr)
+	case <-time.After(25 * time.Millisecond):
+	}
+
+	if err := wc.completeReadLeaseWrite(leaseID, nil); err != nil {
+		t.Fatalf("completeReadLeaseWrite: %v", err)
+	}
+	select {
+	case awaitErr := <-resultCh:
+		if awaitErr != nil {
+			t.Fatalf("await after successful write: %v", awaitErr)
+		}
+	case <-time.After(readPumpTestTimeout):
+		t.Fatal("await did not resume after the write committed")
+	}
+}
+
+func TestCaptureLeaseRejectsFailedInFlightWrite(t *testing.T) {
+	wc := &WsConnection{}
+	wc.state.Store(int32(StateConnected))
+	if err := wc.BeginReadLease("failed-write"); err != nil {
+		t.Fatalf("BeginReadLease: %v", err)
+	}
+	leaseID, _, err := wc.beginReadLeaseWrite(websocket.TextMessage)
+	if err != nil {
+		t.Fatalf("beginReadLeaseWrite: %v", err)
+	}
+
+	captured, err := wc.captureReadLease()
+	if err != nil {
+		t.Fatalf("captureReadLease: %v", err)
+	}
+	resultCh := make(chan error, 1)
+	go func() { resultCh <- wc.awaitCapturedReadLease(captured) }()
+	select {
+	case awaitErr := <-resultCh:
+		t.Fatalf("await returned before the in-flight write failed: %v", awaitErr)
+	case <-time.After(25 * time.Millisecond):
+	}
+
+	writeErr := errors.New("write: broken pipe")
+	if err := wc.completeReadLeaseWrite(leaseID, writeErr); !errors.Is(err, writeErr) {
+		t.Fatalf("completeReadLeaseWrite error = %v, want %v", err, writeErr)
+	}
+	select {
+	case awaitErr := <-resultCh:
+		if awaitErr == nil {
+			t.Fatal("failed request write was accepted as a committed response lease")
+		}
+	case <-time.After(readPumpTestTimeout):
+		t.Fatal("await did not resume after the write failed")
+	}
+}
+
+func TestReadPumpProcessesPingWhileResponseWaitsForWriteCommit(t *testing.T) {
+	startResponse := make(chan struct{})
+	finishResponse := make(chan struct{})
+	pongSeen := make(chan struct{}, 1)
+	var finishOnce sync.Once
+	finish := func() { finishOnce.Do(func() { close(finishResponse) }) }
+
+	_, wc := newReadPumpTestConnectionWithUpgrader(t, websocket.Upgrader{WriteBufferSize: 64}, func(conn *websocket.Conn) {
+		conn.SetPongHandler(func(string) error {
+			select {
+			case pongSeen <- struct{}{}:
+			default:
+			}
+			return nil
+		})
+		go func() { _, _, _ = conn.ReadMessage() }()
+		<-startResponse
+
+		writer, err := conn.NextWriter(websocket.TextMessage)
+		if err != nil {
+			t.Errorf("NextWriter: %v", err)
+			return
+		}
+		payload := []byte(`{"type":"response.output_text.delta","delta":"` + strings.Repeat("fast", 2048) + `"}`)
+		if _, err := writer.Write(payload); err != nil {
+			t.Errorf("write first response fragments: %v", err)
+			return
+		}
+		if err := conn.WriteControl(websocket.PingMessage, []byte("during-write"), time.Now().Add(time.Second)); err != nil {
+			t.Errorf("write interleaved ping: %v", err)
+			return
+		}
+		<-finishResponse
+		if err := writer.Close(); err != nil {
+			t.Errorf("close response writer: %v", err)
+		}
+	})
+	t.Cleanup(finish)
+
+	if err := wc.BeginReadLease("fast-response"); err != nil {
+		t.Fatalf("BeginReadLease: %v", err)
+	}
+	leaseID, _, err := wc.beginReadLeaseWrite(websocket.TextMessage)
+	if err != nil {
+		t.Fatalf("beginReadLeaseWrite: %v", err)
+	}
+	close(startResponse)
+
+	select {
+	case <-pongSeen:
+	case <-time.After(readPumpTestTimeout):
+		t.Fatal("read pump did not process an interleaved Ping before the request write committed")
+	}
+	if err := wc.completeReadLeaseWrite(leaseID, nil); err != nil {
+		t.Fatalf("completeReadLeaseWrite: %v", err)
+	}
+	finish()
+
+	messageType, payload, err := readPumpMessage(t, wc)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	if messageType != websocket.TextMessage || !strings.Contains(string(payload), strings.Repeat("fast", 2048)) {
+		t.Fatalf("response = (%d, %d bytes), want the complete text message", messageType, len(payload))
+	}
+}
+
+func TestReadPumpProcessesPingAfterCompleteEarlyResponseBeforeWriteCommit(t *testing.T) {
+	startResponse := make(chan struct{})
+	responseSent := make(chan struct{})
+	finishServer := make(chan struct{})
+	pongSeen := make(chan struct{}, 1)
+	var finishOnce sync.Once
+	finish := func() { finishOnce.Do(func() { close(finishServer) }) }
+
+	_, wc := newReadPumpTestConnection(t, func(conn *websocket.Conn) {
+		conn.SetPongHandler(func(string) error {
+			select {
+			case pongSeen <- struct{}{}:
+			default:
+			}
+			return nil
+		})
+		go func() { _, _, _ = conn.ReadMessage() }()
+		<-startResponse
+		if err := conn.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.output_text.delta","delta":"early"}`)); err != nil {
+			t.Errorf("write complete early response: %v", err)
+			return
+		}
+		close(responseSent)
+		if err := conn.WriteControl(websocket.PingMessage, []byte("after-complete-message"), time.Now().Add(time.Second)); err != nil {
+			t.Errorf("write ping after complete response: %v", err)
+			return
+		}
+		<-finishServer
+	})
+	t.Cleanup(finish)
+
+	if err := wc.BeginReadLease("complete-early-response"); err != nil {
+		t.Fatalf("BeginReadLease: %v", err)
+	}
+	leaseID, _, err := wc.beginReadLeaseWrite(websocket.TextMessage)
+	if err != nil {
+		t.Fatalf("beginReadLeaseWrite: %v", err)
+	}
+	close(startResponse)
+	<-responseSent
+
+	select {
+	case <-pongSeen:
+	case <-time.After(250 * time.Millisecond):
+		_ = wc.completeReadLeaseWrite(leaseID, nil)
+		t.Fatal("read pump stopped processing control frames after a complete early response")
+	}
+	if err := wc.completeReadLeaseWrite(leaseID, nil); err != nil {
+		t.Fatalf("completeReadLeaseWrite: %v", err)
+	}
+	finish()
+
+	messageType, payload, err := readPumpMessage(t, wc)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	if messageType != websocket.TextMessage || !strings.Contains(string(payload), `"delta":"early"`) {
+		t.Fatalf("response = (%d, %s), want the complete early response", messageType, payload)
+	}
+}
+
+func TestFailedWriteNeverBecomesReusable(t *testing.T) {
+	wc := &WsConnection{}
+	wc.state.Store(int32(StateConnected))
+	if err := wc.BeginReadLease("failed-write"); err != nil {
+		t.Fatalf("BeginReadLease: %v", err)
+	}
+	leaseID, _, err := wc.beginReadLeaseWrite(websocket.TextMessage)
+	if err != nil {
+		t.Fatalf("beginReadLeaseWrite: %v", err)
+	}
+
+	writeErr := errors.New("write: broken pipe")
+	if err := wc.completeReadLeaseWrite(leaseID, writeErr); !errors.Is(err, writeErr) {
+		t.Fatalf("completeReadLeaseWrite error = %v, want %v", err, writeErr)
+	}
+	if wc.readPumpReusable() {
+		t.Fatal("failed write exposed the connection as reusable")
+	}
+	if err := wc.BeginReadLease("next-request"); err == nil {
+		t.Fatal("failed write allowed a later request to reserve the connection")
+	}
+}
+
+func TestProvisionalTerminalFrameReleasesLeaseOnlyAfterWriteCommit(t *testing.T) {
+	wc := &WsConnection{}
+	wc.state.Store(int32(StateConnected))
+	if err := wc.BeginReadLease("early-terminal"); err != nil {
+		t.Fatalf("BeginReadLease: %v", err)
+	}
+	leaseID, _, err := wc.beginReadLeaseWrite(websocket.TextMessage)
+	if err != nil {
+		t.Fatalf("beginReadLeaseWrite: %v", err)
+	}
+	captured, err := wc.captureReadLease()
+	if err != nil {
+		t.Fatalf("captureReadLease: %v", err)
+	}
+	if err := wc.enqueueBusinessFrameForCapturedLease(
+		websocket.TextMessage,
+		[]byte(`{"type":"response.completed","response":{"id":"early"}}`),
+		captured,
+	); err != nil {
+		t.Fatalf("enqueue provisional terminal: %v", err)
+	}
+
+	state := wc.ensureReadState()
+	state.mu.Lock()
+	activeBeforeCommit := state.activeLease
+	phaseBeforeCommit := state.leasePhase
+	terminalQueued := state.leaseTerminalQueued
+	state.mu.Unlock()
+	if activeBeforeCommit != leaseID || phaseBeforeCommit != readLeaseWriting || !terminalQueued {
+		t.Fatalf("before commit = (lease %q, phase %d, terminal %v), want writing lease retained", activeBeforeCommit, phaseBeforeCommit, terminalQueued)
+	}
+
+	if err := wc.completeReadLeaseWrite(leaseID, nil); err != nil {
+		t.Fatalf("completeReadLeaseWrite: %v", err)
+	}
+	if err := wc.awaitCapturedReadLease(captured); err != nil {
+		t.Fatalf("awaitCapturedReadLease: %v", err)
+	}
+	state.mu.Lock()
+	activeAfterCommit := state.activeLease
+	phaseAfterCommit := state.leasePhase
+	terminalQueued = state.leaseTerminalQueued
+	state.mu.Unlock()
+	if activeAfterCommit != "" || phaseAfterCommit != readLeaseIdle || terminalQueued {
+		t.Fatalf("after commit = (lease %q, phase %d, terminal %v), want idle lease with queued response", activeAfterCommit, phaseAfterCommit, terminalQueued)
+	}
+	if wc.readPumpReusable() {
+		t.Fatal("connection became reusable before the queued terminal frame was consumed")
+	}
+}
+
+func TestProvisionalTerminalSurvivesNormalCloseBeforeSuccessfulCommit(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		code int
+	}{
+		{name: "normal closure", code: websocket.CloseNormalClosure},
+		{name: "going away", code: websocket.CloseGoingAway},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			wc := &WsConnection{}
+			wc.state.Store(int32(StateConnected))
+			state := wc.ensureReadState()
+			state.mu.Lock()
+			state.pumpStarted = true
+			state.mu.Unlock()
+
+			if err := wc.BeginReadLease("terminal-before-close"); err != nil {
+				t.Fatalf("BeginReadLease: %v", err)
+			}
+			leaseID, _, err := wc.beginReadLeaseWrite(websocket.TextMessage)
+			if err != nil {
+				t.Fatalf("beginReadLeaseWrite: %v", err)
+			}
+			captured, err := wc.captureReadLease()
+			if err != nil {
+				t.Fatalf("captureReadLease: %v", err)
+			}
+			terminal := []byte(`{"type":"response.completed","response":{"id":"complete"}}`)
+			if err := wc.enqueueBusinessFrameForCapturedLease(websocket.TextMessage, terminal, captured); err != nil {
+				t.Fatalf("enqueue provisional terminal: %v", err)
+			}
+
+			wc.finishReadPump(&websocket.CloseError{Code: tt.code, Text: "response complete"}, true)
+			if err := wc.completeReadLeaseWrite(leaseID, nil); err != nil {
+				t.Fatalf("successful write after complete response and normal close: %v", err)
+			}
+			if err := wc.awaitCapturedReadLease(captured); err != nil {
+				t.Fatalf("completed response was rejected: %v", err)
+			}
+			if wc.IsConnected() || wc.readPumpReusable() {
+				t.Fatal("normally closed physical connection must remain retired")
+			}
+		})
+	}
+}
+
+func TestReadPumpEnforcesQueuedItemLimit(t *testing.T) {
+	const maxQueuedItems = 4096
+
+	wc := &WsConnection{}
+	wc.SetState(StateConnected)
+	if err := wc.BeginReadLease("tiny-frame-flood"); err != nil {
+		t.Fatalf("BeginReadLease: %v", err)
+	}
+	state := wc.ensureReadState()
+	state.mu.Lock()
+	state.leasePhase = readLeaseCommitted
+	state.mu.Unlock()
+	for i := 0; i < maxQueuedItems; i++ {
+		if err := wc.enqueueBusinessFrameForLease(websocket.TextMessage, nil, "tiny-frame-flood"); err != nil {
+			t.Fatalf("enqueue item %d: %v", i+1, err)
+		}
+	}
+	if err := wc.enqueueBusinessFrameForLease(websocket.TextMessage, nil, "tiny-frame-flood"); !errors.Is(err, errReadPumpQueueOverflow) {
+		t.Fatalf("item %d error = %v, want %v", maxQueuedItems+1, err, errReadPumpQueueOverflow)
+	}
+}
+
+func TestReadPumpPropagatesPrematureNormalClose(t *testing.T) {
+	holdOpen := make(chan struct{})
+	t.Cleanup(func() { close(holdOpen) })
+
+	manager, wc := newReadPumpTestConnection(t, func(conn *websocket.Conn) {
+		if _, _, err := conn.ReadMessage(); err != nil {
+			t.Errorf("read request: %v", err)
+			return
+		}
+		if err := conn.WriteControl(
+			websocket.CloseMessage,
+			websocket.FormatCloseMessage(websocket.CloseNormalClosure, "premature normal close"),
+			time.Now().Add(time.Second),
+		); err != nil {
+			t.Errorf("write normal close: %v", err)
+			return
+		}
+		<-holdOpen
+	})
+
+	pr := wc.session.AddPendingRequest("read-pump-test")
+	if err := wc.BeginReadLease(pr.RequestID); err != nil {
+		t.Fatalf("BeginReadLease: %v", err)
+	}
+	if err := wc.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.create"}`)); err != nil {
+		t.Fatalf("write request: %v", err)
+	}
+
+	response := &WsResponse{conn: wc, pendingReq: pr, sessionID: "read-pump-test", manager: manager}
+	err := response.ReadStream(func([]byte) bool { return true })
+	if err == nil {
+		t.Fatal("premature close 1000 was treated as a successful stream completion")
+	}
+	if !strings.Contains(err.Error(), "websocket read error") ||
+		!strings.Contains(err.Error(), "1000") ||
+		!strings.Contains(err.Error(), "premature normal close") {
+		t.Fatalf("normal close error = %v, want wrapped code and reason", err)
+	}
+	response.mu.Lock()
+	broken := response.connBroken
+	response.mu.Unlock()
+	if !broken {
+		t.Fatal("premature normal close did not mark the connection broken")
+	}
+	if closeErr := response.Close(); closeErr != nil {
+		t.Fatalf("response Close: %v", closeErr)
+	}
+}
+
+func TestReadPumpAcquireRetriesEarlyReaderFailure(t *testing.T) {
+	var handshakes atomic.Int32
+	holdSecond := make(chan struct{})
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade websocket: %v", err)
+			return
+		}
+		defer conn.Close()
+		if handshakes.Add(1) == 1 {
+			_ = conn.WriteControl(
+				websocket.CloseMessage,
+				websocket.FormatCloseMessage(websocket.CloseInternalServerErr, "close first connection"),
+				time.Now().Add(time.Second),
+			)
+			time.Sleep(25 * time.Millisecond)
+			return
+		}
+		<-holdSecond
+	}))
+
+	manager := NewManager()
+	t.Cleanup(func() {
+		manager.Stop()
+		close(holdSecond)
+		server.Close()
+	})
+	account := &auth.Account{DBID: 1}
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	wc, pr, err := manager.AcquireConnection(ctx, account, wsURL, "retry-early-close", http.Header{}, "")
+	if err != nil {
+		t.Fatalf("AcquireConnection: %v", err)
+	}
+	waitForReadPumpCondition(t, func() bool {
+		return handshakes.Load() >= 2 || !wc.IsConnected()
+	}, "first connection neither failed nor triggered a retry")
+	if got := handshakes.Load(); got != 2 {
+		t.Fatalf("handshakes = %d, want 2 after one bounded retry", got)
+	}
+	if wc == nil || pr == nil || !wc.IsConnected() {
+		t.Fatal("AcquireConnection did not return the healthy second connection")
+	}
+	if manager.ConnectionCount() != 1 || manager.SessionCount() != 1 {
+		t.Fatalf("pool leak after retry: connections=%d sessions=%d", manager.ConnectionCount(), manager.SessionCount())
+	}
+	if pending := wc.session.PendingCount(); pending != 1 {
+		t.Fatalf("healthy session pending count = %d, want 1", pending)
+	}
+}
+
+func TestReadPumpRejectsIdleBusinessFrame(t *testing.T) {
+	tests := []struct {
+		name        string
+		messageType int
+		payload     []byte
+	}{
+		{name: "text", messageType: websocket.TextMessage, payload: []byte(`{"type":"response.output_text.delta","delta":"stale"}`)},
+		{name: "terminal text", messageType: websocket.TextMessage, payload: []byte(`{"type":"response.completed","response":{"id":"stale"}}`)},
+		{name: "binary", messageType: websocket.BinaryMessage, payload: []byte("stale")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			holdOpen := make(chan struct{})
+			t.Cleanup(func() { close(holdOpen) })
+			manager, wc := newReadPumpTestConnection(t, func(conn *websocket.Conn) {
+				if err := conn.WriteMessage(tt.messageType, tt.payload); err != nil {
+					t.Errorf("write idle business frame: %v", err)
+					return
+				}
+				<-holdOpen
+			})
+
+			waitForReadPumpCondition(t, func() bool {
+				_, exists := manager.connections.Load(wc.PoolKey)
+				return !wc.IsConnected() && !exists
+			}, "idle business frame did not poison the connection")
+			if _, ok := manager.connections.Load(wc.PoolKey); ok {
+				t.Fatal("polluted connection remained in Manager")
+			}
+			if err := wc.BeginReadLease("next-request"); err == nil {
+				t.Fatal("polluted connection accepted a subsequent lease")
+			}
+		})
+	}
+}
+
+func TestReadPumpReusesConnectionAcrossLeases(t *testing.T) {
+	holdOpen := make(chan struct{})
+	t.Cleanup(func() { close(holdOpen) })
+
+	_, wc := newReadPumpTestConnection(t, func(conn *websocket.Conn) {
+		for i := 1; i <= 2; i++ {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				t.Errorf("read request %d: %v", i, err)
+				return
+			}
+			frames := [][]byte{
+				[]byte(`{"type":"response.output_text.delta","delta":"lease-` + string(rune('0'+i)) + `-1"}`),
+				[]byte(`{"type":"response.completed","response":{"id":"resp_` + string(rune('0'+i)) + `"}}`),
+			}
+			for _, frame := range frames {
+				if err := conn.WriteMessage(websocket.TextMessage, frame); err != nil {
+					t.Errorf("write response %d: %v", i, err)
+					return
+				}
+			}
+		}
+		<-holdOpen
+	})
+
+	for i := 1; i <= 2; i++ {
+		requestID := "request-" + string(rune('0'+i))
+		if err := wc.BeginReadLease(requestID); err != nil {
+			t.Fatalf("BeginReadLease(%q): %v", requestID, err)
+		}
+		if err := wc.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.create"}`)); err != nil {
+			t.Fatalf("write request %d: %v", i, err)
+		}
+
+		wantFrames := []string{
+			`{"type":"response.output_text.delta","delta":"lease-` + string(rune('0'+i)) + `-1"}`,
+			`{"type":"response.completed","response":{"id":"resp_` + string(rune('0'+i)) + `"}}`,
+		}
+		for frameIndex, want := range wantFrames {
+			messageType, payload, err := readPumpMessage(t, wc)
+			if err != nil {
+				t.Fatalf("lease %d frame %d: %v", i, frameIndex, err)
+			}
+			if messageType != websocket.TextMessage || string(payload) != want {
+				t.Fatalf("lease %d frame %d = (%d, %s), want (%d, %s)", i, frameIndex, messageType, payload, websocket.TextMessage, want)
+			}
+		}
+	}
+}
+
+func TestReadPumpPropagatesActiveClose(t *testing.T) {
+	triggerClose := make(chan struct{})
+	holdOpen := make(chan struct{})
+	t.Cleanup(func() { close(holdOpen) })
+
+	manager, wc := newReadPumpTestConnection(t, func(conn *websocket.Conn) {
+		<-triggerClose
+		if err := conn.WriteControl(
+			websocket.CloseMessage,
+			websocket.FormatCloseMessage(websocket.CloseInternalServerErr, "active close"),
+			time.Now().Add(time.Second),
+		); err != nil {
+			t.Errorf("write close: %v", err)
+			return
+		}
+		<-holdOpen
+	})
+
+	pr := wc.session.AddPendingRequest("read-pump-test")
+	if err := wc.BeginReadLease(pr.RequestID); err != nil {
+		t.Fatalf("BeginReadLease: %v", err)
+	}
+	if err := wc.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.create"}`)); err != nil {
+		t.Fatalf("write request: %v", err)
+	}
+	close(triggerClose)
+
+	response := &WsResponse{conn: wc, pendingReq: pr, sessionID: "read-pump-test", manager: manager}
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- response.ReadStream(func([]byte) bool { return true })
+	}()
+
+	select {
+	case err := <-errCh:
+		if err == nil {
+			t.Fatal("active close 1011 did not reach the response consumer")
+		}
+		if !strings.Contains(err.Error(), "websocket read error") || !strings.Contains(err.Error(), "1011") {
+			t.Fatalf("active close error = %v, want existing wrapped websocket close semantics", err)
+		}
+	case <-time.After(readPumpTestTimeout):
+		t.Fatal("active close did not unblock WsResponse.ReadStream")
+	}
+
+	waitForReadPumpCondition(t, func() bool { return !wc.IsConnected() }, "active close did not mark connection unavailable")
+	if closeErr := response.Close(); closeErr != nil {
+		t.Fatalf("response Close: %v", closeErr)
+	}
+}
+
+func TestReadPumpEnforcesQueuedPayloadLimit(t *testing.T) {
+	triggerFrames := make(chan struct{})
+	holdOpen := make(chan struct{})
+	t.Cleanup(func() { close(holdOpen) })
+
+	manager, wc := newReadPumpTestConnection(t, func(conn *websocket.Conn) {
+		<-triggerFrames
+		payload := strings.Repeat("x", readPumpMaxQueuedPayload/2+1)
+		for range 2 {
+			if err := conn.WriteMessage(websocket.TextMessage, []byte(payload)); err != nil {
+				t.Errorf("write oversized queue payload: %v", err)
+				return
+			}
+		}
+		<-holdOpen
+	})
+
+	if err := wc.BeginReadLease("large-response"); err != nil {
+		t.Fatalf("BeginReadLease: %v", err)
+	}
+	if err := wc.WriteMessage(websocket.TextMessage, []byte(`{"type":"response.create"}`)); err != nil {
+		t.Fatalf("write request: %v", err)
+	}
+	close(triggerFrames)
+	waitForReadPumpCondition(t, func() bool {
+		_, exists := manager.connections.Load(wc.PoolKey)
+		return !wc.IsConnected() && !exists
+	}, "queue overflow did not poison the connection")
+	if _, ok := manager.connections.Load(wc.PoolKey); ok {
+		t.Fatal("queue-overflow connection remained in Manager")
+	}
+
+	if _, payload, err := readPumpMessage(t, wc); err != nil || len(payload) != readPumpMaxQueuedPayload/2+1 {
+		t.Fatalf("first queued frame = (%d bytes, %v), want %d bytes", len(payload), err, readPumpMaxQueuedPayload/2+1)
+	}
+	if _, _, err := readPumpMessage(t, wc); !errors.Is(err, errReadPumpQueueOverflow) {
+		t.Fatalf("overflow read error = %v, want %v", err, errReadPumpQueueOverflow)
+	}
+}
+
+func TestReadPumpMapsReadLimitToClose1009(t *testing.T) {
+	wc := &WsConnection{}
+	wc.state.Store(int32(StateConnected))
+	if err := wc.BeginReadLease("oversized-response"); err != nil {
+		t.Fatalf("BeginReadLease: %v", err)
+	}
+	state := wc.ensureReadState()
+	state.mu.Lock()
+	state.leasePhase = readLeaseCommitted
+	state.mu.Unlock()
+
+	wc.finishReadPump(websocket.ErrReadLimit, true)
+	_, _, err := wc.ReadMessage()
+	if !errors.Is(err, websocket.ErrReadLimit) {
+		t.Fatalf("read error = %v, want preserved ErrReadLimit", err)
+	}
+	var closeErr *websocket.CloseError
+	if !errors.As(err, &closeErr) {
+		t.Fatalf("read error = %v, want CloseError 1009", err)
+	}
+	if closeErr.Code != websocket.CloseMessageTooBig {
+		t.Fatalf("close code = %d, want %d", closeErr.Code, websocket.CloseMessageTooBig)
+	}
+	if shouldRetryWebsocketSendError(err) {
+		t.Fatal("mapped read-limit error must reach HTTP fallback without WebSocket reconnects")
+	}
+}
+
+func TestCompleteReadLeaseWritePreservesPeerCloseCause(t *testing.T) {
+	wc := &WsConnection{}
+	wc.state.Store(int32(StateConnected))
+	state := wc.ensureReadState()
+	state.mu.Lock()
+	state.pumpStarted = true
+	state.activeLease = "large-request"
+	state.leasePhase = readLeaseWriting
+	state.mu.Unlock()
+
+	peerClose := &websocket.CloseError{
+		Code: websocket.CloseMessageTooBig,
+		Text: "message too big",
+	}
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		wc.finishReadPump(peerClose, true)
+	}()
+
+	err := wc.completeReadLeaseWrite("large-request", websocket.ErrCloseSent)
+	select {
+	case <-state.readerDone:
+	case <-time.After(readPumpTestTimeout):
+		t.Fatal("reader failure did not finish")
+	}
+
+	var closeErr *websocket.CloseError
+	if !errors.As(err, &closeErr) {
+		t.Fatalf("write error = %v, want preserved peer CloseError", err)
+	}
+	if closeErr.Code != websocket.CloseMessageTooBig {
+		t.Fatalf("close code = %d, want %d", closeErr.Code, websocket.CloseMessageTooBig)
+	}
+}
+
+func TestCompleteReadLeaseWritePreservesPeerCloseAfterTransportWriteError(t *testing.T) {
+	for _, writeErr := range []error{
+		errors.New("write tcp: broken pipe"),
+		errors.New("write tcp: connection reset by peer"),
+	} {
+		t.Run(writeErr.Error(), func(t *testing.T) {
+			wc := &WsConnection{}
+			wc.state.Store(int32(StateConnected))
+			state := wc.ensureReadState()
+			state.mu.Lock()
+			state.pumpStarted = true
+			state.activeLease = "large-request"
+			state.leasePhase = readLeaseWriting
+			state.mu.Unlock()
+
+			go func() {
+				time.Sleep(10 * time.Millisecond)
+				wc.finishReadPump(&websocket.CloseError{
+					Code: websocket.CloseMessageTooBig,
+					Text: "message too big",
+				}, true)
+			}()
+
+			err := wc.completeReadLeaseWrite("large-request", writeErr)
+			select {
+			case <-state.readerDone:
+			case <-time.After(readPumpTestTimeout):
+				t.Fatal("reader failure did not finish")
+			}
+
+			var closeErr *websocket.CloseError
+			if !errors.As(err, &closeErr) {
+				t.Fatalf("write error = %v, want preserved peer CloseError", err)
+			}
+			if closeErr.Code != websocket.CloseMessageTooBig {
+				t.Fatalf("close code = %d, want %d", closeErr.Code, websocket.CloseMessageTooBig)
+			}
+		})
+	}
+}
+
+func TestProvisionalFrameDoesNotMaskPeerCloseAfterTransportWriteError(t *testing.T) {
+	wc := &WsConnection{}
+	wc.state.Store(int32(StateConnected))
+	state := wc.ensureReadState()
+	state.mu.Lock()
+	state.pumpStarted = true
+	state.mu.Unlock()
+
+	if err := wc.BeginReadLease("provisional-close"); err != nil {
+		t.Fatalf("BeginReadLease: %v", err)
+	}
+	leaseID, _, err := wc.beginReadLeaseWrite(websocket.TextMessage)
+	if err != nil {
+		t.Fatalf("beginReadLeaseWrite: %v", err)
+	}
+	captured, err := wc.captureReadLease()
+	if err != nil {
+		t.Fatalf("captureReadLease: %v", err)
+	}
+	if err := wc.enqueueBusinessFrameForCapturedLease(
+		websocket.TextMessage,
+		[]byte(`{"type":"response.output_text.delta","delta":"early"}`),
+		captured,
+	); err != nil {
+		t.Fatalf("enqueue provisional response: %v", err)
+	}
+
+	writeResult := make(chan error, 1)
+	writeErr := errors.New("write tcp: broken pipe")
+	go func() { writeResult <- wc.completeReadLeaseWrite(leaseID, writeErr) }()
+	waitForReadPumpCondition(t, func() bool { return !wc.IsConnected() }, "failed writer did not seal the connection")
+	wc.finishReadPump(&websocket.CloseError{
+		Code: websocket.CloseMessageTooBig,
+		Text: "message too big",
+	}, true)
+
+	resolvedWriteErr := <-writeResult
+	var closeErr *websocket.CloseError
+	if !errors.As(resolvedWriteErr, &closeErr) || closeErr.Code != websocket.CloseMessageTooBig {
+		t.Fatalf("resolved write error = %v, want peer CloseError 1009", resolvedWriteErr)
+	}
+	if err := wc.awaitCapturedReadLease(captured); !errors.As(err, &closeErr) || closeErr.Code != websocket.CloseMessageTooBig {
+		t.Fatalf("provisional frame result = %v, want peer CloseError 1009", err)
+	}
+}
+
+func TestCompleteSuccessfulWritePreservesConcurrentPeerCloseCause(t *testing.T) {
+	wc := &WsConnection{}
+	wc.state.Store(int32(StateConnected))
+	state := wc.ensureReadState()
+	state.mu.Lock()
+	state.pumpStarted = true
+	state.activeLease = "successful-large-request"
+	state.leasePhase = readLeaseWriting
+	state.mu.Unlock()
+
+	wc.finishReadPump(&websocket.CloseError{
+		Code: websocket.CloseMessageTooBig,
+		Text: "message too big",
+	}, true)
+
+	err := wc.completeReadLeaseWrite("successful-large-request", nil)
+	var closeErr *websocket.CloseError
+	if !errors.As(err, &closeErr) {
+		t.Fatalf("commit error = %v, want preserved peer CloseError", err)
+	}
+	if closeErr.Code != websocket.CloseMessageTooBig {
+		t.Fatalf("close code = %d, want %d", closeErr.Code, websocket.CloseMessageTooBig)
+	}
+}
+
+func TestReadPumpPreservesPeerCloseCauseDuringSocketWrite(t *testing.T) {
+	closeSent := make(chan error, 1)
+	_, wc := newReadPumpTestConnection(t, func(conn *websocket.Conn) {
+		if _, _, err := conn.NextReader(); err != nil {
+			closeSent <- err
+			return
+		}
+		closeSent <- conn.WriteControl(
+			websocket.CloseMessage,
+			websocket.FormatCloseMessage(websocket.CloseMessageTooBig, "message too big"),
+			time.Now().Add(time.Second),
+		)
+		time.Sleep(100 * time.Millisecond)
+	})
+
+	if err := wc.BeginReadLease("large-socket-write"); err != nil {
+		t.Fatalf("BeginReadLease: %v", err)
+	}
+	payload := []byte(strings.Repeat("x", 8*1024*1024))
+	err := wc.WriteMessage(websocket.TextMessage, payload)
+	if sendErr := <-closeSent; sendErr != nil {
+		t.Fatalf("server close 1009: %v", sendErr)
+	}
+
+	var closeErr *websocket.CloseError
+	if !errors.As(err, &closeErr) {
+		t.Fatalf("socket write error = %v, want preserved peer CloseError", err)
+	}
+	if closeErr.Code != websocket.CloseMessageTooBig {
+		t.Fatalf("close code = %d, want %d", closeErr.Code, websocket.CloseMessageTooBig)
+	}
+}
+
+func TestPreservePeerCloseCauseHasBoundedWait(t *testing.T) {
+	wc := &WsConnection{}
+	wc.state.Store(int32(StateConnected))
+	state := wc.ensureReadState()
+	state.mu.Lock()
+	state.pumpStarted = true
+	state.activeLease = "stalled-reader"
+	state.leasePhase = readLeaseWriting
+	state.mu.Unlock()
+
+	started := time.Now()
+	err := wc.completeReadLeaseWrite("stalled-reader", websocket.ErrCloseSent)
+	elapsed := time.Since(started)
+	if !errors.Is(err, websocket.ErrCloseSent) {
+		t.Fatalf("write error = %v, want original ErrCloseSent after bounded wait", err)
+	}
+	if elapsed < readPumpCloseCauseWait/2 || elapsed > 5*readPumpCloseCauseWait {
+		t.Fatalf("close-cause wait = %s, want bounded near %s", elapsed, readPumpCloseCauseWait)
+	}
+}


### PR DESCRIPTION
## 问题

连接归还池后没有持续 reader，Gorilla 无法处理空闲期间到达的 Ping/Pong/Close。旧探活只要 Ping 写成功就判活，因此已排队 Close 1011 的连接会被再次分配，造成首包前重试、断流和 status 598。

## 修复

- 每条物理 WebSocket 连接只启动一个永久 raw read pump，空闲时也持续处理控制帧。
- 业务帧通过有界队列和请求 lease 分发；writing 阶段的早到响应使用 provisional commit token，raw reader 永不等待业务写入。
- 探活等待唯一 payload 对应的 Pong，并用单一绝对截止时间串行化并发 probe。
- 空闲帧、跨 lease 残留帧、队列超限、reader 失败都会污染并精确淘汰当前连接。
- 保留与写入竞态的真实 Close 1009，并将 Gorilla ErrReadLimit 映射为 1009，使大请求直接进入现有 HTTP fallback。
- 连接淘汰时立即停止 session heartbeat；已完整收到 terminal 后的正常 Close 仍交付结果，但物理连接不会复用。

## 回归覆盖

- 空闲 Ping/Pong、已排队 Close 1011 与 matching-Pong probe
- 分片/完整早到响应后独立控制帧仍持续读取
- writing/committed、terminal、跨 lease 与失败写入竞态
- broken pipe/reset 与 Close 1009 原因保真、ErrReadLimit fallback
- 16 MiB / 4096 条队列上限、连接复用与 session 清理

## 验证

- `go test ./... -count=1`
- `go test ./proxy/wsrelay -count=20`
- `go test -race ./proxy/wsrelay -count=10`
- `go vet ./...`
- `npm run typecheck`
- `npm run build`

Closes #349

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a WebSocket read pump that delivers messages in-order using request “leases,” with built-in ping/pong handling, liveness probing, and protection via queue/payload limits.
* **Bug Fixes**
  * Improved send retry gating for specific WebSocket close conditions and refined read/stream error handling.
  * Strengthened connection lifecycle: idempotent close/discard behavior and safer heartbeat management (including skipping heartbeats for disconnected connections).
* **Tests**
  * Expanded unit test coverage for the read pump, retry behavior, and close/error propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->