### PR TITLE
fix(wsrelay): WS 握手 401 还原为真实状态码，使用日志可见并触发账号冷却

### DIFF
--- a/proxy/ws_handshake_401_test.go
+++ b/proxy/ws_handshake_401_test.go
@@ -1,0 +1,112 @@
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/tidwall/gjson"
+
+	"github.com/codex2api/auth"
+	"github.com/codex2api/database"
+)
+
+// WS 上游握手 401 经 wsrelay 还原成真实状态码响应后，Responses 主链路必须
+// 走既有非 2xx 分支：usage log 记 401、账号按 unauthorized 冷却、对下游按
+// issue #323 约定改写为 503 account_pool_unauthorized（而不是把 401 埋进
+// transport/598）。
+func TestResponsesWebsocketHandshake401CoolsAccountAndLogs401(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	previousSettings := CurrentRuntimeSettings()
+	t.Cleanup(func() { ApplyRuntimeSettings(previousSettings) })
+	nextSettings := previousSettings
+	nextSettings.CodexForceWebsocket = true
+	ApplyRuntimeSettings(nextSettings)
+
+	previousWS := WebsocketExecuteFunc
+	t.Cleanup(func() { WebsocketExecuteFunc = previousWS })
+	upstreamBody := `{"error":{"message":"Provided authentication token is expired. Please try signing in again.","type":"invalid_request_error","code":"token_expired"}}`
+	WebsocketExecuteFunc = func(ctx context.Context, account *auth.Account, requestBody []byte, sessionID string, proxyOverride string, apiKey string, deviceCfg *DeviceProfileConfig, headers http.Header, poolRouteKey string) (*http.Response, error) {
+		// 模拟 wsrelay.ExecuteRequestWebsocket 对握手 401 的转换产物。
+		return &http.Response{
+			StatusCode: http.StatusUnauthorized,
+			Status:     "401 Unauthorized",
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(upstreamBody)),
+		}, nil
+	}
+
+	dbPath := filepath.Join(t.TempDir(), "codex2api.db")
+	db, err := database.New("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("database.New: %v", err)
+	}
+	defer db.Close()
+	db.SetUsageLogConfig("all", 1, 1)
+
+	store := auth.NewStore(nil, nil, &database.SystemSettings{
+		MaxConcurrency:      2,
+		MaxRetries:          0,
+		MaxRateLimitRetries: 0,
+	})
+	account := &auth.Account{DBID: 1, AccessToken: "expired-token", PlanType: "plus"}
+	store.AddAccount(account)
+	handler := NewHandler(store, db, nil, nil)
+
+	body := []byte(`{"model":"gpt-5.4","stream":true,"input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"hi"}]}]}`)
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Request = req
+
+	handler.Responses(ctx)
+
+	// 下游收到 503 池级错误，而不是裸 401（issue #323 语义：上游账号 401 是
+	// 账号侧问题，不能让下游误判自己的 key 失效）。具体 code 取决于收尾路径
+	// （重试耗尽 vs 无可用账号），两者都可接受。
+	if recorder.Code != http.StatusServiceUnavailable {
+		t.Fatalf("downstream status = %d, want 503; body=%s", recorder.Code, recorder.Body.String())
+	}
+	if code := gjson.GetBytes(recorder.Body.Bytes(), "error.code").String(); code != "account_pool_unauthorized" && code != "no_available_account" {
+		t.Fatalf("downstream error.code = %q, want pool-level error; body=%s", code, recorder.Body.String())
+	}
+
+	// 账号必须按 unauthorized 处置（禁用/冷却），不能留在调度池里被反复拨号。
+	if account.IsAvailable() {
+		t.Fatal("account should be disabled/cooled down after handshake 401")
+	}
+
+	// usage log 必须出现真实的 401 行（原缺陷：只会记成 598/transport 或被静默吞掉）。
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		logs, err := db.ListUsageLogsByTimeRange(context.Background(), time.Now().Add(-time.Hour), time.Now().Add(time.Hour))
+		if err != nil {
+			t.Fatalf("ListUsageLogsByTimeRange: %v", err)
+		}
+		var found bool
+		for _, l := range logs {
+			if l.StatusCode == http.StatusUnauthorized && l.Endpoint == "/v1/responses" {
+				found = true
+				if !strings.Contains(l.ErrorMessage, "token is expired") {
+					t.Fatalf("401 row error message = %q, want upstream token_expired message", l.ErrorMessage)
+				}
+			}
+		}
+		if found {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("no 401 usage log row recorded; rows=%d", len(logs))
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+}

