### PR TITLE
fix(responses): cache streamed tool calls for continuation

### DIFF
--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -2626,6 +2626,7 @@ func (h *Handler) Responses(c *gin.Context) {
 		var responseJSON []byte
 		var imageLogInfo imageUsageLogInfo
 		var terminalFailurePayload []byte
+		var streamedOutputItems []json.RawMessage
 
 		if isStream {
 			// 流式透传 + TTFT 跟踪
@@ -2675,6 +2676,12 @@ func (h *Handler) Responses(c *gin.Context) {
 				if image, ok := extractImageFromOutputItemDone(data, logModel); ok {
 					imageLogInfo = mergeImageUsageLogInfo(imageLogInfo, imageUsageLogInfoFromImage(image))
 				}
+				if eventType == "response.output_item.done" {
+					item := parsed.Get("item")
+					if isCodexToolCallContextType(item.Get("type").String()) {
+						streamedOutputItems = append(streamedOutputItems, json.RawMessage(item.Raw))
+					}
+				}
 
 				// 提取 usage + service_tier
 				if eventType == "response.completed" {
@@ -2683,7 +2690,7 @@ func (h *Handler) Responses(c *gin.Context) {
 						actualServiceTier = tier
 					}
 					// 缓存响应上下文，供后续 previous_response_id 展开使用
-					cacheCompletedResponse(respCacheOwner, []byte(expandedInputRaw), data)
+					cacheCompletedResponseWithOutputItems(respCacheOwner, []byte(expandedInputRaw), data, streamedOutputItems)
 					gotTerminal = true
 				}
 				if eventType == "response.failed" {
@@ -2821,7 +2828,7 @@ func (h *Handler) Responses(c *gin.Context) {
 						actualServiceTier = tier
 					}
 					// 缓存响应上下文，供后续 previous_response_id 展开使用
-					cacheCompletedResponse(respCacheOwner, []byte(expandedInputRaw), data)
+					cacheCompletedResponseWithOutputItems(respCacheOwner, []byte(expandedInputRaw), data, outputItems)
 					gotTerminal = true
 					lastResponseData = data
 					return false

--- a/proxy/response_cache.go
+++ b/proxy/response_cache.go
@@ -286,6 +286,12 @@ func isCodexToolCallOutputType(typ string) bool {
 // 与当前请求的 expanded input 合并后存入 owner 命名空间的缓存。
 // 仅在响应包含需要 call_id 续链的 Codex 工具调用时才缓存，避免为普通对话浪费内存。
 func cacheCompletedResponse(owner string, expandedInputRaw []byte, completedData []byte) {
+	cacheCompletedResponseWithOutputItems(owner, expandedInputRaw, completedData, nil)
+}
+
+// cacheCompletedResponseWithOutputItems 在 response.completed.output 未携带工具调用时，
+// 使用流式 response.output_item.done 中已收集的 outputItems 作为兜底。
+func cacheCompletedResponseWithOutputItems(owner string, expandedInputRaw []byte, completedData []byte, outputItems []json.RawMessage) {
 	respID := gjson.GetBytes(completedData, "response.id").String()
 	if respID == "" {
 		return
@@ -294,19 +300,28 @@ func cacheCompletedResponse(owner string, expandedInputRaw []byte, completedData
 	// 仅在响应包含 Codex 工具调用时才缓存（普通对话无需 previous_response_id 展开）。
 	// image_generation_call / web_search_call 虽然也是 *_call 结尾，但不属于 call_id 工具续链体系。
 	output := gjson.GetBytes(completedData, "response.output")
-	if !output.IsArray() {
+	if !output.IsArray() && len(outputItems) == 0 {
 		return
 	}
-	hasToolCallContext := false
+	completedHasToolCallContext := false
 	output.ForEach(func(_, item gjson.Result) bool {
 		if isCodexToolCallContextType(item.Get("type").String()) {
-			hasToolCallContext = true
+			completedHasToolCallContext = true
 			return false
 		}
 		return true
 	})
-	if !hasToolCallContext {
-		return
+	if !completedHasToolCallContext {
+		hasToolCallContext := false
+		for _, raw := range outputItems {
+			if isCodexToolCallContextType(gjson.GetBytes(raw, "type").String()) {
+				hasToolCallContext = true
+				break
+			}
+		}
+		if !hasToolCallContext {
+			return
+		}
 	}
 
 	var items []json.RawMessage
@@ -330,6 +345,13 @@ func cacheCompletedResponse(owner string, expandedInputRaw []byte, completedData
 		}
 		return true
 	})
+	if !completedHasToolCallContext {
+		for _, raw := range outputItems {
+			if item, ok := replayableCachedOutputItem(gjson.ParseBytes(raw)); ok {
+				items = append(items, item)
+			}
+		}
+	}
 
 	if len(items) > 0 {
 		setResponseCache(owner, respID, items)

--- a/proxy/response_cache_test.go
+++ b/proxy/response_cache_test.go
@@ -37,6 +37,39 @@ func TestCacheCompletedResponseCachesCodexNativeToolCalls(t *testing.T) {
 	}
 }
 
+func TestCacheCompletedResponseUsesOutputItemDoneFallback(t *testing.T) {
+	resetResponseCacheForTest()
+
+	expandedInput := []byte(`[{"type":"message","role":"user","content":"inspect workspace"}]`)
+	completed := []byte(`{"type":"response.completed","response":{"id":"resp_stream"}}`)
+	outputItems := []json.RawMessage{
+		json.RawMessage(`{"type":"function_call","id":"fc_stream","call_id":"call_stream","name":"manage_todo_list","arguments":"{}"}`),
+	}
+	cacheCompletedResponseWithOutputItems("key:1", expandedInput, completed, outputItems)
+
+	next := []byte(`{"model":"gpt-5.6-sol","previous_response_id":"resp_stream","input":[{"type":"function_call_output","call_id":"call_stream","output":"ok"}]}`)
+	got, _ := PrepareResponsesBodyForOwner(next, "key:1")
+	items := gjson.GetBytes(got, "input").Array()
+	if len(items) != 3 {
+		t.Fatalf("expanded input count = %d, want 3; body=%s", len(items), got)
+	}
+	if typ := items[0].Get("type").String(); typ != "message" {
+		t.Fatalf("input[0].type = %q, want message", typ)
+	}
+	if typ := items[1].Get("type").String(); typ != "function_call" {
+		t.Fatalf("input[1].type = %q, want function_call", typ)
+	}
+	if id := items[1].Get("id"); id.Exists() {
+		t.Fatalf("cached function_call id should be stripped, got %s", id.Raw)
+	}
+	if typ := items[2].Get("type").String(); typ != "function_call_output" {
+		t.Fatalf("input[2].type = %q, want function_call_output", typ)
+	}
+	if gjson.GetBytes(got, "previous_response_id").Exists() {
+		t.Fatalf("previous_response_id should be removed after expansion: %s", got)
+	}
+}
+
 func TestExpandPreviousResponseUsesCachedCodexNativeToolContext(t *testing.T) {
 	resetResponseCacheForTest()
 


### PR DESCRIPTION
Some Responses streams omit tool calls from response.completed.output after sending them in response.output_item.done. Cache those streamed items as a fallback so previous_response_id expansion can restore the original call/output pair.

Fixes #414


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved response caching for streamed interactions involving Codex tool calls.
  * Preserved tool-call context when completion events omit embedded output items.
  * Ensured follow-up requests correctly expand cached tool-call and tool-output information.

* **Tests**
  * Added coverage for restoring tool-call context from streamed output items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->