### PR TITLE
fix(billing): charge quota when usage logs are disabled

### DIFF
--- a/database/postgres.go
+++ b/database/postgres.go
@@ -257,6 +257,7 @@ func NormalizeUsageLogFlushIntervalSeconds(n int) int {
 
 // usageLogEntry 日志缓冲条目
 type usageLogEntry struct {
+	StoreUsageLog        bool
 	AccountID            int64
 	ClientIP             string
 	ClientUserAgent      string
@@ -2428,11 +2429,12 @@ type UsageLog struct {
 	ErrorMessage         string    `json:"error_message"`
 }
 
-// InsertUsageLog 将日志追加到内存缓冲（非阻塞）
+// InsertUsageLog 将用量事件追加到内存缓冲（非阻塞）。
 func (db *DB) InsertUsageLog(ctx context.Context, log *UsageLogInput) error {
-	if db == nil || log == nil || !db.shouldStoreUsageLog(log) {
+	if db == nil || log == nil {
 		return nil
 	}
+	storeUsageLog := db.shouldStoreUsageLog(log)
 
 	// 计算计费金额（基于 input/output tokens 和模型）
 	// 使用 EffectiveModel 作为计费模型（如果有映射则使用映射后的模型）
@@ -2462,9 +2464,13 @@ func (db *DB) InsertUsageLog(ctx context.Context, log *UsageLogInput) error {
 
 	// 用户计费金额与账号计费金额相同（简化版，未来可支持倍率）
 	userBilled := accountBilled
+	if !storeUsageLog && (log.APIKeyID <= 0 || userBilled <= 0 || log.StatusCode == 499) {
+		return nil
+	}
 
 	db.logMu.Lock()
 	db.logBuf = append(db.logBuf, usageLogEntry{
+		StoreUsageLog:        storeUsageLog,
 		AccountID:            log.AccountID,
 		ClientIP:             log.ClientIP,
 		ClientUserAgent:      log.ClientUserAgent,
@@ -2663,9 +2669,33 @@ func (db *DB) flushLogs() {
 		return
 	}
 
-	if len(batch) > 10 {
-		log.Printf("批量写入 %d 条使用日志", len(batch))
+	if storedLogCount := countStoredUsageLogs(batch); storedLogCount > 10 {
+		log.Printf("批量写入 %d 条使用日志", storedLogCount)
 	}
+}
+
+func countStoredUsageLogs(batch []usageLogEntry) int {
+	count := 0
+	for _, entry := range batch {
+		if entry.StoreUsageLog {
+			count++
+		}
+	}
+	return count
+}
+
+func storedUsageLogs(batch []usageLogEntry) []usageLogEntry {
+	storedCount := countStoredUsageLogs(batch)
+	if storedCount == len(batch) {
+		return batch
+	}
+	stored := make([]usageLogEntry, 0, storedCount)
+	for _, entry := range batch {
+		if entry.StoreUsageLog {
+			stored = append(stored, entry)
+		}
+	}
+	return stored
 }
 
 func (db *DB) requeueUsageLogBatch(batch []usageLogEntry) {
@@ -2700,27 +2730,30 @@ func (db *DB) insertSQLiteUsageLogBatch(ctx context.Context, batch []usageLogEnt
 	}
 	defer tx.Rollback()
 
-	stmt, err := tx.PrepareContext(ctx,
-		`INSERT INTO usage_logs (account_id, client_ip, endpoint, model, effective_model, prompt_tokens, completion_tokens, total_tokens, status_code, duration_ms,
-			  input_tokens, output_tokens, reasoning_tokens, first_token_ms, ws_acquire_ms, reasoning_effort, inbound_endpoint, upstream_endpoint, stream, compact, cached_tokens, service_tier,
-			  requested_service_tier, actual_service_tier, billing_service_tier,
-			  api_key_id, api_key_name, api_key_masked, image_count, image_width, image_height, image_bytes, image_format, image_size, account_billed, user_billed,
-			  is_retry_attempt, attempt_index, upstream_error_kind, error_message, via_websocket,
-			  client_user_agent, upstream_user_agent, user_agent_overridden)
-			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43, $44)`)
-	if err != nil {
-		return fmt.Errorf("准备语句: %w", err)
-	}
-	defer stmt.Close()
+	logsToStore := storedUsageLogs(batch)
+	if len(logsToStore) > 0 {
+		stmt, err := tx.PrepareContext(ctx,
+			`INSERT INTO usage_logs (account_id, client_ip, endpoint, model, effective_model, prompt_tokens, completion_tokens, total_tokens, status_code, duration_ms,
+				  input_tokens, output_tokens, reasoning_tokens, first_token_ms, ws_acquire_ms, reasoning_effort, inbound_endpoint, upstream_endpoint, stream, compact, cached_tokens, service_tier,
+				  requested_service_tier, actual_service_tier, billing_service_tier,
+				  api_key_id, api_key_name, api_key_masked, image_count, image_width, image_height, image_bytes, image_format, image_size, account_billed, user_billed,
+				  is_retry_attempt, attempt_index, upstream_error_kind, error_message, via_websocket,
+				  client_user_agent, upstream_user_agent, user_agent_overridden)
+				 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43, $44)`)
+		if err != nil {
+			return fmt.Errorf("准备语句: %w", err)
+		}
+		defer stmt.Close()
 
-	for _, e := range batch {
-		if _, err := stmt.ExecContext(ctx, e.AccountID, e.ClientIP, e.Endpoint, e.Model, e.EffectiveModel, e.PromptTokens, e.CompletionTokens, e.TotalTokens, e.StatusCode, e.DurationMs,
-			e.InputTokens, e.OutputTokens, e.ReasoningTokens, e.FirstTokenMs, e.WsAcquireMs, e.ReasoningEffort, e.InboundEndpoint, e.UpstreamEndpoint, e.Stream, e.Compact, e.CachedTokens, e.ServiceTier,
-			e.RequestedServiceTier, e.ActualServiceTier, e.BillingServiceTier,
-			e.APIKeyID, e.APIKeyName, e.APIKeyMasked, e.ImageCount, e.ImageWidth, e.ImageHeight, e.ImageBytes, e.ImageFormat, e.ImageSize, e.AccountBilled, e.UserBilled,
-			e.IsRetryAttempt, e.AttemptIndex, e.UpstreamErrorKind, e.ErrorMessage, e.ViaWebsocket,
-			e.ClientUserAgent, e.UpstreamUserAgent, e.UserAgentOverridden); err != nil {
-			return fmt.Errorf("执行插入: %w", err)
+		for _, e := range logsToStore {
+			if _, err := stmt.ExecContext(ctx, e.AccountID, e.ClientIP, e.Endpoint, e.Model, e.EffectiveModel, e.PromptTokens, e.CompletionTokens, e.TotalTokens, e.StatusCode, e.DurationMs,
+				e.InputTokens, e.OutputTokens, e.ReasoningTokens, e.FirstTokenMs, e.WsAcquireMs, e.ReasoningEffort, e.InboundEndpoint, e.UpstreamEndpoint, e.Stream, e.Compact, e.CachedTokens, e.ServiceTier,
+				e.RequestedServiceTier, e.ActualServiceTier, e.BillingServiceTier,
+				e.APIKeyID, e.APIKeyName, e.APIKeyMasked, e.ImageCount, e.ImageWidth, e.ImageHeight, e.ImageBytes, e.ImageFormat, e.ImageSize, e.AccountBilled, e.UserBilled,
+				e.IsRetryAttempt, e.AttemptIndex, e.UpstreamErrorKind, e.ErrorMessage, e.ViaWebsocket,
+				e.ClientUserAgent, e.UpstreamUserAgent, e.UserAgentOverridden); err != nil {
+				return fmt.Errorf("执行插入: %w", err)
+			}
 		}
 	}
 
@@ -2746,15 +2779,16 @@ func (db *DB) batchInsertLogs(ctx context.Context, batch []usageLogEntry) error 
 	}
 	defer tx.Rollback()
 
+	logsToStore := storedUsageLogs(batch)
 	const maxRowsPerBatch = 1500
 
 	// 分批处理
-	for start := 0; start < len(batch); start += maxRowsPerBatch {
+	for start := 0; start < len(logsToStore); start += maxRowsPerBatch {
 		end := start + maxRowsPerBatch
-		if end > len(batch) {
-			end = len(batch)
+		if end > len(logsToStore) {
+			end = len(logsToStore)
 		}
-		subBatch := batch[start:end]
+		subBatch := logsToStore[start:end]
 
 		if err := db.batchInsertLogsChunk(ctx, tx, subBatch); err != nil {
 			return err

--- a/database/sqlite_test.go
+++ b/database/sqlite_test.go
@@ -765,7 +765,7 @@ func TestSQLiteUsageLogsHasAPIKeyColumns(t *testing.T) {
 	}
 }
 
-func TestUsageLogModeErrorsSkipsSuccessfulLogs(t *testing.T) {
+func TestUsageLogModeErrorsSkipsSuccessfulLogsButChargesQuota(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "codex2api.db")
 
 	db, err := New("sqlite", dbPath)
@@ -776,11 +776,17 @@ func TestUsageLogModeErrorsSkipsSuccessfulLogs(t *testing.T) {
 	db.SetUsageLogConfig(UsageLogModeErrors, 10, 5)
 
 	ctx := context.Background()
+	apiKeyID, err := db.InsertAPIKey(ctx, "mode-errors", "sk-mode-errors-1234567890")
+	if err != nil {
+		t.Fatalf("InsertAPIKey 返回错误: %v", err)
+	}
 	if err := db.InsertUsageLog(ctx, &UsageLogInput{
-		AccountID:  1,
-		Endpoint:   "/v1/responses",
-		Model:      "gpt-5.4",
-		StatusCode: 200,
+		AccountID:   1,
+		APIKeyID:    apiKeyID,
+		Endpoint:    "/v1/responses",
+		Model:       "gpt-5.4",
+		StatusCode:  200,
+		InputTokens: 1000,
 	}); err != nil {
 		t.Fatalf("InsertUsageLog success 返回错误: %v", err)
 	}
@@ -804,6 +810,15 @@ func TestUsageLogModeErrorsSkipsSuccessfulLogs(t *testing.T) {
 	}
 	if logs[0].StatusCode != 500 {
 		t.Fatalf("StatusCode = %d, want 500", logs[0].StatusCode)
+	}
+
+	want := calculateCost(1000, 0, 0, "gpt-5.4", "")
+	var quotaUsed, totalUsed float64
+	if err := db.conn.QueryRowContext(ctx, `SELECT quota_used, total_used FROM api_keys WHERE id = $1`, apiKeyID).Scan(&quotaUsed, &totalUsed); err != nil {
+		t.Fatalf("查询 API Key 用量返回错误: %v", err)
+	}
+	if math.Abs(quotaUsed-want) > 1e-12 || math.Abs(totalUsed-want) > 1e-12 {
+		t.Fatalf("API Key usage = quota %.12f total %.12f, want %.12f", quotaUsed, totalUsed, want)
 	}
 }
 
@@ -930,7 +945,7 @@ func TestUsageErrorSummaryAndFilters(t *testing.T) {
 	}
 }
 
-func TestUsageLogModeOffSkipsAllLogs(t *testing.T) {
+func TestUsageLogModeOffSkipsAllLogsButChargesQuota(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "codex2api.db")
 
 	db, err := New("sqlite", dbPath)
@@ -941,11 +956,17 @@ func TestUsageLogModeOffSkipsAllLogs(t *testing.T) {
 	db.SetUsageLogConfig(UsageLogModeOff, 10, 5)
 
 	ctx := context.Background()
+	apiKeyID, err := db.InsertAPIKey(ctx, "mode-off", "sk-mode-off-1234567890")
+	if err != nil {
+		t.Fatalf("InsertAPIKey 返回错误: %v", err)
+	}
 	if err := db.InsertUsageLog(ctx, &UsageLogInput{
-		AccountID:  1,
-		Endpoint:   "/v1/responses",
-		Model:      "gpt-5.4",
-		StatusCode: 500,
+		AccountID:   1,
+		APIKeyID:    apiKeyID,
+		Endpoint:    "/v1/responses",
+		Model:       "gpt-5.4",
+		StatusCode:  200,
+		InputTokens: 1000,
 	}); err != nil {
 		t.Fatalf("InsertUsageLog 返回错误: %v", err)
 	}
@@ -957,6 +978,53 @@ func TestUsageLogModeOffSkipsAllLogs(t *testing.T) {
 	}
 	if len(logs) != 0 {
 		t.Fatalf("len(logs) = %d, want 0", len(logs))
+	}
+
+	want := calculateCost(1000, 0, 0, "gpt-5.4", "")
+	var quotaUsed, totalUsed float64
+	if err := db.conn.QueryRowContext(ctx, `SELECT quota_used, total_used FROM api_keys WHERE id = $1`, apiKeyID).Scan(&quotaUsed, &totalUsed); err != nil {
+		t.Fatalf("查询 API Key 用量返回错误: %v", err)
+	}
+	if math.Abs(quotaUsed-want) > 1e-12 || math.Abs(totalUsed-want) > 1e-12 {
+		t.Fatalf("API Key usage = quota %.12f total %.12f, want %.12f", quotaUsed, totalUsed, want)
+	}
+}
+
+func TestUsageLogModesPreserveCanceledQuotaExemption(t *testing.T) {
+	for _, mode := range []string{UsageLogModeErrors, UsageLogModeOff} {
+		t.Run(mode, func(t *testing.T) {
+			dbPath := filepath.Join(t.TempDir(), "codex2api.db")
+			db, err := New("sqlite", dbPath)
+			if err != nil {
+				t.Fatalf("New(sqlite) 返回错误: %v", err)
+			}
+			defer db.Close()
+			db.SetUsageLogConfig(mode, 10, 5)
+
+			ctx := context.Background()
+			apiKeyID, err := db.InsertAPIKey(ctx, "mode-499-"+mode, "sk-mode-499-"+mode+"-1234567890")
+			if err != nil {
+				t.Fatalf("InsertAPIKey 返回错误: %v", err)
+			}
+			if err := db.InsertUsageLog(ctx, &UsageLogInput{
+				APIKeyID:    apiKeyID,
+				Endpoint:    "/v1/responses",
+				Model:       "gpt-5.4",
+				StatusCode:  499,
+				InputTokens: 1000,
+			}); err != nil {
+				t.Fatalf("InsertUsageLog 返回错误: %v", err)
+			}
+			db.flushLogs()
+
+			var quotaUsed, totalUsed float64
+			if err := db.conn.QueryRowContext(ctx, `SELECT quota_used, total_used FROM api_keys WHERE id = $1`, apiKeyID).Scan(&quotaUsed, &totalUsed); err != nil {
+				t.Fatalf("查询 API Key 用量返回错误: %v", err)
+			}
+			if quotaUsed != 0 || totalUsed != 0 {
+				t.Fatalf("API Key usage = quota %.12f total %.12f, want 0", quotaUsed, totalUsed)
+			}
+		})
 	}
 }
 
@@ -2879,6 +2947,72 @@ func TestFlushLogsRollsBackAndRequeuesWhenQuotaUpdateFails(t *testing.T) {
 	}
 	if count != 0 {
 		t.Fatalf("usage_logs count = %d, want 0 after rolled-back flush", count)
+	}
+}
+
+func TestFlushLogsRetriesQuotaOnlyBatchWithoutDoubleCharge(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "codex2api.db")
+
+	db, err := New("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("New(sqlite) 返回错误: %v", err)
+	}
+	close(db.logStop)
+	db.logWg.Wait()
+	defer db.conn.Close()
+	db.SetUsageLogConfig(UsageLogModeOff, 10, 5)
+
+	ctx := context.Background()
+	apiKeyID, err := db.InsertAPIKey(ctx, "quota-only-retry", "sk-quota-only-retry-1234567890")
+	if err != nil {
+		t.Fatalf("InsertAPIKey 返回错误: %v", err)
+	}
+	if _, err := db.conn.ExecContext(ctx, `ALTER TABLE api_keys RENAME TO api_keys_broken`); err != nil {
+		t.Fatalf("rename api_keys 返回错误: %v", err)
+	}
+	if err := db.InsertUsageLog(ctx, &UsageLogInput{
+		APIKeyID:    apiKeyID,
+		Endpoint:    "/v1/responses",
+		Model:       "gpt-5.4",
+		StatusCode:  200,
+		InputTokens: 1000,
+	}); err != nil {
+		t.Fatalf("InsertUsageLog 返回错误: %v", err)
+	}
+
+	db.flushLogs()
+	db.logMu.Lock()
+	if len(db.logBuf) != 1 {
+		db.logMu.Unlock()
+		t.Fatalf("len(logBuf) = %d, want 1", len(db.logBuf))
+	}
+	if db.logBuf[0].StoreUsageLog {
+		db.logMu.Unlock()
+		t.Fatal("quota-only event unexpectedly marked for usage log storage")
+	}
+	db.logMu.Unlock()
+
+	if _, err := db.conn.ExecContext(ctx, `ALTER TABLE api_keys_broken RENAME TO api_keys`); err != nil {
+		t.Fatalf("restore api_keys 返回错误: %v", err)
+	}
+	db.flushLogs()
+	db.flushLogs()
+
+	want := calculateCost(1000, 0, 0, "gpt-5.4", "")
+	var quotaUsed, totalUsed float64
+	if err := db.conn.QueryRowContext(ctx, `SELECT quota_used, total_used FROM api_keys WHERE id = $1`, apiKeyID).Scan(&quotaUsed, &totalUsed); err != nil {
+		t.Fatalf("查询 API Key 用量返回错误: %v", err)
+	}
+	if math.Abs(quotaUsed-want) > 1e-12 || math.Abs(totalUsed-want) > 1e-12 {
+		t.Fatalf("API Key usage = quota %.12f total %.12f, want exactly one charge %.12f", quotaUsed, totalUsed, want)
+	}
+
+	var count int
+	if err := db.conn.QueryRowContext(ctx, `SELECT COUNT(*) FROM usage_logs`).Scan(&count); err != nil {
+		t.Fatalf("count usage_logs 返回错误: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("usage_logs count = %d, want 0", count)
 	}
 }
 


### PR DESCRIPTION
## Description

Fixes #418.

usage_log_mode is intended to control usage_logs persistence, but the current early return also skips cost calculation and API key quota accounting. This change keeps billable usage events in the existing flush pipeline and filters only the audit rows written to usage_logs.

## Changes

- Record whether each buffered usage event should persist an audit log.
- Apply usage_log_mode filtering only to SQLite/PostgreSQL usage_logs inserts.
- Continue updating quota_used and total_used from the complete billable batch in the same transaction.
- Requeue quota-only batches when an update fails, preserving retry behavior.
- Keep the existing status 499 quota exemption unchanged.
- Add regression coverage for errors/off modes and retry without double charging.

## Behavior

| Mode | usage_logs | API key quota |
| --- | --- | --- |
| full | all requests | charged |
| errors | errors only | charged for billable requests |
| off | none | charged for billable requests |

## Test

- [x] Added unit/regression tests
- [x] go test ./database ./proxy -count=1
- [x] go vet ./database ./proxy
- [x] npm run build
- [x] go test ./... -count=1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Usage logging modes now correctly control which logs are stored.
  - Quota and billing usage are still applied when logs are not persisted.
  - Canceled requests remain exempt from quota usage.
  - Retry processing avoids charging quota more than once.
  - Background flushing reports and stores only eligible usage logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->