--- a/proxy/wsrelay/executor.go
+++ b/proxy/wsrelay/executor.go
@@ -644,6 +644,13 @@ func ExecuteRequestWebsocket(ctx context.Context, account *auth.Account, request
 	exec := GetExecutor()
 	wsResp, err := exec.ExecuteRequestViaWebsocket(ctx, account, requestBody, sessionID, proxyOverride, apiKey, deviceCfg, headers, poolRouteKey)
 	if err != nil {
+		// 握手阶段的上游 401（token 失效/撤销）还原成真实状态码的 HTTP 响应返回，
+		// 而不是 transport 错误：否则 401 在使用日志里只会以 598/transport 出现，
+		// 且账号既不触发 unauthorized 冷却也不触发鉴权探针，失效账号会一直留在
+		// 调度池里被反复拨号（对比 HTTP 路径的 401 直接可见并立即冷却）。
+		if resp, ok := handshakeUnauthorizedHTTPResponse(err); ok {
+			return resp, nil
+		}
 		return nil, err
 	}
 

--- a/proxy/wsrelay/handshake_error.go
+++ b/proxy/wsrelay/handshake_error.go
@@ -3,6 +3,7 @@ package wsrelay
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -11,6 +12,42 @@ import (
 )
 
 const handshakeErrorBodyLimit = 4 << 10 // 4 KiB
+
+// HandshakeHTTPError 是握手阶段收到上游 HTTP 错误响应时的结构化错误：
+// 除人类可读的错误文本外，保留原始状态码、响应头与规范化后的 JSON body，
+// 供上层把鉴权失败（401）还原成真实状态码处理，而不是笼统的 transport 错误。
+type HandshakeHTTPError struct {
+	StatusCode int
+	Header     http.Header
+	// Body 是上游错误 body 的规范化文本（JSON 紧凑化、非 JSON 空白折叠），
+	// 可直接用 gjson 解析 error.code / error.message。
+	Body string
+	msg  string
+}
+
+func (e *HandshakeHTTPError) Error() string { return e.msg }
+
+// handshakeUnauthorizedHTTPResponse 把握手阶段的 401 转换成携带真实状态码与
+// 上游原始错误体的 HTTP 响应，让调用方复用既有非 2xx 分支：usage log 记 401、
+// applyCooldownForModel 的 unauthorized 冷却与 missing_scope 特判、换号重试。
+// 其他状态码保持原有 transport 错误语义（如 503 握手限流仍走粘滞重试），
+// 不在此转换。
+func handshakeUnauthorizedHTTPResponse(err error) (*http.Response, bool) {
+	var hs *HandshakeHTTPError
+	if !errors.As(err, &hs) || hs.StatusCode != http.StatusUnauthorized {
+		return nil, false
+	}
+	header := http.Header{}
+	if hs.Header != nil {
+		header = hs.Header.Clone()
+	}
+	return &http.Response{
+		StatusCode: hs.StatusCode,
+		Status:     fmt.Sprintf("%d %s", hs.StatusCode, http.StatusText(hs.StatusCode)),
+		Header:     header,
+		Body:       io.NopCloser(strings.NewReader(hs.Body)),
+	}, true
+}
 
 // formatDialHandshakeError 把 Dial 失败包装成可诊断的错误。
 // gorilla/websocket 在 bad handshake 时仍返回 *http.Response，并已预读最多 1KB body；
@@ -48,7 +85,12 @@ func formatDialHandshakeError(err error, resp *http.Response) error {
 		b.WriteString(":\n")
 		b.WriteString(body)
 	}
-	return fmt.Errorf("%s", b.String())
+	return &HandshakeHTTPError{
+		StatusCode: status,
+		Header:     resp.Header.Clone(),
+		Body:       body,
+		msg:        b.String(),
+	}
 }
 
 // formatFailedHandshakeHTTPBody 用于握手 HTTP 响应状态非 2xx/101 时构造 body 文本。

