### PR TITLE
fix(proxy): preserve SSE for relay compaction triggers (#361)

### DIFF
--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -1668,18 +1668,26 @@ func (h *Handler) Responses(c *gin.Context) {
 	// 不接受，会 400 或返回非压缩响应导致客户端报
 	// "expected exactly one compaction output item"。
 	// 处理：池中还有可用官方账号时，把这类请求钉在官方账号上保持原生透传；
-	// 官方账号全不可用（如纯中转部署）时整体提升到 compact 专用链路——
-	// 该链路对两类账号都能正确完成压缩。
-	pinBodySignalToCodexAccounts := requestBodyHasCompactionTrigger(rawBody)
-	if pinBodySignalToCodexAccounts {
-		if !h.storeHasAvailableCodexAccount() {
-			h.ResponsesCompact(c)
-			return
-		}
+	// 纯中转池的流式请求也必须继续走 /responses SSE，否则 ResponsesCompact 的
+	// 一次性 JSON 会让客户端在收到 response.completed 前遇到 EOF（issue #361）。
+	// 非流式请求仍可提升到 compact 专用链路，保留只实现 /responses/compact 的
+	// 中转兼容性。
+	bodySignalCompact := requestBodyHasCompactionTrigger(rawBody)
+	pinBodySignalToCodexAccounts := bodySignalCompact && h.storeHasAvailableCodexAccount()
+	streamingRelayBodySignal := bodySignalCompact && !pinBodySignalToCodexAccounts && gjson.GetBytes(rawBody, "stream").Bool()
+	if bodySignalCompact && !pinBodySignalToCodexAccounts && !streamingRelayBodySignal {
+		h.ResponsesCompact(c)
+		return
 	}
 
 	supportedModels := h.supportedModelIDs(c.Request.Context())
-	rawBody, requestModel, mappedModel, mappingApplied := h.applyConfiguredModelMappingToBody(rawBody, supportedModels)
+	var requestModel, mappedModel string
+	var mappingApplied bool
+	if streamingRelayBodySignal {
+		rawBody, requestModel, mappedModel, mappingApplied = h.applyConfiguredCompactModelMappingToBody(rawBody, supportedModels)
+	} else {
+		rawBody, requestModel, mappedModel, mappingApplied = h.applyConfiguredModelMappingToBody(rawBody, supportedModels)
+	}
 	setRawRequestBody(c, rawBody)
 
 	// Validate request
@@ -1769,7 +1777,13 @@ func (h *Handler) Responses(c *gin.Context) {
 	if releaseAPIKeyConcurrency != nil {
 		defer releaseAPIKeyConcurrency()
 	}
-	accountFilter := accountFilterForResponsesModelWithOriginal(logModel, effectiveModel, modelIDInList(effectiveModel, SupportedModelIDs(c.Request.Context(), h.db)))
+	allowCodexAccounts := modelIDInList(effectiveModel, SupportedModelIDs(c.Request.Context(), h.db))
+	var accountFilter auth.AccountFilter
+	if streamingRelayBodySignal {
+		accountFilter = accountFilterForCompactResponsesModelWithOriginal(logModel, effectiveModel, allowCodexAccounts)
+	} else {
+		accountFilter = accountFilterForResponsesModelWithOriginal(logModel, effectiveModel, allowCodexAccounts)
+	}
 	accountFilter = h.withModelCooldownFilter(effectiveModel, accountFilter)
 	if pinBodySignalToCodexAccounts {
 		accountFilter = excludeRelayAccountsFilter(accountFilter)
@@ -1854,7 +1868,15 @@ func (h *Handler) Responses(c *gin.Context) {
 			baseURL, _ := account.OpenAIResponsesCredentials()
 			upstreamEndpoint := auth.OpenAIResponsesEndpoint(baseURL, "/v1/responses")
 			upstreamBody := getOpenAIResponsesBody()
-			if mappedBody, mappedModel, ok := h.applyAccountModelMappingToBodyForModels(upstreamBody, account, logModel, effectiveModel); ok {
+			var mappedBody []byte
+			var mappedModel string
+			var accountMappingApplied bool
+			if streamingRelayBodySignal {
+				mappedBody, mappedModel, accountMappingApplied = h.applyAccountCompactModelMappingToBody(upstreamBody, account, logModel, effectiveModel)
+			} else {
+				mappedBody, mappedModel, accountMappingApplied = h.applyAccountModelMappingToBodyForModels(upstreamBody, account, logModel, effectiveModel)
+			}
+			if accountMappingApplied {
 				upstreamBody = mappedBody
 				attemptEffectiveModel = mappedModel
 				attemptLogEffectiveModel = usageEffectiveModelForMapping(logModel, attemptEffectiveModel, true)

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -2764,10 +2764,10 @@ func TestResolveAPIKeyDistinguishesDBFailureFrom404(t *testing.T) {
 	}
 }
 
-// body-signal compact:中转账号池收到带 compaction_trigger 的普通 /responses
-// 请求时,必须整体提升到 compact 专用链路(上游命中 /v1/responses/compact),
-// 否则中转上游返回非压缩响应,客户端报 expected exactly one compaction output item。
-func TestResponses_BodySignalCompactPromotedOnRelayOnlyPool(t *testing.T) {
+// body-signal compact:中转账号池收到带 compaction_trigger 的流式 /responses
+// 请求时，必须保留 /responses 的 SSE 协议；compact 专用模型映射只能改写模型，
+// 不能把请求改道到返回一次性 JSON 的 /responses/compact（issue #361）。
+func TestResponses_BodySignalCompactStaysStreamingOnRelayOnlyPool(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	var seenPath string
@@ -2775,15 +2775,22 @@ func TestResponses_BodySignalCompactPromotedOnRelayOnlyPool(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		seenPath = r.URL.Path
 		seenBody, _ = io.ReadAll(r.Body)
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{
-			"id":"resp_compaction_test",
-			"object":"response.compaction",
-			"created_at":1710000000,
-			"model":"gpt-4.1-direct",
-			"output":[{"type":"compaction_summary","summary":"user likes blue"}],
-			"usage":{"input_tokens":3,"output_tokens":2,"total_tokens":5}
-		}`))
+		if r.URL.Path == "/v1/responses/compact" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+				"id":"resp_compaction_test",
+				"object":"response.compaction",
+				"created_at":1710000000,
+				"model":"gpt-4.1-direct",
+				"output":[{"type":"compaction_summary","summary":"user likes blue"}],
+				"usage":{"input_tokens":3,"output_tokens":2,"total_tokens":5}
+			}`))
+			return
+		}
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, `data: {"type":"response.created","response":{"id":"resp_compaction_test"}}`+"\n\n")
+		_, _ = io.WriteString(w, `data: {"type":"response.completed","response":{"id":"resp_compaction_test","status":"completed","output":[{"type":"compaction_summary","summary":"user likes blue"}],"usage":{"input_tokens":3,"output_tokens":2,"total_tokens":5}}}`+"\n\n")
 	}))
 	defer upstream.Close()
 
@@ -2823,21 +2830,137 @@ func TestResponses_BodySignalCompactPromotedOnRelayOnlyPool(t *testing.T) {
 	if recorder.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200; body=%s", recorder.Code, recorder.Body.String())
 	}
-	if seenPath != "/v1/responses/compact" {
-		t.Fatalf("upstream path = %q, want /v1/responses/compact (body-signal must be promoted)", seenPath)
+	if seenPath != "/v1/responses" {
+		t.Fatalf("upstream path = %q, want /v1/responses to preserve streaming", seenPath)
 	}
-	if gjson.GetBytes(seenBody, "stream").Exists() {
-		t.Fatalf("promoted upstream body should not carry stream, got %s", seenBody)
+	if !gjson.GetBytes(seenBody, "stream").Bool() {
+		t.Fatalf("upstream body must preserve stream=true, got %s", seenBody)
 	}
-	// compact 端点不认识 client_metadata,提升时必须剥除(issue #340)。
-	if gjson.GetBytes(seenBody, "client_metadata").Exists() {
-		t.Fatalf("promoted upstream body should not carry client_metadata, got %s", seenBody)
+	if !requestBodyHasCompactionTrigger(seenBody) {
+		t.Fatalf("upstream body lost compaction_trigger: %s", seenBody)
 	}
 	if model := gjson.GetBytes(seenBody, "model").String(); model != "gpt-4.1-direct" {
-		t.Fatalf("promoted compact model = %q, want one-pass mapping to gpt-4.1-direct; body=%s", model, seenBody)
+		t.Fatalf("streaming compact model = %q, want one-pass mapping to gpt-4.1-direct; body=%s", model, seenBody)
 	}
-	if id := gjson.GetBytes(recorder.Body.Bytes(), "id").String(); id != "resp_compaction_test" {
-		t.Fatalf("response id = %q, want resp_compaction_test; body=%s", id, recorder.Body.String())
+	if contentType := recorder.Header().Get("Content-Type"); !strings.Contains(contentType, "text/event-stream") {
+		t.Fatalf("Content-Type = %q, want text/event-stream; body=%s", contentType, recorder.Body.String())
+	}
+	if !strings.Contains(recorder.Body.String(), `"type":"response.completed"`) {
+		t.Fatalf("downstream stream missing response.completed; body=%s", recorder.Body.String())
+	}
+}
+
+// 流式 body-signal 继续走 /responses 时，也必须保留账号级 compact 专用映射；
+// 否则 compact-only alias 无法选中中转账号，或会把错误模型发给上游（PR #350）。
+func TestResponses_BodySignalCompactStreamingUsesAccountCompactMapping(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	var seenPath string
+	var seenBody []byte
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenPath = r.URL.Path
+		seenBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, `data: {"type":"response.completed","response":{"id":"resp_account_mapping","status":"completed","output":[{"type":"compaction_summary","summary":"mapped"}],"usage":{"input_tokens":3,"output_tokens":2,"total_tokens":5}}}`+"\n\n")
+	}))
+	defer upstream.Close()
+
+	store := auth.NewStore(nil, nil, &database.SystemSettings{
+		MaxConcurrency:      2,
+		MaxRetries:          0,
+		MaxRateLimitRetries: 0,
+	})
+	store.AddAccount(&auth.Account{
+		DBID:         1,
+		UpstreamType: auth.UpstreamOpenAIResponses,
+		BaseURL:      upstream.URL,
+		APIKey:       "sk-direct",
+		Models:       []string{"gpt-4.1-direct"},
+		ModelMapping: `{"gpt-5.4-openai-compact":"gpt-4.1-direct"}`,
+		PlanType:     "api",
+	})
+	handler := NewHandler(store, nil, nil, nil)
+
+	body := []byte(`{
+		"model":"gpt-5.4",
+		"stream":true,
+		"input":[{"type":"compaction_trigger"}]
+	}`)
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Request = req
+
+	handler.Responses(ctx)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", recorder.Code, recorder.Body.String())
+	}
+	if seenPath != "/v1/responses" {
+		t.Fatalf("upstream path = %q, want /v1/responses", seenPath)
+	}
+	if model := gjson.GetBytes(seenBody, "model").String(); model != "gpt-4.1-direct" {
+		t.Fatalf("upstream model = %q, want account compact mapping target gpt-4.1-direct; body=%s", model, seenBody)
+	}
+}
+
+// 非流式 body-signal 没有 SSE 契约，继续使用 compact 专用端点以兼容只实现
+// /responses/compact 的中转账号。
+func TestResponses_NonStreamingBodySignalCompactStillUsesCompactEndpoint(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	var seenPath string
+	var seenBody []byte
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenPath = r.URL.Path
+		seenBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"id":"resp_non_stream_compaction",
+			"object":"response.compaction",
+			"output":[{"type":"compaction_summary","summary":"done"}],
+			"usage":{"input_tokens":3,"output_tokens":2,"total_tokens":5}
+		}`))
+	}))
+	defer upstream.Close()
+
+	store := auth.NewStore(nil, nil, &database.SystemSettings{
+		MaxConcurrency:      2,
+		MaxRetries:          0,
+		MaxRateLimitRetries: 0,
+	})
+	store.AddAccount(&auth.Account{
+		DBID:         1,
+		UpstreamType: auth.UpstreamOpenAIResponses,
+		BaseURL:      upstream.URL,
+		APIKey:       "sk-direct",
+		Models:       []string{"gpt-4.1-direct"},
+		PlanType:     "api",
+	})
+	handler := NewHandler(store, nil, nil, nil)
+
+	body := []byte(`{
+		"model":"gpt-4.1-direct",
+		"stream":false,
+		"input":[{"type":"compaction_trigger"}]
+	}`)
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Request = req
+
+	handler.Responses(ctx)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", recorder.Code, recorder.Body.String())
+	}
+	if seenPath != "/v1/responses/compact" {
+		t.Fatalf("upstream path = %q, want /v1/responses/compact", seenPath)
+	}
+	if gjson.GetBytes(seenBody, "stream").Exists() {
+		t.Fatalf("compact upstream body should not carry stream, got %s", seenBody)
 	}
 }
 

--- a/proxy/model_mapping.go
+++ b/proxy/model_mapping.go
@@ -328,8 +328,9 @@ func usageEffectiveModelForMapping(originalModel string, effectiveModel string, 
 const compactOpenAIModelSuffix = "-openai-compact"
 
 // stripCompactModelSuffix 去除 compact 模型名上的 -openai-compact 后缀，返回去除后的
-// 模型名与是否发生改写。仅供 /v1/responses/compact 使用：让 newapi 侧渠道仍能以
-// gpt-5.4-openai-compact 命名，而 codex2api 内部按 gpt-5.4 校验与转发上游。
+// 模型名与是否发生改写。供显式 /v1/responses/compact 及普通 /v1/responses 中的
+// compaction_trigger 使用：让 newapi 侧渠道仍能以 gpt-5.4-openai-compact 命名，
+// 而 codex2api 内部按 gpt-5.4 校验与转发上游。
 func stripCompactModelSuffix(model string) (string, bool) {
 	trimmed := strings.TrimSpace(model)
 	if trimmed == "" {
@@ -415,10 +416,10 @@ func compactAliasScopedRules(rules []modelMappingRule) []modelMappingRule {
 	return scoped
 }
 
-// normalizeCompactMappingTarget 剥离映射目标上的 -openai-compact 后缀。codex2api
-// 发往上游的始终是 /v1/responses/compact 端点，该后缀只是入站别名约定；把它原样
-// 转发会让上游按字面模型名查找而失败（中转模型列表里的 xxx-openai-compact 通常
-// 只是路由标记，不是可直接请求的模型）。
+// normalizeCompactMappingTarget 剥离映射目标上的 -openai-compact 后缀。无论 compact
+// 语义最终走显式 /v1/responses/compact，还是为了保留 SSE 而走带 compaction_trigger
+// 的 /v1/responses，该后缀都只是入站别名约定；把它原样转发会让上游按字面模型名
+// 查找而失败（中转模型列表里的 xxx-openai-compact 通常只是路由标记）。
 func normalizeCompactMappingTarget(model string) string {
 	if base, stripped := stripCompactModelSuffix(model); stripped {
 		return base


### PR DESCRIPTION
## Summary

- keep `stream=true` `compaction_trigger` requests on the normal `/v1/responses` SSE path for relay-only account pools
- preserve compact-aware global and per-account model mapping without switching the transport to non-streaming `/v1/responses/compact`
- retain the existing compact endpoint fallback for non-streaming body-signal requests
- add regression coverage for `response.completed`, global/account compact mappings, and non-stream compatibility

## Verification

- `go test ./... -count=1`
- targeted `go test -race ./proxy` compaction regression tests
- `go vet ./proxy`
- `git diff --check origin/main...HEAD`
- independent pre-landing review: no blockers
- coverage audit: no blocking gaps

Closes #361

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Streaming requests containing `compaction_trigger` now remain on the standard streaming response path, preventing unexpected end-of-file errors.
  * Non-streaming compaction requests continue to use the dedicated compact response path.
  * Compact model mapping is applied consistently across streaming and non-streaming requests.
  * Compact endpoint requests now omit unsupported streaming-related fields.

* **Tests**
  * Expanded coverage for compaction behavior across streaming, non-streaming, and relay scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->