### PR TITLE
fix(proxy): 上下文压缩轮豁免首字超时看门狗 (issue #381)

### DIFF
--- a/proxy/first_token_timeout.go
+++ b/proxy/first_token_timeout.go
@@ -91,3 +91,16 @@ func firstTokenTimeoutOutcome(timeout time.Duration) streamOutcome {
 func firstTokenTimeoutError(timeout time.Duration) error {
 	return ErrUpstreamTimeout(fmt.Errorf("first token timeout after %s", timeout.Round(time.Millisecond)))
 }
+
+// firstTokenTimeoutForRequest 返回本轮请求应使用的首字超时。上下文压缩轮
+// （请求体含 compaction_trigger）豁免看门狗：压缩需要先读入整段历史上下文
+// 才吐出首个 compaction 输出项，首帧天然可能超过用户配置的较短阈值（如 30s），
+// 而这一轮的 encrypted_content 绑定原账号，超时换号重试大概率继续失败并耗尽
+// attempt，导致会话彻底废掉（issue #381）。故对压缩轮返回 0（关闭看门狗），
+// 让其思考时间不受限；异常挂死仍由客户端自身超时兜底。
+func firstTokenTimeoutForRequest(base time.Duration, isCompactionTrigger bool) time.Duration {
+	if isCompactionTrigger {
+		return 0
+	}
+	return base
+}

--- a/proxy/first_token_timeout_test.go
+++ b/proxy/first_token_timeout_test.go
@@ -155,6 +155,23 @@ func TestApplyRuntimeSettingsFromSystemCodexWebSocketRetrySettings(t *testing.T)
 	}
 }
 