--- a/proxy/wsrelay/handshake_error_test.go
+++ b/proxy/wsrelay/handshake_error_test.go
@@ -1,6 +1,7 @@
 package wsrelay
 
 import (
+	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
@@ -117,4 +118,80 @@ func TestReadHTTPErrorBodyPreservesJSON(t *testing.T) {
 	if !strings.Contains(got, `"code":"token_expired"`) || !strings.Contains(got, `"message":"expired"`) {
 		t.Fatalf("unexpected body: %q", got)
 	}
+}
+
+func TestFormatDialHandshakeErrorReturnsTypedError(t *testing.T) {
+	body := `{"error":{"message":"Provided authentication token is expired.","type":"invalid_request_error","code":"token_expired"}}`
+	resp := &http.Response{
+		StatusCode: http.StatusUnauthorized,
+		Header:     http.Header{"Cf-Ray": []string{"ray-1"}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+	err := formatDialHandshakeError(websocket.ErrBadHandshake, resp)
+
+	var hs *HandshakeHTTPError
+	if !errors.As(err, &hs) {
+		t.Fatalf("expected *HandshakeHTTPError, got %T", err)
+	}
+	if hs.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("StatusCode = %d, want 401", hs.StatusCode)
+	}
+	if !strings.Contains(hs.Body, `"code":"token_expired"`) {
+		t.Fatalf("Body missing raw json: %q", hs.Body)
+	}
+	if hs.Header.Get("Cf-Ray") != "ray-1" {
+		t.Fatalf("Header not preserved: %v", hs.Header)
+	}
+}
+
+func TestHandshakeUnauthorizedHTTPResponse(t *testing.T) {
+	makeErr := func(status int, body string) error {
+		resp := &http.Response{
+			StatusCode: status,
+			Header:     http.Header{"X-Request-Id": []string{"req-1"}},
+			Body:       io.NopCloser(strings.NewReader(body)),
+		}
+		return formatDialHandshakeError(websocket.ErrBadHandshake, resp)
+	}
+
+	t.Run("401 converts to real-status response with raw body", func(t *testing.T) {
+		body := `{"error":{"message":"token expired","code":"token_expired"}}`
+		resp, ok := handshakeUnauthorizedHTTPResponse(makeErr(http.StatusUnauthorized, body))
+		if !ok {
+			t.Fatal("expected conversion for 401")
+		}
+		if resp.StatusCode != http.StatusUnauthorized {
+			t.Fatalf("StatusCode = %d, want 401", resp.StatusCode)
+		}
+		got, _ := io.ReadAll(resp.Body)
+		// body 必须是可直接 gjson 解析的上游原始错误体（供 missing_scope 特判
+		// 与 usage log 错误消息提取），不能带 "websocket handshake failed" 前缀。
+		// readHTTPErrorBody 会重排 JSON 键序，故按字段断言而非整串比对。
+		if !json.Valid(got) {
+			t.Fatalf("body is not valid json: %q", got)
+		}
+		if !strings.Contains(string(got), `"code":"token_expired"`) || !strings.Contains(string(got), `"message":"token expired"`) {
+			t.Fatalf("body missing upstream error fields: %q", got)
+		}
+		if resp.Header.Get("X-Request-Id") != "req-1" {
+			t.Fatalf("header not preserved: %v", resp.Header)
+		}
+	})
+
+	t.Run("non-401 handshake statuses keep transport error semantics", func(t *testing.T) {
+		for _, status := range []int{http.StatusForbidden, http.StatusTooManyRequests, http.StatusServiceUnavailable} {
+			if _, ok := handshakeUnauthorizedHTTPResponse(makeErr(status, `{"error":{"message":"x"}}`)); ok {
+				t.Fatalf("status %d should not convert", status)
+			}
+		}
+	})
+
+	t.Run("plain errors pass through", func(t *testing.T) {
+		if _, ok := handshakeUnauthorizedHTTPResponse(errors.New("dial tcp timeout")); ok {
+			t.Fatal("plain error should not convert")
+		}
+		if _, ok := handshakeUnauthorizedHTTPResponse(formatDialHandshakeError(errors.New("dial tcp timeout"), nil)); ok {
+			t.Fatal("no-response handshake error should not convert")
+		}
+	})
 }

--- a/proxy/wsrelay/manager_test.go
+++ b/proxy/wsrelay/manager_test.go
@@ -2,8 +2,12 @@ package wsrelay
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
+	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -450,5 +454,51 @@ func TestLookupResponseConnIsolatesAPIKeys(t *testing.T) {
 	}
 	if got, _ := manager.lookupResponseConn("resp_owned", 7, "key-A"); got != wc {
 		t.Fatal("owner api key must hit")
+	}
+}
+
+// 上游对 WS upgrade 回 401 时，结构化握手错误必须原样穿透 AcquireConnection
+// 的传播链（不被二次包装），执行器才能把它还原成真实状态码的 HTTP 响应；
+// 否则 401 在使用日志里只会以 transport/598 出现且账号不触发 unauthorized 冷却。
+func TestAcquireConnectionDial401ReturnsTypedHandshakeError(t *testing.T) {
+	upstreamBody := `{"error":{"message":"Provided authentication token is expired.","type":"invalid_request_error","code":"token_expired"}}`
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(upstreamBody))
+	}))
+	defer upstream.Close()
+
+	manager := NewManager()
+	t.Cleanup(manager.Stop)
+
+	account := &auth.Account{DBID: 42}
+	wsURL := strings.Replace(upstream.URL, "http://", "ws://", 1)
+
+	_, _, err := manager.AcquireConnection(context.Background(), account, wsURL, "session-1", http.Header{}, "")
+	if err == nil {
+		t.Fatal("expected handshake error")
+	}
+
+	var hs *HandshakeHTTPError
+	if !errors.As(err, &hs) {
+		t.Fatalf("expected *HandshakeHTTPError to survive propagation, got %T: %v", err, err)
+	}
+	if hs.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("StatusCode = %d, want 401", hs.StatusCode)
+	}
+
+	resp, ok := handshakeUnauthorizedHTTPResponse(err)
+	if !ok {
+		t.Fatal("expected 401 handshake error to convert to HTTP response")
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("converted StatusCode = %d, want 401", resp.StatusCode)
+	}
+	got, _ := io.ReadAll(resp.Body)
+	// readHTTPErrorBody 会重排 JSON 键序，按字段断言。
+	if !strings.Contains(string(got), `"code":"token_expired"`) || strings.Contains(string(got), "websocket handshake failed") {
+		t.Fatalf("converted body should be raw upstream json, got %q", got)
 	}
 }


