### PR TITLE
fix(usage): keep newer Responses 429 cooldowns authoritative

### DIFF
--- a/auth/store.go
+++ b/auth/store.go
@@ -5820,16 +5820,26 @@ func isUsageLimitCooldownReason(reason string) bool {
 	}
 }
 
-// ConfirmResponsesAvailable clears only a usage/rate-limit cooldown after a
-// completed Responses request succeeds. Authentication and unrelated error
-// states are intentionally untouched.
+// ConfirmResponsesAvailable preserves the original API for callers whose
+// success evidence is current at call time.
 func (s *Store) ConfirmResponsesAvailable(acc *Account) bool {
+	return s.ConfirmResponsesAvailableSince(acc, time.Now())
+}
+
+// ConfirmResponsesAvailableSince clears only a usage/rate-limit cooldown when
+// a completed Responses request started after the latest rate-limit evidence.
+// A stale in-flight success must not undo a newer usage_limit_reached result.
+// Authentication and unrelated error states are intentionally untouched.
+func (s *Store) ConfirmResponsesAvailableSince(acc *Account, requestStartedAt time.Time) bool {
 	if s == nil || acc == nil {
 		return false
 	}
 
 	acc.mu.Lock()
-	if !acc.ignoreUsageLimitStatus || acc.Status != StatusCooldown || !isUsageLimitCooldownReason(acc.CooldownReason) {
+	if !acc.ignoreUsageLimitStatus ||
+		acc.Status != StatusCooldown ||
+		!isUsageLimitCooldownReason(acc.CooldownReason) ||
+		(!acc.LastRateLimitedAt.IsZero() && !requestStartedAt.After(acc.LastRateLimitedAt)) {
 		acc.mu.Unlock()
 		return false
 	}

--- a/auth/store_scheduler_test.go
+++ b/auth/store_scheduler_test.go
@@ -345,6 +345,36 @@ func TestResponsesSuccessClearsOnlyUsageCooldownWhenIgnored(t *testing.T) {
 	}
 }
 
+func TestConfirmResponsesAvailableSinceRespectsLatestRateLimit(t *testing.T) {
+	store := NewStore(nil, nil, &database.SystemSettings{
+		MaxConcurrency:         2,
+		TestConcurrency:        1,
+		TestModel:              "gpt-5.4",
+		IgnoreUsageLimitStatus: true,
+	})
+	account := &Account{DBID: 107, AccessToken: "token", Status: StatusReady, PlanType: "plus"}
+	store.AddAccount(account)
+
+	staleRequestStartedAt := time.Now()
+	store.MarkCooldown(account, time.Hour, "rate_limited")
+	if store.ConfirmResponsesAvailableSince(account, staleRequestStartedAt) {
+		t.Fatal("a request started before the latest rate limit must not clear its cooldown")
+	}
+	if !account.HasActiveCooldown() || account.IsAvailable() {
+		t.Fatal("newer rate-limit evidence should keep the account unavailable")
+	}
+
+	account.mu.RLock()
+	freshRequestStartedAt := account.LastRateLimitedAt.Add(time.Nanosecond)
+	account.mu.RUnlock()
+	if !store.ConfirmResponsesAvailableSince(account, freshRequestStartedAt) {
+		t.Fatal("a request started after the latest rate limit should clear its cooldown")
+	}
+	if account.HasActiveCooldown() || !account.IsAvailable() {
+		t.Fatal("fresh successful Responses evidence should restore account availability")
+	}
+}
+
 func TestNeedsUsageProbeRateLimitedAllowsResetCreditsRefresh(t *testing.T) {
 	// 429 冷却 + 重置次数从未探测过（stale）：应允许探针（wham-only）刷新「主动重置次数」。
 	acc := &Account{

--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -2227,7 +2227,7 @@ func (h *Handler) Responses(c *gin.Context) {
 				h.store.UnbindSessionAffinity(affinityKey, account.ID())
 			} else if outcome.logStatusCode == http.StatusOK {
 				h.store.ClearModelCooldown(account, attemptEffectiveModel)
-				h.store.ConfirmResponsesAvailable(account)
+				h.store.ConfirmResponsesAvailableSince(account, start)
 				h.store.ReportRequestSuccess(account, time.Duration(totalDuration)*time.Millisecond)
 			}
 			h.store.Release(account)
@@ -2745,7 +2745,7 @@ func (h *Handler) Responses(c *gin.Context) {
 			h.store.UnbindSessionAffinity(affinityKey, account.ID())
 		} else if outcome.logStatusCode == http.StatusOK {
 			h.store.ClearModelCooldown(account, effectiveModel)
-			h.store.ConfirmResponsesAvailable(account)
+			h.store.ConfirmResponsesAvailableSince(account, start)
 			h.store.ReportRequestSuccess(account, time.Duration(totalDuration)*time.Millisecond)
 		}
 		h.store.Release(account)

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -294,6 +295,88 @@ func TestResponsesWebSocketForwardsResponsesEvents(t *testing.T) {
 	case <-bodyCh:
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for second upstream request")
+	}
+}
+
+func TestResponsesWebSocketSuccessPreservesNewerUsageLimitCooldown(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	previousExec := WebsocketExecuteFunc
+	t.Cleanup(func() {
+		WebsocketExecuteFunc = previousExec
+	})
+
+	started := make(chan struct{}, 1)
+	release := make(chan struct{}, 1)
+	t.Cleanup(func() {
+		select {
+		case release <- struct{}{}:
+		default:
+		}
+	})
+	WebsocketExecuteFunc = func(ctx context.Context, account *auth.Account, requestBody []byte, sessionID string, proxyOverride string, apiKey string, deviceCfg *DeviceProfileConfig, headers http.Header, poolRouteKey string) (*http.Response, error) {
+		pr, pw := io.Pipe()
+		started <- struct{}{}
+		go func() {
+			<-release
+			_, _ = io.WriteString(pw, `data: {"type":"response.completed","response":{"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}}`+"\n\n")
+			_ = pw.Close()
+		}()
+		return &http.Response{StatusCode: http.StatusOK, Header: make(http.Header), Body: pr}, nil
+	}
+
+	store := auth.NewStore(nil, nil, &database.SystemSettings{
+		MaxConcurrency:         1,
+		MaxRetries:             0,
+		MaxRateLimitRetries:    0,
+		IgnoreUsageLimitStatus: true,
+	})
+	account := &auth.Account{DBID: 1, AccessToken: "at-1", PlanType: "pro", AccountID: "acct-1"}
+	store.AddAccount(account)
+	handler := NewHandler(store, nil, &config.Config{AllowAnonymousV1: true}, nil)
+
+	router := gin.New()
+	handler.RegisterRoutes(router)
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/v1/responses"
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial websocket failed: %v", err)
+	}
+	defer conn.Close()
+
+	if err := conn.WriteMessage(websocket.TextMessage, []byte(`{"model":"gpt-5.4","input":"hi"}`)); err != nil {
+		t.Fatalf("write request: %v", err)
+	}
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for upstream request")
+	}
+
+	store.MarkCooldown(account, time.Hour, "rate_limited")
+	release <- struct{}{}
+
+	_ = conn.SetReadDeadline(time.Now().Add(time.Second))
+	_, completed, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatalf("read terminal event: %v", err)
+	}
+	if eventType := gjson.GetBytes(completed, "type").String(); eventType != "response.completed" {
+		t.Fatalf("terminal event type = %q body=%s", eventType, completed)
+	}
+
+	deadline := time.Now().Add(time.Second)
+	for atomic.LoadInt64(&account.ActiveRequests) != 0 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if got := atomic.LoadInt64(&account.ActiveRequests); got != 0 {
+		t.Fatalf("ActiveRequests = %d after completed response, want 0", got)
+	}
+	if !account.HasActiveCooldown() || account.IsAvailable() {
+		t.Fatal("a stale WebSocket success must not clear a newer usage-limit cooldown")
 	}
 }
 
