### PR TITLE
fix(proxy): 为 GPT-5.6 Anthropic 映射保留 max 思考强度

### DIFF
--- a/proxy/anthropic.go
+++ b/proxy/anthropic.go
@@ -300,7 +300,7 @@ func TranslateAnthropicToCodexWithModels(rawJSON []byte, modelMappingJSON string
 
 	// reasoning effort: align Claude Code /v1/messages with the Responses reasoning shape.
 	out["reasoning"] = map[string]any{
-		"effort":  resolveReasoningEffort(req.OutputConfig),
+		"effort":  resolveReasoningEffort(req.OutputConfig, codexModel),
 		"summary": "auto",
 	}
 
@@ -499,9 +499,9 @@ func extractToolResultText(b anthropicContentBlock) string {
 // resolveReasoningEffort maps Claude output_config.effort to Responses reasoning.effort.
 // Claude thinking.type/budget_tokens only indicates that thinking mode exists; it
 // does not control effort on this OpenAI/Codex compatibility path.
-func resolveReasoningEffort(outputConfig *anthropicOutputConfig) string {
+func resolveReasoningEffort(outputConfig *anthropicOutputConfig, model string) string {
 	if outputConfig != nil && strings.TrimSpace(outputConfig.Effort) != "" {
-		return normalizeReasoningEffort(outputConfig.Effort)
+		return normalizeReasoningEffortForModel(outputConfig.Effort, model)
 	}
 	return "high"
 }

--- a/proxy/anthropic_test.go
+++ b/proxy/anthropic_test.go
@@ -113,6 +113,30 @@ func TestTranslateAnthropicToCodex_OutputConfigEffortTakesPrecedence(t *testing.
 	}
 }
 
+func TestTranslateAnthropicToCodex_OutputConfigMaxPreservedForGPT56(t *testing.T) {
+	raw := []byte(`{
+		"model":"claude-sonnet-4-5",
+		"messages":[{"role":"user","content":"hello"}],
+		"output_config":{"effort":"max"}
+	}`)
+
+	got, _, err := TranslateAnthropicToCodexWithModels(
+		raw,
+		`{"claude-sonnet-4-5":"gpt-5.6-sol"}`,
+		[]string{"gpt-5.6-sol"},
+	)
+	if err != nil {
+		t.Fatalf("TranslateAnthropicToCodexWithModels returned error: %v", err)
+	}
+
+	if model := gjson.GetBytes(got, "model").String(); model != "gpt-5.6-sol" {
+		t.Fatalf("model = %q, want gpt-5.6-sol; body=%s", model, got)
+	}
+	if effort := gjson.GetBytes(got, "reasoning.effort").String(); effort != "max" {
+		t.Fatalf("reasoning.effort = %q, want max; body=%s", effort, got)
+	}
+}
+
 func TestTranslateAnthropicToCodex_OutputConfigHighIsExplicit(t *testing.T) {
 	raw := []byte(`{
 		"model":"claude-sonnet-4-5",


### PR DESCRIPTION
## 问题说明

Anthropic Messages 请求中的 `output_config.effort` 会被转换为 Responses API 的 `reasoning.effort`。

此前该转换未使用映射后的 Codex 模型信息，导致请求映射到 `gpt-5.6-sol` 等 GPT-5.6 系列模型后，`max` 仍被错误降级为 `xhigh`。

## 修复方式

将映射后的 Codex 模型传入思考强度归一化逻辑：

- GPT-5.6 及更高版本保留 `max`
- GPT-5.5 及更早版本继续将 `max` 降级为 `xhigh`
- 其他思考强度及默认行为保持不变

## 测试

新增单元测试，验证 Anthropic 模型映射到 `gpt-5.6-sol` 时能够保留 `reasoning.effort: "max"`。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the requested maximum reasoning effort when using supported GPT-5.6 models.
  * Improved model-specific handling of reasoning effort during Anthropic request translation.

* **Tests**
  * Added coverage verifying model selection and preservation of the `"max"` reasoning effort setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->