### PR TITLE
feat(account): dedupe OAuth accounts by workspace identity

### DIFF
--- a/admin/handler.go
+++ b/admin/handler.go
@@ -33,6 +33,7 @@ import (
 	"github.com/codex2api/cache"
 	"github.com/codex2api/database"
 	"github.com/codex2api/internal/imagestore"
+	"github.com/codex2api/internal/openaiidentity"
 	"github.com/codex2api/proxy"
 	"github.com/codex2api/security"
 	"github.com/codex2api/security/promptfilter"
@@ -89,9 +90,9 @@ type Handler struct {
 	resetCreditPostClosed     bool
 	settingsUpdateMu          sync.Mutex
 
-	// 重复账号合并互斥锁：串行化 mergeRefreshedDuplicateIntoExisting，
-	// 防止并发导入同一身份的多个账号时互相合并、把双方都软删（账号丢失）。
-	mergeDuplicateMu sync.Mutex
+	// OAuth workspace 身份互斥锁：串行化身份查询、更新和合并，避免并发导入
+	// 同一 email + workspace_id 时同时通过查询并各自插入。
+	oauthIdentityMu sync.Mutex
 }
 
 type chartCacheEntry struct {
@@ -187,7 +188,7 @@ func (h *Handler) probeImportedAccountUsage(ctx context.Context, accountID int64
 	if account.IsCodexAgentIdentity() {
 		return
 	}
-	// AT / codex_at 账号的 OAuth 身份（email + account_id）在插入时无法从
+	// AT / codex_at 账号的 OAuth 身份（email + workspace_id）在插入时无法从
 	// JWT 解出，由上面的 wham 探针补齐并落库。身份既已可知，此刻回查是否与
 	// 已有账号同一身份：若重复则把凭证合并进旧账号并软删本账号——与 RT 路径
 	// refreshImportedAccountAndProbe 对称，补上 AT 导入/添加事后无法去重的缺口
@@ -235,8 +236,8 @@ func (h *Handler) mergeRefreshedDuplicateIntoExisting(newID int64, source string
 	}
 	// 串行化合并：并发导入同一身份的多个账号时，两个合并流程若交错执行，
 	// 可能互相把对方选为“已有账号”，导致双方都被软删（账号丢失）。
-	h.mergeDuplicateMu.Lock()
-	defer h.mergeDuplicateMu.Unlock()
+	h.oauthIdentityMu.Lock()
+	defer h.oauthIdentityMu.Unlock()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -245,31 +246,39 @@ func (h *Handler) mergeRefreshedDuplicateIntoExisting(newID int64, source string
 	if err != nil || newRow == nil {
 		return false
 	}
-	// 勾选"允许重复添加"导入的副本是用户故意保留的，不合并。
-	if strings.EqualFold(strings.TrimSpace(newRow.GetCredential("allow_duplicate")), "true") {
-		return false
-	}
 	email := strings.TrimSpace(newRow.GetCredential("email"))
-	identity := strings.TrimSpace(newRow.GetCredential("account_id"))
-	if identity == "" {
-		identity = strings.TrimSpace(newRow.GetCredential("chatgpt_account_id"))
+	workspaceID := strings.TrimSpace(newRow.GetCredential("workspace_id"))
+	if runtimeAccount := h.store.FindByID(newID); runtimeAccount != nil {
+		runtimeEmail, runtimeWorkspaceID := runtimeAccount.OAuthIdentity()
+		if email == "" {
+			email = runtimeEmail
+		}
+		if workspaceID == "" {
+			workspaceID = runtimeWorkspaceID
+		}
 	}
-	if identity == "" {
-		identity = strings.TrimSpace(newRow.GetCredential("user_id"))
-	}
-	if email == "" || identity == "" {
+	if email == "" || workspaceID == "" {
 		return false
 	}
-	oldID, err := h.db.FindActiveAccountByOAuthIdentity(ctx, email, identity, newID)
+	oldID, err := h.db.FindActiveAccountByOAuthIdentity(ctx, email, workspaceID, newID)
 	if err != nil || oldID <= 0 {
 		return false
 	}
 
 	updates := make(map[string]interface{})
-	for _, key := range []string{"refresh_token", "session_token", "access_token", "access_token_type", "id_token", "expires_at", "email", "account_id", "user_id", "plan_type", "subscription_expires_at"} {
+	for _, key := range []string{"refresh_token", "session_token", "access_token", "access_token_type", "id_token", "expires_at", "email", "workspace_id", "user_id", "plan_type", "subscription_expires_at"} {
 		if v := strings.TrimSpace(newRow.GetCredential(key)); v != "" {
 			updates[key] = v
 		}
+	}
+	if customHeaders := newRow.GetCredentialStringMap("custom_headers"); len(customHeaders) > 0 {
+		updates["custom_headers"] = cloneCustomHeaders(customHeaders)
+	}
+	if _, ok := updates["email"]; !ok {
+		updates["email"] = email
+	}
+	if _, ok := updates["workspace_id"]; !ok {
+		updates["workspace_id"] = workspaceID
 	}
 	if len(updates) == 0 {
 		return false
@@ -289,6 +298,7 @@ func (h *Handler) mergeRefreshedDuplicateIntoExisting(newID int64, source string
 	// 两边都被软删。软删前置让后续任何查重都看不到新账号。
 	if err := h.db.SoftDeleteAccount(ctx, newID); err != nil {
 		log.Printf("软删重复导入账号 %d 失败: %v", newID, err)
+		return false
 	}
 	h.store.RemoveAccount(newID)
 	if err := h.reloadTokenAccount(ctx, oldID, source); err != nil {
@@ -967,7 +977,7 @@ func (h *Handler) ListAccounts(c *gin.Context) {
 			Name:                     row.Name,
 			Email:                    email,
 			EmailDomain:              accountEmailDomain(email),
-			ChatGPTAccountID:         row.GetCredential("account_id"),
+			ChatGPTAccountID:         accountWorkspaceID(row),
 			PlanType:                 planType,
 			SubscriptionExpiresAt:    row.GetCredential("subscription_expires_at"),
 			Status:                   row.Status,
@@ -2439,8 +2449,9 @@ func (h *Handler) AddATAccount(c *gin.Context) {
 
 	// AT 去重：非身份型 AT-only（无法从 JWT 解出 email + 工作区/用户 ID，如 codex_at）
 	// 按 access_token 原文去重；身份型 AT 由 upsertOAuthIdentityAccount 按 OAuth 身份
-	//（email + account_id/user_id）去重/更新——AT 会轮换，仅按原文去重会重复导入同一账号。
-	// 勾选"允许重复添加"时跳过全部去重，强制新建。
+	//（email + workspace_id）去重/更新；workspace_id 缺失时只按凭证原文去重。
+	// workspace_id 为空时，勾选"允许重复添加"可跳过凭证原文去重；
+	// 已确认 workspace 身份时仍按 OAuth 身份更新已有账号。
 	existingATs := make(map[string]bool)
 	seenAT := make(map[string]bool)
 	if !req.AllowDuplicate {
@@ -2464,7 +2475,7 @@ func (h *Handler) AddATAccount(c *gin.Context) {
 			allowDuplicate: req.AllowDuplicate,
 			customHeaders:  customHeaders,
 		})
-		if !req.AllowDuplicate && seed.email != "" && (seed.accountID != "" || seed.userID != "") {
+		if seed.email != "" && seed.workspaceID != "" {
 			id, updated, err := h.upsertOAuthIdentityAccount(ctx, name, req.ProxyURL, seed, "manual_at")
 			if err != nil {
 				log.Printf("添加 AT 账号 %d 失败: %v", i+1, err)
@@ -2583,7 +2594,7 @@ func (h *Handler) streamAddATAccounts(c *gin.Context, req addATAccountReq, token
 		}
 
 		seed := normalizeTokenCredentialSeed(tokenCredentialSeed{accessToken: at, allowDuplicate: req.AllowDuplicate, customHeaders: req.CustomHeaders})
-		if !req.AllowDuplicate && seed.email != "" && (seed.accountID != "" || seed.userID != "") {
+		if seed.email != "" && seed.workspaceID != "" {
 			id, updated, err := h.upsertOAuthIdentityAccount(ctx, name, req.ProxyURL, seed, "manual_at")
 			if err != nil {
 				log.Printf("添加 AT 账号 %d 失败: %v", i+1, err)
@@ -3116,8 +3127,7 @@ type importToken struct {
 	name                  string
 	email                 string
 	idToken               string
-	accountID             string
-	chatgptAccountID      string // sub2api 等导出格式中的 ChatGPT 账号唯一标识，用于精确去重
+	workspaceID           string // canonical value supplied by a trusted parser or test fixture
 	planType              string
 	expiresAt             string
 	codex7DUsedPercent    string
@@ -3127,6 +3137,8 @@ type importToken struct {
 	codex5HUsageUpdatedAt string
 	codexUsageUpdatedAt   string
 	// Agent Identity（auth_mode=agentIdentity）：无 RT/ST/AT，凭私钥动态签名。
+	// accountID 仅供 Agent Identity 元数据使用，不参与 OAuth workspace 身份判断。
+	accountID       string
 	agentRuntimeID  string
 	agentPrivateKey string
 	agentTaskID     string
@@ -3177,15 +3189,17 @@ func agentIdentityImportTokenFromNode(node *jsonAgentIdentityNode, fallbackName 
 
 // jsonAccountEntry CLIProxyAPI 凭证 JSON 条目
 type jsonAccountEntry struct {
-	AuthMode              string                 `json:"auth_mode"`
-	AgentIdentity         *jsonAgentIdentityNode `json:"agent_identity"`
-	RefreshToken          string                 `json:"refresh_token"`
-	SessionToken          string                 `json:"session_token"`
-	SessionTokenCamel     string                 `json:"sessionToken"`
-	AccessToken           string                 `json:"access_token"`
-	AccessTokenCamel      string                 `json:"accessToken"`
-	IDToken               string                 `json:"id_token"`
-	IDTokenCamel          string                 `json:"idToken"`
+	AuthMode          string                 `json:"auth_mode"`
+	AgentIdentity     *jsonAgentIdentityNode `json:"agent_identity"`
+	RefreshToken      string                 `json:"refresh_token"`
+	SessionToken      string                 `json:"session_token"`
+	SessionTokenCamel string                 `json:"sessionToken"`
+	AccessToken       string                 `json:"access_token"`
+	AccessTokenCamel  string                 `json:"accessToken"`
+	IDToken           string                 `json:"id_token"`
+	IDTokenCamel      string                 `json:"idToken"`
+	// Legacy exporter fields are accepted for format compatibility only; the
+	// canonical identity is derived from the JWT into workspace_id.
 	AccountID             string                 `json:"account_id"`
 	ChatGPTAccountID      string                 `json:"chatgpt_account_id"`
 	Email                 string                 `json:"email"`
@@ -3203,6 +3217,14 @@ type jsonAccountEntry struct {
 	Codex5HResetAt        string                 `json:"codex_5h_reset_at"`
 	Codex5HUsageUpdatedAt string                 `json:"codex_5h_usage_updated_at"`
 	CodexUsageUpdatedAt   string                 `json:"codex_usage_updated_at"`
+	Tokens                jsonAccountTokens      `json:"tokens"`
+}
+
+type jsonAccountTokens struct {
+	RefreshToken string `json:"refresh_token"`
+	AccessToken  string `json:"access_token"`
+	IDToken      string `json:"id_token"`
+	AccountID    string `json:"account_id"` // legacy metadata; never used for identity
 }
 
 type jsonAccountUser struct {
@@ -3236,8 +3258,8 @@ type sub2apiAccountCredentials struct {
 	AccessTokenCamel      string                 `json:"accessToken"`
 	IDToken               string                 `json:"id_token"`
 	IDTokenCamel          string                 `json:"idToken"`
-	AccountID             string                 `json:"account_id"`
-	ChatGPTAccountID      string                 `json:"chatgpt_account_id"`
+	AccountID             string                 `json:"account_id"`         // legacy metadata
+	ChatGPTAccountID      string                 `json:"chatgpt_account_id"` // legacy metadata
 	Email                 string                 `json:"email"`
 	PlanType              string                 `json:"plan_type"`
 	PlanTypeCamel         string                 `json:"planType"`
@@ -3324,14 +3346,13 @@ func parseFlatJSONImportTokens(data []byte) []importToken {
 func jsonAccountEntriesToTokens(entries []jsonAccountEntry) []importToken {
 	tokens := make([]importToken, 0, len(entries))
 	for _, entry := range entries {
-		rt := strings.TrimSpace(entry.RefreshToken)
+		rt := firstNonEmpty(entry.RefreshToken, entry.Tokens.RefreshToken)
 		st := firstNonEmpty(entry.SessionToken, entry.SessionTokenCamel)
-		at := firstNonEmpty(entry.AccessToken, entry.AccessTokenCamel)
-		idTok := firstNonEmpty(entry.IDToken, entry.IDTokenCamel)
+		at := firstNonEmpty(entry.AccessToken, entry.AccessTokenCamel, entry.Tokens.AccessToken)
+		idTok := firstNonEmpty(entry.IDToken, entry.IDTokenCamel, entry.Tokens.IDToken)
 		email := firstNonEmpty(entry.Email, entry.User.Email)
 		name := firstNonEmpty(entry.Name, entry.User.Name, email)
 		planType := firstNonEmpty(entry.PlanType, entry.PlanTypeCamel, entry.Account.PlanType, entry.Account.PlanTypeCamel)
-		accID := firstNonEmpty(entry.AccountID, entry.User.ID, entry.Account.ID)
 		expiresAt := firstNonEmpty(entry.ExpiresAt.String(), entry.Expired.String(), entry.Expires.String())
 
 		// Agent Identity 条目：无 RT/ST/AT，单独识别。
@@ -3348,8 +3369,6 @@ func jsonAccountEntriesToTokens(entries []jsonAccountEntry) []importToken {
 				name:                  name,
 				email:                 email,
 				idToken:               idTok,
-				accountID:             strings.TrimSpace(entry.AccountID),
-				chatgptAccountID:      firstNonEmpty(entry.ChatGPTAccountID, accID),
 				planType:              planType,
 				expiresAt:             expiresAt,
 				codex7DUsedPercent:    strings.TrimSpace(entry.Codex7DUsedPercent.String()),
@@ -3384,7 +3403,6 @@ func parseSub2APIJSONImportTokens(data []byte) []importToken {
 			name = email
 		}
 		planType := firstNonEmpty(c.PlanType, c.PlanTypeCamel, c.Account.PlanType, c.Account.PlanTypeCamel)
-		accID := firstNonEmpty(c.AccountID, c.User.ID, c.Account.ID)
 		expiresAt := firstNonEmpty(c.ExpiresAt.String(), c.Expired.String(), c.Expires.String())
 
 		// Agent Identity 条目：无 RT/ST/AT，单独识别。
@@ -3401,8 +3419,6 @@ func parseSub2APIJSONImportTokens(data []byte) []importToken {
 				name:                  name,
 				email:                 email,
 				idToken:               idTok,
-				accountID:             strings.TrimSpace(c.AccountID),
-				chatgptAccountID:      firstNonEmpty(c.ChatGPTAccountID, accID),
 				planType:              planType,
 				expiresAt:             expiresAt,
 				codex7DUsedPercent:    strings.TrimSpace(c.Codex7DUsedPercent.String()),
@@ -3418,25 +3434,12 @@ func parseSub2APIJSONImportTokens(data []byte) []importToken {
 	return tokens
 }
 
-func importTokenCredentialIdentity(t importToken) string {
-	switch {
-	case t.refreshToken != "":
-		return "rt:" + t.refreshToken
-	case t.sessionToken != "":
-		return "st:" + t.sessionToken
-	case t.accessToken != "":
-		return "at:" + t.accessToken
-	default:
-		return ""
-	}
-}
-
 func importCredentialFingerprint(refreshToken, sessionToken, accessToken string) string {
 	return strings.TrimSpace(refreshToken) + "\x00" + strings.TrimSpace(sessionToken) + "\x00" + strings.TrimSpace(accessToken)
 }
 
-func importTokenCredentialFingerprint(t importToken, conflicts map[string]bool) string {
-	seed := importTokenSeed(t, conflicts)
+func importTokenCredentialFingerprint(t importToken) string {
+	seed := importTokenSeed(t)
 	return importCredentialFingerprint(seed.refreshToken, seed.sessionToken, seed.accessToken)
 }
 
@@ -3451,56 +3454,13 @@ func importAccountCredentialFingerprint(row *database.AccountRow) string {
 	)
 }
 
-func conflictingImportChatGPTIDs(tokens []importToken) map[string]bool {
-	identitiesByID := make(map[string]map[string]struct{})
-	for _, t := range tokens {
-		id := strings.TrimSpace(t.chatgptAccountID)
-		if id == "" {
-			continue
-		}
-		identity := importTokenCredentialIdentity(t)
-		if identity == "" {
-			continue
-		}
-		identities := identitiesByID[id]
-		if identities == nil {
-			identities = make(map[string]struct{}, 1)
-			identitiesByID[id] = identities
-		}
-		identities[identity] = struct{}{}
-	}
-
-	conflicts := make(map[string]bool)
-	for id, identities := range identitiesByID {
-		if len(identities) > 1 {
-			conflicts[id] = true
-		}
-	}
-	return conflicts
-}
-
-func reliableImportChatGPTID(t importToken, conflicts map[string]bool) string {
-	id := strings.TrimSpace(t.chatgptAccountID)
-	if id == "" || conflicts[id] {
-		return ""
-	}
-	return id
-}
-
-func importStoredAccountID(t importToken, conflicts map[string]bool) string {
-	if strings.TrimSpace(t.accountID) != "" {
-		return strings.TrimSpace(t.accountID)
-	}
-	return reliableImportChatGPTID(t, conflicts)
-}
-
-func importTokenSeed(t importToken, conflicts map[string]bool) tokenCredentialSeed {
+func importTokenSeed(t importToken) tokenCredentialSeed {
 	return normalizeTokenCredentialSeed(tokenCredentialSeed{
 		refreshToken:          t.refreshToken,
 		sessionToken:          t.sessionToken,
 		accessToken:           t.accessToken,
 		idToken:               t.idToken,
-		accountID:             importStoredAccountID(t, conflicts),
+		workspaceID:           t.workspaceID,
 		email:                 t.email,
 		planType:              t.planType,
 		expiresAtRaw:          t.expiresAt,
@@ -3513,22 +3473,14 @@ func importTokenSeed(t importToken, conflicts map[string]bool) tokenCredentialSe
 	})
 }
 
-func importTokenOAuthIdentityKey(t importToken, conflicts map[string]bool) string {
-	seed := importTokenSeed(t, conflicts)
+func importTokenOAuthIdentityKey(t importToken) string {
+	seed := importTokenSeed(t)
 	email := strings.ToLower(strings.TrimSpace(seed.email))
-	accountID := strings.TrimSpace(seed.accountID)
-	if accountID == "" && strings.TrimSpace(t.accountID) == "" {
-		accountID = strings.TrimSpace(t.chatgptAccountID)
-	}
-	// 个人账号可能只有 user_id（无工作区 account_id），用它兜底做身份键，
-	// 否则文件导入会退化为凭证原文比对，AT 轮换后重复导入。
-	if accountID == "" {
-		accountID = strings.TrimSpace(seed.userID)
-	}
-	if email == "" || accountID == "" {
+	workspaceID := strings.TrimSpace(seed.workspaceID)
+	if email == "" || workspaceID == "" {
 		return ""
 	}
-	return email + "\x00" + accountID
+	return email + "\x00" + workspaceID
 }
 
 // ImportAccounts 批量导入账号（支持 TXT / JSON）
@@ -3824,19 +3776,16 @@ func (h *Handler) importAccountsCommon(c *gin.Context, tokens []importToken, pro
 	}
 	tokens = regularTokens
 	// 文件内去重：
-	// 1) 当条目可解析出 email + account_id 时，以它作为 OAuth 身份键；
+	// 1) 当 JWT 可解析出 email + workspace_id 时，以它作为 OAuth 身份键；
 	//    同身份同 RT/ST/AT 折叠，同身份不同 RT/ST/AT 整组跳过，避免任选一个覆盖。
-	// 2) 没有 OAuth 身份时，退回到 RT / ST / AT 顺序去重（兼容旧导出格式）。
-	// 3) 同一份文件内若出现"同一个 RT 对应多个不同 chatgpt_account_id"，
-	//    会被全部保留为独立账号；数据库层面 refresh_token 没有 UNIQUE 约束，因此安全。
-	conflictingChatGPTIDs := conflictingImportChatGPTIDs(tokens)
+	// 2) workspace_id 为空时不做身份去重；未开启允许重复时仍按 RT / ST / AT 原文去重。
 	type oauthIdentityImportState struct {
 		count        int
 		fingerprints map[string]struct{}
 	}
 	oauthIdentityStates := make(map[string]*oauthIdentityImportState)
 	for _, t := range tokens {
-		oauthIdentity := importTokenOAuthIdentityKey(t, conflictingChatGPTIDs)
+		oauthIdentity := importTokenOAuthIdentityKey(t)
 		if oauthIdentity == "" {
 			continue
 		}
@@ -3846,7 +3795,7 @@ func (h *Handler) importAccountsCommon(c *gin.Context, tokens []importToken, pro
 			oauthIdentityStates[oauthIdentity] = state
 		}
 		state.count++
-		state.fingerprints[importTokenCredentialFingerprint(t, conflictingChatGPTIDs)] = struct{}{}
+		state.fingerprints[importTokenCredentialFingerprint(t)] = struct{}{}
 	}
 
 	seenOAuthIdentity := make(map[string]bool)
@@ -3856,7 +3805,7 @@ func (h *Handler) importAccountsCommon(c *gin.Context, tokens []importToken, pro
 	var unique []importToken
 	ambiguousOAuthIdentityCount := 0
 	for _, t := range tokens {
-		oauthIdentity := importTokenOAuthIdentityKey(t, conflictingChatGPTIDs)
+		oauthIdentity := importTokenOAuthIdentityKey(t)
 		if oauthIdentity != "" {
 			state := oauthIdentityStates[oauthIdentity]
 			if state != nil && len(state.fingerprints) > 1 {
@@ -3879,6 +3828,10 @@ func (h *Handler) importAccountsCommon(c *gin.Context, tokens []importToken, pro
 			if t.accessToken != "" {
 				seenAT[t.accessToken] = true
 			}
+			unique = append(unique, t)
+			continue
+		}
+		if allowDuplicate {
 			unique = append(unique, t)
 			continue
 		}
@@ -3922,80 +3875,68 @@ func (h *Handler) importAccountsCommon(c *gin.Context, tokens []importToken, pro
 	var newTokens []importToken
 	duplicateCount := ambiguousOAuthIdentityCount
 
-	if allowDuplicate {
-		// 允许重复添加：跳过数据库去重，所有解析出的 token 均作为新账号导入。
-		newTokens = tokens
-		duplicateCount = 0
-	} else {
-		existingRTs, err := h.db.GetAllRefreshTokens(dedupeCtx)
-		if err != nil {
+	existingRTs := make(map[string]bool)
+	existingSTs := make(map[string]bool)
+	existingATs := make(map[string]bool)
+	if !allowDuplicate {
+		var err error
+		if existingRTs, err = h.db.GetAllRefreshTokens(dedupeCtx); err != nil {
 			log.Printf("查询已有 RT 失败: %v", err)
 			existingRTs = make(map[string]bool)
 		}
-
-		// 存在 AT-only token 时额外查询已有 AT
-		hasAT := len(seenAT) > 0
-		var existingATs map[string]bool
-		if hasAT {
-			existingATs, err = h.db.GetAllAccessTokens(dedupeCtx)
-			if err != nil {
-				log.Printf("查询已有 AT 失败: %v", err)
-				existingATs = make(map[string]bool)
-			}
-		}
-		hasST := len(seenST) > 0
-		var existingSTs map[string]bool
-		if hasST {
-			existingSTs, err = h.db.GetAllSessionTokens(dedupeCtx)
-			if err != nil {
+		if len(seenST) > 0 {
+			if existingSTs, err = h.db.GetAllSessionTokens(dedupeCtx); err != nil {
 				log.Printf("查询已有 ST 失败: %v", err)
 				existingSTs = make(map[string]bool)
 			}
 		}
-
-		for _, t := range unique {
-			oauthIdentity := importTokenOAuthIdentityKey(t, conflictingChatGPTIDs)
-			if oauthIdentity != "" {
-				seed := importTokenSeed(t, conflictingChatGPTIDs)
-				if duplicateID, err := h.findOAuthIdentityDuplicate(dedupeCtx, seed, 0); err != nil {
-					log.Printf("查询已有 OAuth 身份失败: %v", err)
-				} else if duplicateID > 0 {
-					row, err := h.db.GetAccountByID(dedupeCtx, duplicateID)
-					if err != nil {
-						log.Printf("查询已有 OAuth 账号 %d 失败: %v", duplicateID, err)
-					} else if importAccountCredentialFingerprint(row) == importTokenCredentialFingerprint(t, conflictingChatGPTIDs) {
-						duplicateCount++
-						continue
-					}
-				}
-				newTokens = append(newTokens, t)
-				continue
+		if len(seenAT) > 0 {
+			if existingATs, err = h.db.GetAllAccessTokens(dedupeCtx); err != nil {
+				log.Printf("查询已有 AT 失败: %v", err)
+				existingATs = make(map[string]bool)
 			}
-			switch {
-			case t.refreshToken != "":
-				if existingRTs[t.refreshToken] {
+		}
+	}
+
+	for _, t := range unique {
+		if importTokenOAuthIdentityKey(t) != "" {
+			seed := importTokenSeed(t)
+			if duplicateID, err := h.findOAuthIdentityDuplicate(dedupeCtx, seed, 0); err != nil {
+				log.Printf("查询已有 OAuth 身份失败: %v", err)
+			} else if duplicateID > 0 {
+				row, err := h.db.GetAccountByID(dedupeCtx, duplicateID)
+				if err != nil {
+					log.Printf("查询已有 OAuth 账号 %d 失败: %v", duplicateID, err)
+				} else if importAccountCredentialFingerprint(row) == importTokenCredentialFingerprint(t) {
 					duplicateCount++
-				} else if t.sessionToken != "" && existingSTs[t.sessionToken] {
-					duplicateCount++
-				} else if t.accessToken != "" && existingATs[t.accessToken] {
-					duplicateCount++
-				} else {
-					newTokens = append(newTokens, t)
+					continue
 				}
-			case t.sessionToken != "":
-				if existingSTs[t.sessionToken] {
-					duplicateCount++
-				} else if t.accessToken != "" && existingATs[t.accessToken] {
-					duplicateCount++
-				} else {
-					newTokens = append(newTokens, t)
-				}
-			case t.accessToken != "":
-				if existingATs[t.accessToken] {
-					duplicateCount++
-				} else {
-					newTokens = append(newTokens, t)
-				}
+			}
+			newTokens = append(newTokens, t)
+			continue
+		}
+		if allowDuplicate {
+			newTokens = append(newTokens, t)
+			continue
+		}
+		switch {
+		case t.refreshToken != "":
+			if existingRTs[t.refreshToken] || t.sessionToken != "" && existingSTs[t.sessionToken] || t.accessToken != "" && existingATs[t.accessToken] {
+				duplicateCount++
+			} else {
+				newTokens = append(newTokens, t)
+			}
+		case t.sessionToken != "":
+			if existingSTs[t.sessionToken] || t.accessToken != "" && existingATs[t.accessToken] {
+				duplicateCount++
+			} else {
+				newTokens = append(newTokens, t)
+			}
+		case t.accessToken != "":
+			if existingATs[t.accessToken] {
+				duplicateCount++
+			} else {
+				newTokens = append(newTokens, t)
 			}
 		}
 	}
@@ -4061,14 +4002,14 @@ func (h *Handler) importAccountsCommon(c *gin.Context, tokens []importToken, pro
 
 			name := tok.name
 
-			seed := importTokenSeed(tok, conflictingChatGPTIDs)
+			seed := importTokenSeed(tok)
 			seed.allowDuplicate = allowDuplicate
 			seed.customHeaders = cloneCustomHeaders(importCustomHeaders)
 			importSource := "import"
 			if tok.accessToken != "" && tok.refreshToken == "" {
 				importSource = "import_at"
 			}
-			if !allowDuplicate && seed.email != "" && (seed.accountID != "" || seed.userID != "") {
+			if seed.email != "" && seed.workspaceID != "" {
 				if name == "" {
 					if importSource == "import_at" {
 						name = fmt.Sprintf("at-import-%d", idx+1)
@@ -4432,6 +4373,10 @@ func (h *Handler) restoreAccountByID(ctx context.Context, id int64) error {
 		return err
 	}
 	seed := tokenCredentialSeedFromAccountRow(row)
+	if seed.email != "" && seed.workspaceID != "" {
+		h.oauthIdentityMu.Lock()
+		defer h.oauthIdentityMu.Unlock()
+	}
 	if duplicateID, err := h.findOAuthIdentityDuplicate(ctx, seed, id); err != nil {
 		return err
 	} else if duplicateID > 0 {
@@ -4439,6 +4384,12 @@ func (h *Handler) restoreAccountByID(ctx context.Context, id int64) error {
 	}
 
 	if err := h.db.RestoreAccount(ctx, id); err != nil {
+		if errors.Is(err, database.ErrDuplicateOAuthIdentity) {
+			duplicateID, lookupErr := h.findOAuthIdentityDuplicate(ctx, seed, id)
+			if lookupErr == nil && duplicateID > 0 {
+				return fmt.Errorf("%w: 已存在相同 OAuth 账号 (id=%d)，请先删除正常账号或清理回收站账号", errDuplicateOAuthIdentity, duplicateID)
+			}
+		}
 		return err
 	}
 	if h.store != nil {
@@ -4460,7 +4411,7 @@ func tokenCredentialSeedFromAccountRow(row *database.AccountRow) tokenCredential
 		sessionToken:          row.GetCredential("session_token"),
 		accessToken:           row.GetCredential("access_token"),
 		idToken:               row.GetCredential("id_token"),
-		accountID:             firstNonEmpty(row.GetCredential("account_id"), row.GetCredential("chatgpt_account_id")),
+		workspaceID:           row.GetCredential("workspace_id"),
 		email:                 row.GetCredential("email"),
 		planType:              row.GetCredential("plan_type"),
 		expiresAtRaw:          row.GetCredential("expires_at"),
@@ -8428,6 +8379,18 @@ type accountAuthJSONTokens struct {
 	AccountID    string `json:"account_id"`
 }
 
+func accountWorkspaceID(row *database.AccountRow) string {
+	if row == nil {
+		return ""
+	}
+	if info := accountInfoFromTokens(row.GetCredential("id_token"), row.GetCredential("access_token")); info != nil {
+		if workspaceID := strings.TrimSpace(info.ChatGPTAccountID); workspaceID != "" {
+			return workspaceID
+		}
+	}
+	return openaiidentity.NormalizeWorkspaceID(row.GetCredential("workspace_id"))
+}
+
 type accountAuthJSON struct {
 	AuthMode     string                `json:"auth_mode"`
 	OpenAIAPIKey *string               `json:"OPENAI_API_KEY"`
@@ -8459,7 +8422,7 @@ func (h *Handler) GetAccountAuthJSON(c *gin.Context) {
 	refreshToken := row.GetCredential("refresh_token")
 	accessToken := row.GetCredential("access_token")
 	idToken := row.GetCredential("id_token")
-	accountID := row.GetCredential("account_id")
+	accountID := accountWorkspaceID(row)
 	if refreshToken == "" {
 		writeError(c, http.StatusBadRequest, "该账号没有 refresh_token，无法生成 auth.json")
 		return
@@ -8509,11 +8472,7 @@ func accountRowToCPAExportEntry(row *database.AccountRow) (cpaExportEntry, bool)
 	if rt == "" && at == "" {
 		return cpaExportEntry{}, false
 	}
-	// account_id 在凭据中存储为 chatgpt_account_id（新字段）或 account_id（历史字段）
-	accountID := row.GetCredential("chatgpt_account_id")
-	if accountID == "" {
-		accountID = row.GetCredential("account_id")
-	}
+	accountID := accountWorkspaceID(row)
 	return cpaExportEntry{
 		Type:                  "codex",
 		Email:                 row.GetCredential("email"),
@@ -8722,7 +8681,6 @@ func (h *Handler) MigrateAccounts(c *gin.Context) {
 			name:                  name,
 			email:                 strings.TrimSpace(entry.Email),
 			idToken:               strings.TrimSpace(entry.IDToken),
-			accountID:             strings.TrimSpace(entry.AccountID),
 			planType:              strings.TrimSpace(entry.PlanType),
 			expiresAt:             strings.TrimSpace(entry.Expired),
 			codex7DUsedPercent:    strings.TrimSpace(entry.Codex7DUsedPercent),

--- a/admin/handler_test.go
+++ b/admin/handler_test.go
@@ -735,7 +735,7 @@ func TestGetAccountAuthJSONReturnsCodexAuthFile(t *testing.T) {
 	if err := db.UpdateCredentials(context.Background(), accountID, map[string]interface{}{
 		"id_token":     "id_test",
 		"access_token": "access_test",
-		"account_id":   "account_test",
+		"workspace_id": "account_test",
 	}); err != nil {
 		t.Fatalf("seed credentials: %v", err)
 	}
@@ -2237,21 +2237,25 @@ func TestRestoreAccountRejectsDuplicateOAuthIdentity(t *testing.T) {
 	activeID, err := db.InsertAccountWithCredentials(context.Background(), "active", map[string]interface{}{
 		"refresh_token": "rt-active",
 		"email":         "restore@example.com",
-		"account_id":    "acc-restore",
+		"workspace_id":  "acc-restore",
 	}, "")
 	if err != nil {
 		t.Fatalf("Insert active: %v", err)
 	}
 	deletedID, err := db.InsertAccountWithCredentials(context.Background(), "deleted", map[string]interface{}{
 		"refresh_token": "rt-deleted",
-		"email":         "Restore@Example.com",
-		"account_id":    "acc-restore",
 	}, "")
 	if err != nil {
 		t.Fatalf("Insert deleted: %v", err)
 	}
 	if err := db.SoftDeleteAccount(context.Background(), deletedID); err != nil {
 		t.Fatalf("SoftDeleteAccount: %v", err)
+	}
+	if err := db.UpdateCredentials(context.Background(), deletedID, map[string]interface{}{
+		"email":        "Restore@Example.com",
+		"workspace_id": "acc-restore",
+	}); err != nil {
+		t.Fatalf("Update deleted identity: %v", err)
 	}
 
 	recorder := httptest.NewRecorder()

--- a/admin/import_json_test.go
+++ b/admin/import_json_test.go
@@ -62,6 +62,42 @@ func TestParseImportJSONTokensSupportsFlatArray(t *testing.T) {
 	}
 }
 
+func TestParseImportJSONTokensReadsCodexAuthJSONAndDerivesWorkspaceFromJWT(t *testing.T) {
+	idToken := makeAdminTestJWT(t, map[string]interface{}{
+		"email": "auth@example.com",
+		"https://api.openai.com/auth": map[string]interface{}{
+			"chatgpt_account_id": "workspace-from-token",
+		},
+	})
+	data, err := json.Marshal(map[string]interface{}{
+		"auth_mode": "chatgpt",
+		"tokens": map[string]interface{}{
+			"id_token":      idToken,
+			"access_token":  "opaque-at",
+			"refresh_token": "rt-auth-json",
+			"account_id":    "user-legacy-value",
+		},
+	})
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+
+	tokens, err := parseImportJSONTokens(data)
+	if err != nil {
+		t.Fatalf("parseImportJSONTokens returned error: %v", err)
+	}
+	if len(tokens) != 1 {
+		t.Fatalf("tokens len = %d, want 1", len(tokens))
+	}
+	seed := importTokenSeed(tokens[0])
+	if seed.workspaceID != "workspace-from-token" {
+		t.Fatalf("workspaceID = %q, want workspace-from-token", seed.workspaceID)
+	}
+	if got := importTokenOAuthIdentityKey(tokens[0]); got != "auth@example.com\x00workspace-from-token" {
+		t.Fatalf("identity key = %q, want JWT-derived workspace identity", got)
+	}
+}
+
 func TestParseImportJSONTokensSupportsSub2API(t *testing.T) {
 	data := []byte(`{
 		"exported_at": "2026-04-03T14:49:53Z",
@@ -152,26 +188,20 @@ func TestParseImportJSONTokensSupportsSub2APINumericExpiresAt(t *testing.T) {
 	}
 }
 
-func TestConflictingImportChatGPTIDs(t *testing.T) {
-	tokens := []importToken{
-		{chatgptAccountID: "shared", refreshToken: "rt-1"},
-		{chatgptAccountID: "shared", refreshToken: "rt-2"},
-		{chatgptAccountID: "stable", refreshToken: "rt-3"},
-		{chatgptAccountID: "stable", refreshToken: "rt-3"},
+func TestImportTokenOAuthIdentityUsesJWTWorkspaceOnly(t *testing.T) {
+	token := makeAdminTestJWT(t, map[string]interface{}{
+		"https://api.openai.com/profile": map[string]interface{}{"email": "workspace@example.com"},
+		"https://api.openai.com/auth": map[string]interface{}{
+			"chatgpt_account_id": "workspace-1",
+		},
+	})
+	parsed := importToken{accessToken: token}
+	if got := importTokenOAuthIdentityKey(parsed); got != "workspace@example.com\x00workspace-1" {
+		t.Fatalf("identity key = %q, want email + workspace_id", got)
 	}
-
-	conflicts := conflictingImportChatGPTIDs(tokens)
-	if !conflicts["shared"] {
-		t.Fatal("shared chatgpt_account_id should be marked conflicting")
-	}
-	if conflicts["stable"] {
-		t.Fatal("stable chatgpt_account_id should not be marked conflicting")
-	}
-	if got := reliableImportChatGPTID(tokens[0], conflicts); got != "" {
-		t.Fatalf("reliableImportChatGPTID(shared) = %q, want empty", got)
-	}
-	if got := reliableImportChatGPTID(tokens[2], conflicts); got != "stable" {
-		t.Fatalf("reliableImportChatGPTID(stable) = %q, want stable", got)
+	withoutWorkspace := importToken{email: "workspace@example.com", accessToken: makeAdminTestJWT(t, map[string]interface{}{"email": "workspace@example.com"})}
+	if got := importTokenOAuthIdentityKey(withoutWorkspace); got != "" {
+		t.Fatalf("identity key without workspace = %q, want empty", got)
 	}
 }
 
@@ -231,7 +261,7 @@ func TestParseImportJSONTokensPreservesCPAFields(t *testing.T) {
 	if token.codexUsageUpdatedAt != "2026-05-11T11:39:07+08:00" {
 		t.Fatalf("usageUpdatedAt = %q, want timestamp", token.codexUsageUpdatedAt)
 	}
-	if token.idToken != "id-cpa" || token.accountID != "acc-cpa" || token.expiresAt != "2026-04-25T12:00:00Z" {
+	if token.idToken != "id-cpa" || token.expiresAt != "2026-04-25T12:00:00Z" {
 		t.Fatalf("metadata = %+v, want CPA token metadata preserved", token)
 	}
 }
@@ -412,7 +442,7 @@ func TestImportAccountsJSONRejectsInvalidJSONFile(t *testing.T) {
 	}
 }
 
-func TestImportAccountsCommonDoesNotCollapseConflictingChatGPTAccountID(t *testing.T) {
+func TestImportAccountsCommonDoesNotCollapseOpaqueCredentialsWithoutWorkspaceID(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	db := newTestAdminDB(t)
@@ -430,8 +460,8 @@ func TestImportAccountsCommonDoesNotCollapseConflictingChatGPTAccountID(t *testi
 	ctx.Request = httptest.NewRequest(http.MethodPost, "/api/admin/accounts/import", nil)
 
 	handler.importAccountsCommon(ctx, []importToken{
-		{name: "sub2api-1", refreshToken: "rt-shared-id-1", accessToken: "at-shared-id-1", chatgptAccountID: "same-exported-id"},
-		{name: "sub2api-2", refreshToken: "rt-shared-id-2", accessToken: "at-shared-id-2", chatgptAccountID: "same-exported-id"},
+		{name: "sub2api-1", refreshToken: "rt-shared-id-1", accessToken: "at-shared-id-1"},
+		{name: "sub2api-2", refreshToken: "rt-shared-id-2", accessToken: "at-shared-id-2"},
 	}, "", false)
 
 	rows, err := db.ListActive(context.Background())
@@ -442,9 +472,49 @@ func TestImportAccountsCommonDoesNotCollapseConflictingChatGPTAccountID(t *testi
 		t.Fatalf("active rows = %d, want 2", len(rows))
 	}
 	for _, row := range rows {
-		if got := row.GetCredential("account_id"); got != "" {
-			t.Fatalf("account_id = %q, want empty for conflicting chatgpt_account_id", got)
+		if got := row.GetCredential("workspace_id"); got != "" {
+			t.Fatalf("workspace_id = %q, want empty when JWT cannot be parsed", got)
 		}
+	}
+}
+
+func TestImportAccountsCommonAllowsSameEmailWithoutWorkspaceID(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	db := newTestAdminDB(t)
+	store := auth.NewStore(db, nil, &database.SystemSettings{MaxConcurrency: 2, TestConcurrency: 1, TestModel: "gpt-5.4"})
+	handler := &Handler{
+		db:    db,
+		store: store,
+		probeUsage: func(context.Context, *auth.Account) error {
+			return nil
+		},
+	}
+	makeAT := func(userID string, exp int64) string {
+		return makeAdminTestJWT(t, map[string]interface{}{
+			"exp": exp,
+			"https://api.openai.com/profile": map[string]interface{}{
+				"email": "same@example.com",
+			},
+			"https://api.openai.com/auth": map[string]interface{}{
+				"user_id": userID,
+			},
+		})
+	}
+
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Request = httptest.NewRequest(http.MethodPost, "/api/admin/accounts/import", nil)
+	handler.importAccountsCommon(ctx, []importToken{
+		{accessToken: makeAT("user-1", time.Now().Add(time.Hour).Unix())},
+		{accessToken: makeAT("user-2", time.Now().Add(2*time.Hour).Unix())},
+	}, "", false)
+
+	rows, err := db.ListActive(context.Background())
+	if err != nil {
+		t.Fatalf("ListActive: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("active rows = %d, want 2 for empty workspace_id", len(rows))
 	}
 }
 
@@ -466,7 +536,7 @@ func TestImportAccountsCommonUpdatesExistingOAuthIdentity(t *testing.T) {
 	existingID, err := db.InsertAccountWithCredentials(context.Background(), "existing", map[string]interface{}{
 		"refresh_token": "rt-old",
 		"email":         "import@example.com",
-		"account_id":    "acc-import",
+		"workspace_id":  "acc-import",
 	}, "")
 	if err != nil {
 		t.Fatalf("InsertAccountWithCredentials: %v", err)
@@ -480,7 +550,7 @@ func TestImportAccountsCommonUpdatesExistingOAuthIdentity(t *testing.T) {
 		refreshToken: "rt-new",
 		accessToken:  "at-new",
 		email:        "Import@Example.com",
-		accountID:    "acc-import",
+		workspaceID:  "acc-import",
 		planType:     "team",
 	}}, "", false)
 
@@ -537,7 +607,7 @@ func TestImportAccountsCommonSkipsExistingOAuthIdentityWithSameCredentials(t *te
 		"session_token": "st-same",
 		"access_token":  "at-same",
 		"email":         "same@example.com",
-		"account_id":    "acc-same",
+		"workspace_id":  "acc-same",
 	}, "")
 	if err != nil {
 		t.Fatalf("InsertAccountWithCredentials: %v", err)
@@ -552,7 +622,7 @@ func TestImportAccountsCommonSkipsExistingOAuthIdentityWithSameCredentials(t *te
 		sessionToken: "st-same",
 		accessToken:  "at-same",
 		email:        "Same@Example.com",
-		accountID:    "acc-same",
+		workspaceID:  "acc-same",
 	}}, "", false)
 
 	var payload map[string]interface{}
@@ -594,7 +664,7 @@ func TestImportAccountsCommonSkipsAmbiguousOAuthIdentityWithExistingAccount(t *t
 	existingID, err := db.InsertAccountWithCredentials(context.Background(), "existing", map[string]interface{}{
 		"refresh_token": "rt-old",
 		"email":         "ambiguous@example.com",
-		"account_id":    "acc-ambiguous",
+		"workspace_id":  "acc-ambiguous",
 	}, "")
 	if err != nil {
 		t.Fatalf("InsertAccountWithCredentials: %v", err)
@@ -605,8 +675,8 @@ func TestImportAccountsCommonSkipsAmbiguousOAuthIdentityWithExistingAccount(t *t
 	ctx.Request = httptest.NewRequest(http.MethodPost, "/api/admin/accounts/import", nil)
 
 	handler.importAccountsCommon(ctx, []importToken{
-		{refreshToken: "rt-new-1", email: "ambiguous@example.com", accountID: "acc-ambiguous"},
-		{refreshToken: "rt-new-2", email: "Ambiguous@Example.com", accountID: "acc-ambiguous"},
+		{refreshToken: "rt-new-1", email: "ambiguous@example.com", workspaceID: "acc-ambiguous"},
+		{refreshToken: "rt-new-2", email: "Ambiguous@Example.com", workspaceID: "acc-ambiguous"},
 	}, "", false)
 
 	var payload map[string]interface{}
@@ -650,8 +720,8 @@ func TestImportAccountsCommonSkipsAmbiguousOAuthIdentityWithoutExistingAccount(t
 	ctx.Request = httptest.NewRequest(http.MethodPost, "/api/admin/accounts/import", nil)
 
 	handler.importAccountsCommon(ctx, []importToken{
-		{refreshToken: "rt-new-1", email: "new-ambiguous@example.com", accountID: "acc-new-ambiguous"},
-		{refreshToken: "rt-new-2", email: "New-Ambiguous@Example.com", accountID: "acc-new-ambiguous"},
+		{refreshToken: "rt-new-1", email: "new-ambiguous@example.com", workspaceID: "acc-new-ambiguous"},
+		{refreshToken: "rt-new-2", email: "New-Ambiguous@Example.com", workspaceID: "acc-new-ambiguous"},
 	}, "", false)
 
 	var payload map[string]interface{}
@@ -695,8 +765,8 @@ func TestImportAccountsCommonCollapsesIdenticalOAuthIdentityInFile(t *testing.T)
 	ctx.Request = httptest.NewRequest(http.MethodPost, "/api/admin/accounts/import", nil)
 
 	handler.importAccountsCommon(ctx, []importToken{
-		{refreshToken: "rt-same-file", accessToken: "at-same-file", email: "same-file@example.com", accountID: "acc-same-file"},
-		{refreshToken: "rt-same-file", accessToken: "at-same-file", email: "Same-File@Example.com", accountID: "acc-same-file"},
+		{refreshToken: "rt-same-file", accessToken: "at-same-file", email: "same-file@example.com", workspaceID: "acc-same-file"},
+		{refreshToken: "rt-same-file", accessToken: "at-same-file", email: "Same-File@Example.com", workspaceID: "acc-same-file"},
 	}, "", false)
 
 	if !strings.Contains(recorder.Body.String(), `"type":"complete"`) ||
@@ -874,7 +944,7 @@ func TestImportAccountsCommonRefreshesOAuthIdentityRTOnlyImport(t *testing.T) {
 	handler.importAccountsCommon(ctx, []importToken{{
 		refreshToken: "rt-oauth-identity-refresh-probe",
 		email:        "identity-refresh@example.com",
-		accountID:    "acc-identity-refresh",
+		workspaceID:  "acc-identity-refresh",
 	}}, "", false)
 
 	select {
@@ -985,9 +1055,8 @@ func newMultipartRequest(t *testing.T, files map[string]string) *http.Request {
 	return req
 }
 
-// TestImportAccountsCommonAllowDuplicateBypassesDedup 验证：勾选"允许重复添加"后，
-// 同一 OAuth 身份会被作为独立账号新建，而不是更新已有账号。
-func TestImportAccountsCommonAllowDuplicateBypassesDedup(t *testing.T) {
+// 已识别 workspace_id 时，即使勾选“允许重复添加”也必须更新已有账号。
+func TestImportAccountsCommonAllowDuplicateDoesNotBypassWorkspaceDedup(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	db := newTestAdminDB(t)
@@ -1003,7 +1072,7 @@ func TestImportAccountsCommonAllowDuplicateBypassesDedup(t *testing.T) {
 	if _, err := db.InsertAccountWithCredentials(context.Background(), "existing", map[string]interface{}{
 		"refresh_token": "rt-dup",
 		"email":         "dup@example.com",
-		"account_id":    "acc-dup",
+		"workspace_id":  "acc-dup",
 	}, ""); err != nil {
 		t.Fatalf("InsertAccountWithCredentials: %v", err)
 	}
@@ -1015,15 +1084,15 @@ func TestImportAccountsCommonAllowDuplicateBypassesDedup(t *testing.T) {
 	handler.importAccountsCommon(ctx, []importToken{{
 		refreshToken: "rt-dup-2",
 		email:        "dup@example.com",
-		accountID:    "acc-dup",
+		workspaceID:  "acc-dup",
 	}}, "", true)
 
 	rows, err := db.ListActive(context.Background())
 	if err != nil {
 		t.Fatalf("ListActive: %v", err)
 	}
-	if len(rows) != 2 {
-		t.Fatalf("active rows = %d, want 2 (duplicate allowed)", len(rows))
+	if len(rows) != 1 {
+		t.Fatalf("active rows = %d, want 1 for a known workspace identity", len(rows))
 	}
 }
 
@@ -1148,7 +1217,8 @@ func TestAddATAccountCountsUpdateNotNew(t *testing.T) {
 	}
 }
 
-// 先导入 AT（个人账号，只有 user_id 身份），后导入裸 RT——RT 刷新后身份可知，// 应把新凭证合并进已有 AT 账号（RT 升级）、软删新账号，且旧账号的用量快照保留。
+// 先导入 AT，后导入裸 RT——两者 workspace_id 相同，应把新凭证合并进已有
+// AT 账号（RT 升级）、软删新账号，且旧账号的用量快照保留。
 func TestMergeRefreshedDuplicateIntoExisting(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
@@ -1160,7 +1230,7 @@ func TestMergeRefreshedDuplicateIntoExisting(t *testing.T) {
 	oldID, err := db.InsertAccountWithCredentials(context.Background(), "at-first", map[string]interface{}{
 		"access_token":          "at-rotation-1",
 		"email":                 "solo@example.com",
-		"user_id":               "user-merge1",
+		"workspace_id":          "workspace-merge1",
 		"codex_7d_used_percent": "42.5",
 	}, "")
 	if err != nil {
@@ -1171,13 +1241,19 @@ func TestMergeRefreshedDuplicateIntoExisting(t *testing.T) {
 	newID, err := db.InsertAccountWithCredentials(context.Background(), "rt-later", map[string]interface{}{
 		"refresh_token": "rt-fresh",
 		"access_token":  "at-rotation-2",
-		"email":         "solo@example.com",
-		"user_id":       "user-merge1",
+		"custom_headers": map[string]string{
+			"X-Import-Source": "rt-later",
+		},
 	}, "")
 	if err != nil {
 		t.Fatalf("Insert new: %v", err)
 	}
-	store.AddAccount(&auth.Account{DBID: newID, RefreshToken: "rt-fresh"})
+	store.AddAccount(&auth.Account{
+		DBID:         newID,
+		RefreshToken: "rt-fresh",
+		Email:        "solo@example.com",
+		AccountID:    "workspace-merge1",
+	})
 
 	if merged := handler.mergeRefreshedDuplicateIntoExisting(newID, "test"); !merged {
 		t.Fatal("expected duplicate to be merged into existing account")
@@ -1195,6 +1271,9 @@ func TestMergeRefreshedDuplicateIntoExisting(t *testing.T) {
 	}
 	if got := oldRow.GetCredential("codex_7d_used_percent"); got != "42.5" {
 		t.Fatalf("codex_7d_used_percent = %q, want 42.5 (用量统计必须保留)", got)
+	}
+	if got := oldRow.GetCredentialStringMap("custom_headers"); len(got) != 1 || got["X-Import-Source"] != "rt-later" {
+		t.Fatalf("custom_headers = %#v, want imported headers", got)
 	}
 
 	rows, err := db.ListActive(context.Background())
@@ -1220,7 +1299,7 @@ func TestProbeImportedAccountUsageMergesAfterIdentityLearned(t *testing.T) {
 	oldID, err := db.InsertAccountWithCredentials(context.Background(), "at-first", map[string]interface{}{
 		"access_token":          "at-old",
 		"email":                 "solo@example.com",
-		"account_id":            "user-probe1",
+		"workspace_id":          "workspace-probe1",
 		"codex_7d_used_percent": "37.0",
 	}, "")
 	if err != nil {
@@ -1236,9 +1315,9 @@ func TestProbeImportedAccountUsageMergesAfterIdentityLearned(t *testing.T) {
 	}
 	store.AddAccount(&auth.Account{DBID: newID, AccessToken: "at-new", Status: auth.StatusReady})
 
-	// 模拟 wham 探针：补齐 email + account_id（与旧账号同一身份）并落库。
+	// 模拟 wham 探针：补齐 email + workspace_id 并落库。
 	handler.probeUsage = func(ctx context.Context, acc *auth.Account) error {
-		store.UpdateAccountIdentity(acc, "solo@example.com", "user-probe1")
+		store.UpdateAccountIdentity(acc, "solo@example.com", "workspace-probe1")
 		return nil
 	}
 
@@ -1264,8 +1343,9 @@ func TestProbeImportedAccountUsageMergesAfterIdentityLearned(t *testing.T) {
 	}
 }
 
-// 勾选"允许重复添加"导入的 RT 账号刷新后不得被合并。
-func TestMergeRefreshedDuplicateSkipsAllowDuplicate(t *testing.T) {	gin.SetMode(gin.TestMode)
+// 同邮箱、同 user_id 但缺少 workspace_id 的账号允许同时存在。
+func TestMergeRefreshedDuplicateAllowsMissingWorkspaceID(t *testing.T) {
+	gin.SetMode(gin.TestMode)
 
 	db := newTestAdminDB(t)
 	store := auth.NewStore(db, nil, &database.SystemSettings{MaxConcurrency: 2, TestConcurrency: 1, TestModel: "gpt-5.4"})
@@ -1289,14 +1369,14 @@ func TestMergeRefreshedDuplicateSkipsAllowDuplicate(t *testing.T) {	gin.SetMode(
 	}
 
 	if merged := handler.mergeRefreshedDuplicateIntoExisting(forcedID, "test"); merged {
-		t.Fatal("allow_duplicate copy must not be merged")
+		t.Fatal("account without workspace_id must not be merged")
 	}
 	rows, err := db.ListActive(context.Background())
 	if err != nil {
 		t.Fatalf("ListActive: %v", err)
 	}
 	if len(rows) != 2 {
-		t.Fatalf("active rows = %d, want 2 (forced copy preserved)", len(rows))
+		t.Fatalf("active rows = %d, want 2 (empty workspace identities may repeat)", len(rows))
 	}
 }
 

--- a/admin/oauth.go
+++ b/admin/oauth.go
@@ -315,16 +315,10 @@ func (h *Handler) findOAuthIdentityDuplicate(ctx context.Context, seed tokenCred
 		return 0, nil
 	}
 	seed = normalizeTokenCredentialSeed(seed)
-	// 身份键优先用工作区 ID；个人账号 JWT 可能只有 user_id，此时用它兜底，
-	// 否则 AT 轮换后按原文去重永远失配，同一账号会被重复导入。
-	identity := seed.accountID
-	if identity == "" {
-		identity = seed.userID
-	}
-	if seed.email == "" || identity == "" {
+	if seed.email == "" || seed.workspaceID == "" {
 		return 0, nil
 	}
-	id, err := h.db.FindActiveAccountByOAuthIdentity(ctx, seed.email, identity, excludeID)
+	id, err := h.db.FindActiveAccountByOAuthIdentity(ctx, seed.email, seed.workspaceID, excludeID)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return 0, nil
@@ -334,9 +328,33 @@ func (h *Handler) findOAuthIdentityDuplicate(ctx context.Context, seed tokenCred
 	return id, nil
 }
 
+func (h *Handler) updateExistingOAuthIdentityAccount(ctx context.Context, duplicateID int64, proxyURL string, seed tokenCredentialSeed, source string) (int64, bool, error) {
+	row, err := h.db.GetAccountByID(ctx, duplicateID)
+	if err != nil {
+		return 0, false, err
+	}
+	effectiveProxyURL := strings.TrimSpace(proxyURL)
+	if effectiveProxyURL == "" {
+		effectiveProxyURL = strings.TrimSpace(row.ProxyURL)
+	}
+	if err := h.db.UpdateOAuthAccountCredentials(ctx, duplicateID, tokenCredentialMap(seed), effectiveProxyURL); err != nil {
+		return 0, false, err
+	}
+	// 条件更新只清除数据库当前仍为 error / unauthorized 的状态，避免旧快照
+	// 覆盖并发 probe 刚写入的 rate_limited 或其他冷却。
+	if _, err := h.db.ClearErrorIfErrorOrUnauthorized(ctx, duplicateID); err != nil {
+		log.Printf("重新导入清除账号 %d 错误状态失败: %v", duplicateID, err)
+	}
+	if err := h.reloadTokenAccount(ctx, duplicateID, source); err != nil {
+		return 0, false, err
+	}
+	h.db.InsertAccountEventAsync(duplicateID, "updated", source)
+	return duplicateID, true, nil
+}
+
 func (h *Handler) upsertOAuthIdentityAccount(ctx context.Context, name, proxyURL string, seed tokenCredentialSeed, source string) (int64, bool, error) {
 	seed = normalizeTokenCredentialSeed(seed)
-	if seed.email == "" || (seed.accountID == "" && seed.userID == "") {
+	if seed.email == "" || seed.workspaceID == "" {
 		id, err := h.db.InsertAccountWithCredentials(ctx, name, tokenCredentialMap(seed), proxyURL)
 		if err != nil {
 			return 0, false, err
@@ -345,56 +363,29 @@ func (h *Handler) upsertOAuthIdentityAccount(ctx context.Context, name, proxyURL
 		h.loadInsertedTokenAccount(id, proxyURL, seed, source)
 		return id, false, nil
 	}
+	h.oauthIdentityMu.Lock()
+	defer h.oauthIdentityMu.Unlock()
 
 	if duplicateID, err := h.findOAuthIdentityDuplicate(ctx, seed, 0); err != nil {
 		return 0, false, err
 	} else if duplicateID > 0 {
-		row, err := h.db.GetAccountByID(ctx, duplicateID)
-		if err != nil {
-			return 0, false, err
-		}
-		effectiveProxyURL := strings.TrimSpace(proxyURL)
-		if effectiveProxyURL == "" {
-			effectiveProxyURL = strings.TrimSpace(row.ProxyURL)
-		}
-		if err := h.db.UpdateOAuthAccountCredentials(ctx, duplicateID, tokenCredentialMap(seed), effectiveProxyURL); err != nil {
-			return 0, false, err
-		}
-		// 重新导入有效凭证时，若该账号此前处于错误/封禁（401）态，清除错误状态，
-		// 让重新加载后的运行时账号脱离 banned，并交由后续 probe 重新判定。
-		// 仅针对 error / unauthorized，避免误清合法的限速冷却（rate_limited）。
-		if accountErrorStateNeedsReset(row) {
-			if err := h.db.ClearError(ctx, duplicateID); err != nil {
-				log.Printf("重新导入清除账号 %d 错误状态失败: %v", duplicateID, err)
-			}
-		}
-		if err := h.reloadTokenAccount(ctx, duplicateID, source); err != nil {
-			return 0, false, err
-		}
-		h.db.InsertAccountEventAsync(duplicateID, "updated", source)
-		return duplicateID, true, nil
+		return h.updateExistingOAuthIdentityAccount(ctx, duplicateID, proxyURL, seed, source)
 	}
 
 	id, err := h.db.InsertAccountWithCredentials(ctx, name, tokenCredentialMap(seed), proxyURL)
 	if err != nil {
+		if errors.Is(err, database.ErrDuplicateOAuthIdentity) {
+			if duplicateID, lookupErr := h.findOAuthIdentityDuplicate(ctx, seed, 0); lookupErr != nil {
+				return 0, false, lookupErr
+			} else if duplicateID > 0 {
+				return h.updateExistingOAuthIdentityAccount(ctx, duplicateID, proxyURL, seed, source)
+			}
+		}
 		return 0, false, err
 	}
 	h.db.InsertAccountEventAsync(id, "added", source)
 	h.loadInsertedTokenAccount(id, proxyURL, seed, source)
 	return id, false, nil
-}
-
-// accountErrorStateNeedsReset 判断一个已存在账号是否处于"重新导入有效凭证后应清除"的
-// 错误/封禁态：status='error'（RT 失效、鉴权失败等）或 401 unauthorized 冷却。
-// 限速冷却（rate_limited*）不在此列，避免重新导入误清合法的限速窗口。
-func accountErrorStateNeedsReset(row *database.AccountRow) bool {
-	if row == nil {
-		return false
-	}
-	if strings.EqualFold(strings.TrimSpace(row.Status), "error") {
-		return true
-	}
-	return strings.EqualFold(strings.TrimSpace(row.CooldownReason), "unauthorized")
 }
 
 func (h *Handler) loadInsertedTokenAccount(id int64, proxyURL string, seed tokenCredentialSeed, source string) {
@@ -515,6 +506,10 @@ func (h *Handler) UpdateOAuthAccountCode(c *gin.Context) {
 		idToken:      tokenResp.IDToken,
 		expiresIn:    tokenResp.ExpiresIn,
 	})
+	if seed.email != "" && seed.workspaceID != "" {
+		h.oauthIdentityMu.Lock()
+		defer h.oauthIdentityMu.Unlock()
+	}
 	if duplicateID, err := h.findOAuthIdentityDuplicate(ctx, seed, id); err != nil {
 		writeInternalError(c, err)
 		return
@@ -526,6 +521,12 @@ func (h *Handler) UpdateOAuthAccountCode(c *gin.Context) {
 		if errors.Is(err, sql.ErrNoRows) {
 			writeError(c, http.StatusNotFound, "账号不存在")
 			return
+		}
+		if errors.Is(err, database.ErrDuplicateOAuthIdentity) {
+			if duplicateID, lookupErr := h.findOAuthIdentityDuplicate(ctx, seed, id); lookupErr == nil && duplicateID > 0 {
+				writeError(c, http.StatusConflict, oauthIdentityDuplicateMessage(duplicateID))
+				return
+			}
 		}
 		writeError(c, http.StatusInternalServerError, "Token 写入数据库失败: "+err.Error())
 		return

--- a/admin/oauth_test.go
+++ b/admin/oauth_test.go
@@ -7,7 +7,9 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -204,7 +206,7 @@ func TestExchangeOAuthCodeUpdatesDuplicateOAuthIdentity(t *testing.T) {
 	existingID, err := db.InsertAccountWithCredentials(context.Background(), "existing", map[string]interface{}{
 		"refresh_token": "existing-refresh",
 		"email":         "duplicate@example.com",
-		"account_id":    "acc-duplicate",
+		"workspace_id":  "acc-duplicate",
 	}, "")
 	if err != nil {
 		t.Fatalf("InsertAccountWithCredentials: %v", err)
@@ -263,6 +265,97 @@ func TestExchangeOAuthCodeUpdatesDuplicateOAuthIdentity(t *testing.T) {
 	}
 	if account := store.FindByID(existingID); account == nil {
 		t.Fatalf("runtime account %d not found after update", existingID)
+	}
+}
+
+func TestUpsertOAuthIdentitySerializesConcurrentWorkspaceImports(t *testing.T) {
+	db := newTestAdminDB(t)
+	handler := &Handler{db: db}
+	const workers = 20
+	var wg sync.WaitGroup
+	errs := make(chan error, workers)
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, _, err := handler.upsertOAuthIdentityAccount(context.Background(), fmt.Sprintf("account-%d", i), "", tokenCredentialSeed{
+				accessToken: fmt.Sprintf("at-%d", i),
+				email:       "same@example.com",
+				workspaceID: "workspace-concurrent",
+			}, "test")
+			errs <- err
+		}(i)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("upsertOAuthIdentityAccount: %v", err)
+		}
+	}
+	rows, err := db.ListActive(context.Background())
+	if err != nil {
+		t.Fatalf("ListActive: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("active rows = %d, want 1", len(rows))
+	}
+}
+
+func TestUpsertOAuthIdentityAcrossHandlersUsesDatabaseConstraint(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "oauth-concurrent.sqlite")
+	db1, err := database.New("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("database.New db1: %v", err)
+	}
+	defer db1.Close()
+	db2, err := database.New("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("database.New db2: %v", err)
+	}
+	defer db2.Close()
+
+	type result struct {
+		id      int64
+		updated bool
+		err     error
+	}
+	start := make(chan struct{})
+	results := make(chan result, 2)
+	upsert := func(handler *Handler, token string) {
+		<-start
+		id, updated, err := handler.upsertOAuthIdentityAccount(context.Background(), "concurrent", "", tokenCredentialSeed{
+			accessToken: token,
+			email:       "multi-handler@example.com",
+			workspaceID: "workspace-multi-handler",
+		}, "test")
+		results <- result{id: id, updated: updated, err: err}
+	}
+
+	go upsert(&Handler{db: db1}, "at-handler-1")
+	go upsert(&Handler{db: db2}, "at-handler-2")
+	close(start)
+
+	first := <-results
+	second := <-results
+	for _, got := range []result{first, second} {
+		if got.err != nil {
+			t.Fatalf("upsertOAuthIdentityAccount: %v", got.err)
+		}
+	}
+	if first.id <= 0 || first.id != second.id {
+		t.Fatalf("upsert ids = %d/%d, want same positive id", first.id, second.id)
+	}
+	if first.updated == second.updated {
+		t.Fatalf("updated flags = %v/%v, want one insert and one update", first.updated, second.updated)
+	}
+
+	rows, err := db1.ListActive(context.Background())
+	if err != nil {
+		t.Fatalf("ListActive: %v", err)
+	}
+	if len(rows) != 1 || rows[0].ID != first.id {
+		t.Fatalf("active rows = %#v, want one row id %d", rows, first.id)
 	}
 }
 
@@ -525,7 +618,7 @@ func TestUpdateOAuthAccountCodeRejectsDuplicateOAuthIdentity(t *testing.T) {
 	targetID, err := db.InsertAccountWithCredentials(context.Background(), "target", map[string]interface{}{
 		"refresh_token": "target-refresh",
 		"email":         "target@example.com",
-		"account_id":    "acc-target",
+		"workspace_id":  "acc-target",
 	}, "")
 	if err != nil {
 		t.Fatalf("Insert target: %v", err)
@@ -533,7 +626,7 @@ func TestUpdateOAuthAccountCodeRejectsDuplicateOAuthIdentity(t *testing.T) {
 	duplicateID, err := db.InsertAccountWithCredentials(context.Background(), "duplicate", map[string]interface{}{
 		"refresh_token": "duplicate-refresh",
 		"email":         "duplicate@example.com",
-		"account_id":    "acc-duplicate",
+		"workspace_id":  "acc-duplicate",
 	}, "")
 	if err != nil {
 		t.Fatalf("Insert duplicate: %v", err)
@@ -688,7 +781,7 @@ func TestUpsertOAuthIdentityAccountClearsBanOnReimport(t *testing.T) {
 		"refresh_token": "old-refresh",
 		"access_token":  "old-access",
 		"email":         "banned@example.com",
-		"account_id":    "acc-banned",
+		"workspace_id":  "acc-banned",
 	}, "")
 	if err != nil {
 		t.Fatalf("InsertAccountWithCredentials: %v", err)
@@ -714,7 +807,7 @@ func TestUpsertOAuthIdentityAccountClearsBanOnReimport(t *testing.T) {
 	seed := tokenCredentialSeed{
 		accessToken: "fresh-access",
 		email:       "banned@example.com",
-		accountID:   "acc-banned",
+		workspaceID: "acc-banned",
 	}
 	newID, updated, err := handler.upsertOAuthIdentityAccount(ctx, "banned", "", seed, "manual_at")
 	if err != nil {

--- a/admin/refresh_probe_test.go
+++ b/admin/refresh_probe_test.go
@@ -19,7 +19,7 @@ func TestRefreshAccountByIDTriggersUsageProbe(t *testing.T) {
 		"refresh_token": "rt-renew",
 		"access_token":  "at-renew",
 		"email":         "renew@example.com",
-		"account_id":    "acc-renew",
+		"workspace_id":  "acc-renew",
 	}, "")
 	if err != nil {
 		t.Fatalf("InsertAccountWithCredentials: %v", err)

--- a/admin/self_service.go
+++ b/admin/self_service.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"context"
+	"errors"
 	"log"
 	"net/http"
 	"regexp"
@@ -9,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/codex2api/database"
 	"github.com/codex2api/security"
 	"github.com/gin-gonic/gin"
 )
@@ -243,7 +245,9 @@ func (h *Handler) SubmitAccountPortalCode(c *gin.Context) {
 // 不加入运行时调度池（管理员批准后再启用）。重复账号返回 errDuplicateOAuthIdentity。
 func (h *Handler) upsertSelfServiceAccount(ctx context.Context, name, proxyURL string, seed tokenCredentialSeed, contactEmail string) (int64, error) {
 	seed = normalizeTokenCredentialSeed(seed)
-	if seed.email != "" && (seed.accountID != "" || seed.userID != "") {
+	if seed.email != "" && seed.workspaceID != "" {
+		h.oauthIdentityMu.Lock()
+		defer h.oauthIdentityMu.Unlock()
 		if duplicateID, err := h.findOAuthIdentityDuplicate(ctx, seed, 0); err != nil {
 			return 0, err
 		} else if duplicateID > 0 {
@@ -253,6 +257,9 @@ func (h *Handler) upsertSelfServiceAccount(ctx context.Context, name, proxyURL s
 
 	id, err := h.db.InsertAccountWithCredentials(ctx, name, tokenCredentialMap(seed), proxyURL)
 	if err != nil {
+		if errors.Is(err, database.ErrDuplicateOAuthIdentity) {
+			return 0, errDuplicateOAuthIdentity
+		}
 		return 0, err
 	}
 	// 待审核：禁用 + 备注 + 打标；不调用 Store.AddAccount，故不进调度池。

--- a/admin/self_service_test.go
+++ b/admin/self_service_test.go
@@ -139,7 +139,7 @@ func TestUpsertSelfServiceAccountPendingAndNotScheduled(t *testing.T) {
 		refreshToken: "rt-abc",
 		accessToken:  "at-abc",
 		email:        "provider@example.com",
-		accountID:    "acct-1",
+		workspaceID:  "acct-1",
 	}
 	id, err := handler.upsertSelfServiceAccount(ctx, "provider@example.com", "", seed, "contact@x.com")
 	if err != nil {
@@ -186,7 +186,7 @@ func TestApproveSelfServiceAccountLoadsIntoPool(t *testing.T) {
 	handler.RegisterRoutes(router)
 	ctx := context.Background()
 
-	seed := tokenCredentialSeed{refreshToken: "rt-x", accessToken: "at-x", email: "p2@example.com", accountID: "acct-2"}
+	seed := tokenCredentialSeed{refreshToken: "rt-x", accessToken: "at-x", email: "p2@example.com", workspaceID: "acct-2"}
 	id, err := handler.upsertSelfServiceAccount(ctx, "p2@example.com", "", seed, "c@x.com")
 	if err != nil {
 		t.Fatalf("upsertSelfServiceAccount: %v", err)

--- a/admin/sub2api_import.go
+++ b/admin/sub2api_import.go
@@ -123,7 +123,7 @@ func (h *Handler) PreviewSub2APIAccounts(c *gin.Context) {
 }
 
 // ImportFromSub2API 从 sub2api 拉取账号并按 scope 导入到本系统。
-// 复用 importAccountsCommon 的 SSE 进度推送、chatgpt_account_id 去重等逻辑。
+// 复用 importAccountsCommon 的 SSE 进度推送、JWT workspace_id 去重等逻辑。
 func (h *Handler) ImportFromSub2API(c *gin.Context) {
 	var req sub2apiImportRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -226,7 +226,7 @@ func fetchSub2APISummaries(ctx context.Context, baseURL, apiKey string) ([]sub2a
 			Credentials: dataAcc.Credentials,
 		}
 		if dataAcc.Credentials != nil {
-			merged.ChatGPTAccountID = stringFromMap(dataAcc.Credentials, "chatgpt_account_id", "account_id")
+			merged.ChatGPTAccountID = sub2apiWorkspaceID(dataAcc.Credentials)
 			merged.Email = stringFromMap(dataAcc.Credentials, "email")
 			merged.PlanType = stringFromMap(dataAcc.Credentials, "plan_type")
 		}
@@ -241,6 +241,17 @@ func fetchSub2APISummaries(ctx context.Context, baseURL, apiKey string) ([]sub2a
 		out = append(out, merged)
 	}
 	return out, nil
+}
+
+func sub2apiWorkspaceID(credentials map[string]interface{}) string {
+	if credentials == nil {
+		return ""
+	}
+	seed := normalizeTokenCredentialSeed(tokenCredentialSeed{
+		idToken:     stringFromMap(credentials, "id_token", "idToken"),
+		accessToken: stringFromMap(credentials, "access_token", "accessToken"),
+	})
+	return seed.workspaceID
 }
 
 // summarizeSub2API 从聚合数据生成给前端的预览统计 + 列表。
@@ -313,9 +324,7 @@ func sub2apiAccountToImportToken(a sub2apiAccountInternal) (importToken, bool) {
 		accessToken:           at,
 		name:                  a.Name,
 		email:                 a.Email,
-		idToken:               stringFromMap(c, "id_token"),
-		accountID:             stringFromMap(c, "account_id"),
-		chatgptAccountID:      a.ChatGPTAccountID,
+		idToken:               stringFromMap(c, "id_token", "idToken"),
 		planType:              a.PlanType,
 		expiresAt:             stringFromMap(c, "expires_at"),
 		codex7DUsedPercent:    stringFromMap(c, "codex_7d_used_percent"),

--- a/admin/token_credentials.go
+++ b/admin/token_credentials.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/codex2api/auth"
+	"github.com/codex2api/internal/openaiidentity"
 )
 
 type tokenCredentialSeed struct {
@@ -14,13 +15,11 @@ type tokenCredentialSeed struct {
 	accessToken     string
 	accessTokenType string
 	idToken         string
-	accountID       string
-	// userID 是 OpenAI 用户 ID（user-...），个人账号的 JWT 可能没有工作区
-	// account_id，此时以 email+userID 作为 OAuth 身份去重键 (重复导入问题)。
+	workspaceID     string
+	// userID 是 OpenAI 用户 ID，仅作为账号元数据保存，不参与 workspace 身份去重。
 	userID string
-	// allowDuplicate 标记该账号是用户勾选"允许重复添加"强制导入的副本。
-	// 持久化为 credentials.allow_duplicate，身份判重与启动时的 dedupe 迁移
-	// 都会跳过带标记的账号，避免把用户故意保留的重复当垃圾合并。
+	// allowDuplicate 仅允许 workspace_id 为空的凭证绕过 RT/ST/AT 原文去重；
+	// 已确认 workspace 身份时仍必须保持 email + workspace_id 唯一。
 	allowDuplicate        bool
 	email                 string
 	planType              string
@@ -43,7 +42,7 @@ func normalizeTokenCredentialSeed(seed tokenCredentialSeed) tokenCredentialSeed 
 	seed.accessToken = strings.TrimSpace(seed.accessToken)
 	seed.accessTokenType = strings.TrimSpace(seed.accessTokenType)
 	seed.idToken = strings.TrimSpace(seed.idToken)
-	seed.accountID = strings.TrimSpace(seed.accountID)
+	seed.workspaceID = openaiidentity.NormalizeWorkspaceID(seed.workspaceID)
 	seed.userID = strings.TrimSpace(seed.userID)
 	seed.email = strings.TrimSpace(seed.email)
 	seed.planType = strings.TrimSpace(seed.planType)
@@ -63,8 +62,8 @@ func normalizeTokenCredentialSeed(seed tokenCredentialSeed) tokenCredentialSeed 
 		accessTokenForJWT = ""
 	}
 	if info := accountInfoFromTokens(seed.idToken, accessTokenForJWT); info != nil {
-		if seed.accountID == "" {
-			seed.accountID = info.ChatGPTAccountID
+		if seed.workspaceID == "" {
+			seed.workspaceID = info.ChatGPTAccountID
 		}
 		if seed.userID == "" {
 			seed.userID = info.UserID
@@ -157,13 +156,13 @@ func tokenCredentialMap(seed tokenCredentialSeed) map[string]interface{} {
 	if !seed.expiresAt.IsZero() {
 		credentials["expires_at"] = seed.expiresAt.Format(time.RFC3339)
 	}
-	if seed.accountID != "" {
-		credentials["account_id"] = seed.accountID
+	if seed.workspaceID != "" {
+		credentials["workspace_id"] = seed.workspaceID
 	}
 	if seed.userID != "" {
 		credentials["user_id"] = seed.userID
 	}
-	if seed.allowDuplicate {
+	if seed.allowDuplicate && seed.workspaceID == "" {
 		credentials["allow_duplicate"] = "true"
 	}
 	if seed.email != "" {
@@ -207,7 +206,7 @@ func accountFromCredentialSeed(id int64, proxyURL string, seed tokenCredentialSe
 		SessionToken:          seed.sessionToken,
 		AccessToken:           seed.accessToken,
 		ExpiresAt:             seed.expiresAt,
-		AccountID:             seed.accountID,
+		AccountID:             seed.workspaceID,
 		Email:                 seed.email,
 		PlanType:              seed.planType,
 		ProxyURL:              proxyURL,

--- a/admin/token_credentials_test.go
+++ b/admin/token_credentials_test.go
@@ -53,8 +53,8 @@ func TestNormalizeTokenCredentialSeedTreatsCodexATAsOpaque(t *testing.T) {
 	if seed.accessTokenType != accessTokenTypeCodexAT {
 		t.Fatalf("accessTokenType = %q, want %q", seed.accessTokenType, accessTokenTypeCodexAT)
 	}
-	if seed.email != "" || seed.accountID != "" || seed.planType != "" {
-		t.Fatalf("codex_at parsed JWT fields: email=%q accountID=%q planType=%q", seed.email, seed.accountID, seed.planType)
+	if seed.email != "" || seed.workspaceID != "" || seed.planType != "" {
+		t.Fatalf("codex_at parsed JWT fields: email=%q workspaceID=%q planType=%q", seed.email, seed.workspaceID, seed.planType)
 	}
 	if seed.expiresAt.Before(before.Add(50*time.Minute)) || seed.expiresAt.After(before.Add(70*time.Minute)) {
 		t.Fatalf("expiresAt = %s, want fallback around 1h from now", seed.expiresAt)
@@ -67,7 +67,7 @@ func TestNormalizeTokenCredentialSeedTreatsCodexATAsOpaque(t *testing.T) {
 	if _, ok := credentials["email"]; ok {
 		t.Fatalf("credentials should not include email for opaque codex_at: %#v", credentials)
 	}
-	if _, ok := credentials["account_id"]; ok {
-		t.Fatalf("credentials should not include account_id for opaque codex_at: %#v", credentials)
+	if _, ok := credentials["workspace_id"]; ok {
+		t.Fatalf("credentials should not include workspace_id for opaque codex_at: %#v", credentials)
 	}
 }

--- a/auth/store.go
+++ b/auth/store.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/codex2api/cache"
 	"github.com/codex2api/database"
+	"github.com/codex2api/internal/openaiidentity"
 	"github.com/codex2api/security/promptfilter"
 )
 
@@ -493,6 +494,16 @@ func (a *Account) EffectiveAccountID() string {
 		return v
 	}
 	return strings.TrimSpace(a.AccountID)
+}
+
+// OAuthIdentity 返回运行时缓存中的 email 和 workspace_id。
+func (a *Account) OAuthIdentity() (email, workspaceID string) {
+	if a == nil {
+		return "", ""
+	}
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return strings.TrimSpace(a.Email), strings.TrimSpace(a.AccountID)
 }
 
 // AccountIDOverridden 判断自定义请求头是否把流量导向了与 OAuth 身份不同的空间。
@@ -3885,8 +3896,19 @@ func (s *Store) buildAccountFromRow(ctx context.Context, row *database.AccountRo
 
 	// 尝试从 credentials 恢复已有的 AT
 	if at != "" {
+		workspaceID := openaiidentity.NormalizeWorkspaceID(row.GetCredential("workspace_id"))
+		if workspaceID == "" {
+			if info := ParseIDToken(row.GetCredential("id_token")); info != nil {
+				workspaceID = openaiidentity.NormalizeWorkspaceID(info.ChatGPTAccountID)
+			}
+			if workspaceID == "" {
+				if info := ParseAccessToken(at); info != nil {
+					workspaceID = openaiidentity.NormalizeWorkspaceID(info.ChatGPTAccountID)
+				}
+			}
+		}
 		account.AccessToken = at
-		account.AccountID = row.GetCredential("account_id")
+		account.AccountID = workspaceID
 		account.Email = row.GetCredential("email")
 		account.PlanType = row.GetCredential("plan_type")
 		if account.Status != StatusError {
@@ -6666,14 +6688,14 @@ func (s *Store) UpdateAccountPlanType(acc *Account, planType string) bool {
 	return changed
 }
 
-// UpdateAccountIdentity persists account identity observed from upstream usage APIs.
-func (s *Store) UpdateAccountIdentity(acc *Account, email, accountID string) bool {
+// UpdateAccountIdentity persists the workspace identity observed from upstream usage APIs.
+func (s *Store) UpdateAccountIdentity(acc *Account, email, workspaceID string) bool {
 	if s == nil || acc == nil {
 		return false
 	}
 	email = strings.TrimSpace(email)
-	accountID = strings.TrimSpace(accountID)
-	if email == "" && accountID == "" {
+	workspaceID = openaiidentity.NormalizeWorkspaceID(workspaceID)
+	if email == "" && workspaceID == "" {
 		return false
 	}
 
@@ -6685,9 +6707,9 @@ func (s *Store) UpdateAccountIdentity(acc *Account, email, accountID string) boo
 		fields["email"] = email
 		changed = true
 	}
-	if accountID != "" && acc.AccountID != accountID {
-		acc.AccountID = accountID
-		fields["account_id"] = accountID
+	if workspaceID != "" && acc.AccountID != workspaceID {
+		acc.AccountID = workspaceID
+		fields["workspace_id"] = workspaceID
 		changed = true
 	}
 	acc.mu.Unlock()
@@ -7555,7 +7577,7 @@ func (s *Store) refreshAccountWithOptions(ctx context.Context, acc *Account, for
 	}
 	if info != nil {
 		if info.ChatGPTAccountID != "" {
-			credentials["account_id"] = info.ChatGPTAccountID
+			credentials["workspace_id"] = info.ChatGPTAccountID
 		}
 		if info.Email != "" {
 			credentials["email"] = info.Email

--- a/auth/token.go
+++ b/auth/token.go
@@ -3,7 +3,6 @@ package auth
 import (
 	"context"
 	"crypto/sha256"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -15,6 +14,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/codex2api/internal/openaiidentity"
 )
 
 // OpenAI OAuth 常量（与 CLIProxyAPI / sub2api 一致）
@@ -139,7 +140,7 @@ func RefreshAccessToken(ctx context.Context, refreshToken string, proxyURL strin
 	info := parseIDToken(tokenResp.IDToken)
 
 	// 回退：如果 id_token 中缺少字段，尝试从 access_token 提取
-	if tokenResp.AccessToken != "" && (info.PlanType == "" || info.SubscriptionExpiresAt.IsZero()) {
+	if tokenResp.AccessToken != "" && (info.Email == "" || info.ChatGPTAccountID == "" || info.UserID == "" || info.PlanType == "" || info.SubscriptionExpiresAt.IsZero()) {
 		if atInfo := ParseAccessToken(tokenResp.AccessToken); atInfo != nil {
 			if info.PlanType == "" && atInfo.PlanType != "" {
 				log.Printf("[token] id_token 缺少 plan_type，从 access_token 回退获取: %s", atInfo.PlanType)
@@ -151,6 +152,9 @@ func RefreshAccessToken(ctx context.Context, refreshToken string, proxyURL strin
 			}
 			if info.ChatGPTAccountID == "" && atInfo.ChatGPTAccountID != "" {
 				info.ChatGPTAccountID = atInfo.ChatGPTAccountID
+			}
+			if info.UserID == "" && atInfo.UserID != "" {
+				info.UserID = atInfo.UserID
 			}
 			if info.SubscriptionExpiresAt.IsZero() && !atInfo.SubscriptionExpiresAt.IsZero() {
 				info.SubscriptionExpiresAt = atInfo.SubscriptionExpiresAt
@@ -331,48 +335,18 @@ func isNonRetryable(err error) bool {
 
 // parseIDToken 解析 JWT id_token 的 payload（不验签）
 func parseIDToken(idToken string) *AccountInfo {
-	if idToken == "" {
-		return &AccountInfo{}
-	}
-
-	parts := strings.Split(idToken, ".")
-	if len(parts) != 3 {
-		return &AccountInfo{}
-	}
-
-	payload := parts[1]
-	switch len(payload) % 4 {
-	case 2:
-		payload += "=="
-	case 3:
-		payload += "="
-	}
-
-	decoded, err := base64.URLEncoding.DecodeString(payload)
+	claims, err := openaiidentity.ParseJWT(idToken)
 	if err != nil {
-		decoded, err = base64.StdEncoding.DecodeString(payload)
-		if err != nil {
-			return &AccountInfo{}
-		}
-	}
-
-	var claims struct {
-		Email      string `json:"email"`
-		OpenAIAuth *struct {
-			ChatGPTAccountID               string `json:"chatgpt_account_id"`
-			UserID                         string `json:"user_id"`
-			ChatGPTUserID                  string `json:"chatgpt_user_id"`
-			PlanType                       string `json:"chatgpt_plan_type"`
-			ChatGPTSubscriptionActiveUntil string `json:"chatgpt_subscription_active_until"`
-		} `json:"https://api.openai.com/auth"`
-	}
-	if err := json.Unmarshal(decoded, &claims); err != nil {
 		return &AccountInfo{}
 	}
 
-	info := &AccountInfo{Email: claims.Email}
+	profileEmail := ""
+	if claims.OpenAIProfile != nil {
+		profileEmail = claims.OpenAIProfile.Email
+	}
+	info := &AccountInfo{Email: firstNonEmptyTrimmed(claims.Email, profileEmail)}
 	if claims.OpenAIAuth != nil {
-		info.ChatGPTAccountID = claims.OpenAIAuth.ChatGPTAccountID
+		info.ChatGPTAccountID = claims.WorkspaceID()
 		info.UserID = firstNonEmptyTrimmed(claims.OpenAIAuth.UserID, claims.OpenAIAuth.ChatGPTUserID)
 		info.PlanType = claims.OpenAIAuth.PlanType
 		if s := claims.OpenAIAuth.ChatGPTSubscriptionActiveUntil; s != "" {
@@ -406,45 +380,8 @@ func firstNonEmptyTrimmed(values ...string) string {
 // ParseAccessToken 解析 Access Token 的 JWT payload（不验签）
 // AT 的 email 在 https://api.openai.com/profile 下，与 id_token 不同
 func ParseAccessToken(accessToken string) *AccessTokenInfo {
-	if accessToken == "" {
-		return nil
-	}
-
-	parts := strings.Split(accessToken, ".")
-	if len(parts) != 3 {
-		return nil
-	}
-
-	payload := parts[1]
-	switch len(payload) % 4 {
-	case 2:
-		payload += "=="
-	case 3:
-		payload += "="
-	}
-
-	decoded, err := base64.URLEncoding.DecodeString(payload)
+	claims, err := openaiidentity.ParseJWT(accessToken)
 	if err != nil {
-		decoded, err = base64.StdEncoding.DecodeString(payload)
-		if err != nil {
-			return nil
-		}
-	}
-
-	var claims struct {
-		Exp        int64 `json:"exp"`
-		OpenAIAuth *struct {
-			ChatGPTAccountID               string `json:"chatgpt_account_id"`
-			UserID                         string `json:"user_id"`
-			ChatGPTUserID                  string `json:"chatgpt_user_id"`
-			PlanType                       string `json:"chatgpt_plan_type"`
-			ChatGPTSubscriptionActiveUntil string `json:"chatgpt_subscription_active_until"`
-		} `json:"https://api.openai.com/auth"`
-		OpenAIProfile *struct {
-			Email string `json:"email"`
-		} `json:"https://api.openai.com/profile"`
-	}
-	if err := json.Unmarshal(decoded, &claims); err != nil {
 		return nil
 	}
 
@@ -453,7 +390,7 @@ func ParseAccessToken(accessToken string) *AccessTokenInfo {
 		info.Email = claims.OpenAIProfile.Email
 	}
 	if claims.OpenAIAuth != nil {
-		info.ChatGPTAccountID = claims.OpenAIAuth.ChatGPTAccountID
+		info.ChatGPTAccountID = claims.WorkspaceID()
 		info.UserID = firstNonEmptyTrimmed(claims.OpenAIAuth.UserID, claims.OpenAIAuth.ChatGPTUserID)
 		info.PlanType = claims.OpenAIAuth.PlanType
 		if s := claims.OpenAIAuth.ChatGPTSubscriptionActiveUntil; s != "" {
@@ -462,8 +399,8 @@ func ParseAccessToken(accessToken string) *AccessTokenInfo {
 			}
 		}
 	}
-	if claims.Exp > 0 {
-		info.ExpiresAt = time.Unix(claims.Exp, 0)
+	if claims.ExpiresAt > 0 {
+		info.ExpiresAt = time.Unix(claims.ExpiresAt, 0)
 	}
 	return info
 }

--- a/auth/token_parse_test.go
+++ b/auth/token_parse_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -45,6 +46,25 @@ func TestParseIDTokenMissingAuthClaim(t *testing.T) {
 	info := parseIDToken(jwt)
 	if info.PlanType != "" {
 		t.Fatalf("PlanType = %q, want empty", info.PlanType)
+	}
+}
+
+func TestParseIDTokenUsesProfileEmailFallback(t *testing.T) {
+	jwt := makeTestJWT(map[string]interface{}{
+		"https://api.openai.com/profile": map[string]interface{}{
+			"email": "profile@example.com",
+		},
+		"https://api.openai.com/auth": map[string]interface{}{
+			"chatgpt_account_id": "workspace-profile-email",
+		},
+	})
+
+	info := parseIDToken(jwt)
+	if info.Email != "profile@example.com" {
+		t.Fatalf("Email = %q, want profile@example.com", info.Email)
+	}
+	if info.ChatGPTAccountID != "workspace-profile-email" {
+		t.Fatalf("ChatGPTAccountID = %q, want workspace-profile-email", info.ChatGPTAccountID)
 	}
 }
 
@@ -103,6 +123,41 @@ func TestRefreshAccessTokenRejectsEmptyAccessToken(t *testing.T) {
 	}
 }
 
+func TestRefreshAccessTokenSupplementsWorkspaceFromAccessToken(t *testing.T) {
+	idToken := makeTestJWT(map[string]interface{}{
+		"email": "id@example.com",
+		"https://api.openai.com/auth": map[string]interface{}{
+			"chatgpt_plan_type":                 "pro",
+			"chatgpt_subscription_active_until": time.Now().Add(24 * time.Hour).UTC().Format(time.RFC3339),
+		},
+	})
+	accessToken := makeTestJWT(map[string]interface{}{
+		"exp":                            time.Now().Add(time.Hour).Unix(),
+		"https://api.openai.com/profile": map[string]interface{}{"email": "id@example.com"},
+		"https://api.openai.com/auth": map[string]interface{}{
+			"chatgpt_account_id": "workspace-from-at",
+			"chatgpt_plan_type":  "pro",
+		},
+	})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{"access_token":%q,"refresh_token":"rt-new","id_token":%q,"expires_in":3600}`, accessToken, idToken)
+	}))
+	defer server.Close()
+
+	oldDecorator := ResinRequestDecorator
+	ResinRequestDecorator = func(targetURL, accountID string) string { return server.URL }
+	defer func() { ResinRequestDecorator = oldDecorator }()
+
+	_, info, err := RefreshAccessToken(context.Background(), "rt-old", "", "account-1")
+	if err != nil {
+		t.Fatalf("RefreshAccessToken returned error: %v", err)
+	}
+	if info.ChatGPTAccountID != "workspace-from-at" {
+		t.Fatalf("ChatGPTAccountID = %q, want workspace-from-at", info.ChatGPTAccountID)
+	}
+}
+
 func TestRefreshTokenReusedIsNonRetryable(t *testing.T) {
 	reusedErr := errors.New(`刷新失败 (status 401): {"error":{"code":"refresh_token_reused"}}`)
 	if !isNonRetryable(reusedErr) {
@@ -154,7 +209,7 @@ func TestRefreshWithSessionToken(t *testing.T) {
 }
 
 // 个人账号 JWT 可能没有 chatgpt_account_id，只有 user_id；解析必须带出它，
-// 供 AT 导入按 email+user_id 做身份去重（重复导入问题）。
+// 供 AT 导入保存用户元数据；user_id 不再作为身份去重键。
 func TestParseAccessTokenExtractsUserID(t *testing.T) {
 	jwt := makeTestJWT(map[string]interface{}{
 		"exp": 9999999999,

--- a/database/data_migrations.go
+++ b/database/data_migrations.go
@@ -3,11 +3,14 @@ package database
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"log"
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/codex2api/internal/openaiidentity"
 )
 
 const (
@@ -18,8 +21,9 @@ const (
 	dataMigrationOAuthIdentityDedupeV2 = "20260702_oauth_identity_dedupe_v2"
 	// usage_logs.channel 回填：按 accounts.platform 推导渠道（xai→grok，其余→codex）；
 	// 账号已删的历史行默认 codex（Grok 上线前的流量全部是 codex）。
-	dataMigrationUsageLogChannelV1 = "20260721_usage_log_channel_backfill_v1"
-	dataMigrationTimeout           = 5 * time.Minute
+	dataMigrationUsageLogChannelV1   = "20260721_usage_log_channel_backfill_v1"
+	dataMigrationWorkspaceIdentityV3 = "20260722_workspace_identity_v3"
+	dataMigrationTimeout             = 5 * time.Minute
 )
 
 type oauthIdentityDedupeAccount struct {
@@ -41,7 +45,10 @@ func (db *DB) runDataMigrations(ctx context.Context) error {
 	if err := db.runDataMigrationOnce(ctx, dataMigrationOAuthIdentityDedupeV2, db.dedupeOAuthIdentityAccounts); err != nil {
 		return err
 	}
-	return db.runDataMigrationOnce(ctx, dataMigrationUsageLogChannelV1, db.backfillUsageLogChannel)
+	if err := db.runDataMigrationOnce(ctx, dataMigrationUsageLogChannelV1, db.backfillUsageLogChannel); err != nil {
+		return err
+	}
+	return db.runDataMigrationOnce(ctx, dataMigrationWorkspaceIdentityV3, db.migrateWorkspaceIdentityV3)
 }
 
 // backfillUsageLogChannel 给存量 usage_logs 回填 channel：先按现存账号的 platform
@@ -127,7 +134,126 @@ func (db *DB) dedupeOAuthIdentityAccounts(ctx context.Context, tx *sql.Tx) error
 	if err != nil {
 		return err
 	}
+	return db.dedupeIdentityAccounts(
+		ctx,
+		tx,
+		accounts,
+		oauthIdentityDedupeAliases,
+		"oauth_identity_dedupe_v1",
+		dataMigrationOAuthIdentityDedupeV1,
+	)
+}
 
+func (db *DB) migrateWorkspaceIdentityV3(ctx context.Context, tx *sql.Tx) error {
+	rows, err := tx.QueryContext(ctx, `
+		SELECT id, credentials
+		FROM accounts
+		WHERE type = 'oauth'
+		  AND status <> 'deleted'
+		  AND COALESCE(error_message, '') <> 'deleted'
+	`)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	type update struct {
+		id          int64
+		credentials map[string]interface{}
+	}
+	var updates []update
+	for rows.Next() {
+		var id int64
+		var raw interface{}
+		if err := rows.Scan(&id, &raw); err != nil {
+			return err
+		}
+		credentials := decodeCredentials(raw)
+		workspaceID := ""
+		email := ""
+		for _, tokenKey := range []string{"id_token", "access_token"} {
+			if token := credentialStringFromMap(credentials, tokenKey); token != "" {
+				if claims, parseErr := openaiidentity.ParseJWT(token); parseErr == nil {
+					if workspaceID == "" {
+						workspaceID = claims.WorkspaceID()
+					}
+					if email == "" {
+						email = strings.TrimSpace(claims.Email)
+						if email == "" && claims.OpenAIProfile != nil {
+							email = strings.TrimSpace(claims.OpenAIProfile.Email)
+						}
+					}
+					if workspaceID != "" && email != "" {
+						break
+					}
+				}
+			}
+		}
+		storedWorkspaceID := openaiidentity.NormalizeWorkspaceID(credentialStringFromMap(credentials, "workspace_id"))
+		storedEmail := strings.TrimSpace(credentialStringFromMap(credentials, "email"))
+		// 迁移只补充 JWT 能确认的 workspace_id；解析不到时保留历史值，
+		// 包括 user-* 等旧字段，避免扩大迁移的修改范围。
+		workspaceNeedsUpdate := workspaceID != "" && workspaceID != storedWorkspaceID
+		if !workspaceNeedsUpdate && (email == "" || storedEmail != "") {
+			continue
+		}
+		if workspaceNeedsUpdate {
+			credentials["workspace_id"] = workspaceID
+		}
+		if storedEmail == "" && email != "" {
+			credentials["email"] = email
+		}
+		updates = append(updates, update{id: id, credentials: credentials})
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	for _, item := range updates {
+		encoded, err := json.Marshal(item.credentials)
+		if err != nil {
+			return fmt.Errorf("序列化账号 %d credentials 失败: %w", item.id, err)
+		}
+		// 回填不刷新 updated_at，避免迁移改变重复账号的胜出顺序。
+		query := `UPDATE accounts SET credentials = $1 WHERE id = $2`
+		if !db.isSQLite() {
+			query = `UPDATE accounts SET credentials = $1::jsonb WHERE id = $2`
+		}
+		if _, err := tx.ExecContext(ctx, query, encoded, item.id); err != nil {
+			return fmt.Errorf("回填账号 %d workspace_id 失败: %w", item.id, err)
+		}
+	}
+	if err := db.dedupeWorkspaceIdentityAccounts(ctx, tx); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, oauthIdentityUniqueIndexSQL(db.isSQLite())); err != nil {
+		return fmt.Errorf("创建 OAuth 身份唯一索引失败: %w", err)
+	}
+	return nil
+}
+
+func (db *DB) dedupeWorkspaceIdentityAccounts(ctx context.Context, tx *sql.Tx) error {
+	accounts, err := db.listWorkspaceIdentityDedupeAccounts(ctx, tx)
+	if err != nil {
+		return err
+	}
+	return db.dedupeIdentityAccounts(
+		ctx,
+		tx,
+		accounts,
+		workspaceIdentityDedupeAliases,
+		"workspace_identity_v3",
+		dataMigrationWorkspaceIdentityV3,
+	)
+}
+
+func (db *DB) dedupeIdentityAccounts(
+	ctx context.Context,
+	tx *sql.Tx,
+	accounts []oauthIdentityDedupeAccount,
+	aliasesFor func(map[string]interface{}) []string,
+	eventSource string,
+	migrationVersion string,
+) error {
 	parent := make([]int, len(accounts))
 	eligible := make([]bool, len(accounts))
 	for i := range parent {
@@ -150,7 +276,7 @@ func (db *DB) dedupeOAuthIdentityAccounts(ctx context.Context, tx *sql.Tx) error
 
 	aliasOwner := make(map[string]int)
 	for i, account := range accounts {
-		aliases := oauthIdentityDedupeAliases(account.credentials)
+		aliases := aliasesFor(account.credentials)
 		if len(aliases) == 0 {
 			continue
 		}
@@ -194,19 +320,31 @@ func (db *DB) dedupeOAuthIdentityAccounts(ctx context.Context, tx *sql.Tx) error
 	if err := softDeleteAccountsTx(ctx, tx, loserIDs); err != nil {
 		return err
 	}
-	if err := insertAccountEventsTx(ctx, tx, loserIDs, "deleted", "oauth_identity_dedupe_v1"); err != nil {
+	if err := insertAccountEventsTx(ctx, tx, loserIDs, "deleted", eventSource); err != nil {
 		return err
 	}
-	log.Printf("[data_migration] %s: 发现 %d 组重复 OAuth 身份，已软删除 %d 个重复账号", dataMigrationOAuthIdentityDedupeV1, duplicateGroups, len(loserIDs))
+	log.Printf("[data_migration] %s: 发现 %d 组重复 OAuth 身份，已软删除 %d 个重复账号", migrationVersion, duplicateGroups, len(loserIDs))
 	return nil
 }
 
 func (db *DB) listOAuthIdentityDedupeAccounts(ctx context.Context, tx *sql.Tx) ([]oauthIdentityDedupeAccount, error) {
-	rows, err := tx.QueryContext(ctx, `
+	return db.listOAuthIdentityDedupeAccountsFiltered(ctx, tx, false)
+}
+
+func (db *DB) listWorkspaceIdentityDedupeAccounts(ctx context.Context, tx *sql.Tx) ([]oauthIdentityDedupeAccount, error) {
+	return db.listOAuthIdentityDedupeAccountsFiltered(ctx, tx, true)
+}
+
+func (db *DB) listOAuthIdentityDedupeAccountsFiltered(ctx context.Context, tx *sql.Tx, onlyOAuth bool) ([]oauthIdentityDedupeAccount, error) {
+	query := `
 		SELECT id, credentials, COALESCE(enabled, true), COALESCE(locked, false), created_at, updated_at
 		FROM accounts
 		WHERE status <> 'deleted' AND COALESCE(error_message, '') <> 'deleted'
-	`)
+	`
+	if onlyOAuth {
+		query += ` AND type = 'oauth'`
+	}
+	rows, err := tx.QueryContext(ctx, query)
 	if err != nil {
 		return nil, err
 	}
@@ -271,6 +409,18 @@ func oauthIdentityDedupeAliases(credentials map[string]interface{}) []string {
 	}
 	sort.Strings(aliases)
 	return aliases
+}
+
+func workspaceIdentityDedupeAliases(credentials map[string]interface{}) []string {
+	email := strings.ToLower(strings.TrimSpace(credentialStringFromMap(credentials, "email")))
+	if email == "" {
+		return nil
+	}
+	workspaceID := openaiidentity.NormalizeWorkspaceID(credentialStringFromMap(credentials, "workspace_id"))
+	if workspaceID == "" {
+		return nil
+	}
+	return []string{email + "\x00" + workspaceID}
 }
 
 func credentialStringFromMap(credentials map[string]interface{}, key string) string {

--- a/database/helpers.go
+++ b/database/helpers.go
@@ -349,7 +349,7 @@ func (db *DB) insertRowID(ctx context.Context, postgresQuery string, sqliteQuery
 	if db.isSQLite() {
 		res, err := db.conn.ExecContext(ctx, sqliteQuery, args...)
 		if err != nil {
-			return 0, err
+			return 0, wrapOAuthIdentityConstraintError(err)
 		}
 		affected, err := res.RowsAffected()
 		if err == nil && affected == 0 {
@@ -360,7 +360,7 @@ func (db *DB) insertRowID(ctx context.Context, postgresQuery string, sqliteQuery
 
 	var id int64
 	err := db.conn.QueryRowContext(ctx, postgresQuery, args...).Scan(&id)
-	return id, err
+	return id, wrapOAuthIdentityConstraintError(err)
 }
 
 // decodeInt64SliceValue parses a JSON array of integers from a JSONB or TEXT column.

--- a/database/oauth_identity.go
+++ b/database/oauth_identity.go
@@ -1,0 +1,58 @@
+package database
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/lib/pq"
+)
+
+const oauthIdentityUniqueIndexName = "idx_accounts_oauth_identity_active"
+
+// ErrDuplicateOAuthIdentity indicates that an active OAuth account already
+// owns the same normalized email + workspace_id identity.
+var ErrDuplicateOAuthIdentity = errors.New("duplicate oauth identity")
+
+func oauthIdentityEmailExpr(isSQLite bool) string {
+	if isSQLite {
+		return `lower(trim(CASE WHEN json_valid(credentials) THEN COALESCE(json_extract(credentials, '$.email'), '') ELSE '' END))`
+	}
+	return `lower(trim(COALESCE(credentials->>'email', '')))`
+}
+
+func oauthIdentityWorkspaceExpr(isSQLite bool) string {
+	if isSQLite {
+		return `trim(CASE WHEN json_valid(credentials) THEN COALESCE(json_extract(credentials, '$.workspace_id'), '') ELSE '' END)`
+	}
+	return `trim(COALESCE(credentials->>'workspace_id', ''))`
+}
+
+func oauthIdentityUniqueIndexSQL(isSQLite bool) string {
+	emailExpr := oauthIdentityEmailExpr(isSQLite)
+	workspaceExpr := oauthIdentityWorkspaceExpr(isSQLite)
+	return fmt.Sprintf(`
+		CREATE UNIQUE INDEX IF NOT EXISTS %s
+		ON accounts (%s, %s)
+		WHERE type = 'oauth'
+		  AND status <> 'deleted'
+		  AND COALESCE(error_message, '') <> 'deleted'
+		  AND %s <> ''
+		  AND %s <> ''
+		  AND lower(%s) NOT LIKE 'user-%%'
+	`, oauthIdentityUniqueIndexName, emailExpr, workspaceExpr, emailExpr, workspaceExpr, workspaceExpr)
+}
+
+func wrapOAuthIdentityConstraintError(err error) error {
+	if err == nil {
+		return nil
+	}
+	var pqErr *pq.Error
+	if errors.As(err, &pqErr) && pqErr.Constraint == oauthIdentityUniqueIndexName {
+		return fmt.Errorf("%w: %v", ErrDuplicateOAuthIdentity, err)
+	}
+	if strings.Contains(strings.ToLower(err.Error()), strings.ToLower(oauthIdentityUniqueIndexName)) {
+		return fmt.Errorf("%w: %v", ErrDuplicateOAuthIdentity, err)
+	}
+	return err
+}

--- a/database/postgres.go
+++ b/database/postgres.go
@@ -15,6 +15,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/codex2api/internal/openaiidentity"
 	"github.com/lib/pq"
 	_ "modernc.org/sqlite"
 )
@@ -2559,7 +2560,7 @@ func (db *DB) InsertUsageLog(ctx context.Context, log *UsageLogInput) error {
 
 // UsageLogInput 日志写入参数
 type UsageLogInput struct {
-	AccountID            int64
+	AccountID int64
 	// Channel 是处理该请求的上游渠道（codex/grok），写入时固化，空值表示未知。
 	Channel              string
 	ClientIP             string
@@ -5164,7 +5165,7 @@ func (db *DB) updateCredentialsReadMerge(ctx context.Context, id int64, credenti
 		updateQuery = `UPDATE accounts SET credentials = $1::jsonb, updated_at = CURRENT_TIMESTAMP WHERE id = $2`
 	}
 	if _, err := tx.ExecContext(ctx, updateQuery, credJSON, id); err != nil {
-		return err
+		return wrapOAuthIdentityConstraintError(err)
 	}
 	return tx.Commit()
 }
@@ -5198,7 +5199,7 @@ func (db *DB) updateCredentialsSQLite(ctx context.Context, id int64, credentials
 		)
 		res, err := db.conn.ExecContext(ctx, query, args...)
 		if err != nil {
-			return err
+			return wrapOAuthIdentityConstraintError(err)
 		}
 		affected, err := res.RowsAffected()
 		if err != nil {
@@ -5229,7 +5230,7 @@ func (db *DB) updateCredentialsReadMergeSQLite(ctx context.Context, id int64, cr
 		return fmt.Errorf("序列化 credentials 失败: %w", err)
 	}
 	if _, err := tx.ExecContext(ctx, `UPDATE accounts SET credentials = $1, updated_at = CURRENT_TIMESTAMP WHERE id = $2`, credJSON, id); err != nil {
-		return err
+		return wrapOAuthIdentityConstraintError(err)
 	}
 	return tx.Commit()
 }
@@ -5317,7 +5318,7 @@ func (db *DB) UpdateOAuthAccountCredentials(ctx context.Context, id int64, crede
 	}
 	res, err := tx.ExecContext(ctx, updateQuery, credJSON, proxyURL, id)
 	if err != nil {
-		return err
+		return wrapOAuthIdentityConstraintError(err)
 	}
 	affected, err := res.RowsAffected()
 	if err != nil {
@@ -5510,7 +5511,7 @@ func (db *DB) RestoreAccount(ctx context.Context, id int64) error {
 	`
 	res, err := db.conn.ExecContext(ctx, query, id)
 	if err != nil {
-		return err
+		return wrapOAuthIdentityConstraintError(err)
 	}
 	affected, err := res.RowsAffected()
 	if err != nil {
@@ -5625,6 +5626,36 @@ func (db *DB) ClearError(ctx context.Context, id int64) error {
 		_, err := db.conn.ExecContext(ctx, query, id)
 		return err
 	})
+}
+
+// ClearErrorIfErrorOrUnauthorized clears only an account that is currently in
+// an error state without another cooldown, or in an unauthorized cooldown.
+// A newer rate-limited or unrelated cooldown is left untouched.
+func (db *DB) ClearErrorIfErrorOrUnauthorized(ctx context.Context, id int64) (bool, error) {
+	var cleared bool
+	err := db.withSQLiteWriteLock(ctx, func() error {
+		result, err := db.conn.ExecContext(ctx, `
+			UPDATE accounts
+			SET status = 'active', error_message = '', cooldown_reason = '', cooldown_until = NULL, updated_at = CURRENT_TIMESTAMP
+			WHERE id = $1
+			  AND status <> 'deleted'
+			  AND COALESCE(error_message, '') <> 'deleted'
+			  AND (
+					(lower(trim(COALESCE(status, ''))) = 'error' AND trim(COALESCE(cooldown_reason, '')) = '')
+					OR lower(trim(COALESCE(cooldown_reason, ''))) = 'unauthorized'
+				  )
+		`, id)
+		if err != nil {
+			return err
+		}
+		affected, err := result.RowsAffected()
+		if err != nil {
+			return err
+		}
+		cleared = affected > 0
+		return nil
+	})
+	return cleared, err
 }
 
 // SetCooldown 持久化账号冷却状态
@@ -5812,8 +5843,7 @@ func (db *DB) GetAllAccessTokens(ctx context.Context) (map[string]bool, error) {
 	return result, rows.Err()
 }
 
-// GetAllChatGPTAccountIDs 获取所有已存在的 chatgpt_account_id（用于导入去重，排除已删除账号）。
-// 兼容历史字段名：account_id / chatgpt_account_id。
+// GetAllChatGPTAccountIDs 获取所有已存在的 workspace_id（用于导入去重，排除已删除账号）。
 func (db *DB) GetAllChatGPTAccountIDs(ctx context.Context) (map[string]bool, error) {
 	rows, err := db.conn.QueryContext(ctx, `SELECT credentials FROM accounts WHERE status <> 'deleted' AND COALESCE(error_message, '') <> 'deleted'`)
 	if err != nil {
@@ -5827,11 +5857,7 @@ func (db *DB) GetAllChatGPTAccountIDs(ctx context.Context) (map[string]bool, err
 		if err := rows.Scan(&raw); err != nil {
 			return nil, err
 		}
-		if id := strings.TrimSpace(credentialString(raw, "chatgpt_account_id")); id != "" {
-			result[id] = true
-			continue
-		}
-		if id := strings.TrimSpace(credentialString(raw, "account_id")); id != "" {
+		if id := openaiidentity.NormalizeWorkspaceID(credentialString(raw, "workspace_id")); id != "" {
 			result[id] = true
 		}
 	}
@@ -5839,59 +5865,45 @@ func (db *DB) GetAllChatGPTAccountIDs(ctx context.Context) (map[string]bool, err
 }
 
 // FindActiveAccountByOAuthIdentity returns the first non-deleted account with
-// the same email and OAuth identity. The identity matches when either the
-// ChatGPT workspace id (credential keys account_id / chatgpt_account_id) or
-// the OpenAI user id (credential key user_id, "user-...") equals accountID —
-// personal-plan JWTs may lack a workspace id, and legacy rows may have had
-// account_id polluted with a user_id by the old wham backfill, so matching
-// user_id against account_id keys (and vice versa) keeps dedup working for
-// both shapes.
-func (db *DB) FindActiveAccountByOAuthIdentity(ctx context.Context, email, accountID string, excludeIDs ...int64) (int64, error) {
+// the same normalized email and non-empty workspace_id. A missing workspace
+// id is intentionally not an OAuth identity and must not match another row.
+func (db *DB) FindActiveAccountByOAuthIdentity(ctx context.Context, email, workspaceID string, excludeIDs ...int64) (int64, error) {
 	email = strings.ToLower(strings.TrimSpace(email))
-	accountID = strings.TrimSpace(accountID)
-	if email == "" || accountID == "" {
+	workspaceID = strings.TrimSpace(workspaceID)
+	if email == "" || workspaceID == "" || strings.HasPrefix(strings.ToLower(workspaceID), "user-") {
 		return 0, sql.ErrNoRows
 	}
-	excluded := make(map[int64]struct{}, len(excludeIDs))
+	emailExpr := oauthIdentityEmailExpr(db.isSQLite())
+	workspaceExpr := oauthIdentityWorkspaceExpr(db.isSQLite())
+	clauses := []string{
+		"type = 'oauth'",
+		"status <> 'deleted'",
+		"COALESCE(error_message, '') <> 'deleted'",
+		emailExpr + " <> ''",
+		workspaceExpr + " <> ''",
+		"lower(" + workspaceExpr + ") NOT LIKE 'user-%'",
+		fmt.Sprintf("%s = $1", emailExpr),
+		fmt.Sprintf("%s = $2", workspaceExpr),
+	}
+	args := []interface{}{email, workspaceID}
+	var excluded []string
 	for _, id := range excludeIDs {
-		if id > 0 {
-			excluded[id] = struct{}{}
+		if id <= 0 {
+			continue
 		}
+		args = append(args, id)
+		excluded = append(excluded, fmt.Sprintf("$%d", len(args)))
+	}
+	if len(excluded) > 0 {
+		clauses = append(clauses, "id NOT IN ("+strings.Join(excluded, ",")+")")
 	}
 
-	rows, err := db.conn.QueryContext(ctx, `SELECT id, credentials FROM accounts WHERE status <> 'deleted' AND COALESCE(error_message, '') <> 'deleted'`)
-	if err != nil {
+	query := `SELECT id FROM accounts WHERE ` + strings.Join(clauses, " AND ") + ` ORDER BY id LIMIT 1`
+	var id int64
+	if err := db.conn.QueryRowContext(ctx, query, args...).Scan(&id); err != nil {
 		return 0, err
 	}
-	defer rows.Close()
-
-	for rows.Next() {
-		var id int64
-		var raw interface{}
-		if err := rows.Scan(&id, &raw); err != nil {
-			return 0, err
-		}
-		if _, ok := excluded[id]; ok {
-			continue
-		}
-		// 勾选"允许重复添加"强制导入的副本不作为判重锚点：后续正常导入
-		// 应命中/更新主账号，而不是把凭证写进用户故意保留的副本。
-		if strings.EqualFold(strings.TrimSpace(credentialString(raw, "allow_duplicate")), "true") {
-			continue
-		}
-		if strings.ToLower(strings.TrimSpace(credentialString(raw, "email"))) != email {
-			continue
-		}
-		if strings.TrimSpace(credentialString(raw, "account_id")) == accountID ||
-			strings.TrimSpace(credentialString(raw, "chatgpt_account_id")) == accountID ||
-			strings.TrimSpace(credentialString(raw, "user_id")) == accountID {
-			return id, nil
-		}
-	}
-	if err := rows.Err(); err != nil {
-		return 0, err
-	}
-	return 0, sql.ErrNoRows
+	return id, nil
 }
 
 func (db *DB) GetAllOpenAIAPIKeys(ctx context.Context) (map[string]bool, error) {

--- a/database/sqlite_test.go
+++ b/database/sqlite_test.go
@@ -3,6 +3,9 @@ package database
 import (
 	"context"
 	"database/sql"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"path/filepath"
@@ -11,6 +14,15 @@ import (
 	"testing"
 	"time"
 )
+
+func databaseTestJWT(t *testing.T, claims map[string]interface{}) string {
+	t.Helper()
+	payload, err := json.Marshal(claims)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	return "header." + base64.RawURLEncoding.EncodeToString(payload) + ".signature"
+}
 
 func TestNewSQLiteInitializesFreshDatabase(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "codex2api.db")
@@ -192,9 +204,9 @@ func TestFindActiveAccountByOAuthIdentity(t *testing.T) {
 
 	ctx := context.Background()
 	id, err := db.InsertAccountWithCredentials(ctx, "identity", map[string]interface{}{
-		"refresh_token":      "rt-identity",
-		"email":              "User@Example.COM",
-		"chatgpt_account_id": "acc-identity",
+		"refresh_token": "rt-identity",
+		"email":         "User@Example.COM",
+		"workspace_id":  "acc-identity",
 	}, "")
 	if err != nil {
 		t.Fatalf("InsertAccountWithCredentials 返回错误: %v", err)
@@ -208,10 +220,15 @@ func TestFindActiveAccountByOAuthIdentity(t *testing.T) {
 		t.Fatalf("matched id = %d, want %d", got, id)
 	}
 
+	// This test exercises lookup/exclusion behavior with legacy duplicate data;
+	// production writes are protected by the OAuth identity index.
+	if _, err := db.conn.ExecContext(ctx, `DROP INDEX IF EXISTS idx_accounts_oauth_identity_active`); err != nil {
+		t.Fatalf("drop OAuth identity index: %v", err)
+	}
 	otherID, err := db.InsertAccountWithCredentials(ctx, "identity-other", map[string]interface{}{
 		"refresh_token": "rt-identity-other",
 		"email":         "user@example.com",
-		"account_id":    "acc-identity",
+		"workspace_id":  "acc-identity",
 	}, "")
 	if err != nil {
 		t.Fatalf("InsertAccountWithCredentials other 返回错误: %v", err)
@@ -237,10 +254,196 @@ func TestFindActiveAccountByOAuthIdentity(t *testing.T) {
 	}
 }
 
-// 个人账号 JWT 可能没有工作区 account_id，只有 user_id（user-...）；此外旧版
-// wham 回填曾把 user_id 写进 account_id 字段。身份匹配必须两个键都认，
-// 否则 AT 轮换后同一账号会被重复导入。
-func TestFindActiveAccountByOAuthIdentityMatchesUserID(t *testing.T) {
+func TestSQLiteOAuthIdentityLookupUsesUniqueIndex(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "codex2api.db")
+	db, err := New("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("New sqlite: %v", err)
+	}
+	defer db.Close()
+
+	emailExpr := oauthIdentityEmailExpr(true)
+	workspaceExpr := oauthIdentityWorkspaceExpr(true)
+	query := fmt.Sprintf(`
+		EXPLAIN QUERY PLAN
+		SELECT id FROM accounts
+		WHERE type = 'oauth'
+		  AND status <> 'deleted'
+		  AND COALESCE(error_message, '') <> 'deleted'
+		  AND %s <> ''
+		  AND %s <> ''
+		  AND lower(%s) NOT LIKE 'user-%%'
+		  AND %s = $1
+		  AND %s = $2
+		ORDER BY id LIMIT 1
+	`, emailExpr, workspaceExpr, workspaceExpr, emailExpr, workspaceExpr)
+	rows, err := db.conn.QueryContext(context.Background(), query, "lookup@example.com", "workspace-lookup")
+	if err != nil {
+		t.Fatalf("EXPLAIN QUERY PLAN: %v", err)
+	}
+	defer rows.Close()
+
+	usedIndex := false
+	for rows.Next() {
+		var id, parent, unused int
+		var detail string
+		if err := rows.Scan(&id, &parent, &unused, &detail); err != nil {
+			t.Fatalf("scan query plan: %v", err)
+		}
+		if strings.Contains(detail, oauthIdentityUniqueIndexName) {
+			usedIndex = true
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("query plan rows: %v", err)
+	}
+	if !usedIndex {
+		t.Fatalf("OAuth identity lookup did not use %s", oauthIdentityUniqueIndexName)
+	}
+}
+
+func TestSQLiteOAuthIdentityIndexRejectsConcurrentDuplicateInserts(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "codex2api.db")
+	db1, err := New("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("New sqlite db1: %v", err)
+	}
+	defer db1.Close()
+	db2, err := New("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("New sqlite db2: %v", err)
+	}
+	defer db2.Close()
+
+	ctx := context.Background()
+	start := make(chan struct{})
+	results := make(chan error, 2)
+	insert := func(db *DB, token string) {
+		<-start
+		_, err := db.InsertAccountWithCredentials(ctx, "concurrent", map[string]interface{}{
+			"access_token": token,
+			"email":        "concurrent@example.com",
+			"workspace_id": "workspace-concurrent-index",
+		}, "")
+		results <- err
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() { defer wg.Done(); insert(db1, "at-1") }()
+	go func() { defer wg.Done(); insert(db2, "at-2") }()
+	close(start)
+	wg.Wait()
+	close(results)
+
+	successes := 0
+	duplicates := 0
+	for err := range results {
+		if err == nil {
+			successes++
+		} else if errors.Is(err, ErrDuplicateOAuthIdentity) {
+			duplicates++
+		} else {
+			t.Fatalf("concurrent insert error = %v", err)
+		}
+	}
+	if successes != 1 || duplicates != 1 {
+		t.Fatalf("concurrent inserts = successes %d, duplicates %d; want 1/1", successes, duplicates)
+	}
+}
+
+func TestSQLiteOAuthIdentityIndexRejectsConflictingCredentialUpdate(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "codex2api.db")
+	db, err := New("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("New sqlite: %v", err)
+	}
+	defer db.Close()
+
+	ctx := context.Background()
+	if _, err := db.InsertAccountWithCredentials(ctx, "existing", map[string]interface{}{
+		"access_token": "at-existing",
+		"email":        "update-conflict@example.com",
+		"workspace_id": "workspace-update-conflict",
+	}, ""); err != nil {
+		t.Fatalf("Insert existing: %v", err)
+	}
+	newID, err := db.InsertAccountWithCredentials(ctx, "unknown", map[string]interface{}{
+		"access_token": "at-unknown",
+	}, "")
+	if err != nil {
+		t.Fatalf("Insert unknown: %v", err)
+	}
+
+	err = db.UpdateCredentials(ctx, newID, map[string]interface{}{
+		"email":        "Update-Conflict@Example.com",
+		"workspace_id": "workspace-update-conflict",
+	})
+	if !errors.Is(err, ErrDuplicateOAuthIdentity) {
+		t.Fatalf("UpdateCredentials err = %v, want ErrDuplicateOAuthIdentity", err)
+	}
+	row, err := db.GetAccountByID(ctx, newID)
+	if err != nil {
+		t.Fatalf("GetAccountByID: %v", err)
+	}
+	if got := row.GetCredential("workspace_id"); got != "" {
+		t.Fatalf("workspace_id = %q, want atomic rollback", got)
+	}
+}
+
+func TestSQLiteOAuthIdentityIndexRejectsConflictingRestore(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "codex2api.db")
+	db, err := New("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("New sqlite: %v", err)
+	}
+	defer db.Close()
+
+	ctx := context.Background()
+	if _, err := db.InsertAccountWithCredentials(ctx, "active", map[string]interface{}{
+		"refresh_token": "rt-active",
+		"email":         "restore-conflict@example.com",
+		"workspace_id":  "workspace-restore-conflict",
+	}, ""); err != nil {
+		t.Fatalf("Insert active: %v", err)
+	}
+	deletedID, err := db.InsertAccountWithCredentials(ctx, "deleted", map[string]interface{}{
+		"refresh_token": "rt-deleted",
+	}, "")
+	if err != nil {
+		t.Fatalf("Insert deleted: %v", err)
+	}
+	if err := db.SoftDeleteAccount(ctx, deletedID); err != nil {
+		t.Fatalf("SoftDeleteAccount: %v", err)
+	}
+	if err := db.UpdateCredentials(ctx, deletedID, map[string]interface{}{
+		"email":        "Restore-Conflict@Example.com",
+		"workspace_id": "workspace-restore-conflict",
+	}); err != nil {
+		t.Fatalf("Update deleted identity: %v", err)
+	}
+
+	if err := db.RestoreAccount(ctx, deletedID); !errors.Is(err, ErrDuplicateOAuthIdentity) {
+		t.Fatalf("RestoreAccount err = %v, want ErrDuplicateOAuthIdentity", err)
+	}
+	deletedRows, err := db.ListDeleted(ctx)
+	if err != nil {
+		t.Fatalf("ListDeleted: %v", err)
+	}
+	found := false
+	for _, row := range deletedRows {
+		if row.ID == deletedID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("deleted account %d should remain in recycle bin", deletedID)
+	}
+}
+
+// 缺少 workspace_id 时不按 user_id 或历史 account_id 污染值进行身份匹配。
+func TestFindActiveAccountByOAuthIdentityIgnoresUserID(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "codex2api.db")
 
 	db, err := New("sqlite", dbPath)
@@ -251,7 +454,7 @@ func TestFindActiveAccountByOAuthIdentityMatchesUserID(t *testing.T) {
 
 	ctx := context.Background()
 
-	// 账号 A：credentials 里存的是 user_id 键
+	// 账号 A：只有 user_id，不应成为 OAuth 身份键。
 	idA, err := db.InsertAccountWithCredentials(ctx, "uid-key", map[string]interface{}{
 		"access_token": "at-uid-key",
 		"email":        "solo@example.com",
@@ -260,30 +463,24 @@ func TestFindActiveAccountByOAuthIdentityMatchesUserID(t *testing.T) {
 	if err != nil {
 		t.Fatalf("InsertAccountWithCredentials A 返回错误: %v", err)
 	}
-	got, err := db.FindActiveAccountByOAuthIdentity(ctx, "solo@example.com", "user-abc123")
-	if err != nil {
-		t.Fatalf("match by user_id key 返回错误: %v", err)
-	}
-	if got != idA {
-		t.Fatalf("matched id = %d, want %d", got, idA)
+	if _, err := db.FindActiveAccountByOAuthIdentity(ctx, "solo@example.com", "user-abc123"); err != sql.ErrNoRows {
+		t.Fatalf("match by user_id key err = %v, want sql.ErrNoRows", err)
 	}
 
-	// 账号 B：旧版 wham 回填把 user_id 污染进了 account_id 字段
+	// 账号 B：旧版污染的 account_id 也不应成为新身份键。
 	idB, err := db.InsertAccountWithCredentials(ctx, "polluted", map[string]interface{}{
 		"access_token": "at-polluted",
 		"email":        "legacy@example.com",
-		"account_id":   "user-def456", // 实为 user_id
+		"account_id":   "user-def456", // 历史 user_id 污染
 	}, "")
 	if err != nil {
 		t.Fatalf("InsertAccountWithCredentials B 返回错误: %v", err)
 	}
-	got, err = db.FindActiveAccountByOAuthIdentity(ctx, "legacy@example.com", "user-def456")
-	if err != nil {
-		t.Fatalf("match polluted account_id 返回错误: %v", err)
+	if _, err = db.FindActiveAccountByOAuthIdentity(ctx, "legacy@example.com", "user-def456"); err != sql.ErrNoRows {
+		t.Fatalf("match polluted account_id err = %v, want sql.ErrNoRows", err)
 	}
-	if got != idB {
-		t.Fatalf("matched id = %d, want %d", got, idB)
-	}
+	_ = idA
+	_ = idB
 }
 
 // v2 迁移：user_id 也是身份别名——个人账号（credentials 只有 user_id）和被旧版
@@ -352,11 +549,211 @@ func TestSQLiteDataMigrationV2DedupesByUserID(t *testing.T) {
 		t.Fatal("allow_duplicate 副本被迁移误删，应保留")
 	}
 
-	// 强制副本也不作为身份判重锚点：按身份查找应命中主账号而非副本
-	if got, err := db.FindActiveAccountByOAuthIdentity(ctx, "solo@example.com", "user-dup999"); err != nil {
-		t.Fatalf("FindActiveAccountByOAuthIdentity 返回错误: %v", err)
-	} else if got == forcedID {
-		t.Fatal("身份判重不应命中 allow_duplicate 副本")
+	// 新的运行时身份键不再把 user_id 当作 workspace_id。
+	if _, err := db.FindActiveAccountByOAuthIdentity(ctx, "solo@example.com", "user-dup999"); err != sql.ErrNoRows {
+		t.Fatalf("user_id 身份查询 err = %v, want sql.ErrNoRows", err)
+	}
+}
+
+// 缺少 workspace_id 的账号不会因 user_id 或历史 account_id 值被 v3 迁移合并。
+func TestSQLiteWorkspaceMigrationDoesNotDedupeWithoutWorkspaceID(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "codex2api.db")
+	ctx := context.Background()
+
+	db, err := New("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("New(sqlite) 返回错误: %v", err)
+	}
+	defer db.Close()
+
+	if _, err := db.conn.ExecContext(ctx, `DELETE FROM data_migrations WHERE version = $1`, dataMigrationWorkspaceIdentityV3); err != nil {
+		t.Fatalf("清理 workspace migration 标记返回错误: %v", err)
+	}
+
+	pollutedID, err := db.InsertAccountWithCredentials(ctx, "polluted", map[string]interface{}{
+		"access_token": "at-old-rotation",
+		"email":        "solo@example.com",
+		"account_id":   "user-dup999",
+	}, "")
+	if err != nil {
+		t.Fatalf("Insert polluted 返回错误: %v", err)
+	}
+	freshID, err := db.InsertAccountWithCredentials(ctx, "fresh", map[string]interface{}{
+		"access_token": "at-new-rotation",
+		"email":        "solo@example.com",
+		"user_id":      "user-dup999",
+	}, "")
+	if err != nil {
+		t.Fatalf("Insert fresh 返回错误: %v", err)
+	}
+
+	if err := db.runDataMigrationsWithTimeout(); err != nil {
+		t.Fatalf("runDataMigrations 返回错误: %v", err)
+	}
+
+	var remaining int
+	if err := db.conn.QueryRowContext(ctx, `SELECT COUNT(*) FROM accounts WHERE id IN ($1, $2) AND status <> 'deleted' AND COALESCE(error_message, '') <> 'deleted'`, pollutedID, freshID).Scan(&remaining); err != nil {
+		t.Fatalf("查询存活账号数返回错误: %v", err)
+	}
+	if remaining != 2 {
+		t.Fatalf("v3 迁移后存活账号 = %d, want 2（空 workspace_id 允许重复）", remaining)
+	}
+}
+
+func TestSQLiteWorkspaceMigrationBackfillsOnlyJWTWorkspaceID(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "codex2api.db")
+	ctx := context.Background()
+	db, err := New("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("New(sqlite) 返回错误: %v", err)
+	}
+	defer db.Close()
+
+	idToken := databaseTestJWT(t, map[string]interface{}{
+		"email": "migrate@example.com",
+		"https://api.openai.com/auth": map[string]interface{}{
+			"chatgpt_account_id": "workspace-from-jwt",
+			"user_id":            "user-not-workspace",
+		},
+	})
+	id, err := db.InsertAccountWithCredentials(ctx, "legacy", map[string]interface{}{
+		"id_token":      idToken,
+		"account_id":    "user-not-workspace",
+		"refresh_token": "rt-migrate",
+	}, "")
+	if err != nil {
+		t.Fatalf("InsertAccountWithCredentials: %v", err)
+	}
+	nonOAuthID, err := db.InsertAccountWithUpstream(ctx, "non-oauth", "openai", "api", map[string]interface{}{
+		"id_token": idToken,
+	}, "")
+	if err != nil {
+		t.Fatalf("InsertAccountWithUpstream: %v", err)
+	}
+	if _, err := db.conn.ExecContext(ctx, `DELETE FROM data_migrations WHERE version = $1`, dataMigrationWorkspaceIdentityV3); err != nil {
+		t.Fatalf("清理 workspace migration 标记: %v", err)
+	}
+	if err := db.runDataMigrationsWithTimeout(); err != nil {
+		t.Fatalf("runDataMigrations: %v", err)
+	}
+
+	row, err := db.GetAccountByID(ctx, id)
+	if err != nil {
+		t.Fatalf("GetAccountByID: %v", err)
+	}
+	if got := row.GetCredential("workspace_id"); got != "workspace-from-jwt" {
+		t.Fatalf("workspace_id = %q, want workspace-from-jwt", got)
+	}
+	if got := row.GetCredential("email"); got != "migrate@example.com" {
+		t.Fatalf("email = %q, want migrate@example.com", got)
+	}
+	if got := row.GetCredential("account_id"); got != "user-not-workspace" {
+		t.Fatalf("legacy account_id = %q, want preserved for compatibility", got)
+	}
+	if got, err := db.FindActiveAccountByOAuthIdentity(ctx, "MIGRATE@example.com", "workspace-from-jwt"); err != nil || got != id {
+		t.Fatalf("FindActiveAccountByOAuthIdentity = (%d, %v), want (%d, nil)", got, err, id)
+	}
+	nonOAuthRow, err := db.GetAccountByID(ctx, nonOAuthID)
+	if err != nil {
+		t.Fatalf("GetAccountByID(non-OAuth): %v", err)
+	}
+	if got := nonOAuthRow.GetCredential("workspace_id"); got != "" {
+		t.Fatalf("non-OAuth workspace_id = %q, want unchanged", got)
+	}
+	if got := nonOAuthRow.GetCredential("email"); got != "" {
+		t.Fatalf("non-OAuth email = %q, want unchanged", got)
+	}
+}
+
+func TestSQLiteWorkspaceMigrationPreservesUnknownWorkspaceValue(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "codex2api.db")
+	ctx := context.Background()
+	db, err := New("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("New(sqlite): %v", err)
+	}
+	defer db.Close()
+
+	id, err := db.InsertAccountWithCredentials(ctx, "polluted-workspace", map[string]interface{}{
+		"refresh_token": "rt-polluted-workspace",
+		"email":         "polluted@example.com",
+		"workspace_id":  "user-not-a-workspace",
+	}, "")
+	if err != nil {
+		t.Fatalf("InsertAccountWithCredentials: %v", err)
+	}
+	if _, err := db.conn.ExecContext(ctx, `DELETE FROM data_migrations WHERE version = $1`, dataMigrationWorkspaceIdentityV3); err != nil {
+		t.Fatalf("clear workspace migration marker: %v", err)
+	}
+	if err := db.runDataMigrationsWithTimeout(); err != nil {
+		t.Fatalf("runDataMigrations: %v", err)
+	}
+
+	row, err := db.GetAccountByID(ctx, id)
+	if err != nil {
+		t.Fatalf("GetAccountByID: %v", err)
+	}
+	if got := row.GetCredential("workspace_id"); got != "user-not-a-workspace" {
+		t.Fatalf("workspace_id = %q, want historical value preserved", got)
+	}
+	ids, err := db.GetAllChatGPTAccountIDs(ctx)
+	if err != nil {
+		t.Fatalf("GetAllChatGPTAccountIDs: %v", err)
+	}
+	if len(ids) != 0 {
+		t.Fatalf("workspace IDs = %#v, want none", ids)
+	}
+}
+
+func TestSQLiteWorkspaceMigrationLeavesDeletedAccountsUntouched(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "codex2api.db")
+	ctx := context.Background()
+	db, err := New("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("New(sqlite): %v", err)
+	}
+	defer db.Close()
+
+	idToken := databaseTestJWT(t, map[string]interface{}{
+		"email": "deleted@example.com",
+		"https://api.openai.com/auth": map[string]interface{}{
+			"chatgpt_account_id": "workspace-deleted",
+		},
+	})
+	id, err := db.InsertAccountWithCredentials(ctx, "deleted-workspace", map[string]interface{}{
+		"id_token":     idToken,
+		"email":        "deleted@example.com",
+		"workspace_id": "user-deleted-legacy",
+	}, "")
+	if err != nil {
+		t.Fatalf("InsertAccountWithCredentials: %v", err)
+	}
+	if err := db.SoftDeleteAccount(ctx, id); err != nil {
+		t.Fatalf("SoftDeleteAccount: %v", err)
+	}
+	if _, err := db.conn.ExecContext(ctx, `DELETE FROM data_migrations WHERE version = $1`, dataMigrationWorkspaceIdentityV3); err != nil {
+		t.Fatalf("clear workspace migration marker: %v", err)
+	}
+	if err := db.runDataMigrationsWithTimeout(); err != nil {
+		t.Fatalf("runDataMigrations: %v", err)
+	}
+
+	deletedRows, err := db.ListDeleted(ctx)
+	if err != nil {
+		t.Fatalf("ListDeleted: %v", err)
+	}
+	var row *AccountRow
+	for _, candidate := range deletedRows {
+		if candidate.ID == id {
+			row = candidate
+			break
+		}
+	}
+	if row == nil {
+		t.Fatalf("deleted account %d not found", id)
+	}
+	if got := row.GetCredential("workspace_id"); got != "user-deleted-legacy" {
+		t.Fatalf("deleted workspace_id = %q, want historical value preserved", got)
 	}
 }
 
@@ -369,8 +766,11 @@ func TestSQLiteDataMigrationDedupesOAuthIdentityOnce(t *testing.T) {
 		t.Fatalf("New(sqlite) 返回错误: %v", err)
 	}
 
-	if _, err := db.conn.ExecContext(ctx, `DELETE FROM data_migrations WHERE version = $1`, dataMigrationOAuthIdentityDedupeV1); err != nil {
+	if _, err := db.conn.ExecContext(ctx, `DELETE FROM data_migrations WHERE version = $1`, dataMigrationWorkspaceIdentityV3); err != nil {
 		t.Fatalf("清理 data migration 标记返回错误: %v", err)
+	}
+	if _, err := db.conn.ExecContext(ctx, `DROP INDEX IF EXISTS idx_accounts_oauth_identity_active`); err != nil {
+		t.Fatalf("删除 OAuth 身份索引返回错误: %v", err)
 	}
 
 	oldTime := time.Now().Add(-2 * time.Hour).UTC().Truncate(time.Second)
@@ -380,7 +780,7 @@ func TestSQLiteDataMigrationDedupesOAuthIdentityOnce(t *testing.T) {
 	oldID, err := db.InsertAccountWithCredentials(ctx, "old-duplicate", map[string]interface{}{
 		"refresh_token": "rt-old-duplicate",
 		"email":         "User@Example.com",
-		"account_id":    "acc-dedupe",
+		"workspace_id":  "acc-dedupe",
 	}, "")
 	if err != nil {
 		t.Fatalf("Insert old duplicate 返回错误: %v", err)
@@ -388,7 +788,7 @@ func TestSQLiteDataMigrationDedupesOAuthIdentityOnce(t *testing.T) {
 	midID, err := db.InsertAccountWithCredentials(ctx, "mid-duplicate", map[string]interface{}{
 		"access_token":        "at-mid-duplicate",
 		"email":               "user@example.com",
-		"chatgpt_account_id":  "acc-dedupe",
+		"workspace_id":        "acc-dedupe",
 		"codex_7d_reset_at":   newTime.Format(time.RFC3339),
 		"codex_5h_reset_at":   newTime.Format(time.RFC3339),
 		"codex_usage_marker":  "keep-credentials-intact",
@@ -400,7 +800,7 @@ func TestSQLiteDataMigrationDedupesOAuthIdentityOnce(t *testing.T) {
 	winnerID, err := db.InsertAccountWithCredentials(ctx, "new-duplicate", map[string]interface{}{
 		"session_token": "st-new-duplicate",
 		"email":         " user@example.com ",
-		"account_id":    "acc-dedupe",
+		"workspace_id":  "acc-dedupe",
 	}, "")
 	if err != nil {
 		t.Fatalf("Insert winner 返回错误: %v", err)
@@ -408,16 +808,15 @@ func TestSQLiteDataMigrationDedupesOAuthIdentityOnce(t *testing.T) {
 	otherID, err := db.InsertAccountWithCredentials(ctx, "other-workspace", map[string]interface{}{
 		"refresh_token": "rt-other-workspace",
 		"email":         "user@example.com",
-		"account_id":    "acc-other",
+		"workspace_id":  "acc-other",
 	}, "")
 	if err != nil {
 		t.Fatalf("Insert other 返回错误: %v", err)
 	}
 	bridgeOldID, err := db.InsertAccountWithCredentials(ctx, "bridge-old", map[string]interface{}{
-		"refresh_token":      "rt-bridge-old",
-		"email":              "bridge@example.com",
-		"account_id":         "acc-bridge-old",
-		"chatgpt_account_id": "acc-bridge",
+		"refresh_token": "rt-bridge-old",
+		"email":         "bridge@example.com",
+		"workspace_id":  "acc-bridge",
 	}, "")
 	if err != nil {
 		t.Fatalf("Insert bridge old 返回错误: %v", err)
@@ -425,7 +824,7 @@ func TestSQLiteDataMigrationDedupesOAuthIdentityOnce(t *testing.T) {
 	bridgeWinnerID, err := db.InsertAccountWithCredentials(ctx, "bridge-winner", map[string]interface{}{
 		"access_token": "at-bridge-winner",
 		"email":        "Bridge@Example.com",
-		"account_id":   "acc-bridge",
+		"workspace_id": "acc-bridge",
 	}, "")
 	if err != nil {
 		t.Fatalf("Insert bridge winner 返回错误: %v", err)
@@ -433,13 +832,29 @@ func TestSQLiteDataMigrationDedupesOAuthIdentityOnce(t *testing.T) {
 	deletedID, err := db.InsertAccountWithCredentials(ctx, "deleted-duplicate", map[string]interface{}{
 		"refresh_token": "rt-deleted-duplicate",
 		"email":         "user@example.com",
-		"account_id":    "acc-dedupe",
+		"workspace_id":  "acc-dedupe",
 	}, "")
 	if err != nil {
 		t.Fatalf("Insert deleted 返回错误: %v", err)
 	}
 	if err := db.SoftDeleteAccount(ctx, deletedID); err != nil {
 		t.Fatalf("SoftDeleteAccount 返回错误: %v", err)
+	}
+	nonOAuthOldID, err := db.InsertAccountWithUpstream(ctx, "non-oauth-old", "openai", "api", map[string]interface{}{
+		"access_token": "at-non-oauth-old",
+		"email":        "non-oauth@example.com",
+		"workspace_id": "workspace-non-oauth",
+	}, "")
+	if err != nil {
+		t.Fatalf("Insert non-OAuth old 返回错误: %v", err)
+	}
+	nonOAuthNewID, err := db.InsertAccountWithUpstream(ctx, "non-oauth-new", "openai", "api", map[string]interface{}{
+		"access_token": "at-non-oauth-new",
+		"email":        "non-oauth@example.com",
+		"workspace_id": "workspace-non-oauth",
+	}, "")
+	if err != nil {
+		t.Fatalf("Insert non-OAuth new 返回错误: %v", err)
 	}
 
 	for id, ts := range map[int64]time.Time{
@@ -475,6 +890,9 @@ func TestSQLiteDataMigrationDedupesOAuthIdentityOnce(t *testing.T) {
 	if !activeIDs[winnerID] || !activeIDs[otherID] || !activeIDs[bridgeWinnerID] {
 		t.Fatalf("active ids = %v, want winner %d, other %d and bridge winner %d", activeIDs, winnerID, otherID, bridgeWinnerID)
 	}
+	if !activeIDs[nonOAuthOldID] || !activeIDs[nonOAuthNewID] {
+		t.Fatalf("active ids = %v, want non-OAuth duplicates %d/%d preserved", activeIDs, nonOAuthOldID, nonOAuthNewID)
+	}
 	if activeIDs[oldID] || activeIDs[midID] || activeIDs[bridgeOldID] {
 		t.Fatalf("active ids = %v, want duplicates %d/%d/%d soft-deleted", activeIDs, oldID, midID, bridgeOldID)
 	}
@@ -494,7 +912,7 @@ func TestSQLiteDataMigrationDedupesOAuthIdentityOnce(t *testing.T) {
 	}
 
 	var migrationCount int
-	if err := db.conn.QueryRowContext(ctx, `SELECT COUNT(*) FROM data_migrations WHERE version = $1`, dataMigrationOAuthIdentityDedupeV1).Scan(&migrationCount); err != nil {
+	if err := db.conn.QueryRowContext(ctx, `SELECT COUNT(*) FROM data_migrations WHERE version = $1`, dataMigrationWorkspaceIdentityV3).Scan(&migrationCount); err != nil {
 		t.Fatalf("查询 data_migrations 返回错误: %v", err)
 	}
 	if migrationCount != 1 {
@@ -502,32 +920,20 @@ func TestSQLiteDataMigrationDedupesOAuthIdentityOnce(t *testing.T) {
 	}
 
 	var eventCount int
-	if err := db.conn.QueryRowContext(ctx, `SELECT COUNT(*) FROM account_events WHERE source = 'oauth_identity_dedupe_v1' AND account_id IN ($1, $2, $3)`, oldID, midID, bridgeOldID).Scan(&eventCount); err != nil {
+	if err := db.conn.QueryRowContext(ctx, `SELECT COUNT(*) FROM account_events WHERE source = 'workspace_identity_v3' AND account_id IN ($1, $2, $3)`, oldID, midID, bridgeOldID).Scan(&eventCount); err != nil {
 		t.Fatalf("查询 account_events 返回错误: %v", err)
 	}
 	if eventCount != 3 {
 		t.Fatalf("dedupe event count = %d, want 3", eventCount)
 	}
 
-	postMigrationDuplicateID, err := db.InsertAccountWithCredentials(ctx, "post-migration-duplicate", map[string]interface{}{
+	_, err = db.InsertAccountWithCredentials(ctx, "post-migration-duplicate", map[string]interface{}{
 		"refresh_token": "rt-post-migration-duplicate",
 		"email":         "user@example.com",
-		"account_id":    "acc-dedupe",
+		"workspace_id":  "acc-dedupe",
 	}, "")
-	if err != nil {
-		t.Fatalf("Insert post migration duplicate 返回错误: %v", err)
-	}
-	if err := db.Close(); err != nil {
-		t.Fatalf("Close after post migration duplicate 返回错误: %v", err)
-	}
-
-	db, err = New("sqlite", dbPath)
-	if err != nil {
-		t.Fatalf("second reopen New(sqlite) 返回错误: %v", err)
-	}
-
-	if _, err := db.GetAccountByID(ctx, postMigrationDuplicateID); err != nil {
-		t.Fatalf("post migration duplicate should remain active because migration is one-shot: %v", err)
+	if !errors.Is(err, ErrDuplicateOAuthIdentity) {
+		t.Fatalf("post migration duplicate err = %v, want ErrDuplicateOAuthIdentity", err)
 	}
 	if err := db.Close(); err != nil {
 		t.Fatalf("final Close 返回错误: %v", err)
@@ -2356,6 +2762,56 @@ func TestSetCooldownWithErrorPersistsMessage(t *testing.T) {
 	}
 	if !cooldownUntil.Valid {
 		t.Fatal("cooldown_until 未写入")
+	}
+}
+
+func TestClearErrorIfErrorOrUnauthorizedPreservesNewCooldown(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "codex2api.db")
+	db, err := New("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("New(sqlite) 返回错误: %v", err)
+	}
+	defer db.Close()
+
+	ctx := context.Background()
+	id, err := db.InsertAccount(ctx, "conditional-clear", "rt-conditional-clear", "")
+	if err != nil {
+		t.Fatalf("InsertAccount 返回错误: %v", err)
+	}
+
+	if cleared, err := db.ClearErrorIfErrorOrUnauthorized(ctx, id); err != nil || cleared {
+		t.Fatalf("clear active account = (%v, %v), want (false, nil)", cleared, err)
+	}
+	if err := db.SetError(ctx, id, "stale error"); err != nil {
+		t.Fatalf("SetError 返回错误: %v", err)
+	}
+	if cleared, err := db.ClearErrorIfErrorOrUnauthorized(ctx, id); err != nil || !cleared {
+		t.Fatalf("clear error account = (%v, %v), want (true, nil)", cleared, err)
+	}
+
+	if err := db.SetCooldownWithError(ctx, id, "unauthorized", time.Now().Add(time.Hour), "401 unauthorized"); err != nil {
+		t.Fatalf("SetCooldownWithError unauthorized 返回错误: %v", err)
+	}
+	if cleared, err := db.ClearErrorIfErrorOrUnauthorized(ctx, id); err != nil || !cleared {
+		t.Fatalf("clear unauthorized account = (%v, %v), want (true, nil)", cleared, err)
+	}
+
+	if err := db.SetError(ctx, id, "new error"); err != nil {
+		t.Fatalf("SetError before rate limit 返回错误: %v", err)
+	}
+	if err := db.SetCooldownWithError(ctx, id, "rate_limited", time.Now().Add(time.Hour), "429 rate limited"); err != nil {
+		t.Fatalf("SetCooldownWithError rate_limited 返回错误: %v", err)
+	}
+	if cleared, err := db.ClearErrorIfErrorOrUnauthorized(ctx, id); err != nil || cleared {
+		t.Fatalf("clear rate-limited account = (%v, %v), want (false, nil)", cleared, err)
+	}
+
+	var status, reason, message string
+	if err := db.conn.QueryRowContext(ctx, `SELECT status, cooldown_reason, error_message FROM accounts WHERE id = $1`, id).Scan(&status, &reason, &message); err != nil {
+		t.Fatalf("查询 rate-limited 状态返回错误: %v", err)
+	}
+	if status != "error" || reason != "rate_limited" || message != "429 rate limited" {
+		t.Fatalf("state = (%q, %q, %q), want error/rate_limited/429 rate limited", status, reason, message)
 	}
 }
 

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -382,7 +382,7 @@
     "importFile": "Import",
     "importing": "Importing…",
     "importTitle": "Select Import Method",
-    "allowDuplicate": "Allow duplicates (skip dedup, force new)",
+    "allowDuplicate": "Allow duplicates for unknown workspaces (known ones stay unique)",
     "importProxyLabel": "Proxy for Imported Accounts (optional)",
     "importProxyHint": "Applied to every account in this import. Leave blank to import without a proxy.",
     "importTxt": "TXT File",

--- a/frontend/src/locales/zh.json
+++ b/frontend/src/locales/zh.json
@@ -382,7 +382,7 @@
     "importFile": "导入",
     "importing": "导入中…",
     "importTitle": "选择导入方式",
-    "allowDuplicate": "允许重复添加（跳过去重，强制新建）",
+    "allowDuplicate": "允许未识别工作区重复（已识别工作区仍唯一）",
     "importProxyLabel": "导入账号的代理（可选）",
     "importProxyHint": "将统一应用到本次导入的所有账号；留空则不设置代理。",
     "importTxt": "TXT 文件",

--- a/internal/openaiidentity/jwt.go
+++ b/internal/openaiidentity/jwt.go
@@ -1,0 +1,70 @@
+package openaiidentity
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+type Claims struct {
+	Email         string         `json:"email"`
+	Subject       string         `json:"sub"`
+	ExpiresAt     int64          `json:"exp"`
+	OpenAIAuth    *OpenAIAuth    `json:"https://api.openai.com/auth"`
+	OpenAIProfile *OpenAIProfile `json:"https://api.openai.com/profile"`
+}
+
+type OpenAIAuth struct {
+	ChatGPTAccountID               string `json:"chatgpt_account_id"`
+	UserID                         string `json:"user_id"`
+	ChatGPTUserID                  string `json:"chatgpt_user_id"`
+	PlanType                       string `json:"chatgpt_plan_type"`
+	ChatGPTSubscriptionActiveUntil string `json:"chatgpt_subscription_active_until"`
+}
+
+type OpenAIProfile struct {
+	Email string `json:"email"`
+}
+
+func ParseJWT(token string) (*Claims, error) {
+	parts := strings.Split(strings.TrimSpace(token), ".")
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("invalid JWT format")
+	}
+
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		payload, err = base64.URLEncoding.DecodeString(parts[1])
+	}
+	if err != nil {
+		payload, err = base64.RawStdEncoding.DecodeString(parts[1])
+	}
+	if err != nil {
+		payload, err = base64.StdEncoding.DecodeString(parts[1])
+		if err != nil {
+			return nil, fmt.Errorf("decode JWT payload: %w", err)
+		}
+	}
+
+	var claims Claims
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return nil, fmt.Errorf("decode JWT claims: %w", err)
+	}
+	return &claims, nil
+}
+
+func (c *Claims) WorkspaceID() string {
+	if c == nil || c.OpenAIAuth == nil {
+		return ""
+	}
+	return NormalizeWorkspaceID(c.OpenAIAuth.ChatGPTAccountID)
+}
+
+func NormalizeWorkspaceID(value string) string {
+	value = strings.TrimSpace(value)
+	if strings.HasPrefix(strings.ToLower(value), "user-") {
+		return ""
+	}
+	return value
+}

--- a/internal/openaiidentity/jwt_test.go
+++ b/internal/openaiidentity/jwt_test.go
@@ -1,0 +1,44 @@
+package openaiidentity
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+)
+
+func testJWT(t *testing.T, claims map[string]interface{}) string {
+	t.Helper()
+	payload, err := json.Marshal(claims)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	return "header." + base64.RawURLEncoding.EncodeToString(payload) + ".signature"
+}
+
+func TestWorkspaceID(t *testing.T) {
+	claims, err := ParseJWT(testJWT(t, map[string]interface{}{
+		"https://api.openai.com/auth": map[string]interface{}{
+			"chatgpt_account_id": " workspace-1 ",
+		},
+	}))
+	if err != nil {
+		t.Fatalf("ParseJWT: %v", err)
+	}
+	if got := claims.WorkspaceID(); got != "workspace-1" {
+		t.Fatalf("WorkspaceID = %q, want workspace-1", got)
+	}
+}
+
+func TestWorkspaceIDRejectsUserID(t *testing.T) {
+	claims, err := ParseJWT(testJWT(t, map[string]interface{}{
+		"https://api.openai.com/auth": map[string]interface{}{
+			"chatgpt_account_id": "user-not-a-workspace",
+		},
+	}))
+	if err != nil {
+		t.Fatalf("ParseJWT: %v", err)
+	}
+	if got := claims.WorkspaceID(); got != "" {
+		t.Fatalf("WorkspaceID = %q, want empty for user id", got)
+	}
+}

--- a/proxy/usage_wham.go
+++ b/proxy/usage_wham.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/codex2api/auth"
+	"github.com/codex2api/internal/openaiidentity"
 	"github.com/google/uuid"
 )
 
@@ -439,12 +440,11 @@ func ApplyWhamUsage(store *auth.Store, account *auth.Account, usage *WhamUsage) 
 		store.UpdateAccountPlanType(account, usage.PlanType)
 	}
 	if store != nil {
-		// 只回填真正的工作区 ID。此前 account_id 缺失时用 user_id 兜底写入
-		// account_id 字段，会污染 OAuth 身份去重键（JWT 解出的工作区 ID 与
-		// 库里存的 user-... 永远对不上），导致同一账号重复导入(串号池)。
+		// 只回填真正的工作区 ID。user-* 值会被 NormalizeWorkspaceID 丢弃，
+		// 避免再次污染 workspace_id 身份键并导致同一账号重复导入。
 		// 自定义头覆盖了工作区 ID 时,wham 返回的是覆盖后空间的 ID,
 		// 不能回写进 OAuth 身份字段(会覆盖真实身份并与覆盖值反复打架)。
-		identityAccountID := strings.TrimSpace(usage.AccountID)
+		identityAccountID := openaiidentity.NormalizeWorkspaceID(usage.AccountID)
 		if account.AccountIDOverridden() {
 			identityAccountID = ""
 		}

--- a/proxy/usage_wham_test.go
+++ b/proxy/usage_wham_test.go
@@ -228,8 +228,35 @@ func TestApplyWhamUsage_PersistsIdentity(t *testing.T) {
 	if got := row.GetCredential("email"); got != "wham@example.com" {
 		t.Fatalf("credentials.email = %q, want wham@example.com", got)
 	}
-	if got := row.GetCredential("account_id"); got != "account-from-wham" {
-		t.Fatalf("credentials.account_id = %q, want account-from-wham", got)
+	if got := row.GetCredential("workspace_id"); got != "account-from-wham" {
+		t.Fatalf("credentials.workspace_id = %q, want account-from-wham", got)
+	}
+}
+
+func TestApplyWhamUsage_DoesNotPersistUserIDAsWorkspace(t *testing.T) {
+	ctx := context.Background()
+	db, err := database.New("sqlite", filepath.Join(t.TempDir(), "codex2api.db"))
+	if err != nil {
+		t.Fatalf("database.New: %v", err)
+	}
+	defer db.Close()
+	id, err := db.InsertAccountWithCredentials(ctx, "at-only", map[string]interface{}{"access_token": "at"}, "")
+	if err != nil {
+		t.Fatalf("InsertAccountWithCredentials: %v", err)
+	}
+	store := auth.NewStore(db, nil, &database.SystemSettings{MaxConcurrency: 2, TestConcurrency: 1, TestModel: "gpt-5.4"})
+	account := &auth.Account{DBID: id, AccessToken: "at"}
+
+	ApplyWhamUsage(store, account, &WhamUsage{AccountID: "user-not-workspace", Email: "user@example.com"})
+	if account.AccountID != "" {
+		t.Fatalf("account.AccountID = %q, want empty", account.AccountID)
+	}
+	row, err := db.GetAccountByID(ctx, id)
+	if err != nil {
+		t.Fatalf("GetAccountByID: %v", err)
+	}
+	if got := row.GetCredential("workspace_id"); got != "" {
+		t.Fatalf("credentials.workspace_id = %q, want empty", got)
 	}
 }
 


### PR DESCRIPTION
## 背景

现有 OAuth 账号去重使用 `email + account_id/chatgpt_account_id`。这些字段在不同 token/exporter 中可能代表 workspace ID、OpenAI user ID 或历史元数据，无法稳定识别同一 OAuth workspace，也可能把未知身份错误合并。

本 PR 延续上游 #262 的 OAuth 身份去重方案，将 canonical 身份改为标准化的 `email + workspace_id`。

## 改动

### 后端
- 新增统一 JWT 身份解析：优先从 `id_token`，再从 `access_token` 提取 `chatgpt_account_id` 作为 `workspace_id`
- `user-*` 不作为 workspace ID；`user_id` 仅保存为元数据，不参与去重
- OAuth 回调、重新授权、AT 添加、刷新/探针回填统一使用 `email + workspace_id` 去重
- 已知 workspace 身份重复时更新或合并已有账号；workspace ID 为空时不进行 OAuth 身份匹配，因此同邮箱未知 workspace 账号可以并存
- 导入支持 Codex `auth.json`、CLIProxyAPI/Sub2API JSON，并在导入阶段解析 workspace ID
- 恢复、导出和运行时身份回填同步使用新字段

### 数据库约束
- SQLite/PostgreSQL 新增部分唯一表达式索引 `idx_accounts_oauth_identity_active`
- 索引仅覆盖正常池中 `type = oauth`、email 非空、workspace ID 非空且不是 `user-*` 的账号
- 将数据库唯一冲突统一转换为 `database.ErrDuplicateOAuthIdentity`，由 OAuth、导入、重新授权和恢复流程处理
- 数据库约束保证多进程或多个 Handler 并发时也不会持久化重复身份

### 数据迁移
- 保持上游 OAuth 去重 v1/v2 的版本、逻辑和执行顺序不变，仅在现有迁移链末尾新增一次 `20260722_workspace_identity_v3` migration
- v3 在同一事务内完成：从现有 JWT 回填可确认的 `workspace_id`、合并正常池中已知身份重复账号、创建唯一索引
- 解析不到 workspace ID 时保留历史字段，包括已有 `user-*` 值；空 workspace 不参与合并和唯一约束
- 回收站账号不回填、不参与去重，原数据保持不变
- 本 PR 不包含 v4、`workspace_identity_v1` 或补偿/回退迁移

### 前端
- 更新“允许重复添加”提示，说明未知 workspace 可并存、已知 workspace 仍保持唯一

## 测试

- `go test ./...`
- `go vet ./...`
- `go test -race ./admin ./database`
- `npm run typecheck`
- `npm test`
- `npm run build`
- `git diff --check upstream/main..HEAD`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OAuth account matching and imports are now scoped to **email + workspace identity** across restore, refresh, and import flows.
  * Auth JSON/export and token handling now consistently associate accounts using **workspace-based identity**.

* **Bug Fixes**
  * Prevented **concurrent OAuth imports** from creating duplicate active accounts.
  * Dedup/merge behavior is now stricter for **known workspaces**; conflicting updates/restores return a clear **409 conflict**.

* **Documentation**
  * Updated the import **“allow duplicate”** wording to reflect **unknown vs known workspace** behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->