@@ -3079,7 +3162,7 @@ func TestResponses_PlainRequestNotPromotedOnRelayOnlyPool(t *testing.T) {
 	}
 }
 
-func TestResponsesRelaySuccessClearsUsageLimitCooldown(t *testing.T) {
+func TestResponsesRelaySuccessPreservesNewerUsageLimitCooldown(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	var store *auth.Store
@@ -3091,7 +3174,7 @@ func TestResponsesRelaySuccessClearsUsageLimitCooldown(t *testing.T) {
 		PlanType:     "api",
 	}
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		store.MarkCooldown(account, time.Hour, "usage_limit")
+		store.MarkCooldown(account, time.Hour, "rate_limited")
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{
 			"id":"resp_success_clears_limit",
@@ -3126,8 +3209,8 @@ func TestResponsesRelaySuccessClearsUsageLimitCooldown(t *testing.T) {
 	if recorder.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200; body=%s", recorder.Code, recorder.Body.String())
 	}
-	if account.HasActiveCooldown() || !account.IsAvailable() {
-		t.Fatal("successful relay Responses request should clear a concurrent usage-limit cooldown")
+	if !account.HasActiveCooldown() || account.IsAvailable() {
+		t.Fatal("a stale successful relay request must not clear a newer usage-limit cooldown")
 	}
 }
 

--- a/proxy/responses_ws.go
+++ b/proxy/responses_ws.go
@@ -701,7 +701,7 @@ func (h *Handler) streamResponsesWSUpstream(
 		h.store.UnbindSessionAffinity(affinityKey, account.ID())
 	} else if outcome.logStatusCode == http.StatusOK {
 		h.store.ClearModelCooldown(account, effectiveModel)
-		h.store.ConfirmResponsesAvailable(account)
+		h.store.ConfirmResponsesAvailableSince(account, start)
 		h.store.ReportRequestSuccess(account, time.Duration(totalDuration)*time.Millisecond)
 	}
 	h.store.Release(account)


### PR DESCRIPTION
## Summary

- make successful Responses evidence request-order aware
- clear an ignored usage/rate-limit cooldown only when the successful request started after the latest rate-limit event
- pass each attempt start time through the direct Responses relay, Codex HTTP/upstream-WebSocket path, and downstream WebSocket path
- add store, HTTP relay, and WebSocket concurrency regressions

## Relationship to #343

#343 introduced the "ignore usage-limit status" behavior: 5h/7d usage snapshots become informational when enabled, while actual `v1/responses` outcomes remain authoritative for account availability. It also allows a completed successful Responses request to clear a real usage-limit cooldown.

This PR is a focused correctness follow-up to that success-clearing behavior. It does not change the setting, its global/per-account precedence, or the rule that a real `429 usage_limit_reached` limits the account.

## Problem resolved

A Codex conversation can have a turn that was accepted before the quota boundary and remains `Working` while another request observes the newer limit state:

1. Request A starts and continues streaming successfully.
2. Request B receives `429 usage_limit_reached`, so the account enters cooldown.
3. Request A later finishes with `200` / `response.completed`.
4. The previous implementation unconditionally treated A as fresh availability evidence and cleared B's newer cooldown.

That reverses causal ordering: an older in-flight success reopens an account after newer upstream evidence has already said it is limited. The account can then be scheduled again for follow-ups that upstream rejects.

This PR records each request attempt's start time and only clears the cooldown when that request began after `LastRateLimitedAt`. The already-accepted Working response is still allowed to finish on its account, but its stale completion cannot override the newer 429. A later request that genuinely starts after the limit and succeeds can still restore availability under the #343 setting.

This does not attempt to bypass an actual upstream 429 for a new follow-up request.

## Tests

- `go test ./auth ./proxy -count=1`
- `go test -p 6 ./... -count=1`
- `npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented delayed successful Responses requests from clearing newer usage-limit cooldowns.
  * Preserved cooldown state consistently for both relay and WebSocket streaming requests.
  * Continued clearing cooldowns when a successful request began after the latest rate-limit evidence.

* **Tests**
  * Added coverage for delayed responses and newer usage-limit cooldown scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->