### PR TITLE
fix(codex): Agent runtime 删除后将账号标记为封禁

### DIFF
--- a/admin/batch_test_test.go
+++ b/admin/batch_test_test.go
@@ -399,3 +399,39 @@ func TestRunSingleBatchTestUnauthorizedRecordsErrorMessage(t *testing.T) {
 		t.Fatalf("ErrorMsg = %q, want token_invalidated", errorMsg)
 	}
 }
+
+func TestRunSingleBatchTestDeletedAgentRuntimeMarksBanned(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":{"message":"Agent runtime has been deleted.","type":null,"code":"biscuit_baker_service_agent_error_status","param":null},"status":403}`))
+	}))
+	defer server.Close()
+
+	store := auth.NewStore(nil, nil, nil)
+	account := &auth.Account{
+		DBID:         1,
+		UpstreamType: auth.UpstreamOpenAIResponses,
+		BaseURL:      server.URL,
+		APIKey:       "test-key",
+		Models:       []string{"gpt-4o-mini"},
+		Status:       auth.StatusReady,
+		HealthTier:   auth.HealthTierHealthy,
+	}
+	store.AddAccount(account)
+	handler := &Handler{store: store}
+
+	status, msg := handler.runSingleBatchTest(context.Background(), account)
+	if status != "banned" {
+		t.Fatalf("status = %q, message = %q, want banned", status, msg)
+	}
+	if got := account.RuntimeStatus(); got != "unauthorized" {
+		t.Fatalf("RuntimeStatus() = %q, want unauthorized", got)
+	}
+	account.Mu().RLock()
+	errorMsg := account.ErrorMsg
+	account.Mu().RUnlock()
+	if !strings.Contains(errorMsg, "Agent runtime has been deleted") {
+		t.Fatalf("ErrorMsg = %q, want deleted runtime message", errorMsg)
+	}
+}

--- a/admin/batch_test_test.go
+++ b/admin/batch_test_test.go
@@ -400,6 +400,7 @@ func TestRunSingleBatchTestUnauthorizedRecordsErrorMessage(t *testing.T) {
 	}
 }
 