### PR DESCRIPTION
## 问题
WS 模式下上游 401 完全不可见：握手阶段的 HTTP 401 被 `formatDialHandshakeError` 包装成纯文本 transport 错误，使用日志里只会以 598/transport 出现（或被静默重试掩盖）。账号既不触发 unauthorized 冷却，也不触发鉴权探针——token 失效的账号会一直留在调度池里被反复拨号。

强制 WS 的部署里，只有走 HTTP 的显式 `/v1/responses/compact` 能把 401 显影出来，表现为「401 全部集中在 compact 端点」的观测偏差。

## 修复
- `formatDialHandshakeError` 返回结构化 `HandshakeHTTPError`（状态码 / 响应头 / 规范化 JSON body），`Error()` 文本保持不变，测试连接等既有消费方不受影响
- `ExecuteRequestWebsocket` 识别握手 401 后转换成携带真实状态码与上游原始错误体的 HTTP 响应，上层复用既有非 2xx 分支：usage log 记 401、`applyCooldownForModel` 的 unauthorized 冷却与 missing_scope 特判、换号重试
- 刻意只转换 401：403/429/503 握手失败保持原有 transport 语义（503 握手限流仍走粘滞重试）
- 连接存续期间的 close 1008 已有 `VerifyAccountAuthAsync` 探针兜底，不在本次范围

## 测试
- 单元：结构化错误字段保留、401 转换产物为可 gjson 解析的原始上游 body、非 401 / 纯错误不转换
- 集成：httptest 真实拨号 401，验证类型化错误穿透 `AcquireConnection` 传播链不被二次包装
- 端到端：强制 WS 下握手 401 → usage log 出现带 token_expired 消息的 401 行、账号被冷却、下游收到 503 池级错误而非裸 401（issue #323 语义保持）
- `go build ./...` + `go test ./proxy/...` 全部通过

## 备注
与 #377 都触及 `wsrelay`（#377 改 manager.go，本 PR 改 executor.go/handshake_error.go），后合入的一方可能需要小幅 rebase。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * WebSocket requests with expired or unauthorized upstream credentials now return the appropriate account-pool response instead of an unexpected transport error.
  * Affected accounts are placed on cooldown or disabled, helping prevent repeated failed requests.
  * Unauthorized responses preserve the upstream status, headers, and error details for improved logging and handling.
  * Usage logs now record the underlying HTTP 401 error and expiration message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->