### PR TITLE
feat(proxy): payload 请求体重写规则引擎 (issue #321)

### DIFF
--- a/admin/handler.go
+++ b/admin/handler.go
@@ -470,6 +470,7 @@ func (h *Handler) RegisterRoutes(r *gin.Engine) {
 	api.GET("/ops/errors/summary", h.GetOpsErrorSummary)
 	api.GET("/settings", h.GetSettings)
 	api.PUT("/settings", h.UpdateSettings)
+	api.GET("/settings/observed-instructions", h.GetObservedInstructions)
 	api.POST("/settings/background-upload", h.UploadBackgroundAsset)
 	api.POST("/settings/image-storage/test", h.TestImageStorageConnection)
 	api.GET("/prompt-filter/logs", h.ListPromptFilterLogs)
@@ -6079,6 +6080,7 @@ type settingsResponse struct {
 	ExpiredCleaned                     int     `json:"expired_cleaned,omitempty"`
 	ModelMapping                       string  `json:"model_mapping"`
 	CodexModelMapping                  string  `json:"codex_model_mapping"`
+	PayloadRules                       string  `json:"payload_rules"`
 	ReasoningEffortModels              string  `json:"reasoning_effort_models"`
 	ResinURL                           string  `json:"resin_url"`
 	ResinPlatformName                  string  `json:"resin_platform_name"`
@@ -6181,6 +6183,7 @@ type updateSettingsReq struct {
 	AllowRemoteMigration               *bool    `json:"allow_remote_migration"`
 	ModelMapping                       *string  `json:"model_mapping"`
 	CodexModelMapping                  *string  `json:"codex_model_mapping"`
+	PayloadRules                       *string  `json:"payload_rules"`
 	ReasoningEffortModels              *string  `json:"reasoning_effort_models"`
 	ResinURL                           *string  `json:"resin_url"`
 	ResinPlatformName                  *string  `json:"resin_platform_name"`
@@ -6702,6 +6705,12 @@ func (h *Handler) GetBranding(c *gin.Context) {
 }
 
 // GetSettings 获取当前系统设置
+// GetObservedInstructions 返回最近观测到的客户端透传 instructions 样本，
+// 供管理端在配置 payload 重写规则时查看客户端实际发来的系统提示词原文。
+func (h *Handler) GetObservedInstructions(c *gin.Context) {
+	c.JSON(http.StatusOK, gin.H{"samples": proxy.ObservedInstructions()})
+}
+
 func (h *Handler) GetSettings(c *gin.Context) {
 	ctx, cancel := context.WithTimeout(c.Request.Context(), 3*time.Second)
 	defer cancel()
@@ -6794,6 +6803,7 @@ func (h *Handler) GetSettings(c *gin.Context) {
 		CacheLabel:                         h.cacheLabel,
 		ModelMapping:                       h.store.GetModelMapping(),
 		CodexModelMapping:                  h.store.GetCodexModelMapping(),
+		PayloadRules:                       h.store.GetPayloadRules(),
 		ReasoningEffortModels:              h.store.GetReasoningEffortModels(),
 		ResinURL:                           resinURL,
 		ResinPlatformName:                  resinPlatformName,
@@ -7311,6 +7321,19 @@ func (h *Handler) UpdateSettings(c *gin.Context) {
 		h.store.SetCodexModelMapping(*req.CodexModelMapping)
 		log.Printf("设置已更新: codex_model_mapping")
 	}
+	if req.PayloadRules != nil {
+		normalized, err := proxy.NormalizePayloadRulesJSON(*req.PayloadRules)
+		if err != nil {
+			writeError(c, http.StatusBadRequest, err.Error())
+			return
+		}
+		if err := proxy.SetPayloadRulesJSON(normalized); err != nil {
+			writeError(c, http.StatusBadRequest, err.Error())
+			return
+		}
+		h.store.SetPayloadRules(normalized)
+		log.Printf("设置已更新: payload_rules")
+	}
 	if req.ReasoningEffortModels != nil {
 		normalized, err := proxy.NormalizeReasoningEffortModelsJSON(*req.ReasoningEffortModels, proxy.SupportedModelIDs(c.Request.Context(), h.db))
 		if err != nil {
@@ -7672,6 +7695,7 @@ func (h *Handler) UpdateSettings(c *gin.Context) {
 		AllowRemoteMigration:               h.store.GetAllowRemoteMigration() && hasAdminSecret,
 		ModelMapping:                       h.store.GetModelMapping(),
 		CodexModelMapping:                  h.store.GetCodexModelMapping(),
+		PayloadRules:                       h.store.GetPayloadRules(),
 		ReasoningEffortModels:              h.store.GetReasoningEffortModels(),
 		ResinURL:                           resinURL,
 		ResinPlatformName:                  resinPlatformName,
@@ -7803,6 +7827,7 @@ func (h *Handler) UpdateSettings(c *gin.Context) {
 		ExpiredCleaned:                     expiredCleaned,
 		ModelMapping:                       h.store.GetModelMapping(),
 		CodexModelMapping:                  h.store.GetCodexModelMapping(),
+		PayloadRules:                       h.store.GetPayloadRules(),
 		ReasoningEffortModels:              h.store.GetReasoningEffortModels(),
 		ResinURL:                           resinURL,
 		ResinPlatformName:                  resinPlatformName,

--- a/auth/store.go
+++ b/auth/store.go
@@ -2385,6 +2385,7 @@ type Store struct {
 	allowRemoteMigration  atomic.Bool  // 是否允许远程迁移拉取账号
 	modelMapping          atomic.Value // 模型映射 JSON 字符串
 	codexModelMapping     atomic.Value // Codex 模型映射 JSON 字符串
+	payloadRules          atomic.Value // Payload 请求体重写规则 JSON 字符串
 	reasoningEffortModels atomic.Value // 带思考强度的模型别名 JSON 数组
 	schedulerMode         atomic.Value // string: "round_robin" or "remaining_quota"
 	affinityMode          atomic.Value // string: "bounded" / "off" / "strict"
@@ -2843,6 +2844,9 @@ func NewStore(db *database.DB, tc cache.TokenCache, settings *database.SystemSet
 	}
 	if settings.CodexModelMapping != "" {
 		s.codexModelMapping.Store(settings.CodexModelMapping)
+	}
+	if settings.PayloadRules != "" {
+		s.payloadRules.Store(settings.PayloadRules)
 	}
 	if settings.ReasoningEffortModels != "" {
 		s.reasoningEffortModels.Store(settings.ReasoningEffortModels)
@@ -4721,6 +4725,19 @@ func (s *Store) SetCodexModelMapping(mapping string) {
 // GetCodexModelMapping 获取当前 Codex 模型映射 JSON
 func (s *Store) GetCodexModelMapping() string {
 	if v, ok := s.codexModelMapping.Load().(string); ok && v != "" {
+		return v
+	}
+	return "{}"
+}
+
+// SetPayloadRules 动态更新 Payload 请求体重写规则 JSON
+func (s *Store) SetPayloadRules(rules string) {
+	s.payloadRules.Store(rules)
+}
+
+// GetPayloadRules 获取当前 Payload 请求体重写规则 JSON
+func (s *Store) GetPayloadRules() string {
+	if v, ok := s.payloadRules.Load().(string); ok && v != "" {
 		return v
 	}
 	return "{}"

--- a/database/postgres.go
+++ b/database/postgres.go
@@ -774,6 +774,7 @@ func (db *DB) migrate(ctx context.Context) error {
 	ALTER TABLE system_settings ADD COLUMN IF NOT EXISTS lazy_mode BOOLEAN DEFAULT FALSE;
 	ALTER TABLE system_settings ADD COLUMN IF NOT EXISTS model_mapping TEXT DEFAULT '{}';
 	ALTER TABLE system_settings ADD COLUMN IF NOT EXISTS codex_model_mapping TEXT DEFAULT '{}';
+	ALTER TABLE system_settings ADD COLUMN IF NOT EXISTS payload_rules TEXT DEFAULT '{}';
 	ALTER TABLE system_settings ADD COLUMN IF NOT EXISTS reasoning_effort_models TEXT DEFAULT '[]';
 	ALTER TABLE system_settings ADD COLUMN IF NOT EXISTS background_refresh_interval_minutes INT DEFAULT 2;
 	ALTER TABLE system_settings ADD COLUMN IF NOT EXISTS usage_probe_max_age_minutes INT DEFAULT 10;
@@ -1408,6 +1409,7 @@ type SystemSettings struct {
 	AllowRemoteMigration               bool
 	ModelMapping                       string // JSON: {"anthropic_model": "codex_model", ...}
 	CodexModelMapping                  string // JSON: {"requested_codex_model": "upstream_codex_model", ...}
+	PayloadRules                       string // JSON: 请求体重写规则（default/override/append/filter 等规则组）
 	ReasoningEffortModels              string // JSON: [{"model":"gpt-5.5","effort":"xhigh"}, ...]
 	BackgroundRefreshIntervalMinutes   int
 	UsageProbeMaxAgeMinutes            int
@@ -1633,7 +1635,8 @@ func (db *DB) GetSystemSettings(ctx context.Context) (*SystemSettings, error) {
 			       COALESCE(model_pricing_sync_url, ''),
 			       COALESCE(ignore_usage_limit_status, false),
 			       COALESCE(auto_reset_credits_enabled, false),
-			       COALESCE(auto_reset_credits_before_expiry_min, 60)
+			       COALESCE(auto_reset_credits_before_expiry_min, 60),
+			       COALESCE(payload_rules, '{}')
 			FROM system_settings WHERE id = 1
 		`).Scan(
 		&s.SiteName, &s.SiteLogo,
@@ -1686,6 +1689,7 @@ func (db *DB) GetSystemSettings(ctx context.Context) (*SystemSettings, error) {
 		&s.IgnoreUsageLimitStatus,
 		&s.AutoResetCreditsEnabled,
 		&s.AutoResetCreditsBeforeExpiryMin,
+		&s.PayloadRules,
 	)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
@@ -1705,6 +1709,9 @@ func (db *DB) GetSystemSettings(ctx context.Context) (*SystemSettings, error) {
 	if strings.TrimSpace(s.ModelPricingOverrides) == "" {
 		s.ModelPricingOverrides = "{}"
 	}
+	if strings.TrimSpace(s.PayloadRules) == "" {
+		s.PayloadRules = "{}"
+	}
 	s.FirstTokenMode = normalizeFirstTokenMode(s.FirstTokenMode)
 	s.BillingTierPolicy = normalizeBillingTierPolicy(s.BillingTierPolicy)
 	s.AutoResetCreditsBeforeExpiryMin = NormalizeAutoResetCreditsBeforeExpiryMinutes(s.AutoResetCreditsBeforeExpiryMin)
@@ -1722,6 +1729,10 @@ func (db *DB) UpdateSystemSettings(ctx context.Context, s *SystemSettings) error
 	codexUserAgentConfig := strings.TrimSpace(s.CodexUserAgentConfig)
 	if codexUserAgentConfig == "" {
 		codexUserAgentConfig = "{}"
+	}
+	payloadRules := strings.TrimSpace(s.PayloadRules)
+	if payloadRules == "" {
+		payloadRules = "{}"
 	}
 	firstTokenMode := normalizeFirstTokenMode(s.FirstTokenMode)
 	billingTierPolicy := normalizeBillingTierPolicy(s.BillingTierPolicy)
@@ -1778,9 +1789,10 @@ func (db *DB) UpdateSystemSettings(ctx context.Context, s *SystemSettings) error
 					model_pricing_sync_url,
 					ignore_usage_limit_status,
 					auto_reset_credits_enabled,
-					auto_reset_credits_before_expiry_min
+					auto_reset_credits_before_expiry_min,
+					payload_rules
 					)
-						VALUES (1, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43, $44, $45, $46, $47, $48, $49, $50, $51, $52, $53, $54, $55, $56, $57, $58, $59, $60, $61, $62, $63, $64, $65, $66, $67, $68, $69, $70, $71, $72, $73, $74, $75, $76, $77, $78, $79, $80, $81, $82, $83, $84, $85, $86, $87, $88, $89, $90)
+						VALUES (1, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43, $44, $45, $46, $47, $48, $49, $50, $51, $52, $53, $54, $55, $56, $57, $58, $59, $60, $61, $62, $63, $64, $65, $66, $67, $68, $69, $70, $71, $72, $73, $74, $75, $76, $77, $78, $79, $80, $81, $82, $83, $84, $85, $86, $87, $88, $89, $90, $91)
 				ON CONFLICT (id) DO UPDATE SET
 				site_name               = EXCLUDED.site_name,
 				site_logo               = EXCLUDED.site_logo,
@@ -1868,7 +1880,8 @@ func (db *DB) UpdateSystemSettings(ctx context.Context, s *SystemSettings) error
 					codex_cli_version_sync_interval_hours = EXCLUDED.codex_cli_version_sync_interval_hours,
 					ignore_usage_limit_status = EXCLUDED.ignore_usage_limit_status,
 					auto_reset_credits_enabled = EXCLUDED.auto_reset_credits_enabled,
-					auto_reset_credits_before_expiry_min = EXCLUDED.auto_reset_credits_before_expiry_min
+					auto_reset_credits_before_expiry_min = EXCLUDED.auto_reset_credits_before_expiry_min,
+					payload_rules = EXCLUDED.payload_rules
 			`, NormalizeSiteName(s.SiteName), strings.TrimSpace(s.SiteLogo),
 		s.MaxConcurrency, s.GlobalRPM, s.TestModel, testContent, s.TestConcurrency, s.ProxyURL, s.PgMaxConns, s.RedisPoolSize,
 		s.AutoCleanUnauthorized, s.AutoCleanRateLimited, s.AdminSecret, s.AutoCleanFullUsage, s.ProxyPoolEnabled,
@@ -1893,7 +1906,8 @@ func (db *DB) UpdateSystemSettings(ctx context.Context, s *SystemSettings) error
 		s.CodexCLIVersionSyncEnabled, NormalizeCodexCLIVersionSyncIntervalHours(s.CodexCLIVersionSyncIntervalHours),
 		normalizeModelPricingOverridesJSON(s.ModelPricingOverrides), strings.TrimSpace(s.ModelPricingSyncURL),
 		s.IgnoreUsageLimitStatus, s.AutoResetCreditsEnabled,
-		NormalizeAutoResetCreditsBeforeExpiryMinutes(s.AutoResetCreditsBeforeExpiryMin))
+		NormalizeAutoResetCreditsBeforeExpiryMinutes(s.AutoResetCreditsBeforeExpiryMin),
+		payloadRules)
 	return err
 }
 

--- a/database/sqlite.go
+++ b/database/sqlite.go
@@ -457,6 +457,7 @@ func (db *DB) migrateSQLite(ctx context.Context) error {
 		{"system_settings", "allow_remote_migration", "INTEGER DEFAULT 0"},
 		{"system_settings", "model_mapping", "TEXT DEFAULT '{}'"},
 		{"system_settings", "codex_model_mapping", "TEXT DEFAULT '{}'"},
+		{"system_settings", "payload_rules", "TEXT DEFAULT '{}'"},
 		{"system_settings", "reasoning_effort_models", "TEXT DEFAULT '[]'"},
 		{"system_settings", "resin_url", "TEXT DEFAULT ''"},
 		{"system_settings", "resin_platform_name", "TEXT DEFAULT ''"},

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -47,6 +47,7 @@ import type {
   SetupHintsResponse,
   CPAExportEntry,
   SystemSettings,
+  ObservedInstructionsResponse,
   UpdateAccountSchedulerRequest,
   UpdateAPIKeyRequest,
   UpdateOAuthAccountRequest,
@@ -574,6 +575,8 @@ export const api = {
     request<MessageResponse>('/usage/logs', { method: 'DELETE' }),
   getSetupHints: () => request<SetupHintsResponse>('/setup-hints'),
   getSettings: () => request<SystemSettings>('/settings'),
+  getObservedInstructions: () =>
+    request<ObservedInstructionsResponse>('/settings/observed-instructions'),
   updateSettings: (data: Partial<SystemSettings>) =>
     request<SystemSettings>('/settings', { method: 'PUT', body: JSON.stringify(data) }),
   uploadBackground: (file: File) => {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -2531,7 +2531,16 @@
     "generatedModel": "Model List Name",
     "addMapping": "Add Mapping",
     "addReasoningModel": "Add Model",
-    "messagesEndpoint": "Anthropic Messages API endpoint (Claude Code)"
+    "messagesEndpoint": "Anthropic Messages API endpoint (Claude Code)",
+    "payloadRules": "Payload Rewrite Rules",
+    "payloadRulesDesc": "Conditionally rewrite upstream request bodies: append/override the instructions system prompt, override service_tier, remap reasoning effort, etc.",
+    "payloadRulesWarning": "Overriding instructions replaces the official Codex CLI system prompt and may affect its tool-calling behavior; rewriting instructions also invalidates the upstream prompt cache, so keep rule text stable. Image generation requests are not affected.",
+    "payloadRulesHint": "Rule groups: default (set when missing) / override (always set) / append (string concat) / filter (remove fields), plus *_raw raw-JSON variants. Gates: models wildcards, headers, match / not_match / exist / not_exist. Protected fields (model, stream, input, store, prompt_cache_key) cannot be rewritten.",
+    "payloadRulesJsonError": "Invalid JSON",
+    "payloadRulesObserved": "Observed client instructions samples",
+    "payloadRulesObservedDesc": "The gateway has no default system prompt of its own — instructions pass through from clients. Recent originals (pre-rewrite) are shown here as reference for writing append/override rules.",
+    "payloadRulesObservedLoad": "Load samples",
+    "payloadRulesObservedEmpty": "No samples yet — client instructions will appear here once requests flow through the gateway."
   },
   "apiRef": {
     "title": "API Reference",

--- a/frontend/src/locales/zh.json
+++ b/frontend/src/locales/zh.json
@@ -2531,7 +2531,16 @@
     "generatedModel": "模型列表名称",
     "addMapping": "添加映射",
     "addReasoningModel": "添加模型",
-    "messagesEndpoint": "Anthropic Messages API 兼容端点（Claude Code）"
+    "messagesEndpoint": "Anthropic Messages API 兼容端点（Claude Code）",
+    "payloadRules": "请求体重写规则",
+    "payloadRulesDesc": "按条件改写发往上游的请求体：追加/覆盖系统提示词 instructions、覆盖 service_tier、按条件映射思考强度等。",
+    "payloadRulesWarning": "覆盖 instructions 会替换 Codex CLI 自带的官方系统提示词，可能影响其工具调用行为；改写 instructions 也会使上游 prompt cache 失效，请保持规则文本稳定。生图请求不受规则影响。",
+    "payloadRulesHint": "规则组：default（缺失才写入）/ override（无条件覆盖）/ append（字符串追加）/ filter（删除字段）及 *_raw 原始 JSON 变体；匹配门支持 models 通配、headers、match / not_match / exist / not_exist。受保护字段（model、stream、input、store、prompt_cache_key）不允许改写。",
+    "payloadRulesJsonError": "JSON 格式错误",
+    "payloadRulesObserved": "客户端透传的系统提示词样本",
+    "payloadRulesObservedDesc": "网关本身没有默认系统提示词，instructions 由客户端透传；这里展示最近观测到的原文（规则改写前），方便照着写追加/覆盖规则。",
+    "payloadRulesObservedLoad": "加载样本",
+    "payloadRulesObservedEmpty": "暂无样本——有请求经过网关后这里会出现客户端发来的 instructions 原文。"
   },
   "apiRef": {
     "title": "API 文档",

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -7,7 +7,7 @@ import PageHeader from '../components/PageHeader'
 import StateShell from '../components/StateShell'
 import { useDataLoader } from '../hooks/useDataLoader'
 import { useToast } from '../hooks/useToast'
-import type { HealthResponse, ModelInfo, SiteBranding, SystemSettings } from '../types'
+import type { HealthResponse, ModelInfo, ObservedInstructionsSample, SiteBranding, SystemSettings } from '../types'
 import { getErrorMessage } from '../utils/error'
 import { DEFAULT_CLAUDE_MODEL_MAP } from '../lib/modelMapping'
 import { DEFAULT_SITE_LOGO, isBrandingVideo, sanitizeBrandingImage, sanitizeBrandingLogo, useBranding } from '../branding'
@@ -67,7 +67,7 @@ import {
 } from 'lucide-react'
 import { Link } from 'react-router-dom'
 
-type ModelPanelKey = 'registry' | 'anthropic' | 'codex' | 'reasoning'
+type ModelPanelKey = 'registry' | 'anthropic' | 'codex' | 'reasoning' | 'payload'
 
 type ModelMappingEntry = [string, string]
 const EMPTY_MODEL_MAPPING_ENTRIES: ModelMappingEntry[] = []
@@ -306,6 +306,117 @@ const buildCodexUserAgentPreview = (config: CodexUserAgentConfig, minVersion: st
 }
 
 // 模型映射编辑器组件
+const PAYLOAD_RULE_GROUPS = ['default', 'default_raw', 'override', 'override_raw', 'append', 'filter'] as const
+
+function countPayloadRules(raw: string): number {
+  try {
+    const parsed = JSON.parse(raw || '{}') as Record<string, unknown>
+    return PAYLOAD_RULE_GROUPS.reduce((sum, group) => {
+      const rules = parsed[group]
+      return sum + (Array.isArray(rules) ? rules.length : 0)
+    }, 0)
+  } catch {
+    return 0
+  }
+}
+
+function PayloadRulesEditor({ value, onChange }: { value: string; onChange: (v: string) => void }) {
+  const { t } = useTranslation()
+  const [samples, setSamples] = useState<ObservedInstructionsSample[]>([])
+  const [samplesLoaded, setSamplesLoaded] = useState(false)
+  const [loadingSamples, setLoadingSamples] = useState(false)
+  const [expandedSample, setExpandedSample] = useState<number | null>(null)
+
+  const jsonError = useMemo(() => {
+    const trimmed = value.trim()
+    if (!trimmed) return null
+    try {
+      JSON.parse(trimmed)
+      return null
+    } catch (e) {
+      return e instanceof Error ? e.message : String(e)
+    }
+  }, [value])
+
+  const loadSamples = useCallback(async () => {
+    setLoadingSamples(true)
+    try {
+      const resp = await api.getObservedInstructions()
+      setSamples(resp.samples || [])
+      setSamplesLoaded(true)
+    } catch {
+      setSamples([])
+      setSamplesLoaded(true)
+    } finally {
+      setLoadingSamples(false)
+    }
+  }, [])
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs leading-relaxed text-amber-700 dark:text-amber-300">
+        {t('settings2.payloadRulesWarning')}
+      </div>
+      <div className="space-y-1.5">
+        <textarea
+          rows={14}
+          value={value}
+          spellCheck={false}
+          placeholder={PAYLOAD_RULES_PLACEHOLDER}
+          onChange={(e: ChangeEvent<HTMLTextAreaElement>) => onChange(e.target.value)}
+          className="flex w-full resize-y rounded-md border border-input bg-background px-3 py-2 font-mono text-xs text-foreground shadow-xs transition-colors placeholder:text-muted-foreground focus-visible:border-ring focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
+        />
+        {jsonError ? (
+          <p className="text-xs text-destructive">{t('settings2.payloadRulesJsonError')}: {jsonError}</p>
+        ) : (
+          <p className="text-xs text-muted-foreground">{t('settings2.payloadRulesHint')}</p>
+        )}
+      </div>
+      <div className="space-y-2 rounded-lg border border-border bg-muted/20 p-3">
+        <div className="flex items-center justify-between gap-2">
+          <div className="text-xs font-semibold text-foreground">{t('settings2.payloadRulesObserved')}</div>
+          <Button size="sm" variant="outline" onClick={() => void loadSamples()} disabled={loadingSamples}>
+            {loadingSamples ? t('common.loading') : t('settings2.payloadRulesObservedLoad')}
+          </Button>
+        </div>
+        <p className="text-xs text-muted-foreground">{t('settings2.payloadRulesObservedDesc')}</p>
+        {samplesLoaded && samples.length === 0 ? (
+          <p className="text-xs text-muted-foreground">{t('settings2.payloadRulesObservedEmpty')}</p>
+        ) : null}
+        {samples.map((sample, i) => (
+          <div key={i} className="rounded-md border border-border bg-background p-2.5">
+            <button
+              type="button"
+              className="flex w-full items-center justify-between gap-2 text-left"
+              onClick={() => setExpandedSample(expandedSample === i ? null : i)}
+            >
+              <span className="min-w-0 truncate font-mono text-xs font-semibold text-foreground">
+                {sample.model || '-'}
+                <span className="ml-2 font-normal text-muted-foreground">{sample.originator}</span>
+              </span>
+              <span className="shrink-0 text-[11px] text-muted-foreground">
+                {sample.length.toLocaleString()} chars{sample.truncated ? ' (truncated)' : ''}
+              </span>
+            </button>
+            {expandedSample === i ? (
+              <pre className="mt-2 max-h-72 overflow-auto whitespace-pre-wrap break-words rounded bg-muted/40 p-2 text-[11px] leading-relaxed text-foreground">
+                {sample.instructions}
+              </pre>
+            ) : null}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+const PAYLOAD_RULES_PLACEHOLDER = `{
+  "append":   [{"params": {"instructions": "追加到系统提示词末尾的文本"}}],
+  "override": [{"models": ["gpt-*"], "params": {"service_tier": "priority"}},
+               {"match": {"reasoning.effort": "medium"}, "params": {"reasoning.effort": "high"}}],
+  "filter":   [{"params": ["metadata.debug"]}]
+}`
+
 function ModelMappingEditor({
   value,
   onChange,
@@ -1159,6 +1270,7 @@ export default function Settings() {
     cache_label: 'Redis',
     model_mapping: '{}',
     codex_model_mapping: '{}',
+    payload_rules: '{}',
     reasoning_effort_models: '[]',
     resin_url: '',
     resin_platform_name: '',
@@ -1642,6 +1754,10 @@ export default function Settings() {
   const reasoningEffortCount = useMemo(
     () => parseReasoningEffortModelEntries(settingsForm.reasoning_effort_models).length,
     [settingsForm.reasoning_effort_models],
+  )
+  const payloadRuleCount = useMemo(
+    () => countPayloadRules(settingsForm.payload_rules),
+    [settingsForm.payload_rules],
   )
   const showInitialSkeleton = loading && !health
   const codexUserAgentConfig = useMemo(
@@ -3072,6 +3188,13 @@ export default function Settings() {
                 openLabel={t('settings.nav.manage')}
                 onOpen={() => setModelPanel('reasoning')}
               />
+              <ModelSummaryCard
+                title={t('settings2.payloadRules')}
+                description={t('settings2.payloadRulesDesc')}
+                meta={t('settings.nav.mappingCount', { count: payloadRuleCount })}
+                openLabel={t('settings.nav.manage')}
+                onOpen={() => setModelPanel('payload')}
+              />
             </div>
 
             <Sheet open={modelPanel !== null} onOpenChange={(open) => { if (!open) setModelPanel(null) }}>
@@ -3087,7 +3210,9 @@ export default function Settings() {
                         ? t('settings2.anthropicModelMapping')
                         : modelPanel === 'codex'
                           ? t('settings2.codexModelMapping')
-                          : t('settings2.reasoningEffortModels')}
+                          : modelPanel === 'payload'
+                            ? t('settings2.payloadRules')
+                            : t('settings2.reasoningEffortModels')}
                   </SheetTitle>
                   <SheetDescription>
                     {modelPanel === 'registry'
@@ -3096,7 +3221,9 @@ export default function Settings() {
                         ? t('settings2.anthropicModelMappingDesc')
                         : modelPanel === 'codex'
                           ? t('settings2.codexModelMappingDesc')
-                          : t('settings2.reasoningEffortModelsDesc')}
+                          : modelPanel === 'payload'
+                            ? t('settings2.payloadRulesDesc')
+                            : t('settings2.reasoningEffortModelsDesc')}
                   </SheetDescription>
                 </SheetHeader>
                 <SheetBody className="space-y-4">
@@ -3164,6 +3291,12 @@ export default function Settings() {
                       value={settingsForm.reasoning_effort_models}
                       onChange={(v) => setSettingsForm((f) => ({ ...f, reasoning_effort_models: v }))}
                       baseModelOptions={textModelOptions}
+                    />
+                  ) : null}
+                  {modelPanel === 'payload' ? (
+                    <PayloadRulesEditor
+                      value={settingsForm.payload_rules}
+                      onChange={(v) => setSettingsForm((f) => ({ ...f, payload_rules: v }))}
                     />
                   ) : null}
                 </SheetBody>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -637,6 +637,7 @@ export interface SystemSettings {
   expired_cleaned?: number
   model_mapping: string
   codex_model_mapping: string
+  payload_rules: string
   reasoning_effort_models: string
   resin_url: string
   resin_platform_name: string
@@ -1340,4 +1341,17 @@ export interface OAuthExchangeResponse {
   id: number
   email: string
   plan_type: string
+}
+
+export interface ObservedInstructionsSample {
+  model: string
+  originator: string
+  instructions: string
+  length: number
+  truncated: boolean
+  observed_at: string
+}
+
+export interface ObservedInstructionsResponse {
+  samples: ObservedInstructionsSample[]
 }

--- a/proxy/executor.go
+++ b/proxy/executor.go
@@ -330,6 +330,12 @@ func resolveUpstreamSessionID(apiKeyID int64, upstreamSeed, explicitSessionID st
 // useWebsocket 可选：未传时遵循全局强制 WS；传 true/false 时由调用方显式控制。
 // headers 下游请求头，用于设备指纹学习
 func ExecuteRequest(ctx context.Context, account *auth.Account, requestBody []byte, sessionID string, proxyOverride string, apiKey string, deviceCfg *DeviceProfileConfig, headers http.Header, useWebsocket ...bool) (*http.Response, error) {
+	// Payload 规则改写：在 WS/HTTP 分叉前统一应用，两条上游路径共享改写结果。
+	// 生图请求跳过——其 instructions/工具由网关自行构造，改写会破坏桥接协议。
+	if !responsesBodyRequestsImageGeneration(requestBody) {
+		RecordObservedInstructions(requestBody, headers)
+		requestBody = ApplyPayloadRulesToBody(requestBody, gjson.GetBytes(requestBody, "model").String(), headers)
+	}
 	wantWebsocket := CurrentRuntimeSettings().CodexForceWebsocket
 	if len(useWebsocket) > 0 {
 		wantWebsocket = useWebsocket[0]

--- a/proxy/payload_observed.go
+++ b/proxy/payload_observed.go
@@ -1,0 +1,107 @@
+package proxy
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/tidwall/gjson"
+)
+
+// ==================== 透传 instructions 观测 ====================
+//
+// 网关自身没有默认系统提示词：/v1/responses 的 instructions 由客户端透传。
+// 这里在规则改写前记录最近观测到的原始 instructions 样本，供管理端展示，
+// 让管理员配置追加/覆盖规则时能看到客户端实际发来的提示词原文。
+
+const (
+	observedInstructionsMaxSamples = 8
+	observedInstructionsMaxLength  = 32 * 1024
+)
+
+// ObservedInstructionsSample 一条观测样本。
+type ObservedInstructionsSample struct {
+	Model        string    `json:"model"`
+	Originator   string    `json:"originator"`
+	Instructions string    `json:"instructions"`
+	Length       int       `json:"length"`
+	Truncated    bool      `json:"truncated"`
+	ObservedAt   time.Time `json:"observed_at"`
+}
+
+var (
+	observedInstructionsMu      sync.Mutex
+	observedInstructionsSamples []ObservedInstructionsSample
+	observedInstructionsIndex   = map[string]int{} // 去重键 → samples 下标
+)
+
+// RecordObservedInstructions 记录请求体中的原始 instructions（改写前调用）。
+// 按 (模型, originator, 内容哈希) 去重，只保留最近若干条。
+func RecordObservedInstructions(body []byte, headers http.Header) {
+	instructions := gjson.GetBytes(body, "instructions").String()
+	if instructions == "" {
+		return
+	}
+	model := gjson.GetBytes(body, "model").String()
+	originator := ""
+	if headers != nil {
+		originator = headers.Get("Originator")
+		if originator == "" {
+			originator = headers.Get("User-Agent")
+		}
+	}
+	sum := sha256.Sum256([]byte(instructions))
+	key := model + "|" + originator + "|" + hex.EncodeToString(sum[:8])
+
+	sample := ObservedInstructionsSample{
+		Model:        model,
+		Originator:   originator,
+		Instructions: instructions,
+		Length:       len(instructions),
+		ObservedAt:   time.Now(),
+	}
+	if len(sample.Instructions) > observedInstructionsMaxLength {
+		sample.Instructions = sample.Instructions[:observedInstructionsMaxLength]
+		sample.Truncated = true
+	}
+
+	observedInstructionsMu.Lock()
+	defer observedInstructionsMu.Unlock()
+	if idx, ok := observedInstructionsIndex[key]; ok {
+		observedInstructionsSamples[idx].ObservedAt = sample.ObservedAt
+		return
+	}
+	if len(observedInstructionsSamples) >= observedInstructionsMaxSamples {
+		// 淘汰最旧样本
+		oldest := 0
+		for i := 1; i < len(observedInstructionsSamples); i++ {
+			if observedInstructionsSamples[i].ObservedAt.Before(observedInstructionsSamples[oldest].ObservedAt) {
+				oldest = i
+			}
+		}
+		for k, idx := range observedInstructionsIndex {
+			if idx == oldest {
+				delete(observedInstructionsIndex, k)
+			} else if idx > oldest {
+				observedInstructionsIndex[k] = idx - 1
+			}
+		}
+		observedInstructionsSamples = append(observedInstructionsSamples[:oldest], observedInstructionsSamples[oldest+1:]...)
+	}
+	observedInstructionsSamples = append(observedInstructionsSamples, sample)
+	observedInstructionsIndex[key] = len(observedInstructionsSamples) - 1
+}
+
+// ObservedInstructions 返回最近观测样本（新→旧）。
+func ObservedInstructions() []ObservedInstructionsSample {
+	observedInstructionsMu.Lock()
+	defer observedInstructionsMu.Unlock()
+	out := make([]ObservedInstructionsSample, len(observedInstructionsSamples))
+	copy(out, observedInstructionsSamples)
+	for i, j := 0, len(out)-1; i < j; i, j = i+1, j-1 {
+		out[i], out[j] = out[j], out[i]
+	}
+	return out
+}

--- a/proxy/payload_rules.go
+++ b/proxy/payload_rules.go
@@ -1,0 +1,437 @@
+package proxy
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"reflect"
+	"strings"
+	"sync/atomic"
+
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// ==================== Payload 请求体重写规则 ====================
+//
+// 声明式规则引擎：管理员配置 JSON 规则，在请求体发往上游前按条件改写字段。
+// 典型用途：覆盖/追加 instructions（系统提示词）、覆盖 service_tier、
+// 按条件改写 reasoning.effort（如 medium → high）。
+//
+// 规则 JSON 结构（存于 system_settings.payload_rules）：
+//
+//	{
+//	  "default":      [ {rule} ],  // 字段缺失时才写入（first-write-wins）
+//	  "default_raw":  [ {rule} ],  // 同上，值为原始 JSON 字符串
+//	  "override":     [ {rule} ],  // 无条件覆盖（last-write-wins）
+//	  "override_raw": [ {rule} ],  // 同上，值为原始 JSON 字符串
+//	  "append":       [ {rule} ],  // 字符串字段追加（原值 + "\n\n" + 配置值）
+//	  "filter":       [ {rule} ]   // 删除字段（params 为路径数组）
+//	}
+//
+// 每条 rule 的匹配门（全部满足才应用）：
+//
+//	{
+//	  "models":    ["gpt-*"],                        // 模型名通配，空=全部
+//	  "headers":   {"X-Client": "codex*"},           // 入站请求头通配
+//	  "match":     {"reasoning.effort": "medium"},   // JSON 路径等值
+//	  "not_match": {"metadata.mode": "dev"},         // JSON 路径不等值
+//	  "exist":     ["tools.0"],                      // 路径必须存在
+//	  "not_exist": ["metadata.skip"],                // 路径必须不存在
+//	  "params":    {...}                             // 动作参数
+//	}
+//
+// 应用顺序：default → default_raw → override → override_raw → append → filter。
+
+// payloadProtectedRoots 是禁止改写的字段根：网关的调度、计费、会话隔离与
+// WS 帧协议依赖这些字段，规则应用又发生在选号之后，改写会造成状态错位。
+// 模型改写请使用现成的模型映射功能。
+var payloadProtectedRoots = map[string]struct{}{
+	"model":            {},
+	"stream":           {},
+	"input":            {},
+	"prompt_cache_key": {},
+	"store":            {},
+	"type":             {},
+}
+
+// PayloadRule 单条重写规则：匹配门 + 动作参数。
+type PayloadRule struct {
+	Models   []string          `json:"models,omitempty"`
+	Headers  map[string]string `json:"headers,omitempty"`
+	Match    map[string]any    `json:"match,omitempty"`
+	NotMatch map[string]any    `json:"not_match,omitempty"`
+	Exist    []string          `json:"exist,omitempty"`
+	NotExist []string          `json:"not_exist,omitempty"`
+	// Params 动作参数：default/override/append 为 路径→值 map，
+	// default_raw/override_raw 值须为合法 JSON 字符串，filter 为路径数组。
+	Params json.RawMessage `json:"params"`
+}
+
+// PayloadRuleSet 全部规则组。
+type PayloadRuleSet struct {
+	Default     []PayloadRule `json:"default,omitempty"`
+	DefaultRaw  []PayloadRule `json:"default_raw,omitempty"`
+	Override    []PayloadRule `json:"override,omitempty"`
+	OverrideRaw []PayloadRule `json:"override_raw,omitempty"`
+	Append      []PayloadRule `json:"append,omitempty"`
+	Filter      []PayloadRule `json:"filter,omitempty"`
+}
+
+// IsEmpty 报告规则集是否没有任何规则。
+func (rs *PayloadRuleSet) IsEmpty() bool {
+	if rs == nil {
+		return true
+	}
+	return len(rs.Default) == 0 && len(rs.DefaultRaw) == 0 && len(rs.Override) == 0 &&
+		len(rs.OverrideRaw) == 0 && len(rs.Append) == 0 && len(rs.Filter) == 0
+}
+
+var currentPayloadRuleSet atomic.Value // stores *PayloadRuleSet
+
+// CurrentPayloadRules 返回当前生效的规则集（可能为 nil）。
+func CurrentPayloadRules() *PayloadRuleSet {
+	if v, ok := currentPayloadRuleSet.Load().(*PayloadRuleSet); ok {
+		return v
+	}
+	return nil
+}
+
+// SetPayloadRulesJSON 解析并热更规则集；传空串/空对象清空规则。
+// 解析或校验失败时保持现有规则不变并返回错误。
+func SetPayloadRulesJSON(raw string) error {
+	rs, err := ParsePayloadRulesJSON(raw)
+	if err != nil {
+		return err
+	}
+	currentPayloadRuleSet.Store(rs)
+	return nil
+}
+
+// ParsePayloadRulesJSON 解析规则 JSON 并做结构与保护字段校验。
+func ParsePayloadRulesJSON(raw string) (*PayloadRuleSet, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" || raw == "{}" || raw == "null" {
+		return &PayloadRuleSet{}, nil
+	}
+	var rs PayloadRuleSet
+	dec := json.NewDecoder(strings.NewReader(raw))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&rs); err != nil {
+		return nil, fmt.Errorf("payload_rules JSON 解析失败: %w", err)
+	}
+	groups := []struct {
+		name  string
+		rules []PayloadRule
+		kind  string // map / raw / filter / append
+	}{
+		{"default", rs.Default, "map"},
+		{"default_raw", rs.DefaultRaw, "raw"},
+		{"override", rs.Override, "map"},
+		{"override_raw", rs.OverrideRaw, "raw"},
+		{"append", rs.Append, "append"},
+		{"filter", rs.Filter, "filter"},
+	}
+	for _, g := range groups {
+		for i := range g.rules {
+			if err := validatePayloadRuleParams(&g.rules[i], g.kind); err != nil {
+				return nil, fmt.Errorf("%s[%d]: %w", g.name, i, err)
+			}
+		}
+	}
+	return &rs, nil
+}
+
+// NormalizePayloadRulesJSON 校验并返回紧凑化的规则 JSON（供设置保存使用）。
+func NormalizePayloadRulesJSON(raw string) (string, error) {
+	rs, err := ParsePayloadRulesJSON(raw)
+	if err != nil {
+		return "", err
+	}
+	if rs.IsEmpty() {
+		return "{}", nil
+	}
+	normalized, err := json.Marshal(rs)
+	if err != nil {
+		return "", err
+	}
+	return string(normalized), nil
+}
+
+func validatePayloadRuleParams(rule *PayloadRule, kind string) error {
+	if len(rule.Params) == 0 {
+		return fmt.Errorf("params 不能为空")
+	}
+	checkPath := func(path string) error {
+		path = strings.TrimSpace(path)
+		if path == "" {
+			return fmt.Errorf("params 路径不能为空")
+		}
+		if isProtectedPayloadPath(path) {
+			return fmt.Errorf("字段 %q 受保护，不允许改写（模型改写请使用模型映射功能）", path)
+		}
+		return nil
+	}
+	switch kind {
+	case "filter":
+		var paths []string
+		if err := json.Unmarshal(rule.Params, &paths); err != nil {
+			return fmt.Errorf("filter 的 params 须为路径数组: %w", err)
+		}
+		if len(paths) == 0 {
+			return fmt.Errorf("params 不能为空")
+		}
+		for _, p := range paths {
+			if err := checkPath(p); err != nil {
+				return err
+			}
+		}
+	case "raw":
+		var params map[string]string
+		if err := json.Unmarshal(rule.Params, &params); err != nil {
+			return fmt.Errorf("raw 规则的 params 须为 路径→JSON字符串 映射: %w", err)
+		}
+		if len(params) == 0 {
+			return fmt.Errorf("params 不能为空")
+		}
+		for p, v := range params {
+			if err := checkPath(p); err != nil {
+				return err
+			}
+			if !json.Valid([]byte(v)) {
+				return fmt.Errorf("字段 %q 的值不是合法 JSON: %q", p, v)
+			}
+		}
+	case "append":
+		var params map[string]string
+		if err := json.Unmarshal(rule.Params, &params); err != nil {
+			return fmt.Errorf("append 规则的 params 须为 路径→字符串 映射: %w", err)
+		}
+		if len(params) == 0 {
+			return fmt.Errorf("params 不能为空")
+		}
+		for p := range params {
+			if err := checkPath(p); err != nil {
+				return err
+			}
+		}
+	default: // map
+		var params map[string]any
+		if err := json.Unmarshal(rule.Params, &params); err != nil {
+			return fmt.Errorf("params 须为 路径→值 映射: %w", err)
+		}
+		if len(params) == 0 {
+			return fmt.Errorf("params 不能为空")
+		}
+		for p := range params {
+			if err := checkPath(p); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// isProtectedPayloadPath 判断路径根段是否命中保护清单。
+func isProtectedPayloadPath(path string) bool {
+	root := path
+	if idx := strings.IndexAny(path, ".|#("); idx >= 0 {
+		root = path[:idx]
+	}
+	_, protected := payloadProtectedRoots[strings.TrimSpace(root)]
+	return protected
+}
+
+// matchPayloadWildcard 大小写不敏感的 * 通配匹配。
+func matchPayloadWildcard(pattern, value string) bool {
+	pattern = strings.ToLower(strings.TrimSpace(pattern))
+	value = strings.ToLower(strings.TrimSpace(value))
+	if pattern == "" {
+		return false
+	}
+	if pattern == "*" {
+		return true
+	}
+	segments := strings.Split(pattern, "*")
+	if len(segments) == 1 {
+		return pattern == value
+	}
+	if !strings.HasPrefix(value, segments[0]) {
+		return false
+	}
+	rest := value[len(segments[0]):]
+	for _, seg := range segments[1 : len(segments)-1] {
+		if seg == "" {
+			continue
+		}
+		idx := strings.Index(rest, seg)
+		if idx < 0 {
+			return false
+		}
+		rest = rest[idx+len(seg):]
+	}
+	last := segments[len(segments)-1]
+	return last == "" || strings.HasSuffix(rest, last)
+}
+
+// payloadRuleMatches 判断规则的全部匹配门是否满足。
+func payloadRuleMatches(rule *PayloadRule, body []byte, model string, headers http.Header) bool {
+	if len(rule.Models) > 0 {
+		matched := false
+		for _, pattern := range rule.Models {
+			if matchPayloadWildcard(pattern, model) {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return false
+		}
+	}
+	for name, pattern := range rule.Headers {
+		if headers == nil || !matchPayloadWildcard(pattern, headers.Get(name)) {
+			return false
+		}
+	}
+	for path, want := range rule.Match {
+		if !payloadValueEquals(gjson.GetBytes(body, path), want) {
+			return false
+		}
+	}
+	for path, want := range rule.NotMatch {
+		if payloadValueEquals(gjson.GetBytes(body, path), want) {
+			return false
+		}
+	}
+	for _, path := range rule.Exist {
+		result := gjson.GetBytes(body, path)
+		if !result.Exists() || result.Type == gjson.Null {
+			return false
+		}
+	}
+	for _, path := range rule.NotExist {
+		result := gjson.GetBytes(body, path)
+		if result.Exists() && result.Type != gjson.Null {
+			return false
+		}
+	}
+	return true
+}
+
+// payloadValueEquals 比较 gjson 结果与配置值（两侧都来自 JSON，类型天然对齐）。
+func payloadValueEquals(result gjson.Result, want any) bool {
+	if !result.Exists() {
+		return want == nil && result.Type == gjson.Null
+	}
+	return reflect.DeepEqual(result.Value(), want)
+}
+
+// ApplyPayloadRulesToBody 按当前规则集改写请求体。model 为映射后的生效模型，
+// headers 为入站请求头。改写失败的单条动作跳过，不影响其余规则。
+func ApplyPayloadRulesToBody(body []byte, model string, headers http.Header) []byte {
+	rs := CurrentPayloadRules()
+	if rs.IsEmpty() || len(body) == 0 || !gjson.ValidBytes(body) {
+		return body
+	}
+	out := body
+
+	applyMapRules := func(rules []PayloadRule, onlyIfMissing bool) {
+		for i := range rules {
+			rule := &rules[i]
+			if !payloadRuleMatches(rule, out, model, headers) {
+				continue
+			}
+			var params map[string]any
+			if json.Unmarshal(rule.Params, &params) != nil {
+				continue
+			}
+			for path, value := range params {
+				if isProtectedPayloadPath(path) {
+					continue
+				}
+				if onlyIfMissing && gjson.GetBytes(out, path).Exists() {
+					continue
+				}
+				if updated, err := sjson.SetBytes(out, path, value); err == nil {
+					out = updated
+				}
+			}
+		}
+	}
+	applyRawRules := func(rules []PayloadRule, onlyIfMissing bool) {
+		for i := range rules {
+			rule := &rules[i]
+			if !payloadRuleMatches(rule, out, model, headers) {
+				continue
+			}
+			var params map[string]string
+			if json.Unmarshal(rule.Params, &params) != nil {
+				continue
+			}
+			for path, value := range params {
+				if isProtectedPayloadPath(path) || !json.Valid([]byte(value)) {
+					continue
+				}
+				if onlyIfMissing && gjson.GetBytes(out, path).Exists() {
+					continue
+				}
+				if updated, err := sjson.SetRawBytes(out, path, []byte(value)); err == nil {
+					out = updated
+				}
+			}
+		}
+	}
+
+	applyMapRules(rs.Default, true)
+	applyRawRules(rs.DefaultRaw, true)
+	applyMapRules(rs.Override, false)
+	applyRawRules(rs.OverrideRaw, false)
+
+	for i := range rs.Append {
+		rule := &rs.Append[i]
+		if !payloadRuleMatches(rule, out, model, headers) {
+			continue
+		}
+		var params map[string]string
+		if json.Unmarshal(rule.Params, &params) != nil {
+			continue
+		}
+		for path, text := range params {
+			if isProtectedPayloadPath(path) || text == "" {
+				continue
+			}
+			existing := gjson.GetBytes(out, path)
+			// 只对缺失或字符串字段追加；非字符串字段跳过，避免破坏结构。
+			if existing.Exists() && existing.Type != gjson.String {
+				continue
+			}
+			value := text
+			if prev := existing.String(); strings.TrimSpace(prev) != "" {
+				value = prev + "\n\n" + text
+			}
+			if updated, err := sjson.SetBytes(out, path, value); err == nil {
+				out = updated
+			}
+		}
+	}
+
+	for i := range rs.Filter {
+		rule := &rs.Filter[i]
+		if !payloadRuleMatches(rule, out, model, headers) {
+			continue
+		}
+		var paths []string
+		if json.Unmarshal(rule.Params, &paths) != nil {
+			continue
+		}
+		for _, path := range paths {
+			if isProtectedPayloadPath(path) {
+				continue
+			}
+			if updated, err := sjson.DeleteBytes(out, path); err == nil {
+				out = updated
+			}
+		}
+	}
+	return out
+}

--- a/proxy/payload_rules_test.go
+++ b/proxy/payload_rules_test.go
@@ -1,0 +1,219 @@
+package proxy
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func mustParseRules(t *testing.T, raw string) *PayloadRuleSet {
+	t.Helper()
+	rs, err := ParsePayloadRulesJSON(raw)
+	if err != nil {
+		t.Fatalf("ParsePayloadRulesJSON: %v", err)
+	}
+	return rs
+}
+
+func withPayloadRules(t *testing.T, raw string) {
+	t.Helper()
+	prev := CurrentPayloadRules()
+	if err := SetPayloadRulesJSON(raw); err != nil {
+		t.Fatalf("SetPayloadRulesJSON: %v", err)
+	}
+	t.Cleanup(func() {
+		if prev == nil {
+			prev = &PayloadRuleSet{}
+		}
+		currentPayloadRuleSet.Store(prev)
+	})
+}
+
+const payloadTestBody = `{"model":"gpt-5.6-sol","stream":true,"instructions":"official prompt","reasoning":{"effort":"medium"},"input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"hi"}]}]}`
+
+func TestPayloadRulesOverrideInstructions(t *testing.T) {
+	withPayloadRules(t, `{"override":[{"models":["gpt-*"],"params":{"instructions":"my custom prompt"}}]}`)
+	out := ApplyPayloadRulesToBody([]byte(payloadTestBody), "gpt-5.6-sol", nil)
+	if got := gjson.GetBytes(out, "instructions").String(); got != "my custom prompt" {
+		t.Fatalf("instructions = %q, want my custom prompt", got)
+	}
+}
+
+func TestPayloadRulesAppendInstructions(t *testing.T) {
+	withPayloadRules(t, `{"append":[{"params":{"instructions":"extra guard text"}}]}`)
+	out := ApplyPayloadRulesToBody([]byte(payloadTestBody), "gpt-5.6-sol", nil)
+	want := "official prompt\n\nextra guard text"
+	if got := gjson.GetBytes(out, "instructions").String(); got != want {
+		t.Fatalf("instructions = %q, want %q", got, want)
+	}
+	// 缺失时直接写入
+	out = ApplyPayloadRulesToBody([]byte(`{"model":"gpt-5.6-sol"}`), "gpt-5.6-sol", nil)
+	if got := gjson.GetBytes(out, "instructions").String(); got != "extra guard text" {
+		t.Fatalf("instructions(missing) = %q, want extra guard text", got)
+	}
+}
+
+func TestPayloadRulesConditionalEffortMapping(t *testing.T) {
+	withPayloadRules(t, `{"override":[{"models":["gpt-*"],"match":{"reasoning.effort":"medium"},"params":{"reasoning.effort":"high"}}]}`)
+	out := ApplyPayloadRulesToBody([]byte(payloadTestBody), "gpt-5.6-sol", nil)
+	if got := gjson.GetBytes(out, "reasoning.effort").String(); got != "high" {
+		t.Fatalf("reasoning.effort = %q, want high", got)
+	}
+	// 不满足 match 门时不改写
+	low := []byte(strings.Replace(payloadTestBody, `"medium"`, `"low"`, 1))
+	out = ApplyPayloadRulesToBody(low, "gpt-5.6-sol", nil)
+	if got := gjson.GetBytes(out, "reasoning.effort").String(); got != "low" {
+		t.Fatalf("reasoning.effort = %q, want low（match 门不满足）", got)
+	}
+}
+
+func TestPayloadRulesServiceTierOverride(t *testing.T) {
+	withPayloadRules(t, `{"override":[{"params":{"service_tier":"priority"}}]}`)
+	out := ApplyPayloadRulesToBody([]byte(payloadTestBody), "gpt-5.6-sol", nil)
+	if got := gjson.GetBytes(out, "service_tier").String(); got != "priority" {
+		t.Fatalf("service_tier = %q, want priority", got)
+	}
+}
+
+func TestPayloadRulesDefaultOnlyWhenMissing(t *testing.T) {
+	withPayloadRules(t, `{"default":[{"params":{"text.verbosity":"low","instructions":"default prompt"}}]}`)
+	out := ApplyPayloadRulesToBody([]byte(payloadTestBody), "gpt-5.6-sol", nil)
+	if got := gjson.GetBytes(out, "text.verbosity").String(); got != "low" {
+		t.Fatalf("text.verbosity = %q, want low（缺失时写入）", got)
+	}
+	if got := gjson.GetBytes(out, "instructions").String(); got != "official prompt" {
+		t.Fatalf("instructions = %q, want official prompt（已存在不覆盖）", got)
+	}
+}
+
+func TestPayloadRulesFilterRemovesField(t *testing.T) {
+	withPayloadRules(t, `{"filter":[{"params":["reasoning.effort"]}]}`)
+	out := ApplyPayloadRulesToBody([]byte(payloadTestBody), "gpt-5.6-sol", nil)
+	if gjson.GetBytes(out, "reasoning.effort").Exists() {
+		t.Fatalf("reasoning.effort 应被删除")
+	}
+}
+
+func TestPayloadRulesOverrideRaw(t *testing.T) {
+	withPayloadRules(t, `{"override_raw":[{"params":{"text":"{\"verbosity\":\"high\"}"}}]}`)
+	out := ApplyPayloadRulesToBody([]byte(payloadTestBody), "gpt-5.6-sol", nil)
+	if got := gjson.GetBytes(out, "text.verbosity").String(); got != "high" {
+		t.Fatalf("text.verbosity = %q, want high", got)
+	}
+}
+
+func TestPayloadRulesHeaderGate(t *testing.T) {
+	withPayloadRules(t, `{"override":[{"headers":{"Originator":"codex_cli*"},"params":{"service_tier":"priority"}}]}`)
+	h := http.Header{}
+	h.Set("Originator", "codex_cli_rs")
+	out := ApplyPayloadRulesToBody([]byte(payloadTestBody), "gpt-5.6-sol", h)
+	if got := gjson.GetBytes(out, "service_tier").String(); got != "priority" {
+		t.Fatalf("service_tier = %q, want priority（头匹配）", got)
+	}
+	out = ApplyPayloadRulesToBody([]byte(payloadTestBody), "gpt-5.6-sol", http.Header{})
+	if gjson.GetBytes(out, "service_tier").Exists() {
+		t.Fatalf("头不匹配时不应改写")
+	}
+}
+
+func TestPayloadRulesModelGate(t *testing.T) {
+	withPayloadRules(t, `{"override":[{"models":["gpt-5.5*"],"params":{"service_tier":"priority"}}]}`)
+	out := ApplyPayloadRulesToBody([]byte(payloadTestBody), "gpt-5.6-sol", nil)
+	if gjson.GetBytes(out, "service_tier").Exists() {
+		t.Fatalf("模型不匹配时不应改写")
+	}
+}
+
+func TestPayloadRulesExistNotExistGates(t *testing.T) {
+	withPayloadRules(t, `{"override":[{"exist":["reasoning.effort"],"not_exist":["metadata.skip"],"params":{"service_tier":"flex"}}]}`)
+	out := ApplyPayloadRulesToBody([]byte(payloadTestBody), "gpt-5.6-sol", nil)
+	if got := gjson.GetBytes(out, "service_tier").String(); got != "flex" {
+		t.Fatalf("service_tier = %q, want flex", got)
+	}
+	skip := []byte(strings.Replace(payloadTestBody, `"stream":true`, `"stream":true,"metadata":{"skip":1}`, 1))
+	out = ApplyPayloadRulesToBody(skip, "gpt-5.6-sol", nil)
+	if gjson.GetBytes(out, "service_tier").Exists() {
+		t.Fatalf("not_exist 门命中时不应改写")
+	}
+}
+
+func TestPayloadRulesProtectedPathsRejected(t *testing.T) {
+	for _, raw := range []string{
+		`{"override":[{"params":{"model":"gpt-4"}}]}`,
+		`{"override":[{"params":{"stream":false}}]}`,
+		`{"override":[{"params":{"input.0.content":"x"}}]}`,
+		`{"filter":[{"params":["prompt_cache_key"]}]}`,
+		`{"append":[{"params":{"store":"x"}}]}`,
+	} {
+		if _, err := ParsePayloadRulesJSON(raw); err == nil {
+			t.Fatalf("保护字段应被拒绝: %s", raw)
+		}
+	}
+}
+
+func TestPayloadRulesInvalidJSONRejected(t *testing.T) {
+	for _, raw := range []string{
+		`{"override":[{"params":{}}]}`,
+		`{"override_raw":[{"params":{"text":"not-json{"}}]}`,
+		`{"filter":[{"params":["  "]}]}`,
+		`{"unknown_group":[]}`,
+		`not json`,
+	} {
+		if _, err := ParsePayloadRulesJSON(raw); err == nil {
+			t.Fatalf("非法配置应被拒绝: %s", raw)
+		}
+	}
+	// 空配置合法
+	if rs := mustParseRules(t, ""); !rs.IsEmpty() {
+		t.Fatalf("空串应解析为空规则集")
+	}
+	if rs := mustParseRules(t, "{}"); !rs.IsEmpty() {
+		t.Fatalf("{} 应解析为空规则集")
+	}
+}
+
+func TestPayloadRulesNormalize(t *testing.T) {
+	normalized, err := NormalizePayloadRulesJSON(` {"override":[{"models":["gpt-*"],"params":{"service_tier":"priority"}}]} `)
+	if err != nil {
+		t.Fatalf("NormalizePayloadRulesJSON: %v", err)
+	}
+	if !gjson.Valid(normalized) || !gjson.Get(normalized, "override.0.params.service_tier").Exists() {
+		t.Fatalf("normalized = %q", normalized)
+	}
+	if got, _ := NormalizePayloadRulesJSON(""); got != "{}" {
+		t.Fatalf("空配置应归一化为 {}, got %q", got)
+	}
+}
+
+func TestMatchPayloadWildcard(t *testing.T) {
+	cases := []struct {
+		pattern, value string
+		want           bool
+	}{
+		{"gpt-*", "gpt-5.6-sol", true},
+		{"gpt-*", "GPT-5.6", true},
+		{"*", "anything", true},
+		{"gpt-5.6-sol", "gpt-5.6-sol", true},
+		{"gpt-5.6-sol", "gpt-5.6", false},
+		{"*-sol", "gpt-5.6-sol", true},
+		{"*-sol", "gpt-5.6", false},
+		{"gpt-*-sol", "gpt-5.6-sol", true},
+		{"", "x", false},
+	}
+	for _, tc := range cases {
+		if got := matchPayloadWildcard(tc.pattern, tc.value); got != tc.want {
+			t.Errorf("matchPayloadWildcard(%q, %q) = %v, want %v", tc.pattern, tc.value, got, tc.want)
+		}
+	}
+}
+
+func TestPayloadRulesApplyOrder(t *testing.T) {
+	// override 先覆盖，append 再基于覆盖后的值追加
+	withPayloadRules(t, `{"override":[{"params":{"instructions":"base"}}],"append":[{"params":{"instructions":"tail"}}]}`)
+	out := ApplyPayloadRulesToBody([]byte(payloadTestBody), "gpt-5.6-sol", nil)
+	if got := gjson.GetBytes(out, "instructions").String(); got != "base\n\ntail" {
+		t.Fatalf("instructions = %q, want base\\n\\ntail", got)
+	}
+}

--- a/proxy/runtime_config.go
+++ b/proxy/runtime_config.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"log"
 	"os"
 	"strings"
 	"sync"
@@ -252,6 +253,10 @@ func ApplyRuntimeSettingsFromSystem(settings *database.SystemSettings) RuntimeSe
 		next.CodexCLIVersionSyncIntervalHours = settings.CodexCLIVersionSyncIntervalHours
 		next.AutoResetCreditsEnabled = settings.AutoResetCreditsEnabled
 		next.AutoResetCreditsBeforeExpiryMin = settings.AutoResetCreditsBeforeExpiryMin
+		// Payload 重写规则不进 RuntimeSettings（编译后独立存放），此处顺带完成启动种子。
+		if err := SetPayloadRulesJSON(settings.PayloadRules); err != nil {
+			log.Printf("payload_rules 配置解析失败，已忽略: %v", err)
+		}
 	}
 	return storeRuntimeSettings(next)
 }


### PR DESCRIPTION
## 需求

Closes #321

issue 要求：追加系统提示词、覆盖系统提示词、查看默认系统提示词；评论区补充：覆盖 `service_tier`、条件化思考强度映射（medium → high），即链路中挂一层重写代理才能做到的事情，希望网关原生支持。

## 实现

**声明式规则引擎**（`proxy/payload_rules.go`，配置存于系统设置，热更生效）：

```jsonc
{
  "append":   [{"params": {"instructions": "追加到系统提示词末尾的文本"}}],
  "override": [
    {"models": ["gpt-*"], "params": {"service_tier": "priority"}},
    {"match": {"reasoning.effort": "medium"}, "params": {"reasoning.effort": "high"}}
  ],
  "default":  [{"params": {"text.verbosity": "low"}}],
  "filter":   [{"params": ["metadata.debug"]}]
}
```

- 六类规则组：`default` / `default_raw`（缺失才写入）、`override` / `override_raw`（无条件覆盖）、`append`（字符串追加，issue 的"追加系统提示词"）、`filter`（删除字段）
- 匹配门：`models` 通配、`headers` 通配、`match` / `not_match`（JSON 路径等值）、`exist` / `not_exist`
- **保护字段黑名单**：`model` / `stream` / `input` / `store` / `prompt_cache_key` / `type` 拒绝改写（保存时 400 + 明确报错）——规则应用发生在选号之后，改写这些字段会错位调度/计费/会话隔离；模型改写走现成的模型映射
- 应用点：`ExecuteRequest` 顶部（WS/HTTP 分叉前），四种入站协议一次覆盖；生图请求跳过

**"查看默认系统提示词"**：网关自身没有默认系统提示词（instructions 是客户端透传的），故做成观测功能——`GET /api/admin/settings/observed-instructions` 返回改写前最近观测到的客户端 instructions 原文（按模型+originator+内容去重，保留最近 8 条），前端规则面板可直接查看，照着原文写规则。

**前端**：设置页「模型」区新增「请求体重写规则」卡片：JSON 编辑器 + 实时语法校验 + 规则数统计 + 风险提示 + 透传样本查看，中英文案。

## 风险提示（已写入 UI）

- `override` instructions 会替换 Codex CLI 官方系统提示词，可能影响其工具调用行为
- 改写 instructions 会使上游 prompt cache 失效，规则文本应保持稳定

## 测试

**单元**：引擎 14 个用例（六类规则组、全部匹配门、应用顺序、保护字段拒绝、非法配置拒绝、通配匹配表），`go test ./...` 全绿。

**端到端**（docker-compose.pgredis2004.yml 重建实测）：

| 场景 | 结果 |
|---|---|
| override instructions("必须精确回复 RULE_APPLIED") | ✅ 模型回复 `RULE_APPLIED` |
| append instructions("结尾加 BANANA")保留客户端原提示词 | ✅ 回复 `Hello! BANANA` |
| match effort=medium → override high | ✅ 响应回显 `reasoning.effort: high` |
| override text.verbosity high→low | ✅ 响应回显 `low` |
| override service_tier | ✅ 已送达上游（flex 被上游按账号策略拒绝，报 `Unsupported service_tier: flex`，证明改写生效；priority 被 ChatGPT 账号归一化为 default） |
| 保护字段(model)保存 | ✅ 400 + 明确错误 |
| 观测端点 | ✅ 返回改写前的客户端 instructions 原文 |
| 清空规则 | ✅ 恢复纯透传 |
| 容器重启 | ✅ 规则持久化并在启动时重新生效（迁移+种子链路） |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable payload rewrite rules for modifying request fields based on models, headers, and content.
  * Added a Settings panel for editing, validating, and saving rewrite rules.
  * Added an observed-instructions viewer for inspecting captured client instruction samples.
  * Added support for applying rules consistently across supported request types.

* **Bug Fixes**
  * Protected sensitive request fields from being modified by rewrite rules.
  * Invalid configurations and individual rewrite failures are handled without interrupting requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->