### PR TITLE
fix(proxy): 账号维护类请求接入 Resin 反代 (issue #372)

### DIFF
--- a/proxy/resin.go
+++ b/proxy/resin.go
@@ -45,6 +45,19 @@ func IsResinEnabled() bool {
 	return GetResinConfig() != nil
 }
 
+// resinMaintenanceTarget 为账号维护类旁路请求（wham 用量/重置券/订阅到期查询）
+// 决定最终 URL 与客户端。这类请求与 /responses 一样携带账号身份打 chatgpt.com，
+// Resin 启用时必须同样经反代访问并复用 Resin 连接池，否则全部账号共享本机
+// 出口 IP 直连（issue #372）。返回 viaResin=true 时调用方需在请求头设置
+// X-Resin-Account；未启用时返回原 URL 与 nil 客户端，由调用方按既有直连
+// transport 兜底。
+func resinMaintenanceTarget(account *auth.Account, targetURL string) (finalURL string, client *http.Client, viaResin bool) {
+	if !IsResinEnabled() || account == nil {
+		return targetURL, nil, false
+	}
+	return BuildReverseProxyURL(targetURL), getResinHTTPClient(account), true
+}
+
 // ==================== 反向代理 URL 构建 ====================
 
 // BuildReverseProxyURL 将目标 URL 转换为 Resin 反向代理 URL

--- a/proxy/subscription_sync.go
+++ b/proxy/subscription_sync.go
@@ -96,14 +96,17 @@ func QueryChatGPTSubscription(ctx context.Context, account *auth.Account, proxyU
 
 	endpoint := ChatGPTSubscriptionsURL
 	// 网页端点必须用 uTLS Chrome 指纹，与网关的 transport 模式配置无关。
-	transport := NewUTLSTransport(proxyURL)
+	transport := http.RoundTripper(NewUTLSTransport(proxyURL))
 	if subscriptionsURLForTest != "" {
 		endpoint = subscriptionsURLForTest
 		// 测试用 httptest（明文 HTTP），uTLS 拨号无法使用，回退标准 transport。
 		transport = newCodexStandardTransport(proxyURL)
 	}
+	// Resin 启用时经反代访问（指纹由 Resin 侧承担），与其他账号维护请求一致，
+	// 避免全部账号共享本机出口 IP 直连（issue #372）。
+	finalURL, resinClient, viaResin := resinMaintenanceTarget(account, endpoint)
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint+"?account_id="+url.QueryEscape(accountID), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, finalURL+"?account_id="+url.QueryEscape(accountID), nil)
 	if err != nil {
 		return nil, fmt.Errorf("build subscriptions request: %w", err)
 	}
@@ -112,8 +115,14 @@ func QueryChatGPTSubscription(ctx context.Context, account *auth.Account, proxyU
 	req.Header.Set("Origin", "https://chatgpt.com")
 	req.Header.Set("Referer", "https://chatgpt.com/")
 	req.Header.Set("User-Agent", subscriptionsBrowserUserAgent)
+	if viaResin {
+		req.Header.Set("X-Resin-Account", ResinAccountID(account))
+	}
 
-	client := &http.Client{Transport: transport}
+	client := resinClient
+	if client == nil {
+		client = &http.Client{Transport: transport}
+	}
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("subscriptions request: %w", err)

--- a/proxy/subscription_sync_test.go
+++ b/proxy/subscription_sync_test.go
@@ -193,3 +193,33 @@ func TestMaybeSyncSubscriptionExpiry_SkipsPastActiveUntil(t *testing.T) {
 		t.Fatalf("SubscriptionExpiresAt = %v, want zero", account.SubscriptionExpiresAt)
 	}
 }
+
+// Resin 启用时订阅到期查询也必须经反代（issue #372），指纹由 Resin 侧承担。
+func TestQueryChatGPTSubscriptionRoutesThroughResin(t *testing.T) {
+	var gotPath, gotResinAccount, gotAccountIDQuery string
+	fakeResin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotResinAccount = r.Header.Get("X-Resin-Account")
+		gotAccountIDQuery = r.URL.Query().Get("account_id")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer fakeResin.Close()
+
+	SetResinConfig(&ResinConfig{BaseURL: fakeResin.URL, PlatformName: "test"})
+	t.Cleanup(func() { SetResinConfig(nil) })
+
+	account := &auth.Account{DBID: 11, AccessToken: "at-11", AccountID: testWorkspaceUUID}
+	if _, err := QueryChatGPTSubscription(context.Background(), account, ""); err != nil {
+		t.Fatalf("QueryChatGPTSubscription error: %v", err)
+	}
+	if want := "/test/https/chatgpt.com/backend-api/subscriptions"; gotPath != want {
+		t.Fatalf("resin path = %q, want %q", gotPath, want)
+	}
+	if gotResinAccount != "11" {
+		t.Fatalf("X-Resin-Account = %q, want %q", gotResinAccount, "11")
+	}
+	if gotAccountIDQuery != testWorkspaceUUID {
+		t.Fatalf("account_id query = %q, want workspace uuid", gotAccountIDQuery)
+	}
+}

--- a/proxy/usage_wham.go
+++ b/proxy/usage_wham.go
@@ -169,7 +169,8 @@ func queryWhamUsageWithURL(ctx context.Context, account *auth.Account, proxyURL,
 		return nil, nil, fmt.Errorf("account has no access token")
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	finalURL, resinClient, viaResin := resinMaintenanceTarget(account, url)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, finalURL, nil)
 	if err != nil {
 		return nil, nil, fmt.Errorf("build wham request: %w", err)
 	}
@@ -182,10 +183,17 @@ func queryWhamUsageWithURL(ctx context.Context, account *auth.Account, proxyURL,
 	if accountID := account.EffectiveAccountID(); accountID != "" {
 		req.Header.Set("chatgpt-account-id", accountID)
 	}
+	if viaResin {
+		req.Header.Set("X-Resin-Account", ResinAccountID(account))
+	}
 
-	// 复用网关同款 transport（支持 uTLS Chrome 指纹），而非裸标准 transport，
-	// 让 wham 查询与 /responses 走一致的 TLS 指纹，降低被 Cloudflare 拦截的概率。
-	client := &http.Client{Transport: newCodexTransport(proxyURL)}
+	// Resin 未启用时复用网关同款 transport（支持 uTLS Chrome 指纹），而非裸标准
+	// transport，让 wham 查询与 /responses 走一致的 TLS 指纹，降低被 Cloudflare
+	// 拦截的概率。
+	client := resinClient
+	if client == nil {
+		client = &http.Client{Transport: newCodexTransport(proxyURL)}
+	}
 
 	resp, err := client.Do(req)
 	if err != nil {
@@ -285,7 +293,8 @@ func queryWhamResetCreditsWithURL(ctx context.Context, account *auth.Account, pr
 		return nil, nil, fmt.Errorf("account has no access token")
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	finalURL, resinClient, viaResin := resinMaintenanceTarget(account, url)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, finalURL, nil)
 	if err != nil {
 		return nil, nil, fmt.Errorf("build reset-credits list request: %w", err)
 	}
@@ -297,8 +306,14 @@ func queryWhamResetCreditsWithURL(ctx context.Context, account *auth.Account, pr
 	if accountID := account.EffectiveAccountID(); accountID != "" {
 		req.Header.Set("chatgpt-account-id", accountID)
 	}
+	if viaResin {
+		req.Header.Set("X-Resin-Account", ResinAccountID(account))
+	}
 
-	client := &http.Client{Transport: newCodexTransport(proxyURL)}
+	client := resinClient
+	if client == nil {
+		client = &http.Client{Transport: newCodexTransport(proxyURL)}
+	}
 
 	resp, err := client.Do(req)
 	if err != nil {
@@ -371,7 +386,8 @@ func consumeResetCreditWithURL(ctx context.Context, account *auth.Account, proxy
 	}
 	payload, _ := json.Marshal(map[string]string{"redeem_request_id": redeemRequestID})
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload))
+	finalURL, resinClient, viaResin := resinMaintenanceTarget(account, url)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, finalURL, bytes.NewReader(payload))
 	if err != nil {
 		return nil, nil, fmt.Errorf("build reset-credit request: %w", err)
 	}
@@ -384,9 +400,15 @@ func consumeResetCreditWithURL(ctx context.Context, account *auth.Account, proxy
 	if accountID := account.EffectiveAccountID(); accountID != "" {
 		req.Header.Set("chatgpt-account-id", accountID)
 	}
+	if viaResin {
+		req.Header.Set("X-Resin-Account", ResinAccountID(account))
+	}
 
-	// 与 wham 查询、/responses 一致的 transport（支持 uTLS Chrome 指纹）。
-	client := &http.Client{Transport: newCodexTransport(proxyURL)}
+	// Resin 未启用时用与 wham 查询、/responses 一致的 transport（支持 uTLS Chrome 指纹）。
+	client := resinClient
+	if client == nil {
+		client = &http.Client{Transport: newCodexTransport(proxyURL)}
+	}
 
 	resp, err := client.Do(req)
 	if err != nil {

--- a/proxy/usage_wham.go
+++ b/proxy/usage_wham.go
@@ -160,6 +160,18 @@ func QueryWhamUsage(ctx context.Context, account *auth.Account, proxyURL string)
 	return queryWhamUsageWithURL(ctx, account, proxyURL, url)
 }
 
+// whamHTTPClient 是 wham 三个端点共用的 Resin/直连选择：viaResin 时设置
+// X-Resin-Account 并复用按账号隔离的 Resin 连接池；否则回退网关同款
+// transport（支持 uTLS Chrome 指纹），让 wham 请求与 /responses 走一致的
+// TLS 指纹，降低被 Cloudflare 拦截的概率。
+func whamHTTPClient(req *http.Request, account *auth.Account, resinClient *http.Client, viaResin bool, proxyURL string) *http.Client {
+	if viaResin {
+		req.Header.Set("X-Resin-Account", ResinAccountID(account))
+		return resinClient
+	}
+	return &http.Client{Transport: newCodexTransport(proxyURL)}
+}
+
 func queryWhamUsageWithURL(ctx context.Context, account *auth.Account, proxyURL, url string) (*WhamUsage, *http.Response, error) {
 	if account == nil {
 		return nil, nil, fmt.Errorf("account is nil")
@@ -183,17 +195,7 @@ func queryWhamUsageWithURL(ctx context.Context, account *auth.Account, proxyURL,
 	if accountID := account.EffectiveAccountID(); accountID != "" {
 		req.Header.Set("chatgpt-account-id", accountID)
 	}
-	if viaResin {
-		req.Header.Set("X-Resin-Account", ResinAccountID(account))
-	}
-
-	// Resin 未启用时复用网关同款 transport（支持 uTLS Chrome 指纹），而非裸标准
-	// transport，让 wham 查询与 /responses 走一致的 TLS 指纹，降低被 Cloudflare
-	// 拦截的概率。
-	client := resinClient
-	if client == nil {
-		client = &http.Client{Transport: newCodexTransport(proxyURL)}
-	}
+	client := whamHTTPClient(req, account, resinClient, viaResin, proxyURL)
 
 	resp, err := client.Do(req)
 	if err != nil {
@@ -306,14 +308,7 @@ func queryWhamResetCreditsWithURL(ctx context.Context, account *auth.Account, pr
 	if accountID := account.EffectiveAccountID(); accountID != "" {
 		req.Header.Set("chatgpt-account-id", accountID)
 	}
-	if viaResin {
-		req.Header.Set("X-Resin-Account", ResinAccountID(account))
-	}
-
-	client := resinClient
-	if client == nil {
-		client = &http.Client{Transport: newCodexTransport(proxyURL)}
-	}
+	client := whamHTTPClient(req, account, resinClient, viaResin, proxyURL)
 
 	resp, err := client.Do(req)
 	if err != nil {
@@ -400,15 +395,7 @@ func consumeResetCreditWithURL(ctx context.Context, account *auth.Account, proxy
 	if accountID := account.EffectiveAccountID(); accountID != "" {
 		req.Header.Set("chatgpt-account-id", accountID)
 	}
-	if viaResin {
-		req.Header.Set("X-Resin-Account", ResinAccountID(account))
-	}
-
-	// Resin 未启用时用与 wham 查询、/responses 一致的 transport（支持 uTLS Chrome 指纹）。
-	client := resinClient
-	if client == nil {
-		client = &http.Client{Transport: newCodexTransport(proxyURL)}
-	}
+	client := whamHTTPClient(req, account, resinClient, viaResin, proxyURL)
 
 	resp, err := client.Do(req)
 	if err != nil {

--- a/proxy/usage_wham_test.go
+++ b/proxy/usage_wham_test.go
@@ -1061,3 +1061,61 @@ func TestConsumeResetCreditParsed_NonOKReturnsRespForCaller(t *testing.T) {
 		t.Error("expected error body to remain readable for caller")
 	}
 }
+
+// Resin 启用时，wham 用量查询必须经 Resin 反代并携带 X-Resin-Account，
+// 而不是直连 chatgpt.com（issue #372：账号维护请求漏接 Resin，
+// 大量账号会共享本机出口 IP）。
+func TestQueryWhamUsageRoutesThroughResin(t *testing.T) {
+	var gotPath, gotResinAccount string
+	fakeResin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotResinAccount = r.Header.Get("X-Resin-Account")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"plan_type":"plus"}`))
+	}))
+	defer fakeResin.Close()
+
+	SetResinConfig(&ResinConfig{BaseURL: fakeResin.URL, PlatformName: "test"})
+	t.Cleanup(func() { SetResinConfig(nil) })
+
+	account := &auth.Account{DBID: 7, AccessToken: "at-7"}
+	usage, _, err := QueryWhamUsage(context.Background(), account, "")
+	if err != nil {
+		t.Fatalf("QueryWhamUsage error: %v", err)
+	}
+	if usage == nil || usage.PlanType != "plus" {
+		t.Fatalf("unexpected usage result: %+v", usage)
+	}
+	if want := "/test/https/chatgpt.com/backend-api/wham/usage"; gotPath != want {
+		t.Fatalf("resin path = %q, want %q", gotPath, want)
+	}
+	if gotResinAccount != "7" {
+		t.Fatalf("X-Resin-Account = %q, want %q", gotResinAccount, "7")
+	}
+}
+
+// 重置券列表/消费与 wham 查询同一套请求形态，同样必须走 Resin。
+func TestConsumeResetCreditRoutesThroughResin(t *testing.T) {
+	var gotPath, gotResinAccount string
+	fakeResin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotResinAccount = r.Header.Get("X-Resin-Account")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer fakeResin.Close()
+
+	SetResinConfig(&ResinConfig{BaseURL: fakeResin.URL, PlatformName: "test"})
+	t.Cleanup(func() { SetResinConfig(nil) })
+
+	account := &auth.Account{DBID: 9, AccessToken: "at-9"}
+	if _, _, err := ConsumeResetCreditParsed(context.Background(), account, "", "req-1"); err != nil {
+		t.Fatalf("ConsumeResetCreditParsed error: %v", err)
+	}
+	if want := "/test/https/chatgpt.com/backend-api/wham/rate-limit-reset-credits/consume"; gotPath != want {
+		t.Fatalf("resin path = %q, want %q", gotPath, want)
+	}
+	if gotResinAccount != "9" {
+		t.Fatalf("X-Resin-Account = %q, want %q", gotResinAccount, "9")
+	}
+}

--- a/proxy/usage_wham_test.go
+++ b/proxy/usage_wham_test.go
@@ -1119,3 +1119,29 @@ func TestConsumeResetCreditRoutesThroughResin(t *testing.T) {
 		t.Fatalf("X-Resin-Account = %q, want %q", gotResinAccount, "9")
 	}
 }
+
+// 重置券列表端点同样必须走 Resin（与用量查询/消费保持三端点全覆盖）。
+func TestQueryWhamResetCreditsRoutesThroughResin(t *testing.T) {
+	var gotPath, gotResinAccount string
+	fakeResin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotResinAccount = r.Header.Get("X-Resin-Account")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"credits":[]}`))
+	}))
+	defer fakeResin.Close()
+
+	SetResinConfig(&ResinConfig{BaseURL: fakeResin.URL, PlatformName: "test"})
+	t.Cleanup(func() { SetResinConfig(nil) })
+
+	account := &auth.Account{DBID: 13, AccessToken: "at-13"}
+	if _, _, err := QueryWhamResetCredits(context.Background(), account, ""); err != nil {
+		t.Fatalf("QueryWhamResetCredits error: %v", err)
+	}
+	if want := "/test/https/chatgpt.com/backend-api/wham/rate-limit-reset-credits"; gotPath != want {
+		t.Fatalf("resin path = %q, want %q", gotPath, want)
+	}
+	if gotResinAccount != "13" {
+		t.Fatalf("X-Resin-Account = %q, want %q", gotResinAccount, "13")
+	}
+}


### PR DESCRIPTION
## 问题
issue #372：配置了 Resin 后，AI 请求正常走反代，但**账号用量更新走本地直连**——大量账号共享同一出口 IP 直连 OpenAI。

排查后漏接 Resin 的不止用量查询，共 4 处携带账号身份打 chatgpt.com 的维护类调用：
- `QueryWhamUsage`（/backend-api/wham/usage 用量查询，issue 报告的现象）
- `QueryWhamResetCredits`（重置券明细）
- `ConsumeResetCreditParsed`（重置券消费）
- `QueryChatGPTSubscription`（订阅到期查询，issue #360 引入）

## 修复
新增 `resinMaintenanceTarget` 辅助函数，四处调用点统一接入与 executor 主链路同款的 Resin 三件套：
- URL 改写为反代地址（`BuildReverseProxyURL`）
- 复用按账号隔离的 Resin 连接池（`getResinHTTPClient`）
- 请求头携带 `X-Resin-Account`

Resin 未启用时行为完全不变（wham 走 uTLS 指纹 transport、订阅查询走 uTLS Chrome 指纹、测试 URL 回退标准 transport）。

## 测试
- 新增 3 个假 Resin 服务测试：断言用量查询/重置券消费/订阅查询的请求路径为 `/<platform>/https/chatgpt.com/...` 反代格式且携带正确的 `X-Resin-Account`
- `go build ./...` + `go test ./proxy/... ./admin/...` 全部通过

Closes #372

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Maintenance-related subscription, usage (WHAM), and credit-reset requests can now be routed through the configured Resin service.
  * Resin-routed requests include the correct `X-Resin-Account` header for account-aware processing.

* **Bug Fixes**
  * When Resin is enabled, requests are constructed to target the correct proxied URL; when not enabled, existing direct behavior is preserved.

* **Tests**
  * Added coverage to verify Resin routing for subscriptions and WHAM endpoints, including expected paths and headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->