### PR TITLE
feat(frontend): payload 重写规则提升为侧边栏独立页面

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -25,6 +25,7 @@ const ImageStudio = lazy(() => import('./pages/ImageStudio'))
 const PromptFilter = lazy(() => import('./pages/PromptFilter'))
 const ThemeSettings = lazy(() => import('./pages/ThemeSettings'))
 const ModelPricing = lazy(() => import('./pages/ModelPricing'))
+const PayloadRules = lazy(() => import('./pages/PayloadRules'))
 
 export default function App() {
   return (
@@ -68,6 +69,7 @@ function AdminApp() {
           <Route path="/ops/scheduler" element={<SchedulerBoard />} />
           <Route path="/usage" element={<Usage />} />
           <Route path="/model-pricing" element={<ModelPricing />} />
+          <Route path="/payload-rules" element={<PayloadRules />} />
           <Route path="/theme" element={<ThemeSettings />} />
           <Route path="/settings" element={<Settings />} />
           <Route path="/docs" element={<Docs />} />

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,7 +1,7 @@
 import { type CSSProperties, type PropsWithChildren, type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { NavLink, useLocation } from 'react-router-dom'
-import { LayoutDashboard, Users, Activity, Settings, Server, Languages, Globe, BookOpen, KeyRound, Image as ImageIcon, ShieldAlert, ExternalLink, ChevronLeft, Palette, Sun, Moon, LogOut, Download, Loader2, RefreshCw, Menu, X, CircleDollarSign } from 'lucide-react'
+import { LayoutDashboard, Users, Activity, Settings, Server, Languages, Globe, BookOpen, KeyRound, Image as ImageIcon, ShieldAlert, ExternalLink, ChevronLeft, Palette, Sun, Moon, LogOut, Download, Loader2, RefreshCw, Menu, X, CircleDollarSign, Braces } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { api, resetAdminAuthState } from '../api'
 import { DEFAULT_SITE_LOGO, isBrandingVideo, useBranding } from '../branding'
@@ -30,6 +30,7 @@ const navDefs: NavDef[] = [
   { to: '/ops/overview', labelKey: 'nav.ops', icon: <Server className="size-[18px]" />, activePrefix: '/ops' },
   { to: '/usage', labelKey: 'nav.usage', icon: <Activity className="size-[18px]" /> },
   { to: '/model-pricing', labelKey: 'nav.modelPricing', icon: <CircleDollarSign className="size-[18px]" /> },
+  { to: '/payload-rules', labelKey: 'nav.payloadRules', icon: <Braces className="size-[18px]" /> },
   { to: '/theme', labelKey: 'nav.theme', icon: <Palette className="size-[18px]" /> },
   { to: '/settings', labelKey: 'nav.settings', icon: <Settings className="size-[18px]" /> },
   { to: '/docs', labelKey: 'nav2.docs', icon: <BookOpen className="size-[18px]" /> },

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -12,7 +12,8 @@
     "proxies": "Proxies",
     "images": "Images",
     "promptFilter": "Prompt Filter",
-    "modelPricing": "Model Pricing"
+    "modelPricing": "Model Pricing",
+    "payloadRules": "Payload Rules"
   },
   "common": {
     "online": "Online",
@@ -2752,5 +2753,10 @@
     "galleryImagesAdded": "Added {{count}} image(s) from gallery",
     "canvasTitle": "Preview canvas",
     "canvasHint": "Results appear here — click to view full screen"
+  },
+  "payloadRules": {
+    "editorTitle": "Rule Configuration",
+    "unsaved": "Unsaved",
+    "saved": "Rules saved and applied immediately"
   }
 }

--- a/frontend/src/locales/zh.json
+++ b/frontend/src/locales/zh.json
@@ -12,7 +12,8 @@
     "proxies": "代理管理",
     "images": "生图工作台",
     "promptFilter": "Prompt 检查",
-    "modelPricing": "模型定价"
+    "modelPricing": "模型定价",
+    "payloadRules": "请求体重写"
   },
   "common": {
     "online": "在线",
@@ -2752,5 +2753,10 @@
     "galleryImagesAdded": "已从图库添加 {{count}} 张参考图",
     "canvasTitle": "预览画布",
     "canvasHint": "生成结果会显示在此区域，点击可全屏查看"
+  },
+  "payloadRules": {
+    "editorTitle": "规则配置",
+    "unsaved": "未保存",
+    "saved": "规则已保存并即时生效"
   }
 }

--- a/frontend/src/pages/PayloadRules.tsx
+++ b/frontend/src/pages/PayloadRules.tsx
@@ -1,0 +1,217 @@
+import type { ChangeEvent } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { RefreshCw, Save } from 'lucide-react'
+
+import { api } from '@/api'
+import PageHeader from '../components/PageHeader'
+import StateShell from '../components/StateShell'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { useToast } from '../hooks/useToast'
+import { getErrorMessage } from '../utils/error'
+import type { ObservedInstructionsSample } from '../types'
+
+export const PAYLOAD_RULE_GROUPS = ['default', 'default_raw', 'override', 'override_raw', 'append', 'filter'] as const
+
+export function countPayloadRules(raw: string): number {
+  try {
+    const parsed = JSON.parse(raw || '{}') as Record<string, unknown>
+    return PAYLOAD_RULE_GROUPS.reduce((sum, group) => {
+      const rules = parsed[group]
+      return sum + (Array.isArray(rules) ? rules.length : 0)
+    }, 0)
+  } catch {
+    return 0
+  }
+}
+
+const PAYLOAD_RULES_PLACEHOLDER = `{
+  "append":   [{"params": {"instructions": "追加到系统提示词末尾的文本"}}],
+  "override": [{"models": ["gpt-*"], "params": {"service_tier": "priority"}},
+               {"match": {"reasoning.effort": "medium"}, "params": {"reasoning.effort": "high"}}],
+  "filter":   [{"params": ["metadata.debug"]}]
+}`
+
+function prettifyRulesJSON(raw: string): string {
+  try {
+    return JSON.stringify(JSON.parse(raw || '{}'), null, 2)
+  } catch {
+    return raw
+  }
+}
+
+export default function PayloadRules() {
+  const { t } = useTranslation()
+  const { showToast } = useToast()
+
+  const [loading, setLoading] = useState(true)
+  const [loadError, setLoadError] = useState<string | null>(null)
+  const [saved, setSaved] = useState('{}')
+  const [draft, setDraft] = useState('{}')
+  const [saving, setSaving] = useState(false)
+
+  const [samples, setSamples] = useState<ObservedInstructionsSample[]>([])
+  const [samplesLoading, setSamplesLoading] = useState(false)
+  const [expandedSample, setExpandedSample] = useState<number | null>(null)
+
+  const dirty = draft !== saved
+  const ruleCount = useMemo(() => countPayloadRules(draft), [draft])
+
+  const jsonError = useMemo(() => {
+    const trimmed = draft.trim()
+    if (!trimmed) return null
+    try {
+      JSON.parse(trimmed)
+      return null
+    } catch (e) {
+      return e instanceof Error ? e.message : String(e)
+    }
+  }, [draft])
+
+  const loadSamples = useCallback(async () => {
+    setSamplesLoading(true)
+    try {
+      const resp = await api.getObservedInstructions()
+      setSamples(resp.samples || [])
+    } catch {
+      setSamples([])
+    } finally {
+      setSamplesLoading(false)
+    }
+  }, [])
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setLoadError(null)
+    try {
+      const settings = await api.getSettings()
+      const pretty = prettifyRulesJSON(settings.payload_rules || '{}')
+      setSaved(pretty)
+      setDraft(pretty)
+    } catch (error) {
+      setLoadError(getErrorMessage(error))
+    } finally {
+      setLoading(false)
+    }
+    void loadSamples()
+  }, [loadSamples])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  const save = useCallback(async () => {
+    if (jsonError) return
+    setSaving(true)
+    try {
+      const updated = await api.updateSettings({ payload_rules: draft.trim() || '{}' })
+      const pretty = prettifyRulesJSON(updated.payload_rules || '{}')
+      setSaved(pretty)
+      setDraft(pretty)
+      showToast(t('payloadRules.saved'), 'success')
+    } catch (error) {
+      showToast(getErrorMessage(error), 'error')
+    } finally {
+      setSaving(false)
+    }
+  }, [draft, jsonError, showToast, t])
+
+  return (
+    <div className="w-full min-w-0">
+      <PageHeader
+        title={t('settings2.payloadRules')}
+        description={t('settings2.payloadRulesDesc')}
+        onRefresh={() => void load()}
+        actions={
+          <Button
+            size="sm"
+            className="gap-1.5"
+            disabled={saving || !dirty || Boolean(jsonError)}
+            onClick={() => void save()}
+          >
+            <Save className="size-3.5" />
+            {saving ? t('common.saving') : t('common.save')}
+          </Button>
+        }
+      />
+
+      <StateShell
+        variant="page"
+        loading={loading}
+        error={loadError}
+        onRetry={() => void load()}
+      >
+        <div className="space-y-4">
+          <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs leading-relaxed text-amber-700 dark:text-amber-300">
+            {t('settings2.payloadRulesWarning')}
+          </div>
+
+          <div className="rounded-xl border border-border bg-card/85 p-4 shadow-sm">
+            <div className="mb-2 flex items-center justify-between gap-2">
+              <div className="text-sm font-semibold text-foreground">{t('payloadRules.editorTitle')}</div>
+              <div className="flex items-center gap-2">
+                {dirty ? <Badge variant="outline" className="text-[11px]">{t('payloadRules.unsaved')}</Badge> : null}
+                <Badge variant="secondary" className="text-[11px]">
+                  {t('settings.nav.mappingCount', { count: ruleCount })}
+                </Badge>
+              </div>
+            </div>
+            <textarea
+              rows={18}
+              value={draft}
+              spellCheck={false}
+              placeholder={PAYLOAD_RULES_PLACEHOLDER}
+              onChange={(e: ChangeEvent<HTMLTextAreaElement>) => setDraft(e.target.value)}
+              className="flex w-full resize-y rounded-md border border-input bg-background px-3 py-2 font-mono text-xs leading-relaxed text-foreground shadow-xs transition-colors placeholder:text-muted-foreground focus-visible:border-ring focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
+            />
+            {jsonError ? (
+              <p className="mt-1.5 text-xs text-destructive">{t('settings2.payloadRulesJsonError')}: {jsonError}</p>
+            ) : (
+              <p className="mt-1.5 text-xs leading-relaxed text-muted-foreground">{t('settings2.payloadRulesHint')}</p>
+            )}
+          </div>
+
+          <div className="rounded-xl border border-border bg-card/85 p-4 shadow-sm">
+            <div className="mb-1 flex items-center justify-between gap-2">
+              <div className="text-sm font-semibold text-foreground">{t('settings2.payloadRulesObserved')}</div>
+              <Button size="sm" variant="outline" className="gap-1.5" onClick={() => void loadSamples()} disabled={samplesLoading}>
+                <RefreshCw className={samplesLoading ? 'size-3.5 animate-spin' : 'size-3.5'} />
+                {t('settings2.payloadRulesObservedLoad')}
+              </Button>
+            </div>
+            <p className="mb-3 text-xs leading-relaxed text-muted-foreground">{t('settings2.payloadRulesObservedDesc')}</p>
+            {samples.length === 0 ? (
+              <p className="text-xs text-muted-foreground">{t('settings2.payloadRulesObservedEmpty')}</p>
+            ) : (
+              <div className="space-y-2">
+                {samples.map((sample, i) => (
+                  <div key={i} className="rounded-md border border-border bg-background p-2.5">
+                    <button
+                      type="button"
+                      className="flex w-full items-center justify-between gap-2 text-left"
+                      onClick={() => setExpandedSample(expandedSample === i ? null : i)}
+                    >
+                      <span className="min-w-0 truncate font-mono text-xs font-semibold text-foreground">
+                        {sample.model || '-'}
+                        <span className="ml-2 font-normal text-muted-foreground">{sample.originator}</span>
+                      </span>
+                      <span className="shrink-0 text-[11px] text-muted-foreground">
+                        {sample.length.toLocaleString()} chars{sample.truncated ? ' (truncated)' : ''}
+                      </span>
+                    </button>
+                    {expandedSample === i ? (
+                      <pre className="mt-2 max-h-72 overflow-auto whitespace-pre-wrap break-words rounded bg-muted/40 p-2 text-[11px] leading-relaxed text-foreground">
+                        {sample.instructions}
+                      </pre>
+                    ) : null}
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      </StateShell>
+    </div>
+  )
+}

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -7,7 +7,8 @@ import PageHeader from '../components/PageHeader'
 import StateShell from '../components/StateShell'
 import { useDataLoader } from '../hooks/useDataLoader'
 import { useToast } from '../hooks/useToast'
-import type { HealthResponse, ModelInfo, ObservedInstructionsSample, SiteBranding, SystemSettings } from '../types'
+import type { HealthResponse, ModelInfo, SiteBranding, SystemSettings } from '../types'
+import { countPayloadRules } from './PayloadRules'
 import { getErrorMessage } from '../utils/error'
 import { DEFAULT_CLAUDE_MODEL_MAP } from '../lib/modelMapping'
 import { DEFAULT_SITE_LOGO, isBrandingVideo, sanitizeBrandingImage, sanitizeBrandingLogo, useBranding } from '../branding'
@@ -65,9 +66,9 @@ import {
   Wrench,
   X,
 } from 'lucide-react'
-import { Link } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 
-type ModelPanelKey = 'registry' | 'anthropic' | 'codex' | 'reasoning' | 'payload'
+type ModelPanelKey = 'registry' | 'anthropic' | 'codex' | 'reasoning'
 
 type ModelMappingEntry = [string, string]
 const EMPTY_MODEL_MAPPING_ENTRIES: ModelMappingEntry[] = []
@@ -306,117 +307,6 @@ const buildCodexUserAgentPreview = (config: CodexUserAgentConfig, minVersion: st
 }
 
 // 模型映射编辑器组件
-const PAYLOAD_RULE_GROUPS = ['default', 'default_raw', 'override', 'override_raw', 'append', 'filter'] as const
-
-function countPayloadRules(raw: string): number {
-  try {
-    const parsed = JSON.parse(raw || '{}') as Record<string, unknown>
-    return PAYLOAD_RULE_GROUPS.reduce((sum, group) => {
-      const rules = parsed[group]
-      return sum + (Array.isArray(rules) ? rules.length : 0)
-    }, 0)
-  } catch {
-    return 0
-  }
-}
-
-function PayloadRulesEditor({ value, onChange }: { value: string; onChange: (v: string) => void }) {
-  const { t } = useTranslation()
-  const [samples, setSamples] = useState<ObservedInstructionsSample[]>([])
-  const [samplesLoaded, setSamplesLoaded] = useState(false)
-  const [loadingSamples, setLoadingSamples] = useState(false)
-  const [expandedSample, setExpandedSample] = useState<number | null>(null)
-
-  const jsonError = useMemo(() => {
-    const trimmed = value.trim()
-    if (!trimmed) return null
-    try {
-      JSON.parse(trimmed)
-      return null
-    } catch (e) {
-      return e instanceof Error ? e.message : String(e)
-    }
-  }, [value])
-
-  const loadSamples = useCallback(async () => {
-    setLoadingSamples(true)
-    try {
-      const resp = await api.getObservedInstructions()
-      setSamples(resp.samples || [])
-      setSamplesLoaded(true)
-    } catch {
-      setSamples([])
-      setSamplesLoaded(true)
-    } finally {
-      setLoadingSamples(false)
-    }
-  }, [])
-
-  return (
-    <div className="space-y-4">
-      <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs leading-relaxed text-amber-700 dark:text-amber-300">
-        {t('settings2.payloadRulesWarning')}
-      </div>
-      <div className="space-y-1.5">
-        <textarea
-          rows={14}
-          value={value}
-          spellCheck={false}
-          placeholder={PAYLOAD_RULES_PLACEHOLDER}
-          onChange={(e: ChangeEvent<HTMLTextAreaElement>) => onChange(e.target.value)}
-          className="flex w-full resize-y rounded-md border border-input bg-background px-3 py-2 font-mono text-xs text-foreground shadow-xs transition-colors placeholder:text-muted-foreground focus-visible:border-ring focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
-        />
-        {jsonError ? (
-          <p className="text-xs text-destructive">{t('settings2.payloadRulesJsonError')}: {jsonError}</p>
-        ) : (
-          <p className="text-xs text-muted-foreground">{t('settings2.payloadRulesHint')}</p>
-        )}
-      </div>
-      <div className="space-y-2 rounded-lg border border-border bg-muted/20 p-3">
-        <div className="flex items-center justify-between gap-2">
-          <div className="text-xs font-semibold text-foreground">{t('settings2.payloadRulesObserved')}</div>
-          <Button size="sm" variant="outline" onClick={() => void loadSamples()} disabled={loadingSamples}>
-            {loadingSamples ? t('common.loading') : t('settings2.payloadRulesObservedLoad')}
-          </Button>
-        </div>
-        <p className="text-xs text-muted-foreground">{t('settings2.payloadRulesObservedDesc')}</p>
-        {samplesLoaded && samples.length === 0 ? (
-          <p className="text-xs text-muted-foreground">{t('settings2.payloadRulesObservedEmpty')}</p>
-        ) : null}
-        {samples.map((sample, i) => (
-          <div key={i} className="rounded-md border border-border bg-background p-2.5">
-            <button
-              type="button"
-              className="flex w-full items-center justify-between gap-2 text-left"
-              onClick={() => setExpandedSample(expandedSample === i ? null : i)}
-            >
-              <span className="min-w-0 truncate font-mono text-xs font-semibold text-foreground">
-                {sample.model || '-'}
-                <span className="ml-2 font-normal text-muted-foreground">{sample.originator}</span>
-              </span>
-              <span className="shrink-0 text-[11px] text-muted-foreground">
-                {sample.length.toLocaleString()} chars{sample.truncated ? ' (truncated)' : ''}
-              </span>
-            </button>
-            {expandedSample === i ? (
-              <pre className="mt-2 max-h-72 overflow-auto whitespace-pre-wrap break-words rounded bg-muted/40 p-2 text-[11px] leading-relaxed text-foreground">
-                {sample.instructions}
-              </pre>
-            ) : null}
-          </div>
-        ))}
-      </div>
-    </div>
-  )
-}
-
-const PAYLOAD_RULES_PLACEHOLDER = `{
-  "append":   [{"params": {"instructions": "追加到系统提示词末尾的文本"}}],
-  "override": [{"models": ["gpt-*"], "params": {"service_tier": "priority"}},
-               {"match": {"reasoning.effort": "medium"}, "params": {"reasoning.effort": "high"}}],
-  "filter":   [{"params": ["metadata.debug"]}]
-}`
-
 function ModelMappingEditor({
   value,
   onChange,
@@ -1162,6 +1052,7 @@ async function compressSiteLogoFile(file: File, mimeType: string) {
 
 export default function Settings() {
   const { t } = useTranslation()
+  const navigate = useNavigate()
   const { applyBranding } = useBranding()
   const defaultClaudeModelMappingEntries = useMemo(() => getDefaultModelMappingEntries(), [])
   const schedulerModeOptions = [
@@ -3193,7 +3084,7 @@ export default function Settings() {
                 description={t('settings2.payloadRulesDesc')}
                 meta={t('settings.nav.mappingCount', { count: payloadRuleCount })}
                 openLabel={t('settings.nav.manage')}
-                onOpen={() => setModelPanel('payload')}
+                onOpen={() => navigate('/payload-rules')}
               />
             </div>
 
@@ -3210,9 +3101,7 @@ export default function Settings() {
                         ? t('settings2.anthropicModelMapping')
                         : modelPanel === 'codex'
                           ? t('settings2.codexModelMapping')
-                          : modelPanel === 'payload'
-                            ? t('settings2.payloadRules')
-                            : t('settings2.reasoningEffortModels')}
+                          : t('settings2.reasoningEffortModels')}
                   </SheetTitle>
                   <SheetDescription>
                     {modelPanel === 'registry'
@@ -3221,9 +3110,7 @@ export default function Settings() {
                         ? t('settings2.anthropicModelMappingDesc')
                         : modelPanel === 'codex'
                           ? t('settings2.codexModelMappingDesc')
-                          : modelPanel === 'payload'
-                            ? t('settings2.payloadRulesDesc')
-                            : t('settings2.reasoningEffortModelsDesc')}
+                          : t('settings2.reasoningEffortModelsDesc')}
                   </SheetDescription>
                 </SheetHeader>
                 <SheetBody className="space-y-4">
@@ -3291,12 +3178,6 @@ export default function Settings() {
                       value={settingsForm.reasoning_effort_models}
                       onChange={(v) => setSettingsForm((f) => ({ ...f, reasoning_effort_models: v }))}
                       baseModelOptions={textModelOptions}
-                    />
-                  ) : null}
-                  {modelPanel === 'payload' ? (
-                    <PayloadRulesEditor
-                      value={settingsForm.payload_rules}
-                      onChange={(v) => setSettingsForm((f) => ({ ...f, payload_rules: v }))}
                     />
                   ) : null}
                 </SheetBody>


### PR DESCRIPTION
## 背景

#390 引入的 payload 重写规则编辑器原本内嵌在 设置→模型 区块的 Sheet 抽屉里。规则编辑需要更大空间，且观测样本查看是高频操作，提升为侧边栏独立页面。

## 改动

- **新页面 `/payload-rules`**（frontend/src/pages/PayloadRules.tsx）：
  - 规则 JSON 编辑器：实时语法校验、未保存标记、规则数徽章、示例 placeholder
  - 显式保存：PUT 后用服务端归一化结果回显（自动 prettify）；非法 JSON 禁用保存按钮；服务端校验失败（保护字段等）toast 展示错误
  - 风险提示横幅 + 规则语法说明
  - 透传 instructions 样本：进页自动加载 + 手动刷新，条目可展开看原文
- **侧边栏**新增「请求体重写 / Payload Rules」导航项（Braces 图标）
- **设置页**原卡片保留（含规则数统计），点击跳转独立页面；内嵌编辑器与 Sheet 面板移除
- 中英文案

## 验证（headless 浏览器实测）

- 登录 → 侧边栏出现「Payload Rules」项并在页面激活时高亮 ✅
- 页面渲染完整：标题/描述、警告横幅、编辑器、0 rules 徽章、样本区空态 ✅
- UI 编辑规则 → 保存 → GET settings 确认落库 → 代理请求实测规则生效（模型精确回复 UI_SAVED_RULE）✅
- 保存后编辑器回显服务端归一化 JSON，徽章变 1 rules，Save 按钮回到禁用态 ✅
- Load samples 展示真实透传样本（model/originator/长度）✅
- `npm run build` + `tsc --noEmit` 干净 ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Payload Rules page for editing and saving request-body rewrite rules.
  * Added navigation access from the sidebar and mobile menu.
  * Added JSON validation, formatting, rule counts, save status, and immediate-application feedback.
  * Added an Observed section with sample instructions and refresh support.
  * Added English and Chinese translations for the new interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->