### PR TITLE
fix(retry): 上游账号 403 换号重试，不再直接透传给客户端

### DIFF
--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -1496,9 +1496,15 @@ const (
 	logStatusUpstreamStreamBreak = 598
 )
 
-// isRetryableStatus 检查是否可重试的上游状态码
+// isRetryableStatus 检查是否可重试的上游状态码。
+// 403 也视为可重试：Codex 上游 403 全是账号侧问题（payment_required /
+// deactivated_workspace / codex_access_restricted 等 OAuth/套餐/工作区维度），
+// 非请求内容问题，换到号池里其他健康账号即可继续（issue #396）。
 func isRetryableStatus(code int) bool {
-	return code == http.StatusServiceUnavailable || code == http.StatusUnauthorized || code == http.StatusInternalServerError
+	return code == http.StatusServiceUnavailable ||
+		code == http.StatusUnauthorized ||
+		code == http.StatusInternalServerError ||
+		code == http.StatusForbidden
 }
 
 func shouldRetryHTTPStatus(statusCode int, generalRetries *int, rateLimitRetries *int, maxGeneralRetries, maxRateLimitRetries int) bool {
@@ -4674,6 +4680,20 @@ func (h *Handler) sendFinalUpstreamError(c *gin.Context, statusCode int, body []
 				"message": "账号池暂无可用账号（上游账号鉴权失效），请稍后重试",
 				"type":    "server_error",
 				"code":    "account_pool_unauthorized",
+			},
+		})
+		return
+	}
+
+	// 上游账号 403（payment_required / deactivated_workspace / codex_access_restricted）
+	// 同样是账号侧问题：重试已换过号仍拿到 403 说明池内暂无可用账号。原样透传 403 会让
+	// 客户端（如 Claude Code）误判为自身无权限而直接停工（issue #396），改写为 503 池级错误。
+	if statusCode == http.StatusForbidden {
+		c.JSON(http.StatusServiceUnavailable, gin.H{
+			"error": gin.H{
+				"message": "账号池暂无可用账号（上游账号被拒绝访问：额度/套餐或工作区受限），请稍后重试",
+				"type":    "server_error",
+				"code":    "account_pool_forbidden",
 			},
 		})
 		return

--- a/proxy/handler_anthropic.go
+++ b/proxy/handler_anthropic.go
@@ -346,6 +346,12 @@ func (h *Handler) Messages(c *gin.Context) {
 				sendAnthropicError(c, http.StatusServiceUnavailable, "overloaded_error", "账号池暂无可用账号（上游账号鉴权失效），请稍后重试")
 				return
 			}
+			// 上游账号 403 也是账号侧问题（额度/套餐/工作区受限）：换号重试耗尽后仍 403，
+			// 原样透传会让 Claude Code 误判自身无权限而停工（issue #396），改写为 503 池级错误。
+			if resp.StatusCode == http.StatusForbidden {
+				sendAnthropicError(c, http.StatusServiceUnavailable, "overloaded_error", "账号池暂无可用账号（上游账号被拒绝访问：额度/套餐或工作区受限），请稍后重试")
+				return
+			}
 			errType := mapHTTPStatusToAnthropicError(resp.StatusCode)
 			msg := gjson.GetBytes(errBody, "error.message").String()
 			if msg == "" {

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -2542,6 +2542,66 @@ func TestSendFinalUpstreamError_MissingScope401Passthrough(t *testing.T) {
 	}
 }
 
+// TestShouldRetryHTTPStatus403 验证上游 403 现在参与换号重试（issue #396），
+// 受 general-retry 预算限制。
+func TestShouldRetryHTTPStatus403(t *testing.T) {
+	if !isRetryableStatus(http.StatusForbidden) {
+		t.Fatal("403 应被视为可重试状态")
+	}
+	generalRetries := 0
+	rateLimitRetries := 0
+	if !shouldRetryHTTPStatus(http.StatusForbidden, &generalRetries, &rateLimitRetries, 2, 1) {
+		t.Fatal("首个 403（未达上限）应可重试")
+	}
+	if !shouldRetryHTTPStatus(http.StatusForbidden, &generalRetries, &rateLimitRetries, 2, 1) {
+		t.Fatal("第二个 403（仍未达上限）应可重试")
+	}
+	if shouldRetryHTTPStatus(http.StatusForbidden, &generalRetries, &rateLimitRetries, 2, 1) {
+		t.Fatal("达到 general 重试上限后 403 不应再重试")
+	}
+	if generalRetries != 2 {
+		t.Fatalf("generalRetries = %d, want 2", generalRetries)
+	}
+	if rateLimitRetries != 0 {
+		t.Fatalf("403 不应消耗限流预算，rateLimitRetries = %d, want 0", rateLimitRetries)
+	}
+}
+
+// TestSendFinalUpstreamError_Forbidden403RemappedTo503 验证上游账号 403（额度/套餐/
+// 工作区受限）重试耗尽后改写为 503 池级错误，不原样以 403 透传（issue #396），
+// 避免 Claude Code 误判自身无权限而停工。
+func TestSendFinalUpstreamError_Forbidden403RemappedTo503(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	for _, body := range [][]byte{
+		[]byte(`{"error":{"message":"You have hit your usage limit.","code":"insufficient_quota"},"status":403}`),
+		[]byte(`{"detail":{"code":"deactivated_workspace"}}`),
+		[]byte(`{"error":{"code":"codex_access_restricted"}}`),
+	} {
+		recorder := httptest.NewRecorder()
+		ctx, _ := gin.CreateTestContext(recorder)
+		handler := &Handler{}
+
+		handler.sendFinalUpstreamError(ctx, http.StatusForbidden, body)
+
+		if recorder.Code != http.StatusServiceUnavailable {
+			t.Fatalf("body=%s status = %d, want %d (上游 403 不应以客户端 403 透传)", body, recorder.Code, http.StatusServiceUnavailable)
+		}
+		var payload struct {
+			Error struct {
+				Code string `json:"code"`
+				Type string `json:"type"`
+			} `json:"error"`
+		}
+		if err := json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
+			t.Fatalf("decode response: %v", err)
+		}
+		if payload.Error.Code != "account_pool_forbidden" {
+			t.Fatalf("body=%s code = %q, want account_pool_forbidden", body, payload.Error.Code)
+		}
+	}
+}
+
 func TestCompute429CooldownPlusUsesWindowHeaders(t *testing.T) {
 	handler := &Handler{}
 	account := &auth.Account{PlanType: "plus"}


### PR DESCRIPTION
Closes #396

## 背景
Claude Code（`/v1/messages`）等客户端连上游账号，遇到上游 **403** 时网关**直接把 403 透传给客户端并停止**，不换号重试——用户侧表现为「一 403 就停工」。

根因：`isRetryableStatus` 只把 503/401/500 视为可重试，403 不在内。而 Codex 上游 403 全是**账号侧**问题（`payment_required` / `deactivated_workspace` / `codex_access_restricted`，均为 OAuth/套餐/工作区维度，非请求内容问题）。收到 403 时账号已被冷却/标错 + 硬排除，但因 403 不可重试，循环直接把 403 透传给客户端，哪怕号池里还有健康账号。

## 改动
1. **`isRetryableStatus` 加入 403**（`proxy/handler.go`）：所有端点（`/v1/responses`、compact、`/v1/chat/completions`、`/v1/messages`）的重试判定都走 `shouldRetryHTTPStatus`，一处改动即让全部路径在 403 时换号重试；受 `max_retries` 限制，不会无限循环。
2. **重试耗尽后不透传原始 403**：
   - `sendFinalUpstreamError`（`proxy/handler.go`）在 401→503 改写块后新增 403→503 分支，`code: account_pool_forbidden`。
   - `/v1/messages` handler 的独立最终分支（`proxy/handler_anthropic.go`）加对称的 403→503 改写。
3. **冷却/标错语义不变**：`applyCooldownForModel` 对 403 的处理（payment_required 冷却、deactivated_workspace 标错）原样保留，正好让重试自然轮到别的账号。

## 行为（用户已确认）
- 403 换号重试（含 `deactivated_workspace`），重试耗尽才报错；不透传原始 403，改成友好的 503 池级错误。

## 验证
- `go build ./...`、`go vet ./proxy/`、`go test ./proxy/` 全绿。
- 新增单测：`TestShouldRetryHTTPStatus403`（403 可重试、受预算限制、不消耗限流预算）、`TestSendFinalUpstreamError_Forbidden403RemappedTo503`（三类 403 body 均改写为 503 + `account_pool_forbidden`）。
- 回归：401/503/500 行为与 missing_scope 401 透传不变。
- 未做：pgredis2004 端到端本地冒烟（一个必 403 账号 + 一个健康账号同池，验证换号成功；健康账号移除后返回 503 池级错误）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of upstream access restrictions and account-related 403 errors.
  * Automatically retries eligible 403 responses when alternate accounts may be available.
  * Presents a consistent temporary-unavailability response when access remains unavailable.
  * Improved error messaging for Anthropic requests affected by quota, tier, workspace, or access restrictions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->