### PR TITLE
fix(security): 按 Content-Encoding 解压入站请求体 (issue #373)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/codex2api
 go 1.26.5
 
 require (
+	github.com/andybalholm/brotli v1.0.6
 	github.com/aws/aws-sdk-go-v2 v1.41.7
 	github.com/aws/aws-sdk-go-v2/config v1.32.17
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.16
@@ -11,6 +12,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/joho/godotenv v1.5.1
+	github.com/klauspost/compress v1.17.6
 	github.com/lib/pq v1.12.0
 	github.com/redis/go-redis/v9 v9.18.0
 	github.com/refraction-networking/utls v1.8.2
@@ -22,7 +24,6 @@ require (
 )
 
 require (
-	github.com/andybalholm/brotli v1.0.6 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.10 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.23 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23 // indirect
@@ -52,7 +53,6 @@ require (
 	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/goccy/go-yaml v1.19.2 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/klauspost/compress v1.17.6 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect

--- a/main.go
+++ b/main.go
@@ -294,6 +294,7 @@ func main() {
 	r.Use(api.VersionMiddleware())
 	security.MaxRequestBodySize = cfg.MaxRequestBodySize
 	r.Use(security.RequestSizeLimiter(int64(security.MaxRequestBodySize)))
+	r.Use(security.RequestBodyDecompressor(int64(security.MaxRequestBodySize)))
 	r.Use(api.BodyCacheMiddleware())
 	r.Use(api.CORSMiddleware())
 	r.Use(api.SecurityHeadersMiddleware())

--- a/security/decompress.go
+++ b/security/decompress.go
@@ -1,0 +1,182 @@
+package security
+
+import (
+	"bytes"
+	"compress/flate"
+	"compress/gzip"
+	"compress/zlib"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/andybalholm/brotli"
+	"github.com/gin-gonic/gin"
+	"github.com/klauspost/compress/zstd"
+)
+
+// errDecompressedBodyTooLarge 表示解压后的请求体超过大小上限（解压炸弹防护）。
+var errDecompressedBodyTooLarge = errors.New("decompressed body too large")
+
+// parseContentEncodings 解析 Content-Encoding 头，返回小写、去空白的编码列表。
+// 按 RFC 9110，多个编码按施加顺序列出，解码时需要逆序处理；identity 视为无编码。
+func parseContentEncodings(header string) []string {
+	if strings.TrimSpace(header) == "" {
+		return nil
+	}
+	var encodings []string
+	for _, token := range strings.Split(header, ",") {
+		token = strings.ToLower(strings.TrimSpace(token))
+		if token == "" || token == "identity" {
+			continue
+		}
+		encodings = append(encodings, token)
+	}
+	return encodings
+}
+
+func isSupportedContentEncoding(encoding string) bool {
+	switch encoding {
+	case "zstd", "gzip", "x-gzip", "br", "deflate":
+		return true
+	default:
+		return false
+	}
+}
+
+// decodeContentEncodingOnce 按单个编码解压 data，解压结果超过 maxSize 时报错。
+func decodeContentEncodingOnce(data []byte, encoding string, maxSize int64) ([]byte, error) {
+	var reader io.Reader
+	switch encoding {
+	case "zstd":
+		dec, err := zstd.NewReader(
+			bytes.NewReader(data),
+			zstd.WithDecoderConcurrency(1),
+			zstd.WithDecoderMaxMemory(uint64(maxSize)+1),
+		)
+		if err != nil {
+			return nil, err
+		}
+		defer dec.Close()
+		reader = dec
+	case "gzip", "x-gzip":
+		gr, err := gzip.NewReader(bytes.NewReader(data))
+		if err != nil {
+			return nil, err
+		}
+		defer gr.Close()
+		reader = gr
+	case "br":
+		reader = brotli.NewReader(bytes.NewReader(data))
+	case "deflate":
+		// RFC 规定 deflate 是 zlib 封装，但部分客户端会发裸 flate 流，做一次回退。
+		zr, err := zlib.NewReader(bytes.NewReader(data))
+		if err != nil {
+			fr := flate.NewReader(bytes.NewReader(data))
+			defer fr.Close()
+			reader = fr
+		} else {
+			defer zr.Close()
+			reader = zr
+		}
+	default:
+		return nil, fmt.Errorf("unsupported content encoding: %s", encoding)
+	}
+
+	decoded, err := io.ReadAll(io.LimitReader(reader, maxSize+1))
+	if err != nil {
+		if errors.Is(err, zstd.ErrDecoderSizeExceeded) || errors.Is(err, zstd.ErrWindowSizeExceeded) {
+			return nil, errDecompressedBodyTooLarge
+		}
+		return nil, err
+	}
+	if int64(len(decoded)) > maxSize {
+		return nil, errDecompressedBodyTooLarge
+	}
+	return decoded, nil
+}
+
+// RequestBodyDecompressor 按 Content-Encoding 解压入站请求体（zstd/gzip/br/deflate）。
+// 新版 Codex 客户端会用 zstd 压缩 /v1/responses 请求体，不解压的话下游按明文 JSON
+// 解析会读不到任何字段。解压成功后覆盖缓存的 raw_body 与 c.Request.Body，并移除
+// Content-Encoding 头，保证后续流程（含转发上游）看到的都是明文。
+// 未知编码保持原样透传，与历史行为一致。
+func RequestBodyDecompressor(maxSize int64) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		encodings := parseContentEncodings(c.GetHeader("Content-Encoding"))
+		if len(encodings) == 0 {
+			c.Next()
+			return
+		}
+		for _, encoding := range encodings {
+			if !isSupportedContentEncoding(encoding) {
+				c.Next()
+				return
+			}
+		}
+
+		var body []byte
+		if cached, exists := c.Get("raw_body"); exists {
+			body, _ = cached.([]byte)
+		}
+		if body == nil {
+			if c.Request.Body == nil || c.Request.Body == http.NoBody {
+				c.Next()
+				return
+			}
+			data, err := io.ReadAll(io.LimitReader(c.Request.Body, maxSize+1))
+			if err != nil {
+				c.JSON(http.StatusBadRequest, gin.H{
+					"error": gin.H{
+						"message": "读取请求体失败",
+						"type":    "invalid_request_error",
+					},
+				})
+				c.Abort()
+				return
+			}
+			body = data
+		}
+		if len(body) == 0 {
+			c.Next()
+			return
+		}
+
+		decoded := body
+		// 多个编码按施加顺序列出，解码逆序进行。
+		for i := len(encodings) - 1; i >= 0; i-- {
+			var err error
+			decoded, err = decodeContentEncodingOnce(decoded, encodings[i], maxSize)
+			if err != nil {
+				if errors.Is(err, errDecompressedBodyTooLarge) {
+					c.JSON(http.StatusRequestEntityTooLarge, gin.H{
+						"error": gin.H{
+							"message": "请求体过大",
+							"type":    "invalid_request_error",
+							"code":    "request_too_large",
+						},
+					})
+				} else {
+					c.JSON(http.StatusBadRequest, gin.H{
+						"error": gin.H{
+							"message": fmt.Sprintf("请求体解压失败（Content-Encoding: %s）", encodings[i]),
+							"type":    "invalid_request_error",
+							"code":    "invalid_request_body_encoding",
+						},
+					})
+				}
+				c.Abort()
+				return
+			}
+		}
+
+		c.Set("raw_body", decoded)
+		c.Request.Body = io.NopCloser(bytes.NewReader(decoded))
+		c.Request.ContentLength = int64(len(decoded))
+		c.Request.Header.Set("Content-Length", strconv.Itoa(len(decoded)))
+		c.Request.Header.Del("Content-Encoding")
+		c.Next()
+	}
+}

--- a/security/decompress_test.go
+++ b/security/decompress_test.go
@@ -1,0 +1,207 @@
+package security
+
+import (
+	"bytes"
+	"compress/flate"
+	"compress/gzip"
+	"compress/zlib"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/andybalholm/brotli"
+	"github.com/gin-gonic/gin"
+	"github.com/klauspost/compress/zstd"
+)
+
+const testPlainBody = `{"model":"gpt-5.6-sol","stream":true,"input":"hello"}`
+
+func zstdCompress(t *testing.T, data []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	enc, err := zstd.NewWriter(&buf)
+	if err != nil {
+		t.Fatalf("zstd.NewWriter: %v", err)
+	}
+	if _, err := enc.Write(data); err != nil {
+		t.Fatalf("zstd write: %v", err)
+	}
+	if err := enc.Close(); err != nil {
+		t.Fatalf("zstd close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func gzipCompress(t *testing.T, data []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	if _, err := gw.Write(data); err != nil {
+		t.Fatalf("gzip write: %v", err)
+	}
+	if err := gw.Close(); err != nil {
+		t.Fatalf("gzip close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func brotliCompress(t *testing.T, data []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	bw := brotli.NewWriter(&buf)
+	if _, err := bw.Write(data); err != nil {
+		t.Fatalf("brotli write: %v", err)
+	}
+	if err := bw.Close(); err != nil {
+		t.Fatalf("brotli close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func zlibCompress(t *testing.T, data []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := zlib.NewWriter(&buf)
+	if _, err := zw.Write(data); err != nil {
+		t.Fatalf("zlib write: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("zlib close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// runDecompressor 以「RequestSizeLimiter 在前」的真实链路跑中间件，返回下游
+// 处理器看到的 raw_body、请求头与响应。
+func runDecompressor(t *testing.T, body []byte, contentEncoding string, maxSize int64) (downstreamBody []byte, downstreamEncoding string, w *httptest.ResponseRecorder) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(RequestSizeLimiter(maxSize))
+	r.Use(RequestBodyDecompressor(maxSize))
+	r.POST("/test", func(c *gin.Context) {
+		if cached, exists := c.Get("raw_body"); exists {
+			downstreamBody, _ = cached.([]byte)
+		}
+		downstreamEncoding = c.GetHeader("Content-Encoding")
+		got, _ := io.ReadAll(c.Request.Body)
+		if !bytes.Equal(got, downstreamBody) {
+			t.Errorf("c.Request.Body(%d bytes) 与 raw_body(%d bytes) 不一致", len(got), len(downstreamBody))
+		}
+		c.Status(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/test", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	if contentEncoding != "" {
+		req.Header.Set("Content-Encoding", contentEncoding)
+	}
+	w = httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return downstreamBody, downstreamEncoding, w
+}
+
+func TestRequestBodyDecompressorEncodings(t *testing.T) {
+	plain := []byte(testPlainBody)
+	cases := []struct {
+		name     string
+		encoding string
+		body     []byte
+	}{
+		{"zstd", "zstd", zstdCompress(t, plain)},
+		{"gzip", "gzip", gzipCompress(t, plain)},
+		{"x-gzip", "x-gzip", gzipCompress(t, plain)},
+		{"brotli", "br", brotliCompress(t, plain)},
+		{"deflate-zlib", "deflate", zlibCompress(t, plain)},
+		{"identity", "identity", plain},
+		{"none", "", plain},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, encoding, w := runDecompressor(t, tc.body, tc.encoding, 1<<20)
+			if w.Code != http.StatusOK {
+				t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+			}
+			if !bytes.Equal(got, plain) {
+				t.Fatalf("downstream body = %q, want %q", got, plain)
+			}
+			if tc.encoding != "" && tc.encoding != "identity" && encoding != "" {
+				t.Fatalf("Content-Encoding 头未移除: %q", encoding)
+			}
+		})
+	}
+}
+
+func TestRequestBodyDecompressorChainedEncodings(t *testing.T) {
+	plain := []byte(testPlainBody)
+	// 施加顺序 gzip → zstd，头按施加顺序列出，解码应逆序进行。
+	body := zstdCompress(t, gzipCompress(t, plain))
+	got, encoding, w := runDecompressor(t, body, "gzip, zstd", 1<<20)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	if !bytes.Equal(got, plain) {
+		t.Fatalf("downstream body = %q, want %q", got, plain)
+	}
+	if encoding != "" {
+		t.Fatalf("Content-Encoding 头未移除: %q", encoding)
+	}
+}
+
+func TestRequestBodyDecompressorUnknownEncodingPassthrough(t *testing.T) {
+	plain := []byte(testPlainBody)
+	got, encoding, w := runDecompressor(t, plain, "amz-1.0", 1<<20)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	if !bytes.Equal(got, plain) {
+		t.Fatalf("未知编码应原样透传, got %q", got)
+	}
+	if encoding != "amz-1.0" {
+		t.Fatalf("未知编码的 Content-Encoding 头应保留, got %q", encoding)
+	}
+}
+
+func TestRequestBodyDecompressorCorruptBody(t *testing.T) {
+	_, _, w := runDecompressor(t, []byte("not-zstd-data"), "zstd", 1<<20)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400, body = %s", w.Code, w.Body.String())
+	}
+}
+
+func TestRequestBodyDecompressorBombGuard(t *testing.T) {
+	// 压缩后很小、解压后超限的高压缩比载荷。
+	huge := bytes.Repeat([]byte("a"), 1<<20)
+	body := zstdCompress(t, huge)
+	_, _, w := runDecompressor(t, body, "zstd", 1<<10)
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want 413, body = %s", w.Code, w.Body.String())
+	}
+}
+
+func TestRequestBodyDecompressorRawDeflateFallback(t *testing.T) {
+	plain := []byte(testPlainBody)
+	var buf bytes.Buffer
+	fw, err := newRawFlateWriter(&buf)
+	if err != nil {
+		t.Fatalf("flate writer: %v", err)
+	}
+	if _, err := fw.Write(plain); err != nil {
+		t.Fatalf("flate write: %v", err)
+	}
+	if err := fw.Close(); err != nil {
+		t.Fatalf("flate close: %v", err)
+	}
+	got, _, w := runDecompressor(t, buf.Bytes(), "deflate", 1<<20)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	if !bytes.Equal(got, plain) {
+		t.Fatalf("downstream body = %q, want %q", got, plain)
+	}
+}
+
+func newRawFlateWriter(w io.Writer) (io.WriteCloser, error) {
+	return flate.NewWriter(w, flate.DefaultCompression)
+}


### PR DESCRIPTION
## 问题

Fixes #373

新版 Codex Desktop/CLI (0.144.2+) 在 `requires_openai_auth = true` + `experimental_bearer_token` 配置下，发 `/v1/responses` 请求时会带 `content-encoding: zstd`（用户抓包已证实）。codex2api 入站完全不看 Content-Encoding，把 zstd 压缩的二进制当明文 JSON 解析，导致两种表现（同一根因）：

- **大请求体**（真实会话，~42KB）：压缩打散了 JSON 字面量，gjson 读不到 `model` → 本地校验报 `Field 'model' is required`（issue 标题的报错，已本地精确复现）
- **小请求体**：zstd 帧里字面量近乎原样保留，gjson 竟能在压缩帧里扫到 `model` → 校验误通过 → 压缩二进制被漏发上游 → 上游报 `The 'None' model is not supported`

curl 直连正常（明文）、经 AxonHub 分发正常（它入站解了 zstd），均与根因自洽。

## 修复

新增 `security.RequestBodyDecompressor` 中间件，插在 `RequestSizeLimiter` 之后、`BodyCacheMiddleware` 之前（最早读完整 body 的位置之后），统一覆盖所有下游读取点：

- 支持 `zstd` / `gzip` / `x-gzip` / `br` / `deflate`（zlib 封装 + 裸 flate 回退）；多重编码按 RFC 9110 逆序解码
- 解压后覆盖 `raw_body` 缓存与 `c.Request.Body`，移除 `Content-Encoding` 头并修正 `Content-Length`——校验、计费、转发上游全部拿到明文
- 解压炸弹防护：解压结果超过 `MaxRequestBodySize` 返回 413；坏压缩流返回 400（带 `invalid_request_body_encoding` code）
- 未知编码原样透传，不改变既有行为
- 依赖零新增：`klauspost/compress`、`andybalholm/brotli` 本就是间接依赖，仅转为直接

## 测试

**单元测试**（`security/decompress_test.go`，以 RequestSizeLimiter 在前的真实链路跑）：各编码解压、多重编码链、未知编码透传、坏数据 400、解压炸弹 413、裸 flate 回退，全部通过；`go test ./...` 全绿。

**端到端**（docker-compose.pgredis2004.yml 重建后实测）：

| 用例 | 修复前 | 修复后 |
|---|---|---|
| zstd 大 body | `Field 'model' is required` | ✅ 正常响应 |
| zstd 小 body | 上游 `The 'None' model is not supported` | ✅ 正常响应 |
| zstd + stream(SSE) | — | ✅ 正常流式输出 |
| gzip body | — | ✅ 正常响应 |
| 明文回归 | ✅ | ✅ 正常响应 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for automatically decompressing incoming request bodies encoded with gzip, zstd, Brotli, and deflate.
  * Supports chained content encodings and preserves unsupported encodings unchanged.
  * Enforces decompressed size limits to protect against oversized compressed payloads.

* **Bug Fixes**
  * Returns clear errors for invalid compressed requests and payloads exceeding size limits.

* **Tests**
  * Added coverage for supported encodings, chained compression, invalid data, size protection, and raw deflate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->