### PR TITLE
fix(admin): /models/sync 遵循全局 ProxyURL (issue #371)

### DIFF
--- a/admin/handler.go
+++ b/admin/handler.go
@@ -8226,7 +8226,11 @@ func (h *Handler) SyncModels(c *gin.Context) {
 	ctx, cancel := context.WithTimeout(c.Request.Context(), 15*time.Second)
 	defer cancel()
 
-	result, err := proxy.SyncOfficialCodexModels(ctx, h.db)
+	proxyURL := ""
+	if h.store != nil {
+		proxyURL = h.store.GetProxyURL()
+	}
+	result, err := proxy.SyncOfficialCodexModels(ctx, h.db, proxyURL)
 	if err != nil {
 		writeError(c, http.StatusBadGateway, err.Error())
 		return

--- a/proxy/model_registry.go
+++ b/proxy/model_registry.go
@@ -466,11 +466,13 @@ func isAllowedUpstreamCodexModel(id string) bool {
 }
 
 // SyncOfficialCodexModels fetches the fixed official docs page and merges discovered models.
-func SyncOfficialCodexModels(ctx context.Context, db *database.DB) (*ModelSyncResult, error) {
+// proxyURL 为全局出站代理（可为空串直连）：官方模型页与其他上游链路一样可能
+// 被网络环境阻断，同步请求必须遵循全局 ProxyURL（issue #371）。
+func SyncOfficialCodexModels(ctx context.Context, db *database.DB, proxyURL string) (*ModelSyncResult, error) {
 	if db == nil {
 		return nil, fmt.Errorf("数据库不可用，无法同步模型注册表")
 	}
-	client := &http.Client{Timeout: 10 * time.Second}
+	client := &http.Client{Transport: newCodexStandardTransport(proxyURL), Timeout: 10 * time.Second}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, OfficialCodexModelsURL, nil)
 	if err != nil {
 		return nil, err

--- a/proxy/model_registry_test.go
+++ b/proxy/model_registry_test.go
@@ -2,8 +2,12 @@ package proxy
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"path/filepath"
 	"slices"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -305,5 +309,58 @@ func TestIsAllowedUpstreamCodexModel_Policy(t *testing.T) {
 		if got := isAllowedUpstreamCodexModel(id); got != want {
 			t.Errorf("isAllowedUpstreamCodexModel(%q) = %v, want %v", id, got, want)
 		}
+	}
+}
+
+// /models/sync 的出站请求必须遵循全局 ProxyURL（issue #371）：官方模型页
+// （https）经 HTTP 代理访问时表现为一次 CONNECT。这里用假代理记录 CONNECT
+// 目标来证明请求真的走了代理，而不是直连。
+func TestSyncOfficialCodexModelsUsesGlobalProxy(t *testing.T) {
+	db := newTestModelRegistryDB(t)
+
+	var mu sync.Mutex
+	var connectHosts []string
+	fakeProxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		if r.Method == http.MethodConnect {
+			connectHosts = append(connectHosts, r.URL.Host)
+		}
+		mu.Unlock()
+		// 拒绝隧道，令同步以网络错误结束——本测试只关心流量是否经过代理。
+		http.Error(w, "tunnel rejected by test proxy", http.StatusBadGateway)
+	}))
+	defer fakeProxy.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err := SyncOfficialCodexModels(ctx, db, fakeProxy.URL)
+	if err == nil {
+		t.Fatal("expected sync to fail through rejecting test proxy")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(connectHosts) == 0 {
+		t.Fatal("sync request bypassed the configured global proxy (no CONNECT observed)")
+	}
+	wantHost := "developers.openai.com:443"
+	if connectHosts[0] != wantHost {
+		t.Fatalf("CONNECT host = %q, want %q", connectHosts[0], wantHost)
+	}
+}
+
+// 空 proxyURL 保持直连语义：请求应命中目标站点本身（用可覆盖 URL 不可行，
+// 官方 URL 是常量——退而验证空代理不会因代理配置失败而报错，走到网络阶段）。
+func TestSyncOfficialCodexModelsEmptyProxyStillAttempts(t *testing.T) {
+	db := newTestModelRegistryDB(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	// 极短超时：无论网络环境如何都快速返回；断言错误是网络类而非参数类。
+	_, err := SyncOfficialCodexModels(ctx, db, "")
+	if err == nil {
+		return // 网络环境好到 50ms 内完成同步也算通过
+	}
+	if !strings.Contains(err.Error(), "官方模型页面") {
+		t.Fatalf("unexpected error kind: %v", err)
 	}
 }


### PR DESCRIPTION
## 问题
issue #371：`/api/admin/models/sync` 链路里 `SyncOfficialCodexModels` 用裸 `http.Client{Timeout: 10s}` 直连 https://developers.openai.com/codex/models，没有接入全局 ProxyURL——其他上游链路（账号刷新、Codex 请求、CLI 版本同步、定价同步）都走代理，唯独模型同步漏了。

## 修复
- `SyncOfficialCodexModels(ctx, db)` → `SyncOfficialCodexModels(ctx, db, proxyURL)`，复用 `newCodexStandardTransport`（与 `SyncCodexCLIVersion`/定价同步同一套：代理配置失败时日志告警并回退直连）
- 管理端 `SyncModels` 传入 `h.store.GetProxyURL()`，与旁边 `SyncCodexCLIVersion` 处理方式完全一致
- 该函数只有管理端按钮一个调用方，无后台自动同步循环，改动面即全部

## 测试
- 新增 `TestSyncOfficialCodexModelsUsesGlobalProxy`：假 HTTP 代理记录 CONNECT 目标，断言同步请求确实经代理访问 `developers.openai.com:443` 而非直连
- 新增空 proxyURL 直连语义回归
- `go build ./...` + `go test ./proxy/... ./admin/...` 全部通过

Closes #371

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Model synchronization now respects the configured proxy when connecting to the official model service.
  * Synchronization continues to handle direct connections when no proxy is configured.
  * Improved connection behavior provides clearer failures for unreachable model services.

* **Tests**
  * Added coverage for proxied and direct model synchronization scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->