### PR TITLE
fix: adapt optional Codex 5h usage windows

### DIFF
--- a/admin/test_connection.go
+++ b/admin/test_connection.go
@@ -230,10 +230,6 @@ func (h *Handler) TestConnection(c *gin.Context) {
 					}
 				}
 			}
-			// 如果上游未返回用量头，清除旧的用量缓存，避免显示过期数据
-			if !isOpenAIResponsesAccount && !usageState.HasUsage7d && !usageState.HasUsage5h {
-				account.ClearUsageCache()
-			}
 			duration := time.Since(start).Milliseconds()
 			sendTestEvent(c, testEvent{
 				Type: "content",
@@ -942,13 +938,6 @@ func (h *Handler) runSingleBatchTest(ctx context.Context, acc *auth.Account) (st
 		status, msg := h.readBatchTestStreamResult(testCtx, acc, resp, testModel)
 		if status != "success" {
 			return status, msg
-		}
-		if !acc.IsOpenAIResponsesAPI() {
-			if _, hasUsage7d := acc.GetUsagePercent7d(); !hasUsage7d {
-				if _, _, hasUsage5h := acc.GetUsageSnapshot5h(); !hasUsage5h {
-					acc.ClearUsageCache()
-				}
-			}
 		}
 		// 测试成功即重置失败/冷却状态，用量限制由调度器自行判断
 		h.store.RecordManualTestSuccess(acc, time.Since(start))

--- a/admin/usage_probe.go
+++ b/admin/usage_probe.go
@@ -75,6 +75,7 @@ func (h *Handler) ProbeUsageSnapshot(ctx context.Context, account *auth.Account)
 // 「主动重置次数」与用量快照，不上报成功、也不清除冷却（冷却解除交给恢复探针/到期判断），
 // 避免把一次额度查询误判为账号已恢复。
 func (h *Handler) probeUsageViaWham(ctx context.Context, account *auth.Account, limited bool) error {
+	probeStartedAt := time.Now()
 	usage, resp, err := proxy.QueryWhamUsage(ctx, account, h.store.ResolveProxyForAccount(account))
 	if resp != nil {
 		// QueryWhamUsage 在非 200 时不会读 body；这里读取一小段用于账号错误详情。
@@ -106,12 +107,18 @@ func (h *Handler) probeUsageViaWham(ctx context.Context, account *auth.Account, 
 			// not clear a cooldown established by a real Responses failure.
 			return nil
 		}
+		if !state.HasUsage5h && !state.HasUsage7d && !state.Cleared5h {
+			// An empty/malformed WHAM payload is not evidence that a cooldown
+			// ended. Preserve the existing source state and let the next probe
+			// retry with a complete response.
+			return nil
+		}
 		// 限流/冷却态下，用 wham 返回的权威用量窗口重新判定：
 		// 若上游已重置窗口、不再限流（例如官方提前重置了 5h/7d 用量），
 		// 则主动解除限流冷却，无需等待冷却到期或用户手动测试连接。
 		// 仍不调用 ReportRequestSuccess，避免把一次零成本额度查询计入健康成功样本。
 		if !applyUsageLimitedAccountState(h.store, account, state) {
-			h.store.ClearCooldown(account)
+			h.store.ClearUsageLimitCooldownSince(account, probeStartedAt)
 			log.Printf("[账号 %d] wham 显示限流窗口已重置，自动解除限流冷却", account.DBID)
 		}
 		return nil
@@ -119,7 +126,9 @@ func (h *Handler) probeUsageViaWham(ctx context.Context, account *auth.Account, 
 	h.store.ReportRequestSuccess(account, 0)
 	// 用量未耗尽时重置冷却
 	if !applyUsageLimitedAccountState(h.store, account, state) {
-		h.store.ClearCooldown(account)
+		if state.HasUsage5h || state.HasUsage7d || state.Cleared5h {
+			h.store.ClearUsageLimitCooldownSince(account, probeStartedAt)
+		}
 	}
 	return nil
 }
@@ -127,6 +136,7 @@ func (h *Handler) probeUsageViaWham(ctx context.Context, account *auth.Account, 
 // probeUsageViaResponses 原有探针：发送最小 /responses 请求，
 // 通过响应头同步 Codex 用量状态。会真实消耗少量 token。
 func (h *Handler) probeUsageViaResponses(ctx context.Context, account *auth.Account) error {
+	probeStartedAt := time.Now()
 	payload := buildConnectionTestPayload(h.store, h.store.GetTestModel())
 	resp, err := proxy.ExecuteRequest(ctx, account, payload, "", h.store.ResolveProxyForAccount(account), "", nil, nil)
 	if err != nil {
@@ -143,7 +153,7 @@ func (h *Handler) probeUsageViaResponses(ctx context.Context, account *auth.Acco
 		h.store.ReportRequestSuccess(account, 0)
 		// 只有用量未耗尽时才重置状态
 		if !applyUsageLimitedAccountState(h.store, account, usageState) {
-			h.store.ClearCooldown(account)
+			h.store.ClearUsageLimitCooldownSince(account, probeStartedAt)
 		}
 		return nil
 	case http.StatusUnauthorized:

--- a/auth/cooldown_cache_test.go
+++ b/auth/cooldown_cache_test.go
@@ -65,6 +65,22 @@ func TestFastSchedulerSkipsCachedAccountCooldown(t *testing.T) {
 	}
 }
 
+func TestCachedPremium5hCooldownHydratesRiskyTier(t *testing.T) {
+	tokenCache := cache.NewMemory(4)
+	defer tokenCache.Close()
+
+	account := newFastSchedulerTestAccount(9, HealthTierHealthy, 100, 1)
+	store := &Store{accounts: []*Account{account}, maxConcurrency: 1, tokenCache: tokenCache}
+	store.setCachedAccountCooldown(account.DBID, "rate_limited_5h", time.Now().Add(time.Hour))
+
+	if !store.accountHasCachedCooldown(account) {
+		t.Fatal("accountHasCachedCooldown() = false, want true")
+	}
+	if got := account.GetSchedulerDebugSnapshot(1).HealthTier; got != string(HealthTierRisky) {
+		t.Fatalf("hydrated health tier = %q, want %q", got, HealthTierRisky)
+	}
+}
+
 func TestStoreSkipsCachedModelCooldown(t *testing.T) {
 	tokenCache := cache.NewMemory(4)
 	defer tokenCache.Close()

--- a/auth/premium_rate_limit.go
+++ b/auth/premium_rate_limit.go
@@ -9,6 +9,7 @@ import (
 )
 
 const premium5hFallbackWindow = 5 * time.Hour
+const premium5hCooldownReason = "rate_limited_5h"
 
 // NormalizePlanType canonicalizes a plan string for behavior-level comparisons.
 // OpenAI reports the $100 Pro tier as "prolite"; functionally it is a Pro plan
@@ -136,13 +137,126 @@ func (s *Store) PersistUsageSnapshot5hOnly(acc *Account) {
 	}
 }
 
-// MarkPremium5hRateLimited 将账号标记为 premium 5h 限流态，并按 resetAt 驱动恢复。
-func (s *Store) MarkPremium5hRateLimited(acc *Account, resetAt time.Time) {
-	if acc == nil || s == nil {
-		return
+// ClearAbsentUsageSnapshot5h 在上游权威探测未返回 5h 窗口时清除本地 5h 快照。
+// 内存与 credentials 一并清掉（避免「内存无、库里有」重启后重新 hydrate）。
+// 若清理前处于 premium 5h 限流态，同步清除由此驱动的 cooldown。
+// 返回 true 表示清理前本地确实持有有效 5h 快照（或 premium 5h 限流态）。
+func (s *Store) ClearAbsentUsageSnapshot5h(acc *Account) bool {
+	if acc == nil {
+		return false
+	}
+	observedAt := time.Now()
+	cleared := false
+	acc.ApplyUsageObservation(observedAt, func() {
+		cleared = s.ClearAbsentUsageSnapshot5hAt(acc, observedAt)
+	})
+	return cleared
+}
+
+// ClearAbsentUsageSnapshot5hAt applies an authoritative absence observation.
+// It clears only the cooldown created by the 5h window; newer authentication,
+// generic rate-limit, error, and disabled states are deliberately preserved.
+// Usage synchronizers call it from Account.ApplyUsageObservation so memory and
+// persistence remain ordered as one operation.
+func (s *Store) ClearAbsentUsageSnapshot5hAt(acc *Account, observedAt time.Time) bool {
+	if acc == nil {
+		return false
+	}
+	if observedAt.IsZero() {
+		observedAt = time.Now()
 	}
 
-	now := time.Now()
+	acc.mu.Lock()
+	if observedAt.Before(acc.usageObservedAt) {
+		acc.mu.Unlock()
+		return false
+	}
+	acc.usageObservedAt = observedAt
+	had5h := acc.UsagePercent5hValid
+	cleared5hCooldown := s != nil && acc.Status == StatusCooldown && acc.CooldownReason == premium5hCooldownReason
+	priorCooldownUntil := acc.CooldownUtil
+	if !had5h && !cleared5hCooldown {
+		acc.mu.Unlock()
+		return false
+	}
+
+	acc.UsagePercent5h = 0
+	acc.UsagePercent5hValid = false
+	acc.Reset5hAt = time.Time{}
+	acc.UsageUpdatedAt5h = time.Time{}
+	if cleared5hCooldown {
+		acc.Status = StatusReady
+		acc.CooldownUtil = time.Time{}
+		acc.CooldownReason = ""
+		acc.LastRateLimitedAt = time.Time{}
+		if acc.HealthTier != HealthTierBanned {
+			acc.HealthTier = HealthTierWarm
+		}
+	}
+	if s != nil {
+		acc.recomputeSchedulerLocked(atomic.LoadInt64(&s.maxConcurrency))
+	}
+	acc.mu.Unlock()
+
+	if s == nil {
+		// Parse-only callers may pass a nil store. They still get the in-memory
+		// snapshot update, but cooldown transitions remain store-owned.
+		return true
+	}
+	s.fastSchedulerUpdate(acc)
+	if cleared5hCooldown {
+		s.deleteCachedAccountCooldown(acc.DBID)
+		// A newer 401/generic 429 can land after the in-memory transition but
+		// before the cache delete. Restore that newer cooldown if present.
+		acc.mu.RLock()
+		status := acc.Status
+		reason := acc.CooldownReason
+		until := acc.CooldownUtil
+		acc.mu.RUnlock()
+		if status == StatusCooldown && reason != "" {
+			s.setCachedAccountCooldown(acc.DBID, reason, until)
+		}
+	}
+	if s.db == nil {
+		return true
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := s.db.ClearUsageSnapshot5h(ctx, acc.DBID); err != nil {
+		log.Printf("[账号 %d] 清除 5h 用量快照失败: %v", acc.DBID, err)
+	}
+	if cleared5hCooldown {
+		if _, err := s.db.ClearCooldownIfReasonAndUntil(ctx, acc.DBID, premium5hCooldownReason, priorCooldownUntil); err != nil {
+			log.Printf("[账号 %d] 清除 premium 5h 冷却状态失败: %v", acc.DBID, err)
+		}
+	}
+	return true
+}
+
+// MarkPremium5hRateLimited 将账号标记为 premium 5h 限流态，并按 resetAt 驱动恢复。
+func (s *Store) MarkPremium5hRateLimited(acc *Account, resetAt time.Time) {
+	_ = s.MarkPremium5hRateLimitedAt(acc, resetAt, time.Now())
+}
+
+// MarkPremium5hRateLimitedAt marks a 5h cooldown only if this observation is
+// not older than the latest usage synchronization for the account.
+func (s *Store) MarkPremium5hRateLimitedAt(acc *Account, resetAt, observedAt time.Time) bool {
+	if acc == nil || s == nil {
+		return false
+	}
+	return acc.ApplyUsageObservation(observedAt, func() {
+		// observedAt orders competing upstream observations; stateAt reflects
+		// when the state is actually applied after any preceding DB/identity work.
+		s.markPremium5hRateLimited(acc, resetAt, time.Now())
+	})
+}
+
+func (s *Store) markPremium5hRateLimited(acc *Account, resetAt, observedAt time.Time) {
+	now := observedAt
+	if now.IsZero() {
+		now = time.Now()
+	}
 	if resetAt.IsZero() || !resetAt.After(now) {
 		resetAt = now.Add(premium5hFallbackWindow)
 	}
@@ -155,7 +269,7 @@ func (s *Store) MarkPremium5hRateLimited(acc *Account, resetAt time.Time) {
 	acc.LastRateLimitedAt = now
 	acc.Status = StatusCooldown
 	acc.CooldownUtil = resetAt
-	acc.CooldownReason = "rate_limited"
+	acc.CooldownReason = premium5hCooldownReason
 	if acc.HealthTier != HealthTierBanned {
 		acc.HealthTier = HealthTierRisky
 	}
@@ -163,7 +277,7 @@ func (s *Store) MarkPremium5hRateLimited(acc *Account, resetAt time.Time) {
 	acc.mu.Unlock()
 
 	s.fastSchedulerUpdate(acc)
-	s.setCachedAccountCooldown(acc.DBID, "rate_limited", resetAt)
+	s.setCachedAccountCooldown(acc.DBID, premium5hCooldownReason, resetAt)
 
 	if s.db == nil {
 		return
@@ -171,7 +285,7 @@ func (s *Store) MarkPremium5hRateLimited(acc *Account, resetAt time.Time) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	if err := s.db.SetCooldown(ctx, acc.DBID, "rate_limited", resetAt); err != nil {
+	if err := s.db.SetCooldown(ctx, acc.DBID, premium5hCooldownReason, resetAt); err != nil {
 		log.Printf("[账号 %d] 持久化 premium 5h 限流冷却状态失败: %v", acc.DBID, err)
 	}
 	if err := s.db.UpdateUsageSnapshot5h(ctx, acc.DBID, 100, resetAt, now); err != nil {

--- a/auth/premium_rate_limit_test.go
+++ b/auth/premium_rate_limit_test.go
@@ -2,8 +2,12 @@ package auth
 
 import (
 	"context"
+	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/codex2api/database"
 )
 
 func newPremium5hTestAccount(plan string, resetAt time.Time) *Account {
@@ -78,6 +82,166 @@ func TestPremium5hRateLimitedSkipsResponsesProbeButRefreshesResetCredits(t *test
 	acc.MarkResetCreditsProbed(time.Now())
 	if acc.NeedsUsageProbe(10 * time.Minute) {
 		t.Fatal("NeedsUsageProbe() = true, want false before premium 5h reset once reset credits are fresh")
+	}
+}
+
+func TestClearAbsentUsageSnapshot5hPreservesUnrelatedAccountState(t *testing.T) {
+	store := NewStore(nil, nil, &database.SystemSettings{MaxConcurrency: 2, TestConcurrency: 1, TestModel: "gpt-5.4"})
+	tests := []struct {
+		name     string
+		status   AccountStatus
+		reason   string
+		errorMsg string
+		disabled int32
+		health   AccountHealthTier
+	}{
+		{name: "unauthorized", status: StatusCooldown, reason: "unauthorized", disabled: 1, health: HealthTierBanned},
+		{name: "generic 429", status: StatusCooldown, reason: "rate_limited", health: HealthTierRisky},
+		{name: "error", status: StatusError, errorMsg: "workspace disabled", health: HealthTierRisky},
+		{name: "disabled ready account", status: StatusReady, disabled: 1, health: HealthTierWarm},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			observedAt := time.Now()
+			acc := &Account{
+				DBID:           1,
+				AccessToken:    "token",
+				PlanType:       "plus",
+				Status:         tt.status,
+				CooldownReason: tt.reason,
+				CooldownUtil:   observedAt.Add(time.Hour),
+				ErrorMsg:       tt.errorMsg,
+				Disabled:       tt.disabled,
+				HealthTier:     tt.health,
+			}
+			acc.SetUsageSnapshot5hAt(88, observedAt.Add(2*time.Hour), observedAt.Add(-time.Minute))
+
+			if !store.ClearAbsentUsageSnapshot5hAt(acc, observedAt) {
+				t.Fatal("ClearAbsentUsageSnapshot5hAt() = false, want stale snapshot cleared")
+			}
+			if _, ok := acc.GetUsagePercent5h(); ok {
+				t.Fatal("5h snapshot remained valid")
+			}
+			if acc.Status != tt.status || acc.GetCooldownReason() != tt.reason || acc.ErrorMsg != tt.errorMsg {
+				t.Fatalf("state = (%v, %q, %q), want (%v, %q, %q)", acc.Status, acc.GetCooldownReason(), acc.ErrorMsg, tt.status, tt.reason, tt.errorMsg)
+			}
+			if got := atomic.LoadInt32(&acc.Disabled); got != tt.disabled {
+				t.Fatalf("Disabled = %d, want %d", got, tt.disabled)
+			}
+			if tt.health == HealthTierBanned && acc.HealthTier != tt.health {
+				t.Fatalf("HealthTier = %q, want %q", acc.HealthTier, tt.health)
+			}
+		})
+	}
+}
+
+func TestClearUsageLimitCooldownSincePreservesNewerUnrelatedState(t *testing.T) {
+	store := NewStore(nil, nil, &database.SystemSettings{MaxConcurrency: 2, TestConcurrency: 1, TestModel: "gpt-5.4"})
+	observedAt := time.Now()
+
+	generic := &Account{DBID: 2, Status: StatusCooldown, CooldownReason: "rate_limited", CooldownUtil: observedAt.Add(time.Hour), HealthTier: HealthTierRisky}
+	generic.LastRateLimitedAt = observedAt.Add(-time.Minute)
+	if !store.ClearUsageLimitCooldownSince(generic, observedAt) {
+		t.Fatal("generic usage cooldown should be cleared by a fresh successful probe")
+	}
+	if generic.Status != StatusReady || generic.GetCooldownReason() != "" || !generic.LastRateLimitedAt.IsZero() {
+		t.Fatalf("generic cooldown state = (%v, %q, %v), want ready/empty/zero", generic.Status, generic.GetCooldownReason(), generic.LastRateLimitedAt)
+	}
+
+	unauthorized := &Account{DBID: 3, Status: StatusCooldown, CooldownReason: "unauthorized", CooldownUtil: observedAt.Add(time.Hour), HealthTier: HealthTierBanned}
+	if store.ClearUsageLimitCooldownSince(unauthorized, observedAt) {
+		t.Fatal("unauthorized cooldown must not be cleared by a usage probe")
+	}
+	if unauthorized.GetCooldownReason() != "unauthorized" {
+		t.Fatal("unauthorized cooldown reason was changed")
+	}
+
+	newer := &Account{DBID: 4, Status: StatusCooldown, CooldownReason: "rate_limited", CooldownUtil: observedAt.Add(time.Hour), HealthTier: HealthTierRisky}
+	newer.LastRateLimitedAt = observedAt.Add(time.Second)
+	if store.ClearUsageLimitCooldownSince(newer, observedAt) {
+		t.Fatal("newer rate-limit evidence must survive a delayed probe")
+	}
+}
+
+func TestClearAbsentUsageSnapshot5hRejectsStaleObservation(t *testing.T) {
+	store := NewStore(nil, nil, &database.SystemSettings{MaxConcurrency: 2, TestConcurrency: 1, TestModel: "gpt-5.4"})
+	acc := &Account{DBID: 1, AccessToken: "token", PlanType: "plus", Status: StatusReady}
+	freshAt := time.Now()
+	acc.SetUsageSnapshot5hAt(42, freshAt.Add(2*time.Hour), freshAt)
+
+	if store.ClearAbsentUsageSnapshot5hAt(acc, freshAt.Add(-time.Minute)) {
+		t.Fatal("stale absence observation cleared a newer 5h snapshot")
+	}
+	if pct, _, ok := acc.GetUsageSnapshot5h(); !ok || pct != 42 {
+		t.Fatalf("5h snapshot = (%v, %v), want fresh 42%% snapshot", pct, ok)
+	}
+}
+
+func TestClearAbsentUsageSnapshot5hClearsPersistedPremiumCooldown(t *testing.T) {
+	ctx := context.Background()
+	db, err := database.New("sqlite", filepath.Join(t.TempDir(), "codex2api.db"))
+	if err != nil {
+		t.Fatalf("database.New: %v", err)
+	}
+	defer db.Close()
+	id, err := db.InsertAccountWithCredentials(ctx, "premium-5h", map[string]interface{}{
+		"access_token": "token",
+		"plan_type":    "plus",
+	}, "")
+	if err != nil {
+		t.Fatalf("InsertAccountWithCredentials: %v", err)
+	}
+
+	store := NewStore(db, nil, &database.SystemSettings{MaxConcurrency: 2, TestConcurrency: 1, TestModel: "gpt-5.4"})
+	acc := &Account{DBID: id, AccessToken: "token", PlanType: "plus", Status: StatusReady}
+	store.MarkPremium5hRateLimited(acc, time.Now().Add(2*time.Hour))
+	if got := acc.GetCooldownReason(); got != premium5hCooldownReason {
+		t.Fatalf("CooldownReason = %q, want %q", got, premium5hCooldownReason)
+	}
+
+	if !store.ClearAbsentUsageSnapshot5h(acc) {
+		t.Fatal("ClearAbsentUsageSnapshot5h() = false, want premium state cleared")
+	}
+	row, err := db.GetAccountByID(ctx, id)
+	if err != nil {
+		t.Fatalf("GetAccountByID: %v", err)
+	}
+	if row.CooldownReason != "" || row.CooldownUntil.Valid {
+		t.Fatalf("persisted cooldown = (%q, %v), want cleared", row.CooldownReason, row.CooldownUntil)
+	}
+	if got := row.GetCredential("codex_5h_used_percent"); got != "" {
+		t.Fatalf("codex_5h_used_percent = %q, want cleared", got)
+	}
+}
+
+func TestClearAbsentUsageSnapshot5hSkipsPersistenceWithoutLocalState(t *testing.T) {
+	ctx := context.Background()
+	db, err := database.New("sqlite", filepath.Join(t.TempDir(), "codex2api.db"))
+	if err != nil {
+		t.Fatalf("database.New: %v", err)
+	}
+	defer db.Close()
+	id, err := db.InsertAccountWithCredentials(ctx, "db-only-5h", map[string]interface{}{
+		"access_token":              "token",
+		"codex_5h_used_percent":     77,
+		"codex_5h_usage_updated_at": time.Now().Format(time.RFC3339),
+	}, "")
+	if err != nil {
+		t.Fatalf("InsertAccountWithCredentials: %v", err)
+	}
+
+	store := NewStore(db, nil, &database.SystemSettings{MaxConcurrency: 2, TestConcurrency: 1, TestModel: "gpt-5.4"})
+	acc := &Account{DBID: id, AccessToken: "token", PlanType: "plus", Status: StatusReady}
+	if store.ClearAbsentUsageSnapshot5hAt(acc, time.Now()) {
+		t.Fatal("ClearAbsentUsageSnapshot5hAt() = true without an in-memory snapshot or 5h cooldown")
+	}
+	row, err := db.GetAccountByID(ctx, id)
+	if err != nil {
+		t.Fatalf("GetAccountByID: %v", err)
+	}
+	if got := row.GetCredential("codex_5h_used_percent"); got != "77" {
+		t.Fatalf("codex_5h_used_percent = %q, want unchanged 77", got)
 	}
 }
 

--- a/auth/quota_auto_pause_test.go
+++ b/auth/quota_auto_pause_test.go
@@ -61,16 +61,17 @@ func TestQuotaAutoPause5hThresholdFencesAccount(t *testing.T) {
 	}
 }
 
-func TestQuotaAutoPause5hThresholdRefreshesMissing5hBeforeFencing(t *testing.T) {
+func TestQuotaAutoPause5hThresholdAllowsMissingOptionalWindowBeforeFencing(t *testing.T) {
 	acc := newQuotaAutoPauseTestAccount()
 	acc.AutoPause5hThreshold = 0.95
 	acc.UsagePercent7d = 12
 	acc.UsagePercent7dValid = true
 	acc.UsageUpdatedAt = time.Now()
 	setAutoPauseThresholdsWithGuard(acc, 5)
+	acc.MarkResetCreditsProbed(time.Now())
 
-	if !acc.NeedsUsageProbe(10 * time.Minute) {
-		t.Fatal("NeedsUsageProbe() = false, want true when 7d is fresh but 5h snapshot is missing")
+	if acc.NeedsUsageProbe(10 * time.Minute) {
+		t.Fatal("NeedsUsageProbe() = true, want false when the optional 5h window is absent")
 	}
 
 	acc.SetUsageSnapshot5h(95, time.Now().Add(time.Hour))

--- a/auth/store.go
+++ b/auth/store.go
@@ -87,6 +87,8 @@ func NormalizeTestContent(content string) string {
 // Account 运行时账号状态
 type Account struct {
 	mu                      sync.RWMutex
+	usageSyncMu             sync.Mutex
+	usageObservedAt         time.Time
 	DBID                    int64 // 数据库 ID
 	RefreshToken            string
 	SessionToken            string
@@ -105,7 +107,7 @@ type Account struct {
 	CodexClientMetadataMode string
 	Status                  AccountStatus
 	CooldownUtil            time.Time
-	CooldownReason          string // rate_limited / unauthorized / 空
+	CooldownReason          string // rate_limited / rate_limited_5h / unauthorized / 空
 	ErrorMsg                string
 
 	// 用量进度（从 Codex 响应头被动解析）
@@ -1017,6 +1019,9 @@ func (a *Account) recomputeSchedulerLocked(baseLimit int64) {
 	if a.premium5hRateLimitedLocked(now) && tier != HealthTierBanned {
 		tier = HealthTierRisky
 	}
+	if a.Status == StatusCooldown && a.CooldownReason == premium5hCooldownReason && tier != HealthTierBanned {
+		tier = HealthTierRisky
+	}
 	if a.SkipWarmTier && tier == HealthTierWarm {
 		tier = HealthTierHealthy
 	}
@@ -1476,7 +1481,11 @@ func (a *Account) SetCooldownUntil(until time.Time, reason string) {
 	switch reason {
 	case "unauthorized":
 		a.HealthTier = HealthTierBanned
-	case "rate_limited":
+	case "rate_limited_5h":
+		if a.HealthTier != HealthTierBanned {
+			a.HealthTier = HealthTierRisky
+		}
+	case "rate_limited", "rate_limited_7d", "usage_limited", "usage_limit":
 		if a.healthTierLocked() == HealthTierHealthy {
 			a.HealthTier = HealthTierWarm
 		} else {
@@ -1634,10 +1643,39 @@ func (a *Account) SetUsageSnapshot5h(pct float64, resetAt time.Time) {
 func (a *Account) SetUsageSnapshot5hAt(pct float64, resetAt time.Time, updatedAt time.Time) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
+	if updatedAt.After(a.usageObservedAt) {
+		a.usageObservedAt = updatedAt
+	}
 	a.UsagePercent5h = pct
 	a.UsagePercent5hValid = true
 	a.Reset5hAt = resetAt
 	a.UsageUpdatedAt5h = updatedAt
+}
+
+// ApplyUsageObservation serializes one authoritative upstream usage observation,
+// including its database writes. The timestamp check prevents an older observer
+// that waited on the lock from overwriting a newer 5h presence/absence decision.
+func (a *Account) ApplyUsageObservation(observedAt time.Time, apply func()) bool {
+	if a == nil || apply == nil {
+		return false
+	}
+	if observedAt.IsZero() {
+		observedAt = time.Now()
+	}
+
+	a.usageSyncMu.Lock()
+	defer a.usageSyncMu.Unlock()
+
+	a.mu.Lock()
+	if observedAt.Before(a.usageObservedAt) {
+		a.mu.Unlock()
+		return false
+	}
+	a.usageObservedAt = observedAt
+	a.mu.Unlock()
+
+	apply()
+	return true
 }
 
 // GetUsagePercent5h 获取 5h 用量百分比
@@ -2092,7 +2130,7 @@ func (a *Account) NeedsUsageProbe(maxAge time.Duration) bool {
 		// premium 5h 限流期间不发 /responses 探活，但 wham 零成本，仍允许其刷新重置次数。
 		return resetCreditsStale
 	}
-	if a.Status == StatusCooldown && a.CooldownReason == "rate_limited" && (a.CooldownUtil.IsZero() || now.Before(a.CooldownUtil)) {
+	if a.Status == StatusCooldown && isUsageLimitCooldownReason(a.CooldownReason) && (a.CooldownUtil.IsZero() || now.Before(a.CooldownUtil)) {
 		// 429 冷却期间不发 /responses 探活（避免加重限流），但允许 wham-only 探针刷新重置次数——
 		// 这正是用户最需要看到"还剩几次主动重置"的时刻。
 		return resetCreditsStale
@@ -2114,10 +2152,10 @@ func (a *Account) NeedsUsageProbe(maxAge time.Duration) bool {
 	if a.UsagePercent7dValid && !a.Reset7dAt.IsZero() && !a.Reset7dAt.After(now) && a.UsageUpdatedAt.Before(a.Reset7dAt) {
 		return true
 	}
-	if a.effectiveAutoPause5h > 0 && !a.AutoPause5hDisabled {
-		if !a.UsagePercent5hValid || a.UsageUpdatedAt5h.IsZero() {
-			return true
-		}
+	// 5h 是上游可选窗口：仅当本地仍持有有效 5h 快照时才按 maxAge 刷新。
+	// 上游已取消 5h（issue #382）时，缺失快照不应因 auto-pause 5h 配置而永久探测。
+	if a.effectiveAutoPause5h > 0 && !a.AutoPause5hDisabled &&
+		a.UsagePercent5hValid && !a.UsageUpdatedAt5h.IsZero() {
 		if a.Reset5hAt.IsZero() || a.Reset5hAt.After(now) {
 			return now.Sub(a.UsageUpdatedAt5h) > maxAge
 		}
@@ -2182,7 +2220,7 @@ func (a *Account) InLimitedState() bool {
 	if a.premium5hRateLimitedLocked(now) {
 		return true
 	}
-	if a.Status == StatusCooldown && a.CooldownReason == "rate_limited" && (a.CooldownUtil.IsZero() || now.Before(a.CooldownUtil)) {
+	if a.Status == StatusCooldown && isUsageLimitCooldownReason(a.CooldownReason) && (a.CooldownUtil.IsZero() || now.Before(a.CooldownUtil)) {
 		return true
 	}
 	return false
@@ -2542,7 +2580,13 @@ func (s *Store) applyCachedAccountCooldown(acc *Account, record runtimeCooldownR
 		acc.LastUnauthorizedAt = now
 		acc.LastFailureAt = now
 		acc.HealthTier = HealthTierBanned
-	case "rate_limited", "usage_limited", "usage_limit":
+	case "rate_limited_5h":
+		acc.LastRateLimitedAt = now
+		acc.LastFailureAt = now
+		if acc.HealthTier != HealthTierBanned {
+			acc.HealthTier = HealthTierRisky
+		}
+	case "rate_limited", "rate_limited_7d", "usage_limited", "usage_limit":
 		acc.LastRateLimitedAt = now
 		acc.LastFailureAt = now
 		if acc.healthTierLocked() == HealthTierHealthy {
@@ -3809,7 +3853,7 @@ func (s *Store) CleanRateLimitedManual(ctx context.Context) int {
 			continue
 		}
 		status := acc.RuntimeStatus()
-		if status != "rate_limited" && status != "usage_exhausted" {
+		if status != "rate_limited" && status != "rate_limited_5h" && status != "rate_limited_7d" && status != "usage_exhausted" {
 			continue
 		}
 
@@ -5561,7 +5605,12 @@ func (s *Store) markCooldownUntil(acc *Account, until time.Time, reason string, 
 		acc.LastUnauthorizedAt = now
 		acc.LastFailureAt = now
 		acc.HealthTier = HealthTierBanned
-	case "rate_limited", "usage_limited", "usage_limit":
+	case "rate_limited_5h":
+		acc.LastRateLimitedAt = now
+		if acc.HealthTier != HealthTierBanned {
+			acc.HealthTier = HealthTierRisky
+		}
+	case "rate_limited", "rate_limited_7d", "usage_limited", "usage_limit":
 		acc.LastRateLimitedAt = now
 		if acc.healthTierLocked() == HealthTierHealthy {
 			acc.HealthTier = HealthTierWarm
@@ -5607,7 +5656,15 @@ func (s *Store) markCooldown(acc *Account, duration time.Duration, reason string
 		acc.FailureStreak++
 		acc.SuccessStreak = 0
 		acc.HealthTier = HealthTierBanned
-	case "rate_limited":
+	case "rate_limited_5h":
+		acc.LastRateLimitedAt = now
+		acc.LastFailureAt = now
+		acc.FailureStreak++
+		acc.SuccessStreak = 0
+		if acc.HealthTier != HealthTierBanned {
+			acc.HealthTier = HealthTierRisky
+		}
+	case "rate_limited", "rate_limited_7d", "usage_limited", "usage_limit":
 		acc.LastRateLimitedAt = now
 		acc.LastFailureAt = now
 		acc.FailureStreak++
@@ -5811,9 +5868,61 @@ func (s *Store) ClearCooldown(acc *Account) {
 	}
 }
 
+// ClearUsageLimitCooldownSince clears only a usage/rate-limit cooldown that
+// was already present when observedAt was captured. Authentication failures,
+// generic errors, disabled states, and newer cooldowns are left untouched.
+func (s *Store) ClearUsageLimitCooldownSince(acc *Account, observedAt time.Time) bool {
+	if s == nil || acc == nil {
+		return false
+	}
+	if observedAt.IsZero() {
+		observedAt = time.Now()
+	}
+
+	acc.mu.Lock()
+	if acc.Status != StatusCooldown || !isUsageLimitCooldownReason(acc.CooldownReason) ||
+		(!acc.LastRateLimitedAt.IsZero() && acc.LastRateLimitedAt.After(observedAt)) {
+		acc.mu.Unlock()
+		return false
+	}
+	reason := acc.CooldownReason
+	until := acc.CooldownUtil
+	acc.Status = StatusReady
+	acc.CooldownUtil = time.Time{}
+	acc.CooldownReason = ""
+	acc.ErrorMsg = ""
+	acc.LastRateLimitedAt = time.Time{}
+	if acc.HealthTier != HealthTierBanned {
+		acc.HealthTier = HealthTierWarm
+	}
+	acc.recomputeSchedulerLocked(atomic.LoadInt64(&s.maxConcurrency))
+	acc.mu.Unlock()
+
+	s.fastSchedulerUpdate(acc)
+	s.deleteCachedAccountCooldown(acc.DBID)
+	acc.mu.RLock()
+	status := acc.Status
+	currentReason := acc.CooldownReason
+	currentUntil := acc.CooldownUtil
+	acc.mu.RUnlock()
+	if status == StatusCooldown && currentReason != "" {
+		s.setCachedAccountCooldown(acc.DBID, currentReason, currentUntil)
+	}
+	if s.db == nil {
+		return true
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if _, err := s.db.ClearCooldownIfReasonAndUntil(ctx, acc.DBID, reason, until); err != nil {
+		log.Printf("[账号 %d] 清理过期用量冷却状态失败: %v", acc.DBID, err)
+	}
+	return true
+}
+
 func isUsageLimitCooldownReason(reason string) bool {
 	switch strings.ToLower(strings.TrimSpace(reason)) {
-	case "rate_limited", "rate_limited_5h", "rate_limited_7d", "usage_limit":
+	case "rate_limited", "rate_limited_5h", "rate_limited_7d", "usage_limited", "usage_limit":
 		return true
 	default:
 		return false

--- a/auth/store_scheduler_test.go
+++ b/auth/store_scheduler_test.go
@@ -442,7 +442,8 @@ func TestNeedsUsageProbeRefreshesStaleResetCreditsDespiteFreshUsage(t *testing.T
 	}
 }
 
-func TestNeedsUsageProbeRequires5hSnapshotWhen5hAutoPauseEnabled(t *testing.T) {
+func TestNeedsUsageProbeDoesNotRequireMissing5hWhenAutoPauseEnabled(t *testing.T) {
+	// issue #382：上游可永久不返回 5h。auto-pause 5h 配置在无快照时不应强制探测。
 	acc := &Account{
 		AccessToken:          "token",
 		Status:               StatusReady,
@@ -452,10 +453,32 @@ func TestNeedsUsageProbeRequires5hSnapshotWhen5hAutoPauseEnabled(t *testing.T) {
 		AutoPause5hThreshold: 0.95,
 	}
 	acc.recomputeEffectiveAutoPause(nil)
-	acc.MarkResetCreditsProbed(time.Now()) // 隔离 reset-credits 过期影响，专测 5h 快照缺失路径
+	acc.MarkResetCreditsProbed(time.Now()) // 隔离 reset-credits 过期影响
+
+	if acc.NeedsUsageProbe(10 * time.Minute) {
+		t.Fatal("NeedsUsageProbe() = true, want false when 5h auto-pause is enabled but 5h window is absent")
+	}
+}
+
+func TestNeedsUsageProbeRefreshesStale5hWhenAutoPauseEnabled(t *testing.T) {
+	now := time.Now()
+	acc := &Account{
+		AccessToken:          "token",
+		Status:               StatusReady,
+		UsagePercent7d:       12,
+		UsagePercent7dValid:  true,
+		UsageUpdatedAt:       now,
+		AutoPause5hThreshold: 0.95,
+		UsagePercent5h:       40,
+		UsagePercent5hValid:  true,
+		Reset5hAt:            now.Add(2 * time.Hour),
+		UsageUpdatedAt5h:     now.Add(-20 * time.Minute),
+	}
+	acc.recomputeEffectiveAutoPause(nil)
+	acc.MarkResetCreditsProbed(now)
 
 	if !acc.NeedsUsageProbe(10 * time.Minute) {
-		t.Fatal("NeedsUsageProbe() = false, want true when 5h auto-pause is enabled but 5h snapshot is missing")
+		t.Fatal("NeedsUsageProbe() = false, want true when valid 5h snapshot is stale under auto-pause")
 	}
 }
 
@@ -489,7 +512,8 @@ func TestNeedsUsageProbeRefreshesStale5hAfterWindowReset(t *testing.T) {
 	}
 }
 
-func TestPersistUsageSnapshotKeeps5hProbeRequiredWhen5hSnapshotMissing(t *testing.T) {
+func TestPersistUsageSnapshotDoesNotRequireMissing5hAfter7dOnly(t *testing.T) {
+	// issue #382：7d-only 持久化后，缺失 5h 不再因 auto-pause 配置强制探测。
 	store := NewStore(nil, nil, &database.SystemSettings{MaxConcurrency: 2, TestConcurrency: 1, TestModel: "gpt-5.4"})
 	acc := &Account{
 		DBID:                 1,
@@ -503,10 +527,10 @@ func TestPersistUsageSnapshotKeeps5hProbeRequiredWhen5hSnapshotMissing(t *testin
 	acc.recomputeEffectiveAutoPause(store)
 
 	store.PersistUsageSnapshot(acc, 20)
-	acc.MarkResetCreditsProbed(time.Now()) // 隔离 reset-credits 过期影响，专测 5h 快照缺失路径
+	acc.MarkResetCreditsProbed(time.Now())
 
-	if !acc.NeedsUsageProbe(10 * time.Minute) {
-		t.Fatal("NeedsUsageProbe() = false, want true after 7d-only persistence when 5h snapshot is still missing")
+	if acc.NeedsUsageProbe(10 * time.Minute) {
+		t.Fatal("NeedsUsageProbe() = true, want false after 7d-only persistence when 5h window is absent")
 	}
 }
 

--- a/database/usage_snapshot.go
+++ b/database/usage_snapshot.go
@@ -13,3 +13,61 @@ func (db *DB) UpdateUsageSnapshot5h(ctx context.Context, id int64, pct5h float64
 		"codex_5h_usage_updated_at": updatedAt.Format(time.RFC3339),
 	})
 }
+
+// ClearUsageSnapshot5h 清除 credentials 中的 5h 窗口字段（上游未返回 5h 时调用，issue #382）。
+// 使用 null 写入：GetCredential / 加载路径会把 null 当作缺失，重启后不会再 hydrate 5h。
+func (db *DB) ClearUsageSnapshot5h(ctx context.Context, id int64) error {
+	return db.UpdateCredentials(ctx, id, map[string]interface{}{
+		"codex_5h_used_percent":     nil,
+		"codex_5h_reset_at":         nil,
+		"codex_5h_usage_updated_at": nil,
+	})
+}
+
+// ClearCooldownIfReason clears only the cooldown that still has the expected
+// source. A concurrent 401 or generic 429 therefore cannot be erased by a
+// delayed premium-5h absence observation.
+func (db *DB) ClearCooldownIfReason(ctx context.Context, id int64, reason string) (bool, error) {
+	var cleared bool
+	err := db.withSQLiteWriteLock(ctx, func() error {
+		result, err := db.conn.ExecContext(ctx, `
+			UPDATE accounts
+			SET cooldown_reason = '', cooldown_until = NULL, updated_at = CURRENT_TIMESTAMP
+			WHERE id = $1 AND cooldown_reason = $2
+		`, id, reason)
+		if err != nil {
+			return err
+		}
+		affected, err := result.RowsAffected()
+		if err != nil {
+			return err
+		}
+		cleared = affected > 0
+		return nil
+	})
+	return cleared, err
+}
+
+// ClearCooldownIfReasonAndUntil clears a matching cooldown only when both its
+// source and reset time are unchanged. A newer cooldown with the same reason
+// therefore survives a delayed usage probe even if its reset is shorter.
+func (db *DB) ClearCooldownIfReasonAndUntil(ctx context.Context, id int64, reason string, until time.Time) (bool, error) {
+	var cleared bool
+	err := db.withSQLiteWriteLock(ctx, func() error {
+		result, err := db.conn.ExecContext(ctx, `
+			UPDATE accounts
+			SET cooldown_reason = '', cooldown_until = NULL, updated_at = CURRENT_TIMESTAMP
+			WHERE id = $1 AND cooldown_reason = $2 AND cooldown_until = $3
+		`, id, reason, until)
+		if err != nil {
+			return err
+		}
+		affected, err := result.RowsAffected()
+		if err != nil {
+			return err
+		}
+		cleared = affected > 0
+		return nil
+	})
+	return cleared, err
+}

--- a/frontend/src/components/AccountDetailSheet.tsx
+++ b/frontend/src/components/AccountDetailSheet.tsx
@@ -43,6 +43,11 @@ function isFutureTime(value?: string): boolean {
 
 function getRateLimitWindow(account: AccountRow): "5h" | "7d" | null {
   const status = (account.status || "").toLowerCase();
+  const reason = (account.cooldown_reason || "").toLowerCase();
+  if (status === "rate_limited_5h") return "5h";
+  if (status === "rate_limited_7d") return "7d";
+  if (reason === "rate_limited_5h") return "5h";
+  if (reason === "rate_limited_7d") return "7d";
   if (status === "rate_limited" || status === "quota_paused" || status === "usage_exhausted") {
     if (account.reset_5h_at && isFutureTime(account.reset_5h_at)) return "5h";
     if (account.reset_7d_at && isFutureTime(account.reset_7d_at)) return "7d";

--- a/frontend/src/components/StatusBadge.tsx
+++ b/frontend/src/components/StatusBadge.tsx
@@ -13,6 +13,8 @@ const statusConfig: Record<string, { variant: 'default' | 'secondary' | 'destruc
   ready: { variant: 'default', dotColor: 'bg-emerald-500' },
   cooldown: { variant: 'secondary', dotColor: 'bg-amber-500' },
   rate_limited: { variant: 'secondary', dotColor: 'bg-yellow-500' },
+  rate_limited_5h: { variant: 'secondary', dotColor: 'bg-yellow-500' },
+  rate_limited_7d: { variant: 'secondary', dotColor: 'bg-yellow-500' },
   usage_exhausted: { variant: 'secondary', dotColor: 'bg-yellow-500' },
   quota_paused: { variant: 'secondary', dotColor: 'bg-yellow-500' },
   unauthorized: { variant: 'destructive', dotColor: 'bg-red-500' },

--- a/frontend/src/lib/usageFormat.test.mjs
+++ b/frontend/src/lib/usageFormat.test.mjs
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { needsUsageReload } from "./usageFormat.ts";
+
+test("usage reload accepts either optional usage window as sampled", () => {
+  assert.equal(needsUsageReload({ status: "active" }), true);
+  assert.equal(
+    needsUsageReload({ status: "active", usage_percent_5h: 12 }),
+    false,
+  );
+  assert.equal(
+    needsUsageReload({ status: "ready", usage_percent_7d: 34 }),
+    false,
+  );
+});
+
+test("usage reload skips accounts that cannot be sampled", () => {
+  assert.equal(needsUsageReload({ status: "unauthorized" }), false);
+});

--- a/frontend/src/lib/usageFormat.ts
+++ b/frontend/src/lib/usageFormat.ts
@@ -48,3 +48,17 @@ export function formatUsageNumber(
 
   return `${compact}${unit.suffix}`
 }
+
+export function needsUsageReload(account: {
+  status?: string
+  usage_percent_5h?: number | null
+  usage_percent_7d?: number | null
+}): boolean {
+  if (account.status !== 'active' && account.status !== 'ready') return false
+
+  const has5h =
+    account.usage_percent_5h !== null && account.usage_percent_5h !== undefined
+  const has7d =
+    account.usage_percent_7d !== null && account.usage_percent_7d !== undefined
+  return !has5h && !has7d
+}

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1000,6 +1000,8 @@
     "ready": "Ready",
     "cooldown": "Cooling Down",
     "rate_limited": "Rate Limited",
+    "rate_limited_5h": "5h Rate Limited",
+    "rate_limited_7d": "7d Rate Limited",
     "usage_exhausted": "Rate Limited",
     "quota_paused": "Auto-Paused",
     "unauthorized": "Banned",

--- a/frontend/src/locales/zh.json
+++ b/frontend/src/locales/zh.json
@@ -1000,6 +1000,8 @@
     "ready": "就绪",
     "cooldown": "冷却中",
     "rate_limited": "限流",
+    "rate_limited_5h": "5 小时限流",
+    "rate_limited_7d": "7 天限流",
     "usage_exhausted": "限流中",
     "quota_paused": "自动暂停",
     "unauthorized": "封禁",

--- a/frontend/src/pages/Accounts.tsx
+++ b/frontend/src/pages/Accounts.tsx
@@ -34,7 +34,10 @@ import type {
 import { getErrorMessage } from "../utils/error";
 import { formatRelativeTime, formatBeijingTime } from "../utils/time";
 import { buildBatchMetadataUpdate } from "../lib/accountBatchUpdate";
-import { formatLongUsageWindowLabel } from "../lib/usageFormat";
+import {
+  formatLongUsageWindowLabel,
+  needsUsageReload,
+} from "../lib/usageFormat";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -1510,29 +1513,6 @@ export default function Accounts() {
   }, [allGroups]);
 
   useEffect(() => {
-    const needsUsageReload = (account: AccountRow) => {
-      if (account.status !== "active" && account.status !== "ready") {
-        return false;
-      }
-
-      const plan = normalizePlanType(account.plan_type);
-      const has7d =
-        account.usage_percent_7d !== null &&
-        account.usage_percent_7d !== undefined;
-      const has5h =
-        account.usage_percent_5h !== null &&
-        account.usage_percent_5h !== undefined;
-      // 与 UsageCell 的显示判定保持一致:plan_type 可能滞后于真实订阅状态,
-      // 看到 5h 重置时间就当订阅账号处理,触发拉取 5h 数据。
-      const looksLikeSubscription =
-        isPremiumUsagePlan(plan) || !!account.reset_5h_at;
-
-      if (looksLikeSubscription) {
-        return !has5h || !has7d;
-      }
-      return !has7d;
-    };
-
     const missingUsageIds = accounts
       .filter(needsUsageReload)
       .map((account) => account.id);
@@ -11812,8 +11792,7 @@ function UsageWindowStat({
 // 显示策略不再单独依赖 plan_type:
 // 当 plan_type 还停留在按 RT 刷新出来的旧值(例如 "free")、但账号实际已订阅、
 // 后端已经返回 5h 窗口数据时,只看 plan_type 会把 5h 吞掉。
-// 因此这里以"是否真的存在 5h / 7d 数据(含 reset 时间)"作为主判据,
-// plan_type 仅作为 5h 数据缺位时的辅助提示。
+// 因此这里以"是否真的存在 5h / 7d 数据(含 reset 时间)"作为主判据。
 function UsageCell({
   account,
   wide = false,
@@ -11856,26 +11835,23 @@ function UsageCell({
     </button>
   );
 
-  const plan = normalizePlanType(account.plan_type);
   const has7d =
     account.usage_percent_7d !== null && account.usage_percent_7d !== undefined;
   const has5h =
     account.usage_percent_5h !== null && account.usage_percent_5h !== undefined;
   const has7dDetail = hasUsageWindowDetail(account.usage_7d_detail);
-  const has5hDetail = hasUsageWindowDetail(account.usage_5h_detail);
   const has5hReset = !!account.reset_5h_at;
   const has7dReset = !!account.reset_7d_at;
 
-  const fiveHourPresent = has5h || has5hDetail || has5hReset;
+  const fiveHourPresent = has5h || has5hReset;
   const sevenDayPresent = has7d || has7dDetail || has7dReset;
   // 长窗口标签:free/team plan 实为月窗(约 30 天),按真实周期显示 30d 而非误标 7d (issue #324)
   const longWindowLabel = formatLongUsageWindowLabel(account);
-  // plan 表明是订阅型时,即使数据暂未拉到也按订阅布局占位,避免抖动
-  const planSuggestsPremium = isPremiumUsagePlan(plan);
-  const showFiveHour = fiveHourPresent || planSuggestsPremium;
+  // 5h 是上游可选窗口：仅数据存在时展示，不再因 premium plan 强制占位（issue #382）
+  const showFiveHour = fiveHourPresent;
 
   if (showFiveHour) {
-    if (!has5h && !has7d && !has5hDetail && !has7dDetail && !has5hReset && !has7dReset)
+    if (!has5h && !has7d && !has7dDetail && !has5hReset && !has7dReset)
       return <span className="text-[12px] text-muted-foreground">-</span>;
     return (
       <div className={`${wide ? "w-full" : "w-52"} flex items-start gap-1`}>
@@ -11932,12 +11908,16 @@ function UsageCell({
 function BilledCell({ account }: { account: AccountRow }) {
   const h5 = typeof account.billed_5h === "number" ? account.billed_5h.toFixed(2) : null;
   const d7 = typeof account.billed_7d === "number" ? account.billed_7d.toFixed(2) : null;
-  if (h5 === null && d7 === null) return <span className="text-[12px] text-muted-foreground">-</span>;
+  const has5hWindow =
+    (account.usage_percent_5h !== null && account.usage_percent_5h !== undefined) ||
+    !!account.reset_5h_at;
+  const visibleH5 = has5hWindow ? h5 : null;
+  if (visibleH5 === null && d7 === null) return <span className="text-[12px] text-muted-foreground">-</span>;
   const longLabel = formatLongUsageWindowLabel(account);
   return (
     <span className="text-[12px] text-muted-foreground">
-      {h5 !== null ? `5h: $${h5}` : "5h: -"}
-      {" / "}
+      {visibleH5 !== null && `5h: $${visibleH5}`}
+      {visibleH5 !== null && " / "}
       {d7 !== null ? `${longLabel}: $${d7}` : `${longLabel}: -`}
     </span>
   );
@@ -11949,7 +11929,11 @@ function getAccountStatusCountdownUntil(
   const status = account.status;
   if (
     account.cooldown_until &&
-    (status === "rate_limited" || status === "error" || status === "cooldown")
+    (status === "rate_limited" ||
+      status === "rate_limited_5h" ||
+      status === "rate_limited_7d" ||
+      status === "error" ||
+      status === "cooldown")
   ) {
     return account.cooldown_until;
   }

--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -145,6 +145,8 @@ type CodexUsageSyncResult struct {
 	Persisted5hOnly          bool
 	Premium5hRateLimited     bool
 	UsageWindowLimitsIgnored bool
+	// Cleared5h 表示本次同步因上游未返回 5h 窗口而清除了本地陈旧 5h 快照（issue #382）。
+	Cleared5h bool
 }
 
 type codexRateLimitWindow string
@@ -4115,13 +4117,25 @@ type codexWindowUsage struct {
 }
 
 func parseCodexWindowUsage(usedStr, windowStr, resetStr string) codexWindowUsage {
-	if usedStr == "" {
+	if strings.TrimSpace(usedStr) == "" || strings.TrimSpace(windowStr) == "" {
 		return codexWindowUsage{}
 	}
+	var usedPct, windowMin, resetSec float64
+	if _, err := fmt.Sscanf(usedStr, "%f", &usedPct); err != nil {
+		return codexWindowUsage{}
+	}
+	if _, err := fmt.Sscanf(windowStr, "%f", &windowMin); err != nil || windowMin <= 0 {
+		return codexWindowUsage{}
+	}
+	if strings.TrimSpace(resetStr) != "" {
+		if _, err := fmt.Sscanf(resetStr, "%f", &resetSec); err != nil {
+			resetSec = 0
+		}
+	}
 	return codexWindowUsage{
-		usedPct:   parseFloat(usedStr),
-		windowMin: parseFloat(windowStr),
-		resetSec:  parseFloat(resetStr),
+		usedPct:   usedPct,
+		windowMin: windowMin,
+		resetSec:  resetSec,
 		valid:     true,
 	}
 }
@@ -4440,6 +4454,7 @@ func SyncCodexUsageState(store *auth.Store, account *auth.Account, resp *http.Re
 	if account == nil || resp == nil {
 		return result
 	}
+	observedAt := time.Now()
 	if store != nil {
 		planHeader := resp.Header.Get("x-codex-plan-type")
 		store.UpdateAccountPlanType(account, planHeader)
@@ -4450,39 +4465,82 @@ func SyncCodexUsageState(store *auth.Store, account *auth.Account, resp *http.Re
 	}
 	result.UsageWindowLimitsIgnored = account.SkipsUsageWindowLimits()
 
-	result.Used5hHeaders = responseHasCodex5hHeaders(resp)
-	result.UsagePct7d, result.HasUsage7d = parseCodexUsageHeaders(resp, account)
-	if store != nil {
-		if result.HasUsage7d {
-			store.PersistUsageSnapshot(account, result.UsagePct7d)
-			if result.UsagePct7d >= 100 {
-				result.Usage7dRateLimited = store.MarkUsage7dRateLimited(account)
+	observation := parseCodexUsageHeaderObservation(resp)
+	result.Used5hHeaders = observation.w5h.valid
+	usageApplied := false
+	if observation.authoritative {
+		usageApplied = account.ApplyUsageObservation(observedAt, func() {
+			parsed := applyCodexUsageHeaderObservation(store, account, observation, observedAt)
+			result.UsagePct7d = parsed.usagePct7d
+			result.HasUsage7d = parsed.hasUsage7d
+			result.Cleared5h = parsed.cleared5h
+			if store == nil {
+				return
 			}
-		} else if result.Used5hHeaders {
-			store.PersistUsageSnapshot5hOnly(account)
-			result.Persisted5hOnly = true
-		}
+			if result.HasUsage7d {
+				store.PersistUsageSnapshot(account, result.UsagePct7d)
+				if result.UsagePct7d >= 100 {
+					result.Usage7dRateLimited = store.MarkUsage7dRateLimited(account)
+				}
+			} else if result.Used5hHeaders {
+				store.PersistUsageSnapshot5hOnly(account)
+				result.Persisted5hOnly = true
+			}
+		})
 	}
 
 	result.UsagePct5h, result.Reset5hAt, result.HasUsage5h = account.GetUsageSnapshot5h()
-	if store != nil && result.HasUsage5h {
+	if usageApplied && store != nil && result.HasUsage5h {
 		// 被动 /responses 头刷新了 5h 窗口重置时刻：武装「到点即探」，窗口翻新即刷新进度条。
 		store.WakeBoundaryProbe(result.Reset5hAt)
 	}
-	if result.Used5hHeaders && account.IsPremium5hPlan() && result.HasUsage5h && result.UsagePct5h >= 100 && !account.SkipsUsageWindowLimits() {
+	if usageApplied && result.Used5hHeaders && account.IsPremium5hPlan() && result.HasUsage5h && result.UsagePct5h >= 100 && !account.SkipsUsageWindowLimits() {
 		if store != nil {
-			store.MarkPremium5hRateLimited(account, result.Reset5hAt)
+			result.Premium5hRateLimited = store.MarkPremium5hRateLimitedAt(account, result.Reset5hAt, observedAt)
+		} else {
+			result.Premium5hRateLimited = true
 		}
-		result.Premium5hRateLimited = true
 	}
 
 	return result
 }
 
+type codexUsageHeaderParseResult struct {
+	usagePct7d float64
+	hasUsage7d bool
+	cleared5h  bool
+}
+
+type codexUsageHeaderObservation struct {
+	w5h           codexWindowUsage
+	w7d           codexWindowUsage
+	authoritative bool
+}
+
 // parseCodexUsageHeaders 从 Codex 响应头解析 5h/7d 用量百分比
 func parseCodexUsageHeaders(resp *http.Response, account *auth.Account) (float64, bool) {
-	if resp == nil {
+	if resp == nil || account == nil {
 		return 0, false
+	}
+	observedAt := time.Now()
+	observation := parseCodexUsageHeaderObservation(resp)
+	if !observation.authoritative {
+		return 0, false
+	}
+	parsed := codexUsageHeaderParseResult{}
+	account.ApplyUsageObservation(observedAt, func() {
+		parsed = applyCodexUsageHeaderObservation(nil, account, observation, observedAt)
+	})
+	return parsed.usagePct7d, parsed.hasUsage7d
+}
+
+// parseCodexUsageHeaderObservation classifies only windows with a positive,
+// recognizable duration. Used-percent-only partial headers are not authoritative
+// evidence that the optional 5h window disappeared.
+func parseCodexUsageHeaderObservation(resp *http.Response) codexUsageHeaderObservation {
+	out := codexUsageHeaderObservation{}
+	if resp == nil {
+		return out
 	}
 
 	// 解析 primary 和 secondary 窗口
@@ -4496,46 +4554,43 @@ func parseCodexUsageHeaders(resp *http.Response, account *auth.Account) (float64
 	primary := parseCodexWindowUsage(primaryUsedStr, primaryWindowStr, primaryResetStr)
 	secondary := parseCodexWindowUsage(secondaryUsedStr, secondaryWindowStr, secondaryResetStr)
 
-	// 归一化：小窗口 (≤360min) → 5h，大窗口 (>360min) → 7d
-	var w5h, w7d codexWindowUsage
-	now := time.Now()
-
-	if primary.valid && secondary.valid {
-		if primary.windowMin >= secondary.windowMin {
-			w7d, w5h = primary, secondary
-		} else {
-			w7d, w5h = secondary, primary
+	for _, window := range []codexWindowUsage{primary, secondary} {
+		if !window.valid {
+			continue
 		}
-	} else if primary.valid {
-		if primary.windowMin <= 360 && primary.windowMin > 0 {
-			w5h = primary
-		} else {
-			w7d = primary
-		}
-	} else if secondary.valid {
-		if secondary.windowMin <= 360 && secondary.windowMin > 0 {
-			w5h = secondary
-		} else {
-			w7d = secondary
+		switch codexWindowType(window.windowMin) {
+		case codexRateLimitWindow5h:
+			if !out.w5h.valid {
+				out.w5h = window
+			}
+		case codexRateLimitWindow7d:
+			if !out.w7d.valid {
+				out.w7d = window
+			}
 		}
 	}
+	out.authoritative = out.w5h.valid || out.w7d.valid
+	return out
+}
 
-	// 写入 5h
-	if w5h.valid {
-		resetAt := now.Add(time.Duration(w5h.resetSec) * time.Second)
-		account.SetUsageSnapshot5hAt(w5h.usedPct, resetAt, now)
+func applyCodexUsageHeaderObservation(store *auth.Store, account *auth.Account, observation codexUsageHeaderObservation, observedAt time.Time) codexUsageHeaderParseResult {
+	out := codexUsageHeaderParseResult{}
+	if observation.w5h.valid {
+		resetAt := observedAt.Add(time.Duration(observation.w5h.resetSec) * time.Second)
+		account.SetUsageSnapshot5hAt(observation.w5h.usedPct, resetAt, observedAt)
+	} else if observation.authoritative {
+		out.cleared5h = store.ClearAbsentUsageSnapshot5hAt(account, observedAt)
 	}
 
-	// 写入 7d
-	if w7d.valid {
-		resetAt := now.Add(time.Duration(w7d.resetSec) * time.Second)
+	if observation.w7d.valid {
+		resetAt := observedAt.Add(time.Duration(observation.w7d.resetSec) * time.Second)
 		account.SetReset7dAt(resetAt)
-		account.SetWindow7dSeconds(int64(w7d.windowMin * 60))
-		account.SetUsagePercent7d(w7d.usedPct)
-		return w7d.usedPct, true
+		account.SetWindow7dSeconds(int64(observation.w7d.windowMin * 60))
+		account.SetUsagePercent7d(observation.w7d.usedPct)
+		out.usagePct7d = observation.w7d.usedPct
+		out.hasUsage7d = true
 	}
-
-	return 0, false
+	return out
 }
 
 // ParseCodexUsageHeaders 从响应头提取并更新账号用量信息

--- a/proxy/handler_anthropic.go
+++ b/proxy/handler_anthropic.go
@@ -294,9 +294,7 @@ func (h *Handler) Messages(c *gin.Context) {
 			if kind := classifyHTTPFailure(resp.StatusCode); kind != "" {
 				h.store.ReportRequestFailure(account, kind, time.Duration(durationMs)*time.Millisecond)
 			}
-			if usagePct, ok := parseCodexUsageHeaders(resp, account); ok {
-				h.store.PersistUsageSnapshot(account, usagePct)
-			}
+			SyncCodexUsageState(h.store, account, resp)
 			errBody, _ := io.ReadAll(resp.Body)
 			resp.Body.Close()
 			h.store.Release(account)
@@ -542,9 +540,7 @@ func (h *Handler) Messages(c *gin.Context) {
 			log.Printf("上游流在首包前断开，重试 (attempt %d/%d, account %d, /v1/messages): %s",
 				attempt+1, maxRetries+1, account.ID(), outcome.failureMessage)
 			recyclePooledClient(account, proxyURL)
-			if usagePct, ok := parseCodexUsageHeaders(resp, account); ok {
-				h.store.PersistUsageSnapshot(account, usagePct)
-			}
+			SyncCodexUsageState(h.store, account, resp)
 			if isFirstTokenTimeoutOutcome(outcome) {
 				retryExclusions.MarkSoftFirstTokenTimeout(account.ID())
 			} else {
@@ -620,9 +616,7 @@ func (h *Handler) Messages(c *gin.Context) {
 		h.logUsageForRequest(c, logInput)
 
 		resp.Body.Close()
-		if usagePct, ok := parseCodexUsageHeaders(resp, account); ok {
-			h.store.PersistUsageSnapshot(account, usagePct)
-		}
+		SyncCodexUsageState(h.store, account, resp)
 		if outcome.penalize {
 			recyclePooledClient(account, proxyURL)
 			h.store.ReportRequestFailure(account, outcome.failureKind, time.Duration(totalDuration)*time.Millisecond)

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -2983,6 +2983,186 @@ func TestSyncCodexUsageStateCreditAccountSkips7dUsageLimit(t *testing.T) {
 	}
 }
 
+// issue #382：响应头仅有 7d 时清除陈旧 5h；完全无用量头时保留 5h。
+func TestSyncCodexUsageState_Clears5hWhenOnly7dHeaders(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "codex2api.db")
+	db, err := database.New("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("database.New: %v", err)
+	}
+	defer db.Close()
+
+	id, err := db.InsertAccountWithCredentials(ctx, "header-clear-5h", map[string]interface{}{
+		"access_token":          "at",
+		"plan_type":             "plus",
+		"codex_5h_used_percent": 90,
+	}, "")
+	if err != nil {
+		t.Fatalf("InsertAccountWithCredentials: %v", err)
+	}
+
+	store := auth.NewStore(db, nil, &database.SystemSettings{MaxConcurrency: 2, TestConcurrency: 1, TestModel: "gpt-5.4"})
+	account := &auth.Account{DBID: id, AccessToken: "at", PlanType: "plus"}
+	account.SetUsageSnapshot5h(90, time.Now().Add(time.Hour))
+
+	resp := &http.Response{Header: make(http.Header)}
+	resp.Header.Set("x-codex-primary-used-percent", "15")
+	resp.Header.Set("x-codex-primary-window-minutes", "10080")
+	resp.Header.Set("x-codex-primary-reset-after-seconds", "500000")
+
+	result := SyncCodexUsageState(store, account, resp)
+	if result.HasUsage5h {
+		t.Fatalf("result = %+v, want no 5h", result)
+	}
+	if !result.Cleared5h {
+		t.Fatal("Cleared5h = false, want true")
+	}
+	if !result.HasUsage7d || result.UsagePct7d != 15 {
+		t.Fatalf("result = %+v, want 7d=15", result)
+	}
+	if _, ok := account.GetUsagePercent5h(); ok {
+		t.Fatal("in-memory 5h should be cleared")
+	}
+	row, err := db.GetAccountByID(ctx, id)
+	if err != nil {
+		t.Fatalf("GetAccountByID: %v", err)
+	}
+	if got := row.GetCredential("codex_5h_used_percent"); got != "" {
+		t.Errorf("persisted codex_5h_used_percent = %q, want cleared", got)
+	}
+
+	reloadedStore := auth.NewStore(db, nil, &database.SystemSettings{MaxConcurrency: 2, TestConcurrency: 1, TestModel: "gpt-5.4"})
+	if err := reloadedStore.LoadAccountByID(ctx, id); err != nil {
+		t.Fatalf("LoadAccountByID: %v", err)
+	}
+	reloaded := reloadedStore.FindByID(id)
+	if reloaded == nil {
+		t.Fatal("reloaded account is nil")
+	}
+	if _, ok := reloaded.GetUsagePercent5h(); ok {
+		t.Fatal("cleared 5h snapshot was hydrated again after reload")
+	}
+}
+
+func TestSyncCodexUsageState_Preserves5hWhenNoUsageHeaders(t *testing.T) {
+	store := auth.NewStore(nil, nil, &database.SystemSettings{MaxConcurrency: 2, TestConcurrency: 1, TestModel: "gpt-5.4"})
+	account := &auth.Account{DBID: 200, PlanType: "plus"}
+	resetAt := time.Now().Add(2 * time.Hour)
+	account.SetUsageSnapshot5h(55, resetAt)
+
+	resp := &http.Response{Header: make(http.Header)}
+	resp.Header.Set("x-codex-plan-type", "plus")
+	// 无 primary/secondary 用量头：可能是中间件剥头，不能误清 5h
+
+	result := SyncCodexUsageState(store, account, resp)
+	if result.Cleared5h {
+		t.Fatal("Cleared5h = true, want false when response has no usage windows")
+	}
+	pct, ok := account.GetUsagePercent5h()
+	if !ok || pct != 55 {
+		t.Fatalf("usage_percent_5h = (%v, %v), want (55, true)", pct, ok)
+	}
+}
+
+func TestSyncCodexUsageState_PartialUsedPercentHeaderDoesNotClear5h(t *testing.T) {
+	store := auth.NewStore(nil, nil, &database.SystemSettings{MaxConcurrency: 2, TestConcurrency: 1, TestModel: "gpt-5.4"})
+	account := &auth.Account{DBID: 201, PlanType: "plus"}
+	account.SetUsageSnapshot5h(63, time.Now().Add(2*time.Hour))
+
+	resp := &http.Response{Header: make(http.Header)}
+	resp.Header.Set("x-codex-primary-used-percent", "12")
+	result := SyncCodexUsageState(store, account, resp)
+
+	if result.Cleared5h || result.HasUsage7d {
+		t.Fatalf("result = %+v, want partial headers ignored", result)
+	}
+	if pct, ok := account.GetUsagePercent5h(); !ok || pct != 63 {
+		t.Fatalf("usage_percent_5h = (%v, %v), want (63, true)", pct, ok)
+	}
+}
+
+func TestParseCodexUsageHeaders_7dOnlyClearsMemoryWithoutStore(t *testing.T) {
+	account := &auth.Account{DBID: 202, PlanType: "plus"}
+	account.SetUsageSnapshot5h(63, time.Now().Add(2*time.Hour))
+	resp := &http.Response{Header: make(http.Header)}
+	resp.Header.Set("x-codex-primary-used-percent", "12")
+	resp.Header.Set("x-codex-primary-window-minutes", "10080")
+	resp.Header.Set("x-codex-primary-reset-after-seconds", "500000")
+
+	pct7d, ok := ParseCodexUsageHeaders(resp, account)
+	if !ok || pct7d != 12 {
+		t.Fatalf("ParseCodexUsageHeaders() = (%v, %v), want (12, true)", pct7d, ok)
+	}
+	if _, ok := account.GetUsagePercent5h(); ok {
+		t.Fatal("public parse-only path should clear stale in-memory 5h without a store")
+	}
+}
+
+func TestSyncCodexUsageState_NilStorePreservesPremiumCooldown(t *testing.T) {
+	account := &auth.Account{DBID: 203, PlanType: "plus", Status: auth.StatusReady}
+	account.SetUsageSnapshot5h(100, time.Now().Add(2*time.Hour))
+	account.SetCooldownUntil(time.Now().Add(2*time.Hour), "rate_limited_5h")
+
+	resp := &http.Response{Header: make(http.Header)}
+	resp.Header.Set("x-codex-primary-used-percent", "12")
+	resp.Header.Set("x-codex-primary-window-minutes", "10080")
+	resp.Header.Set("x-codex-primary-reset-after-seconds", "500000")
+
+	result := SyncCodexUsageState(nil, account, resp)
+	if !result.Cleared5h {
+		t.Fatal("7d-only parse should clear the stale in-memory snapshot")
+	}
+	if account.Status != auth.StatusCooldown || account.GetCooldownReason() != "rate_limited_5h" {
+		t.Fatalf("nil-store parse changed cooldown state: status=%v reason=%q", account.Status, account.GetCooldownReason())
+	}
+}
+
+func TestSyncCodexUsageState_7dOnlyPreservesNewerUnauthorizedCooldown(t *testing.T) {
+	ctx := context.Background()
+	db, err := database.New("sqlite", filepath.Join(t.TempDir(), "codex2api.db"))
+	if err != nil {
+		t.Fatalf("database.New: %v", err)
+	}
+	defer db.Close()
+	id, err := db.InsertAccountWithCredentials(ctx, "header-preserve-401", map[string]interface{}{
+		"access_token":              "at",
+		"plan_type":                 "plus",
+		"codex_5h_used_percent":     100,
+		"codex_5h_reset_at":         time.Now().Add(2 * time.Hour).Format(time.RFC3339),
+		"codex_5h_usage_updated_at": time.Now().Format(time.RFC3339),
+	}, "")
+	if err != nil {
+		t.Fatalf("InsertAccountWithCredentials: %v", err)
+	}
+
+	store := auth.NewStore(db, nil, &database.SystemSettings{MaxConcurrency: 2, TestConcurrency: 1, TestModel: "gpt-5.4"})
+	account := &auth.Account{DBID: id, AccessToken: "at", PlanType: "plus", Status: auth.StatusReady, HealthTier: auth.HealthTierHealthy}
+	store.MarkPremium5hRateLimited(account, time.Now().Add(2*time.Hour))
+	atomic.StoreInt32(&account.Disabled, 1)
+	store.MarkCooldown(account, time.Hour, "unauthorized")
+
+	resp := &http.Response{Header: make(http.Header)}
+	resp.Header.Set("x-codex-primary-used-percent", "15")
+	resp.Header.Set("x-codex-primary-window-minutes", "10080")
+	resp.Header.Set("x-codex-primary-reset-after-seconds", "500000")
+	result := SyncCodexUsageState(store, account, resp)
+
+	if !result.Cleared5h {
+		t.Fatal("Cleared5h = false, want stale snapshot cleared")
+	}
+	if account.GetCooldownReason() != "unauthorized" || atomic.LoadInt32(&account.Disabled) != 1 {
+		t.Fatalf("runtime state = (%q, disabled=%d), want unauthorized and disabled", account.GetCooldownReason(), atomic.LoadInt32(&account.Disabled))
+	}
+	row, err := db.GetAccountByID(ctx, id)
+	if err != nil {
+		t.Fatalf("GetAccountByID: %v", err)
+	}
+	if row.CooldownReason != "unauthorized" || !row.CooldownUntil.Valid {
+		t.Fatalf("persisted cooldown = (%q, %v), want unauthorized", row.CooldownReason, row.CooldownUntil)
+	}
+}
+
 func TestAuthMiddlewareSetsAPIKeyContext(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/proxy/images.go
+++ b/proxy/images.go
@@ -1354,9 +1354,7 @@ func (h *Handler) forwardImagesRequest(c *gin.Context, inboundEndpoint, requestM
 			if kind := classifyHTTPFailure(resp.StatusCode); kind != "" {
 				h.store.ReportRequestFailure(account, kind, time.Duration(durationMs)*time.Millisecond)
 			}
-			if usagePct, ok := parseCodexUsageHeaders(resp, account); ok {
-				h.store.PersistUsageSnapshot(account, usagePct)
-			}
+			SyncCodexUsageState(h.store, account, resp)
 			errBody, _ := io.ReadAll(resp.Body)
 			resp.Body.Close()
 			h.store.Release(account)

--- a/proxy/usage_wham.go
+++ b/proxy/usage_wham.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"strconv"
 	"strings"
@@ -428,6 +429,7 @@ func ApplyWhamUsage(store *auth.Store, account *auth.Account, usage *WhamUsage) 
 	if account == nil || usage == nil {
 		return result
 	}
+	observedAt := time.Now()
 	result.UsageWindowLimitsIgnored = account.SkipsUsageWindowLimits()
 
 	if store != nil && usage.PlanType != "" {
@@ -458,52 +460,69 @@ func ApplyWhamUsage(store *auth.Store, account *auth.Account, usage *WhamUsage) 
 		account.SetRateLimitResetCredits(usage.RateLimitResetCredits.AvailableCount)
 	}
 
-	now := time.Now()
-
-	// 记录本次成功的 wham 探针时间。「主动重置次数」只能由 wham 刷新，
-	// 用它独立判断重置次数是否过期（见 auth.Account.NeedsUsageProbe）。
-	account.MarkResetCreditsProbed(now)
-
-	w5h, w7d := pickClassifiedWhamWindows(usage.RateLimit.PrimaryWindow, usage.RateLimit.SecondaryWindow, usage.PlanType, now)
-
-	if w5h != nil {
-		resetAt := whamWindowResetAt(w5h, now)
-		account.SetUsageSnapshot5hAt(w5h.UsedPercent, resetAt, now)
-		result.UsagePct5h = w5h.UsedPercent
-		result.Reset5hAt = resetAt
-		result.HasUsage5h = true
-		result.Used5hHeaders = true
-		if store != nil {
-			// 5h 窗口重置时刻武装「到点即探」，窗口翻新即刷新进度条。
-			store.WakeBoundaryProbe(resetAt)
-		}
+	w5h, w7d := pickClassifiedWhamWindows(usage.RateLimit.PrimaryWindow, usage.RateLimit.SecondaryWindow, usage.PlanType, observedAt)
+	// A present-but-empty window object is not evidence that the upstream
+	// removed a window. Normalize those placeholders away so malformed/partial
+	// payloads preserve the last known 5h snapshot.
+	if !usableWhamWindow(w5h) {
+		w5h = nil
 	}
-
-	if w7d != nil {
-		resetAt := whamWindowResetAt(w7d, now)
-		account.SetReset7dAt(resetAt)
-		account.SetWindow7dSeconds(w7d.LimitWindowSeconds)
-		result.UsagePct7d = w7d.UsedPercent
-		result.HasUsage7d = true
-		if store != nil {
-			store.WakeBoundaryProbe(resetAt)
-			store.PersistUsageSnapshot(account, w7d.UsedPercent)
-			if result.UsagePct7d >= 100 {
-				result.Usage7dRateLimited = store.MarkUsage7dRateLimited(account)
+	if !usableWhamWindow(w7d) {
+		w7d = nil
+	}
+	hasAuthoritativeWindow := w5h != nil || w7d != nil
+	if hasAuthoritativeWindow {
+		// Only a structurally valid window response is a successful usage probe;
+		// malformed/empty payloads must not suppress the next retry.
+		account.MarkResetCreditsProbed(observedAt)
+	}
+	usageApplied := false
+	if hasAuthoritativeWindow {
+		usageApplied = account.ApplyUsageObservation(observedAt, func() {
+			if w5h != nil {
+				resetAt := whamWindowResetAt(w5h, observedAt)
+				account.SetUsageSnapshot5hAt(w5h.UsedPercent, resetAt, observedAt)
+				result.UsagePct5h = w5h.UsedPercent
+				result.Reset5hAt = resetAt
+				result.HasUsage5h = true
+				result.Used5hHeaders = true
+				if store != nil {
+					// 5h 窗口重置时刻武装「到点即探」，窗口翻新即刷新进度条。
+					store.WakeBoundaryProbe(resetAt)
+				}
+			} else if hasAuthoritativeWindow {
+				// WHAM 是完整权威探测：payload 无 5h 窗口则清除本地陈旧 5h 快照（issue #382）。
+				result.Cleared5h = store.ClearAbsentUsageSnapshot5hAt(account, observedAt)
 			}
-		}
-	} else if result.Used5hHeaders && store != nil {
-		// 只有 5h 数据时，单独持久化 5h 快照
-		store.PersistUsageSnapshot5hOnly(account)
-		result.Persisted5hOnly = true
+
+			if w7d != nil {
+				resetAt := whamWindowResetAt(w7d, observedAt)
+				account.SetReset7dAt(resetAt)
+				account.SetWindow7dSeconds(w7d.LimitWindowSeconds)
+				result.UsagePct7d = w7d.UsedPercent
+				result.HasUsage7d = true
+				if store != nil {
+					store.WakeBoundaryProbe(resetAt)
+					store.PersistUsageSnapshot(account, w7d.UsedPercent)
+					if result.UsagePct7d >= 100 {
+						result.Usage7dRateLimited = store.MarkUsage7dRateLimited(account)
+					}
+				}
+			} else if result.Used5hHeaders && store != nil {
+				// 只有 5h 数据时，单独持久化 5h 快照
+				store.PersistUsageSnapshot5hOnly(account)
+				result.Persisted5hOnly = true
+			}
+		})
 	}
 
 	// premium 5h 限流标记
-	if result.Used5hHeaders && account.IsPremium5hPlan() && result.HasUsage5h && result.UsagePct5h >= 100 && !account.SkipsUsageWindowLimits() {
+	if usageApplied && result.Used5hHeaders && account.IsPremium5hPlan() && result.HasUsage5h && result.UsagePct5h >= 100 && !account.SkipsUsageWindowLimits() {
 		if store != nil {
-			store.MarkPremium5hRateLimited(account, result.Reset5hAt)
+			result.Premium5hRateLimited = store.MarkPremium5hRateLimitedAt(account, result.Reset5hAt, observedAt)
+		} else {
+			result.Premium5hRateLimited = true
 		}
-		result.Premium5hRateLimited = true
 	}
 
 	return result
@@ -562,6 +581,22 @@ func pickClassifiedWhamWindows(primary, secondary *WhamUsageWindow, planType str
 		}
 	}
 	return w5h, w7d
+}
+
+// usableWhamWindow reports whether a decoded window contains enough positive
+// information to be authoritative. JSON may contain an empty placeholder for
+// an omitted optional window; treating that as a real 5h window would erase a
+// valid snapshot on the next probe.
+func usableWhamWindow(w *WhamUsageWindow) bool {
+	if w == nil || math.IsNaN(w.UsedPercent) || math.IsInf(w.UsedPercent, 0) || w.UsedPercent < 0 || w.UsedPercent > 100 {
+		return false
+	}
+	if w.LimitWindowSeconds > 0 || w.ResetAfterSeconds > 0 || w.ResetAt > 0 {
+		return true
+	}
+	// used_percent without a window duration/reset is a partial payload, not
+	// authoritative evidence about which optional window is present.
+	return false
 }
 
 func shouldTreatUnknownWhamWindowAs7d(w *WhamUsageWindow, planType string, now time.Time) bool {

--- a/proxy/usage_wham_test.go
+++ b/proxy/usage_wham_test.go
@@ -469,6 +469,130 @@ func TestApplyWhamUsage_FreeAccountPrimaryIs7d(t *testing.T) {
 	}
 }
 
+// issue #382：上游 WHAM 不再返回 5h 时，必须清除本地陈旧 5h 快照与 premium 5h 限流。
+func TestApplyWhamUsage_ClearsStale5hWhenUpstreamOmitsWindow(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "codex2api.db")
+	db, err := database.New("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("database.New: %v", err)
+	}
+	defer db.Close()
+
+	id, err := db.InsertAccountWithCredentials(ctx, "wham-no-5h", map[string]interface{}{
+		"plan_type":                 "plus",
+		"codex_5h_used_percent":     80,
+		"codex_5h_reset_at":         time.Now().Add(2 * time.Hour).Format(time.RFC3339),
+		"codex_5h_usage_updated_at": time.Now().Format(time.RFC3339),
+	}, "")
+	if err != nil {
+		t.Fatalf("InsertAccountWithCredentials: %v", err)
+	}
+
+	store := auth.NewStore(db, nil, &database.SystemSettings{MaxConcurrency: 2, TestConcurrency: 1, TestModel: "gpt-5.4"})
+	account := &auth.Account{DBID: id, AccessToken: "at", PlanType: "plus", AccountID: "acc"}
+	account.SetUsageSnapshot5h(80, time.Now().Add(2*time.Hour))
+
+	reset7d := time.Now().Add(7 * 24 * time.Hour).Unix()
+	usage := &WhamUsage{PlanType: "plus"}
+	// 仅 weekly：模拟 OpenAI 临时取消 5h 窗口后的 WHAM 响应
+	usage.RateLimit.PrimaryWindow = &WhamUsageWindow{UsedPercent: 22, LimitWindowSeconds: 604800, ResetAfterSeconds: 604800, ResetAt: reset7d}
+	usage.RateLimit.SecondaryWindow = nil
+
+	result := ApplyWhamUsage(store, account, usage)
+
+	if result.HasUsage5h || result.Used5hHeaders {
+		t.Fatalf("result = %+v, want no 5h window", result)
+	}
+	if !result.Cleared5h {
+		t.Fatal("Cleared5h = false, want true when stale 5h was present")
+	}
+	if !result.HasUsage7d || result.UsagePct7d != 22 {
+		t.Fatalf("7d result = %+v, want UsagePct7d=22", result)
+	}
+	if _, ok := account.GetUsagePercent5h(); ok {
+		t.Fatal("in-memory 5h snapshot should be cleared")
+	}
+	if account.IsPremium5hRateLimited() {
+		t.Fatal("account should not remain premium 5h rate limited")
+	}
+
+	row, err := db.GetAccountByID(ctx, id)
+	if err != nil {
+		t.Fatalf("GetAccountByID: %v", err)
+	}
+	if got := row.GetCredential("codex_5h_used_percent"); got != "" {
+		t.Errorf("persisted codex_5h_used_percent = %q, want empty/cleared", got)
+	}
+	if got := row.GetCredential("codex_7d_used_percent"); got != "22" {
+		t.Errorf("persisted codex_7d_used_percent = %q, want 22", got)
+	}
+}
+
+func TestApplyWhamUsage_ClearsPremium5hCooldownWhenWindowGone(t *testing.T) {
+	store := auth.NewStore(nil, nil, &database.SystemSettings{MaxConcurrency: 2, TestConcurrency: 1, TestModel: "gpt-5.4"})
+	account := &auth.Account{DBID: 42, AccessToken: "at", PlanType: "plus", Status: auth.StatusReady}
+	resetAt := time.Now().Add(3 * time.Hour)
+	store.MarkPremium5hRateLimited(account, resetAt)
+	if !account.IsPremium5hRateLimited() {
+		t.Fatal("precondition: account should be premium 5h rate limited")
+	}
+
+	usage := &WhamUsage{PlanType: "plus"}
+	usage.RateLimit.PrimaryWindow = &WhamUsageWindow{
+		UsedPercent:        10,
+		LimitWindowSeconds: 604800,
+		ResetAfterSeconds:  604800,
+		ResetAt:            time.Now().Add(7 * 24 * time.Hour).Unix(),
+	}
+
+	result := ApplyWhamUsage(store, account, usage)
+	if !result.Cleared5h {
+		t.Fatal("Cleared5h = false, want true")
+	}
+	if account.IsPremium5hRateLimited() {
+		t.Fatal("premium 5h limit should be cleared when upstream omits 5h")
+	}
+	if got := account.RuntimeStatus(); got == "rate_limited" {
+		t.Fatalf("RuntimeStatus() = %q, want not rate_limited after clearing absent 5h", got)
+	}
+}
+
+func TestApplyWhamUsage_EmptyWindowPayloadPreserves5h(t *testing.T) {
+	store := auth.NewStore(nil, nil, &database.SystemSettings{MaxConcurrency: 2, TestConcurrency: 1, TestModel: "gpt-5.4"})
+	account := &auth.Account{DBID: 43, AccessToken: "at", PlanType: "plus", Status: auth.StatusReady}
+	resetAt := time.Now().Add(3 * time.Hour)
+	account.SetUsageSnapshot5h(88, resetAt)
+
+	usage := &WhamUsage{PlanType: "plus"}
+	usage.RateLimit.PrimaryWindow = &WhamUsageWindow{}
+
+	result := ApplyWhamUsage(store, account, usage)
+	if result.Cleared5h || result.HasUsage5h || result.HasUsage7d {
+		t.Fatalf("result = %+v, want malformed payload to be non-authoritative", result)
+	}
+	if pct, gotReset, ok := account.GetUsageSnapshot5h(); !ok || pct != 88 || !gotReset.Equal(resetAt) {
+		t.Fatalf("5h snapshot = (%v, %v, %v), want preserved 88%% and reset %v", pct, gotReset, ok, resetAt)
+	}
+}
+
+func TestApplyWhamUsage_UsedPercentOnlyPayloadPreserves5h(t *testing.T) {
+	store := auth.NewStore(nil, nil, &database.SystemSettings{MaxConcurrency: 2, TestConcurrency: 1, TestModel: "gpt-5.4"})
+	account := &auth.Account{DBID: 44, AccessToken: "at", PlanType: "plus", Status: auth.StatusReady}
+	account.SetUsageSnapshot5h(77, time.Now().Add(2*time.Hour))
+
+	usage := &WhamUsage{PlanType: "plus"}
+	usage.RateLimit.PrimaryWindow = &WhamUsageWindow{UsedPercent: 12}
+
+	result := ApplyWhamUsage(store, account, usage)
+	if result.Cleared5h || result.HasUsage5h || result.HasUsage7d {
+		t.Fatalf("result = %+v, want used-percent-only payload to be non-authoritative", result)
+	}
+	if _, _, ok := account.GetUsageSnapshot5h(); !ok {
+		t.Fatal("5h snapshot should remain valid for a used-percent-only payload")
+	}
+}
+
 // 防御性测试：即使后端把 5h/7d 字段顺序对调，分类也必须按 limit_window_seconds 走。
 func TestApplyWhamUsage_ClassifiesByWindowSeconds(t *testing.T) {
 	store := auth.NewStore(nil, nil, &database.SystemSettings{MaxConcurrency: 2, TestConcurrency: 1, TestModel: "gpt-5.4"})


### PR DESCRIPTION
Closes #382

## Summary
- Treat the 5h usage window as optional and clear stale 5h state only after authoritative 7d-only observations.
- Preserve 5h snapshots and unrelated unauthorized, error, disabled, or newer rate-limit states for empty/partial responses.
- Keep cooldown/source ordering safe across WHAM, Responses, Anthropic, images, persistence, and runtime cache paths.
- Hide absent 5h usage/cost UI and keep account refresh behavior based on available windows.

## Validation
- go test ./...
- go test -race ./auth ./proxy
- npm test
- npm run typecheck
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clear 5-hour and 7-day rate-limit statuses with localized labels.
  * Account details and status badges now show the specific affected usage window.
  * Added automatic restoration for eligible accounts after successful connection tests when enabled.

* **Bug Fixes**
  * Improved usage tracking when upstream data omits or partially reports a usage window.
  * Prevented stale usage and cooldown information from overwriting newer account state.
  * Usage displays now hide unavailable windows instead of showing misleading placeholders.
  * Refined cooldown countdown and usage reload behavior.

* **Tests**
  * Expanded coverage for usage synchronization, cooldown handling, persistence, and account status display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->