+// TestRunSingleBatchTestDeletedAgentRuntimeMarksBanned 验证批量测试会将 runtime 已删除的账号标记为封禁。
 func TestRunSingleBatchTestDeletedAgentRuntimeMarksBanned(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/admin/batch_test_test.go
+++ b/admin/batch_test_test.go
@@ -428,6 +428,10 @@ func TestRunSingleBatchTestDeletedAgentRuntimeMarksBanned(t *testing.T) {
 	if got := account.RuntimeStatus(); got != "unauthorized" {
 		t.Fatalf("RuntimeStatus() = %q, want unauthorized", got)
 	}
+	_, cooldownUntil := account.GetCooldownSnapshot()
+	if remaining := time.Until(cooldownUntil); remaining < 23*time.Hour+59*time.Minute || remaining > 24*time.Hour {
+		t.Fatalf("cooldown remaining = %s, want approximately 24h", remaining)
+	}
 	account.Mu().RLock()
 	errorMsg := account.ErrorMsg
 	account.Mu().RUnlock()

--- a/admin/test_connection.go
+++ b/admin/test_connection.go
@@ -117,6 +117,10 @@ func (h *Handler) TestConnection(c *gin.Context) {
 			switch resp.StatusCode {
 			case http.StatusUnauthorized:
 				h.store.MarkCooldownWithError(account, 24*time.Hour, "unauthorized", errMsg)
+			case http.StatusForbidden:
+				if proxy.IsAgentRuntimeDeletedError(errBody) {
+					h.store.MarkCooldownWithError(account, 24*time.Hour, "unauthorized", errMsg)
+				}
 			case http.StatusTooManyRequests:
 				if isOpenAIResponsesAccount {
 					h.store.MarkCooldown(account, time.Minute, "rate_limited")
@@ -981,6 +985,10 @@ func (h *Handler) runSingleBatchTest(ctx context.Context, acc *auth.Account) (st
 			return h.handleBatchTestReadError(testCtx, acc, readErr)
 		}
 		msg := fmt.Sprintf("上游返回 %d: %s", resp.StatusCode, truncate(string(body), 300))
+		if resp.StatusCode == http.StatusForbidden && proxy.IsAgentRuntimeDeletedError(body) {
+			h.store.MarkCooldownWithError(acc, 24*time.Hour, "unauthorized", msg)
+			return "banned", msg
+		}
 		if shouldMarkBatchTestAccountError(resp.StatusCode, body) {
 			h.store.MarkError(acc, "批量测试"+msg)
 		}

--- a/admin/test_connection.go
+++ b/admin/test_connection.go
@@ -119,7 +119,7 @@ func (h *Handler) TestConnection(c *gin.Context) {
 				h.store.MarkCooldownWithError(account, 24*time.Hour, "unauthorized", errMsg)
 			case http.StatusForbidden:
 				if proxy.IsAgentRuntimeDeletedError(errBody) {
-					h.store.MarkCooldownWithError(account, 24*time.Hour, "unauthorized", errMsg)
+					h.store.MarkCooldownWithErrorExactDuration(account, 24*time.Hour, "unauthorized", errMsg)
 				}
 			case http.StatusTooManyRequests:
 				if isOpenAIResponsesAccount {
@@ -986,7 +986,7 @@ func (h *Handler) runSingleBatchTest(ctx context.Context, acc *auth.Account) (st
 		}
 		msg := fmt.Sprintf("上游返回 %d: %s", resp.StatusCode, truncate(string(body), 300))
 		if resp.StatusCode == http.StatusForbidden && proxy.IsAgentRuntimeDeletedError(body) {
-			h.store.MarkCooldownWithError(acc, 24*time.Hour, "unauthorized", msg)
+			h.store.MarkCooldownWithErrorExactDuration(acc, 24*time.Hour, "unauthorized", msg)
 			return "banned", msg
 		}
 		if shouldMarkBatchTestAccountError(resp.StatusCode, body) {

--- a/admin/test_connection_test.go
+++ b/admin/test_connection_test.go
@@ -177,7 +177,10 @@ func TestConnectionDeletedAgentRuntimeMarksBanned(t *testing.T) {
 	if got := account.RuntimeStatus(); got != "unauthorized" {
 		t.Fatalf("RuntimeStatus() = %q, want unauthorized", got)
 	}
-	_, cooldownUntil := account.GetCooldownSnapshot()
+	cooldownReason, cooldownUntil := account.GetCooldownSnapshot()
+	if cooldownReason != "unauthorized" {
+		t.Fatalf("cooldown reason = %q, want unauthorized", cooldownReason)
+	}
 	if remaining := time.Until(cooldownUntil); remaining < 23*time.Hour+59*time.Minute || remaining > 24*time.Hour {
 		t.Fatalf("cooldown remaining = %s, want approximately 24h", remaining)
 	}

--- a/admin/test_connection_test.go
+++ b/admin/test_connection_test.go
@@ -142,6 +142,7 @@ func TestConnectionUnauthorizedRecordsErrorMessage(t *testing.T) {
 	}
 }
 
+// TestConnectionDeletedAgentRuntimeMarksBanned 验证连接测试会将 runtime 已删除的账号标记为封禁。
 func TestConnectionDeletedAgentRuntimeMarksBanned(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	upstreamBody := `{"error":{"message":"Agent runtime has been deleted.","type":null,"code":"biscuit_baker_service_agent_error_status","param":null},"status":403}`

--- a/admin/test_connection_test.go
+++ b/admin/test_connection_test.go
@@ -177,6 +177,10 @@ func TestConnectionDeletedAgentRuntimeMarksBanned(t *testing.T) {
 	if got := account.RuntimeStatus(); got != "unauthorized" {
 		t.Fatalf("RuntimeStatus() = %q, want unauthorized", got)
 	}
+	_, cooldownUntil := account.GetCooldownSnapshot()
+	if remaining := time.Until(cooldownUntil); remaining < 23*time.Hour+59*time.Minute || remaining > 24*time.Hour {
+		t.Fatalf("cooldown remaining = %s, want approximately 24h", remaining)
+	}
 	account.Mu().RLock()
 	errorMsg := account.ErrorMsg
 	account.Mu().RUnlock()

--- a/admin/test_connection_test.go
+++ b/admin/test_connection_test.go
@@ -142,6 +142,49 @@ func TestConnectionUnauthorizedRecordsErrorMessage(t *testing.T) {
 	}
 }
 
+func TestConnectionDeletedAgentRuntimeMarksBanned(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	upstreamBody := `{"error":{"message":"Agent runtime has been deleted.","type":null,"code":"biscuit_baker_service_agent_error_status","param":null},"status":403}`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(upstreamBody))
+	}))
+	defer server.Close()
+
+	store := auth.NewStore(nil, nil, nil)
+	account := &auth.Account{
+		DBID:         42,
+		UpstreamType: auth.UpstreamOpenAIResponses,
+		BaseURL:      server.URL,
+		APIKey:       "sk-test",
+		Models:       []string{"gpt-4o-mini"},
+		Status:       auth.StatusReady,
+		HealthTier:   auth.HealthTierHealthy,
+	}
+	store.AddAccount(account)
+	handler := &Handler{store: store}
+	router := gin.New()
+	router.GET("/api/admin/accounts/:id/test", handler.TestConnection)
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/api/admin/accounts/42/test", nil)
+	router.ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", recorder.Code)
+	}
+	if got := account.RuntimeStatus(); got != "unauthorized" {
+		t.Fatalf("RuntimeStatus() = %q, want unauthorized", got)
+	}
+	account.Mu().RLock()
+	errorMsg := account.ErrorMsg
+	account.Mu().RUnlock()
+	if !strings.Contains(errorMsg, "Agent runtime has been deleted") {
+		t.Fatalf("ErrorMsg = %q, want deleted runtime message", errorMsg)
+	}
+}
+
 func TestExtractCompletedOutputText(t *testing.T) {
 	event := []byte(`{
 		"type":"response.completed",

--- a/admin/usage_probe.go
+++ b/admin/usage_probe.go
@@ -224,7 +224,12 @@ func (h *Handler) probeUsageViaResponses(ctx context.Context, account *auth.Acco
 			return nil
 		}
 		if shouldMarkUsageProbeAccountError(resp.StatusCode, body) {
-			h.store.MarkError(account, fmt.Sprintf("用量探针上游返回 %d: %s", resp.StatusCode, truncate(string(body), 300)))
+			errorMsg := fmt.Sprintf("用量探针上游返回 %d: %s", resp.StatusCode, truncate(string(body), 300))
+			if resp.StatusCode == http.StatusForbidden && proxy.IsAgentRuntimeDeletedError(body) {
+				h.store.MarkCooldownWithError(account, 24*time.Hour, "unauthorized", errorMsg)
+			} else {
+				h.store.MarkError(account, errorMsg)
+			}
 			return nil
 		}
 		if resp.StatusCode >= 500 {
@@ -239,7 +244,8 @@ func (h *Handler) probeUsageViaResponses(ctx context.Context, account *auth.Acco
 func shouldMarkUsageProbeAccountError(statusCode int, body []byte) bool {
 	switch statusCode {
 	case http.StatusPaymentRequired, http.StatusForbidden:
-		return proxy.IsDeactivatedWorkspaceError(body)
+		return proxy.IsDeactivatedWorkspaceError(body) ||
+			(statusCode == http.StatusForbidden && proxy.IsAgentRuntimeDeletedError(body))
 	default:
 		return false
 	}

--- a/admin/usage_probe.go
+++ b/admin/usage_probe.go
@@ -226,7 +226,7 @@ func (h *Handler) probeUsageViaResponses(ctx context.Context, account *auth.Acco
 		if shouldMarkUsageProbeAccountError(resp.StatusCode, body) {
 			errorMsg := fmt.Sprintf("用量探针上游返回 %d: %s", resp.StatusCode, truncate(string(body), 300))
 			if resp.StatusCode == http.StatusForbidden && proxy.IsAgentRuntimeDeletedError(body) {
-				h.store.MarkCooldownWithError(account, 24*time.Hour, "unauthorized", errorMsg)
+				h.store.MarkCooldownWithErrorExactDuration(account, 24*time.Hour, "unauthorized", errorMsg)
 			} else {
 				h.store.MarkError(account, errorMsg)
 			}

--- a/admin/usage_probe_test.go
+++ b/admin/usage_probe_test.go
@@ -33,6 +33,12 @@ func TestShouldMarkUsageProbeAccountError(t *testing.T) {
 			want:       true,
 		},
 		{
+			name:       "forbidden deleted agent runtime",
+			statusCode: http.StatusForbidden,
+			body:       []byte(`{"error":{"message":"Agent runtime has been deleted.","code":"biscuit_baker_service_agent_error_status"},"status":403}`),
+			want:       true,
+		},
+		{
 			name:       "generic payment required is not account error",
 			statusCode: http.StatusPaymentRequired,
 			body:       []byte(`{"error":{"code":"billing_hard_limit_reached"}}`),

--- a/admin/usage_probe_test.go
+++ b/admin/usage_probe_test.go
@@ -61,6 +61,7 @@ func TestShouldMarkUsageProbeAccountError(t *testing.T) {
 	}
 }
 
+// TestDeletedAgentRuntimeCooldownPersistsFor24Hours 验证用量探针会持久化 24 小时封禁冷却。
 func TestDeletedAgentRuntimeCooldownPersistsFor24Hours(t *testing.T) {
 	db := newTestAdminDB(t)
 	accountID := insertTestAccount(t, db)

--- a/admin/usage_probe_test.go
+++ b/admin/usage_probe_test.go
@@ -61,6 +61,42 @@ func TestShouldMarkUsageProbeAccountError(t *testing.T) {
 	}
 }
 
+func TestDeletedAgentRuntimeCooldownPersistsFor24Hours(t *testing.T) {
+	db := newTestAdminDB(t)
+	accountID := insertTestAccount(t, db)
+	store := auth.NewStore(db, nil, nil)
+	account := &auth.Account{
+		DBID:        accountID,
+		AccessToken: "at-test",
+		Status:      auth.StatusReady,
+		HealthTier:  auth.HealthTierHealthy,
+	}
+	store.AddAccount(account)
+
+	store.MarkCooldownWithErrorExactDuration(
+		account,
+		24*time.Hour,
+		"unauthorized",
+		"用量探针上游返回 403: Agent runtime has been deleted.",
+	)
+
+	_, cooldownUntil := account.GetCooldownSnapshot()
+	if remaining := time.Until(cooldownUntil); remaining < 23*time.Hour+59*time.Minute || remaining > 24*time.Hour {
+		t.Fatalf("runtime cooldown remaining = %s, want approximately 24h", remaining)
+	}
+
+	row, err := db.GetAccountByID(context.Background(), accountID)
+	if err != nil {
+		t.Fatalf("GetAccountByID: %v", err)
+	}
+	if row.CooldownReason != "unauthorized" || !row.CooldownUntil.Valid {
+		t.Fatalf("persisted cooldown = (%q, %v), want active unauthorized cooldown", row.CooldownReason, row.CooldownUntil)
+	}
+	if remaining := time.Until(row.CooldownUntil.Time); remaining < 23*time.Hour+59*time.Minute || remaining > 24*time.Hour {
+		t.Fatalf("persisted cooldown remaining = %s, want approximately 24h", remaining)
+	}
+}
+
 // issue #328：codex_at 账号可能 wham 恒 401 但真实流量可用。
 // wham 单方面 401 不得把账号打入 unauthorized 冷却（误封后手动重置也会被再次封禁）。
 func TestProbeUsageSnapshotWhamUnauthorizedDoesNotBanWhenFallbackUnavailable(t *testing.T) {

--- a/auth/runtime_status_test.go
+++ b/auth/runtime_status_test.go
@@ -79,6 +79,7 @@ func TestMarkCooldownWithErrorKeepsUnauthorizedStatusAndMessage(t *testing.T) {
 	}
 }
 
+// TestUnauthorizedCooldownDurationPolicies 验证 unauthorized 的自适应和精确时长冷却策略。
 func TestUnauthorizedCooldownDurationPolicies(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/auth/runtime_status_test.go
+++ b/auth/runtime_status_test.go
@@ -79,6 +79,57 @@ func TestMarkCooldownWithErrorKeepsUnauthorizedStatusAndMessage(t *testing.T) {
 	}
 }
 
+func TestUnauthorizedCooldownDurationPolicies(t *testing.T) {
+	tests := []struct {
+		name     string
+		method   string
+		recent   bool
+		duration time.Duration
+		want     time.Duration
+	}{
+		{name: "MarkCooldown fresh uses 6h", method: "cooldown", duration: time.Hour, want: 6 * time.Hour},
+		{name: "MarkCooldown recent uses 24h", method: "cooldown", recent: true, duration: time.Hour, want: 24 * time.Hour},
+		{name: "MarkCooldownWithError fresh uses 6h", method: "with_error", duration: time.Hour, want: 6 * time.Hour},
+		{name: "MarkCooldownWithError recent uses 24h", method: "with_error", recent: true, duration: time.Hour, want: 24 * time.Hour},
+		{name: "exact method preserves arbitrary duration", method: "exact", duration: 90 * time.Minute, want: 90 * time.Minute},
+		{name: "exact method preserves 24h", method: "exact", duration: 24 * time.Hour, want: 24 * time.Hour},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := NewStore(nil, nil, nil)
+			acc := &Account{
+				DBID:        1,
+				AccessToken: "at-test",
+				Status:      StatusReady,
+				HealthTier:  HealthTierHealthy,
+			}
+			if tt.recent {
+				acc.LastUnauthorizedAt = time.Now().Add(-time.Hour)
+			}
+
+			switch tt.method {
+			case "cooldown":
+				store.MarkCooldown(acc, tt.duration, "unauthorized")
+			case "with_error":
+				store.MarkCooldownWithError(acc, tt.duration, "unauthorized", "unauthorized")
+			case "exact":
+				store.MarkCooldownWithErrorExactDuration(acc, tt.duration, "unauthorized", "deleted runtime")
+			default:
+				t.Fatalf("unknown method %q", tt.method)
+			}
+
+			reason, until := acc.GetCooldownSnapshot()
+			if reason != "unauthorized" {
+				t.Fatalf("cooldown reason = %q, want unauthorized", reason)
+			}
+			if remaining := time.Until(until); remaining < tt.want-time.Minute || remaining > tt.want {
+				t.Fatalf("cooldown remaining = %s, want approximately %s", remaining, tt.want)
+			}
+		})
+	}
+}
+
 func TestMarkUsage7dRateLimitedUsesActiveResetWindow(t *testing.T) {
 	store := NewStore(nil, nil, nil)
 	acc := &Account{

--- a/auth/store.go
+++ b/auth/store.go
@@ -6059,6 +6059,7 @@ func (s *Store) markCooldownUntil(acc *Account, until time.Time, reason string, 
 	}
 }
 
+// markCooldown 根据 exactDuration 选择自适应或精确时长并应用账号冷却。
 func (s *Store) markCooldown(acc *Account, duration time.Duration, reason string, errorMsg string, exactDuration bool) {
 	if acc == nil {
 		return

--- a/auth/store.go
+++ b/auth/store.go
@@ -5984,12 +5984,18 @@ func normalizeAccountErrorMessage(errorMsg string, fallback string) string {
 
 // MarkCooldown 标记账号进入冷却，并持久化到数据库
 func (s *Store) MarkCooldown(acc *Account, duration time.Duration, reason string) {
-	s.markCooldown(acc, duration, reason, "")
+	s.markCooldown(acc, duration, reason, "", false)
 }
 
 // MarkCooldownWithError 标记账号进入冷却，并同时记录本次上游错误详情。
 func (s *Store) MarkCooldownWithError(acc *Account, duration time.Duration, reason string, errorMsg string) {
-	s.markCooldown(acc, duration, reason, errorMsg)
+	s.markCooldown(acc, duration, reason, errorMsg, false)
+}
+
+// MarkCooldownWithErrorExactDuration 标记账号进入指定时长的冷却，并记录上游错误详情。
+// 与 MarkCooldownWithError 不同，该方法不会应用 unauthorized 的自适应 6/24 小时策略。
+func (s *Store) MarkCooldownWithErrorExactDuration(acc *Account, duration time.Duration, reason string, errorMsg string) {
+	s.markCooldown(acc, duration, reason, errorMsg, true)
 }
 
 func (s *Store) markDispatchCountLimitCooldown(acc *Account, resetAt time.Time, updateScheduler bool) {
@@ -6053,7 +6059,7 @@ func (s *Store) markCooldownUntil(acc *Account, until time.Time, reason string, 
 	}
 }
 
-func (s *Store) markCooldown(acc *Account, duration time.Duration, reason string, errorMsg string) {
+func (s *Store) markCooldown(acc *Account, duration time.Duration, reason string, errorMsg string, exactDuration bool) {
 	if acc == nil {
 		return
 	}
@@ -6063,10 +6069,12 @@ func (s *Store) markCooldown(acc *Account, duration time.Duration, reason string
 	acc.mu.Lock()
 	switch reason {
 	case "unauthorized":
-		if !acc.LastUnauthorizedAt.IsZero() && now.Sub(acc.LastUnauthorizedAt) < 24*time.Hour {
-			duration = 24 * time.Hour
-		} else {
-			duration = 6 * time.Hour
+		if !exactDuration {
+			if !acc.LastUnauthorizedAt.IsZero() && now.Sub(acc.LastUnauthorizedAt) < 24*time.Hour {
+				duration = 24 * time.Hour
+			} else {
+				duration = 6 * time.Hour
+			}
 		}
 		acc.LastUnauthorizedAt = now
 		acc.LastFailureAt = now

--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -1704,6 +1704,15 @@ func IsDeactivatedWorkspaceError(body []byte) bool {
 	return strings.Contains(strings.ToLower(string(body)), "deactivated_workspace")
 }
 
+func IsAgentRuntimeDeletedError(body []byte) bool {
+	code := strings.ToLower(firstGJSONString(body, "error.code", "detail.code", "code"))
+	if code != "biscuit_baker_service_agent_error_status" {
+		return false
+	}
+	message := strings.ToLower(firstGJSONString(body, "error.message", "detail.message", "message"))
+	return strings.Contains(message, "agent runtime has been deleted")
+}
+
 func upstreamAccountErrorMessage(statusCode int, body []byte) string {
 	if IsDeactivatedWorkspaceError(body) {
 		return fmt.Sprintf("上游返回 %d: deactivated_workspace", statusCode)
@@ -1740,6 +1749,9 @@ func upstreamErrorKind(statusCode int, body []byte, decision codex429Decision) s
 	case http.StatusUnauthorized:
 		return "unauthorized"
 	case http.StatusPaymentRequired, http.StatusForbidden:
+		if statusCode == http.StatusForbidden && IsAgentRuntimeDeletedError(body) {
+			return "agent_runtime_deleted"
+		}
 		if IsDeactivatedWorkspaceError(body) {
 			return "deactivated_workspace"
 		}
@@ -4645,6 +4657,13 @@ func (h *Handler) applyCooldownForModel(account *auth.Account, statusCode int, b
 			h.store.MarkCooldown(account, 5*time.Minute, "unauthorized")
 		}
 	case http.StatusPaymentRequired, http.StatusForbidden:
+		if statusCode == http.StatusForbidden && IsAgentRuntimeDeletedError(body) {
+			atomic.StoreInt32(&account.Disabled, 1)
+			errorMsg := upstreamAccountErrorMessage(statusCode, body)
+			log.Printf("账号 %d 的 Agent runtime 已删除，标记为封禁", account.ID())
+			h.store.MarkCooldownWithError(account, 24*time.Hour, "unauthorized", errorMsg)
+			return codex429Decision{}
+		}
 		if IsDeactivatedWorkspaceError(body) {
 			log.Printf("账号 %d 工作区已停用，标记为错误", account.ID())
 			if h.store != nil {

--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -1704,6 +1704,7 @@ func IsDeactivatedWorkspaceError(body []byte) bool {
 	return strings.Contains(strings.ToLower(string(body)), "deactivated_workspace")
 }
 
+// IsAgentRuntimeDeletedError 判断响应体是否表示 Agent runtime 已删除。
 func IsAgentRuntimeDeletedError(body []byte) bool {
 	code := strings.ToLower(firstGJSONString(body, "error.code", "detail.code", "code"))
 	if code != "biscuit_baker_service_agent_error_status" {

--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -4661,7 +4661,7 @@ func (h *Handler) applyCooldownForModel(account *auth.Account, statusCode int, b
 			atomic.StoreInt32(&account.Disabled, 1)
 			errorMsg := upstreamAccountErrorMessage(statusCode, body)
 			log.Printf("账号 %d 的 Agent runtime 已删除，标记为封禁", account.ID())
-			h.store.MarkCooldownWithError(account, 24*time.Hour, "unauthorized", errorMsg)
+			h.store.MarkCooldownWithErrorExactDuration(account, 24*time.Hour, "unauthorized", errorMsg)
 			return codex429Decision{}
 		}
 		if IsDeactivatedWorkspaceError(body) {

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -2529,6 +2529,7 @@ func TestDeactivatedWorkspace402MarksAccountError(t *testing.T) {
 	}
 }
 
+// TestAgentRuntimeDeleted403MarksAccountBanned 验证代理请求会将 runtime 已删除的账号标记为封禁。
 func TestAgentRuntimeDeleted403MarksAccountBanned(t *testing.T) {
 	store := auth.NewStore(nil, nil, &database.SystemSettings{MaxConcurrency: 2, TestConcurrency: 1, TestModel: "gpt-5.4"})
 	account := &auth.Account{DBID: 42, AccessToken: "at", Status: auth.StatusReady, HealthTier: auth.HealthTierHealthy}

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -2553,6 +2553,10 @@ func TestAgentRuntimeDeleted403MarksAccountBanned(t *testing.T) {
 	if !account.IsBanned() {
 		t.Fatal("account should be in banned health tier")
 	}
+	_, cooldownUntil := account.GetCooldownSnapshot()
+	if remaining := time.Until(cooldownUntil); remaining < 23*time.Hour+59*time.Minute || remaining > 24*time.Hour {
+		t.Fatalf("cooldown remaining = %s, want approximately 24h", remaining)
+	}
 	account.Mu().RLock()
 	errorMsg := account.ErrorMsg
 	account.Mu().RUnlock()

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -2529,6 +2529,38 @@ func TestDeactivatedWorkspace402MarksAccountError(t *testing.T) {
 	}
 }
 
+func TestAgentRuntimeDeleted403MarksAccountBanned(t *testing.T) {
+	store := auth.NewStore(nil, nil, &database.SystemSettings{MaxConcurrency: 2, TestConcurrency: 1, TestModel: "gpt-5.4"})
+	account := &auth.Account{DBID: 42, AccessToken: "at", Status: auth.StatusReady, HealthTier: auth.HealthTierHealthy}
+	handler := &Handler{store: store}
+	body := []byte(`{"error":{"message":"Agent runtime has been deleted.","type":null,"code":"biscuit_baker_service_agent_error_status","param":null},"status":403}`)
+
+	if !IsAgentRuntimeDeletedError(body) {
+		t.Fatal("expected deleted Agent runtime body to be detected")
+	}
+	if IsAgentRuntimeDeletedError([]byte(`{"error":{"message":"Agent runtime has been deleted.","code":"permission_denied"}}`)) {
+		t.Fatal("unrelated error code must not be detected as deleted Agent runtime")
+	}
+	if got := upstreamErrorKind(http.StatusForbidden, body, codex429Decision{}); got != "agent_runtime_deleted" {
+		t.Fatalf("upstreamErrorKind = %q, want agent_runtime_deleted", got)
+	}
+
+	handler.applyCooldownForModel(account, http.StatusForbidden, body, &http.Response{Header: make(http.Header)}, "gpt-5.4")
+
+	if got := account.RuntimeStatus(); got != "unauthorized" {
+		t.Fatalf("RuntimeStatus() = %q, want unauthorized", got)
+	}
+	if !account.IsBanned() {
+		t.Fatal("account should be in banned health tier")
+	}
+	account.Mu().RLock()
+	errorMsg := account.ErrorMsg
+	account.Mu().RUnlock()
+	if !strings.Contains(errorMsg, "Agent runtime has been deleted") {
+		t.Fatalf("ErrorMsg = %q, want deleted runtime message", errorMsg)
+	}
+}
+
 func TestSendFinalUpstreamError_UsageLimitRewrites429(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 


### PR DESCRIPTION
## 背景

Agent Identity 账号的 runtime 被删除后，上游返回 403：

```json
{
  "error": {
    "message": "Agent runtime has been deleted.",
    "code": "biscuit_baker_service_agent_error_status"
  },
  "status": 403
}
```

此前该响应会落入通用 `payment_required` 冷却，不会进入 `banned` 强隔离状态，账号仍可能被继续调度。

## 改动

- 精确识别错误码与 `Agent runtime has been deleted` 消息，使用日志分类 `agent_runtime_deleted`。
- 真实代理请求命中后写入 `unauthorized` 冷却和原始错误详情，使账号立即退出调度并显示为封禁。
- 用量探针、单账号连接测试和批量测试复用相同封禁语义。
- 新增代理层及管理端回归测试。

## 验证

- `go test ./... -count=1`
- `npm test`
- `npm run typecheck`
- `npm run build`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of upstream HTTP **403** failures indicating **“agent runtime has been deleted”**, ensuring affected accounts transition to **unauthorized** (and are treated as **banned**).
  - Cooldown is now applied with a consistent **24-hour** duration, and the deleted-runtime message is surfaced reliably across proxy, admin connection, batch, and usage-probe paths.

- **Tests**
  - Added/extended coverage for deleted-runtime detection, banning/unauthorized state transitions, and **24-hour cooldown** persistence and duration policy behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->