+func TestFirstTokenTimeoutForRequestExemptsCompaction(t *testing.T) {
+	base := 30 * time.Second
+
+	// 普通请求保持配置阈值不变。
+	if got := firstTokenTimeoutForRequest(base, false); got != base {
+		t.Fatalf("non-compaction timeout = %s, want %s", got, base)
+	}
+	// 压缩轮豁免看门狗（返回 0）。
+	if got := firstTokenTimeoutForRequest(base, true); got != 0 {
+		t.Fatalf("compaction timeout = %s, want 0", got)
+	}
+	// 看门狗本身遇到 0 阈值不启动，保证豁免生效。
+	if guard := newFirstTokenTimeoutGuard(firstTokenTimeoutForRequest(base, true), func() {}); guard != nil {
+		t.Fatal("compaction round should not create a first token timeout guard")
+	}
+}
+
 func TestNormalizeBillingTierPolicy(t *testing.T) {
 	if got := NormalizeBillingTierPolicy(""); got != BillingTierPolicyActual {
 		t.Fatalf("empty policy = %q, want actual", got)

--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -1874,7 +1874,7 @@ func (h *Handler) Responses(c *gin.Context) {
 			lastUpstreamCancel = upstreamCancel
 			ttftGuard := (*firstTokenTimeoutGuard)(nil)
 			if isStream {
-				ttftGuard = newFirstTokenTimeoutGuard(currentFirstTokenTimeout(), upstreamCancel)
+				ttftGuard = newFirstTokenTimeoutGuard(firstTokenTimeoutForRequest(currentFirstTokenTimeout(), bodySignalCompact), upstreamCancel)
 			}
 			stopTTFTGuard := func() {
 				if ttftGuard != nil {
@@ -2272,7 +2272,7 @@ func (h *Handler) Responses(c *gin.Context) {
 		}
 		upstreamCtx, upstreamCancel := newDrainableUpstreamContext(c.Request.Context(), upstreamDrainTimeout)
 		lastUpstreamCancel = upstreamCancel
-		ttftGuard := newFirstTokenTimeoutGuard(currentFirstTokenTimeout(), upstreamCancel)
+		ttftGuard := newFirstTokenTimeoutGuard(firstTokenTimeoutForRequest(currentFirstTokenTimeout(), bodySignalCompact), upstreamCancel)
 		// WebSocket 上游下剥离自动注入的图片工具，防止模型自主生图产生大体积
 		// 数据卡死 WS 流（issue #220）。显式生图请求已在上面强制走 HTTP。
 		upstreamBody := codexBody

--- a/proxy/responses_ws.go
+++ b/proxy/responses_ws.go
@@ -185,6 +185,8 @@ func (h *Handler) forwardResponsesWebSocketTurn(c *gin.Context, conn *websocket.
 	apiKeyID := requestAPIKeyID(c)
 	affinityKey := sessionAffinityKey(sessionIdentity.affinityID, apiKeyID)
 	respCacheOwner := responseCacheOwner(apiKeyID)
+	// 上下文压缩轮豁免首字超时看门狗（issue #381）：压缩首帧天然慢，超时换号无益。
+	bodySignalCompact := requestBodyHasCompactionTrigger(rawBody)
 	reasoningEffort := extractReasoningEffort(rawBody)
 	serviceTier := extractServiceTier(rawBody)
 	if serviceTier != "" {
@@ -285,7 +287,7 @@ func (h *Handler) forwardResponsesWebSocketTurn(c *gin.Context, conn *websocket.
 		}
 		upstreamCtx, upstreamCancel := newDrainableUpstreamContext(c.Request.Context(), upstreamDrainTimeout)
 		lastUpstreamCancel = upstreamCancel
-		ttftGuard := newFirstTokenTimeoutGuard(currentFirstTokenTimeout(), upstreamCancel)
+		ttftGuard := newFirstTokenTimeoutGuard(firstTokenTimeoutForRequest(currentFirstTokenTimeout(), bodySignalCompact), upstreamCancel)
 		useWebsocket := !wsHTTPFallback.ForceHTTP()
 		// 生图请求改走 HTTP 上游（客户端仍是 WS）：WebSocket 上游传输大体积
 		// 图片数据会卡死（issue #220）；自然语言生图意图也需保留图片工具（issue #288）。


### PR DESCRIPTION
## 问题 (issue #381)

用户报告：用 5.6-sol，**上下文自动压缩后就报错，会话彻底废了**，日志为：

```
handler.go:2315: 上游首字超时，断开并重试 (attempt 1/3, account 12090, /v1/responses): upstream_timeout: first token timeout after 30s
```

## 根因

首字超时看门狗（`firstTokenTimeoutGuard`）本用于快速发现"上游卡死"并换号重试。但**上下文压缩轮**违反了它的两个前提：

1. **首帧天然慢** —— 压缩需先读入整段历史上下文（往往十几万 token）才吐出首个 `compaction` 输出项，首帧耗时可能超过用户配置的较短阈值（如 30s），这不是故障。
2. **重试有害** —— 压缩项的 `encrypted_content` 绑定原账号，超时换号重试大概率继续失败并耗尽 attempt，最终导致会话彻底废掉。对压缩轮触发重试是净负面。

> 注：默认 `first_token_timeout_seconds = 0`（关闭）时不会触发；用户主动配置了较短阈值才会踩到。

## 修复

新增 `firstTokenTimeoutForRequest(base, isCompactionTrigger)`：请求体含 `compaction_trigger` 时返回 `0`（关闭看门狗），普通请求维持配置阈值不变。接入三处会承载压缩轮的路径：

- `Responses()` relay 路径（`handler.go`）
- `Responses()` Codex 账号路径（`handler.go`）
- inbound WS 路径（`responses_ws.go`）

异常挂死仍由客户端自身超时兜底。

## 验证

本地部署（PG+Redis，官方 OAuth 账号）对照实验，故意把首字超时压到 **1s**：

| 实验 | 首帧耗时 | 结果 |
|---|---|---|
| **压缩请求**（带 trigger） | 2.97s（>1s 阈值） | ✅ 成功返回 compaction 项，**无超时、无重试** |
| **普通思考请求**（对照） | >1s | 被看门狗打断 → 3 次 attempt 耗尽 → 504（**看门狗仍正常保护普通请求**）|

对照组日志复现了 issue 同款的 `handler.go 上游首字超时，断开并重试`，证明修复精准：压缩轮豁免、普通请求保护不受影响。

- `go build ./...` 通过
- `go test ./proxy/` 全绿（含新增单元测试）

## 给用户的即时缓解

升级前可先把 `first_token_timeout_seconds` 调大（如 120s）或设为 0（关闭）。

Closes #381

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Compaction requests are no longer interrupted by the first-token timeout while processing full conversation history.
  * Applies consistently to streaming responses over HTTP and WebSocket connections.
* **Tests**
  * Added coverage verifying timeout behavior for regular and compaction requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->