### PR TITLE
fix(import): harden Agent Identity validation and dedupe

### DIFF
--- a/admin/codex_agent_identity.go
+++ b/admin/codex_agent_identity.go
@@ -120,13 +120,30 @@ func parseAgentIdentityAuthJSON(raw string) (*agentIdentityFields, error) {
 		PlanType:   agentIdentityString(node, "plan_type", "planType"),
 		FedRAMP:    agentIdentityBool(node, "chatgpt_account_is_fedramp", "chatgptAccountIsFedramp"),
 	}
-	if fields.RuntimeID == "" || fields.PrivateKey == "" || fields.AccountID == "" || fields.UserID == "" {
-		return nil, fmt.Errorf("agent identity 缺少必要字段（agent_runtime_id / agent_private_key / account_id / chatgpt_user_id）")
-	}
-	if err := auth.ValidateCodexAgentIdentityPrivateKey(fields.PrivateKey); err != nil {
-		return nil, fmt.Errorf("agent identity 私钥无效: %w", err)
+	if err := validateAgentIdentityFields(fields); err != nil {
+		return nil, err
 	}
 	return fields, nil
+}
+
+func validateAgentIdentityFields(fields *agentIdentityFields) error {
+	if fields == nil {
+		return fmt.Errorf("agent identity 字段为空")
+	}
+	runtimeID := strings.TrimSpace(fields.RuntimeID)
+	privateKey := strings.TrimSpace(fields.PrivateKey)
+	accountID := strings.TrimSpace(fields.AccountID)
+	userID := strings.TrimSpace(fields.UserID)
+	if runtimeID == "" || privateKey == "" || accountID == "" || userID == "" {
+		return fmt.Errorf("agent identity 缺少必要字段（agent_runtime_id / agent_private_key / account_id / chatgpt_user_id）")
+	}
+	if !strings.HasPrefix(runtimeID, "agent-") {
+		return fmt.Errorf("agent_runtime_id 必须以 agent- 开头")
+	}
+	if err := auth.ValidateCodexAgentIdentityPrivateKey(privateKey); err != nil {
+		return fmt.Errorf("agent identity 私钥无效: %w", err)
+	}
+	return nil
 }
 
 // ImportCodexAgentIdentity 导入 Codex Agent Identity auth.json 并创建账号。
@@ -159,17 +176,15 @@ func (h *Handler) ImportCodexAgentIdentity(c *gin.Context) {
 		return
 	}
 
-	// 按 agent_runtime_id 去重：同一 runtime 已存在则拒绝。
-	if h.agentIdentityRuntimeExists(fields.RuntimeID) {
-		writeError(c, http.StatusConflict, "该 Agent Identity 账号已存在")
-		return
-	}
-
 	ctx, cancel := context.WithTimeout(c.Request.Context(), 10*time.Second)
 	defer cancel()
-	id, err := h.createAgentIdentityAccount(ctx, fields, req.Name, req.ProxyURL, "agent_identity_import")
+	id, duplicate, err := h.createAgentIdentityAccountIfAbsent(ctx, fields, req.Name, req.ProxyURL, "agent_identity_import")
 	if err != nil {
 		writeInternalError(c, err)
+		return
+	}
+	if duplicate {
+		writeError(c, http.StatusConflict, "该 Agent Identity 账号已存在")
 		return
 	}
 
@@ -181,22 +196,82 @@ func (h *Handler) ImportCodexAgentIdentity(c *gin.Context) {
 	})
 }
 
-// agentIdentityRuntimeExists 判断池中是否已有相同 agent_runtime_id 的账号。
-func (h *Handler) agentIdentityRuntimeExists(runtimeID string) bool {
-	runtimeID = strings.TrimSpace(runtimeID)
-	if runtimeID == "" || h.store == nil {
-		return false
-	}
-	for _, acc := range h.store.Accounts() {
-		if acc.IsCodexAgentIdentity() && strings.EqualFold(strings.TrimSpace(acc.AgentRuntimeID), runtimeID) {
-			return true
+func agentIdentityRuntimeKey(runtimeID string) string {
+	return strings.ToLower(strings.TrimSpace(runtimeID))
+}
+
+func (h *Handler) existingAgentIdentityRuntimeIDs(ctx context.Context) (map[string]struct{}, error) {
+	runtimeIDs := make(map[string]struct{})
+	if h.store != nil {
+		for _, account := range h.store.Accounts() {
+			if account.IsCodexAgentIdentity() {
+				runtimeIDs[agentIdentityRuntimeKey(account.AgentRuntimeID)] = struct{}{}
+			}
 		}
 	}
-	return false
+	if h.db == nil {
+		return runtimeIDs, nil
+	}
+	rows, err := h.db.ListActive(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("查询已有 Agent Identity 账号失败: %w", err)
+	}
+	for _, row := range rows {
+		if isAgentIdentityCredentialRow(row) {
+			runtimeIDs[agentIdentityRuntimeKey(row.GetCredential("agent_runtime_id"))] = struct{}{}
+		}
+	}
+	return runtimeIDs, nil
+}
+
+func (h *Handler) beginAgentIdentityImport(ctx context.Context, allowDuplicate bool) (map[string]struct{}, func(), error) {
+	h.agentIdentityImportMu.Lock()
+	unlock := h.agentIdentityImportMu.Unlock
+	if allowDuplicate {
+		return nil, unlock, nil
+	}
+	runtimeIDs, err := h.existingAgentIdentityRuntimeIDs(ctx)
+	if err != nil {
+		unlock()
+		return nil, nil, err
+	}
+	return runtimeIDs, unlock, nil
+}
+
+func (h *Handler) createAgentIdentityAccountChecked(ctx context.Context, fields *agentIdentityFields, name, proxyURL, source string, runtimeIDs map[string]struct{}, allowDuplicate bool) (int64, bool, error) {
+	if err := validateAgentIdentityFields(fields); err != nil {
+		return 0, false, err
+	}
+	runtimeKey := agentIdentityRuntimeKey(fields.RuntimeID)
+	if !allowDuplicate {
+		if _, exists := runtimeIDs[runtimeKey]; exists {
+			return 0, true, nil
+		}
+	}
+	id, err := h.createAgentIdentityAccount(ctx, fields, name, proxyURL, source)
+	if err != nil {
+		return 0, false, err
+	}
+	if !allowDuplicate {
+		runtimeIDs[runtimeKey] = struct{}{}
+	}
+	return id, false, nil
+}
+
+func (h *Handler) createAgentIdentityAccountIfAbsent(ctx context.Context, fields *agentIdentityFields, name, proxyURL, source string) (int64, bool, error) {
+	runtimeIDs, unlock, err := h.beginAgentIdentityImport(ctx, false)
+	if err != nil {
+		return 0, false, err
+	}
+	defer unlock()
+	return h.createAgentIdentityAccountChecked(ctx, fields, name, proxyURL, source, runtimeIDs, false)
 }
 
 // createAgentIdentityAccount 用解析出的字段建号并加载进池，返回账号 ID。
 func (h *Handler) createAgentIdentityAccount(ctx context.Context, fields *agentIdentityFields, name, proxyURL, source string) (int64, error) {
+	if err := validateAgentIdentityFields(fields); err != nil {
+		return 0, err
+	}
 	planType := fields.PlanType
 	if planType == "" {
 		planType = "free"
@@ -244,7 +319,11 @@ func (h *Handler) importAgentIdentityTokens(ctx context.Context, tokens []import
 	if len(tokens) == 0 {
 		return 0, 0, 0
 	}
-	seen := make(map[string]struct{})
+	runtimeIDs, unlock, err := h.beginAgentIdentityImport(ctx, allowDuplicate)
+	if err != nil {
+		return 0, 0, len(tokens)
+	}
+	defer unlock()
 	for _, t := range tokens {
 		fields := &agentIdentityFields{
 			RuntimeID:  strings.TrimSpace(t.agentRuntimeID),
@@ -256,22 +335,15 @@ func (h *Handler) importAgentIdentityTokens(ctx context.Context, tokens []import
 			PlanType:   strings.TrimSpace(t.planType),
 			FedRAMP:    t.agentFedRAMP,
 		}
-		if err := auth.ValidateCodexAgentIdentityPrivateKey(fields.PrivateKey); err != nil {
+		_, duplicated, err := h.createAgentIdentityAccountChecked(ctx, fields, t.name, proxyURL, "import_agent_identity", runtimeIDs, allowDuplicate)
+		if err != nil {
 			failed++
 			continue
 		}
-		runtimeKey := strings.ToLower(fields.RuntimeID)
-		if !allowDuplicate {
-			if _, dup := seen[runtimeKey]; dup || h.agentIdentityRuntimeExists(fields.RuntimeID) {
-				duplicate++
-				continue
-			}
-		}
-		if _, err := h.createAgentIdentityAccount(ctx, fields, t.name, proxyURL, "import_agent_identity"); err != nil {
-			failed++
+		if duplicated {
+			duplicate++
 			continue
 		}
-		seen[runtimeKey] = struct{}{}
 		success++
 	}
 	return success, duplicate, failed
@@ -317,8 +389,13 @@ func (h *Handler) BatchImportCodexAgentIdentity(c *gin.Context) {
 
 	ctx, cancel := context.WithTimeout(c.Request.Context(), 30*time.Second)
 	defer cancel()
+	runtimeIDs, unlock, err := h.beginAgentIdentityImport(ctx, false)
+	if err != nil {
+		writeInternalError(c, err)
+		return
+	}
+	defer unlock()
 
-	seenRuntimes := make(map[string]struct{})
 	items := make([]agentIdentityImportItem, 0, len(req.Files))
 	imported := 0
 	for _, content := range req.Files {
@@ -330,19 +407,17 @@ func (h *Handler) BatchImportCodexAgentIdentity(c *gin.Context) {
 			continue
 		}
 		item.Email = fields.Email
-		runtimeKey := strings.ToLower(strings.TrimSpace(fields.RuntimeID))
-		if _, dup := seenRuntimes[runtimeKey]; dup || h.agentIdentityRuntimeExists(fields.RuntimeID) {
+		id, duplicated, err := h.createAgentIdentityAccountChecked(ctx, fields, "", req.ProxyURL, "agent_identity_file_import", runtimeIDs, false)
+		if duplicated {
 			item.Error = "账号已存在，已跳过"
 			items = append(items, item)
 			continue
 		}
-		id, err := h.createAgentIdentityAccount(ctx, fields, "", req.ProxyURL, "agent_identity_file_import")
 		if err != nil {
 			item.Error = err.Error()
 			items = append(items, item)
 			continue
 		}
-		seenRuntimes[runtimeKey] = struct{}{}
 		item.OK = true
 		item.ID = id
 		items = append(items, item)

--- a/admin/codex_agent_identity_test.go
+++ b/admin/codex_agent_identity_test.go
@@ -1,12 +1,16 @@
 package admin
 
 import (
+	"context"
 	"crypto/ed25519"
 	"crypto/rand"
 	"crypto/x509"
 	"encoding/base64"
 	"strings"
+	"sync"
 	"testing"
+
+	"github.com/codex2api/auth"
 )
 
 // newTestAgentPrivateKey 生成一把合法的 PKCS8 Ed25519 私钥（base64），供解析测试使用。
@@ -33,19 +37,19 @@ func TestParseAgentIdentityAuthJSON_Forms(t *testing.T) {
 	}{
 		{
 			name: "credentials wrapper flat fields (issue #424)",
-			json: `{"credentials":{"account_id":"acc-1","agent_private_key":"` + pk + `","agent_runtime_id":"rt-1","auth_mode":"agentIdentity","chatgpt_account_is_fedramp":false,"chatgpt_user_id":"user-1","email":"a@b.com"}}`,
+			json: `{"credentials":{"account_id":"acc-1","agent_private_key":"` + pk + `","agent_runtime_id":"agent-rt-1","auth_mode":"agentIdentity","chatgpt_account_is_fedramp":false,"chatgpt_user_id":"user-1","email":"a@b.com"}}`,
 		},
 		{
 			name: "flat root with auth_mode",
-			json: `{"auth_mode":"agentIdentity","agent_runtime_id":"rt-1","agent_private_key":"` + pk + `","account_id":"acc-1","chatgpt_user_id":"user-1"}`,
+			json: `{"auth_mode":"agentIdentity","agent_runtime_id":"agent-rt-1","agent_private_key":"` + pk + `","account_id":"acc-1","chatgpt_user_id":"user-1"}`,
 		},
 		{
 			name: "agent_identity sub-object",
-			json: `{"agent_identity":{"agent_runtime_id":"rt-1","agent_private_key":"` + pk + `","account_id":"acc-1","chatgpt_user_id":"user-1"}}`,
+			json: `{"agent_identity":{"agent_runtime_id":"agent-rt-1","agent_private_key":"` + pk + `","account_id":"acc-1","chatgpt_user_id":"user-1"}}`,
 		},
 		{
 			name: "credentials wrapping agent_identity sub-object",
-			json: `{"credentials":{"agent_identity":{"agent_runtime_id":"rt-1","agent_private_key":"` + pk + `","account_id":"acc-1","chatgpt_user_id":"user-1"}}}`,
+			json: `{"credentials":{"agent_identity":{"agent_runtime_id":"agent-rt-1","agent_private_key":"` + pk + `","account_id":"acc-1","chatgpt_user_id":"user-1"}}}`,
 		},
 		{
 			name:    "plain oauth credentials are not agent identity",
@@ -54,7 +58,12 @@ func TestParseAgentIdentityAuthJSON_Forms(t *testing.T) {
 		},
 		{
 			name:    "missing required fields",
-			json:    `{"credentials":{"auth_mode":"agentIdentity","agent_runtime_id":"rt-1"}}`,
+			json:    `{"credentials":{"auth_mode":"agentIdentity","agent_runtime_id":"agent-rt-1"}}`,
+			wantErr: true,
+		},
+		{
+			name:    "runtime id without agent prefix",
+			json:    `{"agent_identity":{"agent_runtime_id":"rt-1","agent_private_key":"` + pk + `","account_id":"acc-1","chatgpt_user_id":"user-1"}}`,
 			wantErr: true,
 		},
 	}
@@ -71,7 +80,7 @@ func TestParseAgentIdentityAuthJSON_Forms(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if fields.RuntimeID != "rt-1" || fields.AccountID != "acc-1" || fields.UserID != "user-1" {
+			if fields.RuntimeID != "agent-rt-1" || fields.AccountID != "acc-1" || fields.UserID != "user-1" {
 				t.Fatalf("parsed fields mismatch: %+v", fields)
 			}
 			if fields.PrivateKey != pk {
@@ -84,11 +93,120 @@ func TestParseAgentIdentityAuthJSON_Forms(t *testing.T) {
 func TestParseAgentIdentityAuthJSON_WrapperMissingFieldsReportsFieldError(t *testing.T) {
 	// credentials 包装被识别为 Agent Identity 后，缺字段应报"缺少必要字段"，
 	// 而不是"不是 Agent Identity 格式"——确认穿透生效。
-	_, err := parseAgentIdentityAuthJSON(`{"credentials":{"auth_mode":"agentIdentity","agent_runtime_id":"rt-1"}}`)
+	_, err := parseAgentIdentityAuthJSON(`{"credentials":{"auth_mode":"agentIdentity","agent_runtime_id":"agent-rt-1"}}`)
 	if err == nil {
 		t.Fatal("expected missing-field error")
 	}
 	if strings.Contains(err.Error(), "不是 Agent Identity 格式") {
 		t.Fatalf("wrapper should be detected as agent identity, got: %v", err)
+	}
+}
+
+func TestImportAgentIdentityTokensRejectsMissingRequiredFields(t *testing.T) {
+	handler := &Handler{}
+	success, duplicate, failed := handler.importAgentIdentityTokens(context.Background(), []importToken{{
+		agentRuntimeID:  "agent-runtime-1",
+		agentPrivateKey: newTestAgentPrivateKey(t),
+	}}, "", false)
+	if success != 0 || duplicate != 0 || failed != 1 {
+		t.Fatalf("counts = success:%d duplicate:%d failed:%d, want 0/0/1", success, duplicate, failed)
+	}
+}
+
+func TestCreateAgentIdentityAccountIfAbsentChecksDatabase(t *testing.T) {
+	db := newTestAdminDB(t)
+	privateKey := newTestAgentPrivateKey(t)
+	_, err := db.InsertAccountWithCredentials(context.Background(), "existing-agent", map[string]interface{}{
+		"auth_mode":         auth.CodexAuthModeAgentIdentity,
+		"agent_runtime_id":  "agent-existing",
+		"agent_private_key": privateKey,
+		"account_id":        "acc-existing",
+		"chatgpt_user_id":   "user-existing",
+	}, "")
+	if err != nil {
+		t.Fatalf("insert existing account: %v", err)
+	}
+
+	store := auth.NewStore(db, nil, nil)
+	t.Cleanup(store.Stop)
+	handler := &Handler{db: db, store: store}
+	_, duplicate, err := handler.createAgentIdentityAccountIfAbsent(context.Background(), &agentIdentityFields{
+		RuntimeID:  "agent-existing",
+		PrivateKey: privateKey,
+		AccountID:  "acc-new",
+		UserID:     "user-new",
+	}, "new-agent", "", "test")
+	if err != nil {
+		t.Fatalf("create account: %v", err)
+	}
+	if !duplicate {
+		t.Fatal("database-only existing runtime should be detected as duplicate")
+	}
+	rows, err := db.ListActive(context.Background())
+	if err != nil {
+		t.Fatalf("list active accounts: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("active accounts = %d, want 1", len(rows))
+	}
+}
+
+func TestCreateAgentIdentityAccountIfAbsentSerializesConcurrentImports(t *testing.T) {
+	db := newTestAdminDB(t)
+	store := auth.NewStore(db, nil, nil)
+	t.Cleanup(store.Stop)
+	handler := &Handler{
+		db:    db,
+		store: store,
+		probeUsage: func(context.Context, *auth.Account) error {
+			return nil
+		},
+	}
+	fields := &agentIdentityFields{
+		RuntimeID:  "agent-concurrent",
+		PrivateKey: newTestAgentPrivateKey(t),
+		AccountID:  "acc-concurrent",
+		UserID:     "user-concurrent",
+	}
+
+	const workers = 8
+	type result struct {
+		duplicate bool
+		err       error
+	}
+	results := make(chan result, workers)
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, duplicate, err := handler.createAgentIdentityAccountIfAbsent(context.Background(), fields, "concurrent-agent", "", "test")
+			results <- result{duplicate: duplicate, err: err}
+		}()
+	}
+	wg.Wait()
+	close(results)
+
+	created := 0
+	duplicates := 0
+	for result := range results {
+		if result.err != nil {
+			t.Fatalf("concurrent create: %v", result.err)
+		}
+		if result.duplicate {
+			duplicates++
+		} else {
+			created++
+		}
+	}
+	if created != 1 || duplicates != workers-1 {
+		t.Fatalf("created=%d duplicates=%d, want 1/%d", created, duplicates, workers-1)
+	}
+	rows, err := db.ListActive(context.Background())
+	if err != nil {
+		t.Fatalf("list active accounts: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("active accounts = %d, want 1", len(rows))
 	}
 }

--- a/admin/handler.go
+++ b/admin/handler.go
@@ -93,6 +93,10 @@ type Handler struct {
 	// 重复账号合并互斥锁：串行化 mergeRefreshedDuplicateIntoExisting，
 	// 防止并发导入同一身份的多个账号时互相合并、把双方都软删（账号丢失）。
 	mergeDuplicateMu sync.Mutex
+
+	// Agent Identity 导入互斥锁：串行化 runtime_id 的数据库查重与插入，
+	// 防止并发请求在“检查不存在”后同时建号。
+	agentIdentityImportMu sync.Mutex
 }
 
 type chartCacheEntry struct {

--- a/admin/import_json_test.go
+++ b/admin/import_json_test.go
@@ -1384,7 +1384,7 @@ func TestParseImportJSONTokensAgentIdentityFlatCredentials(t *testing.T) {
 				"name": "AI Account",
 				"credentials": {
 					"auth_mode": "agentIdentity",
-					"agent_runtime_id": "rt-flat",
+					"agent_runtime_id": "agent-flat",
 					"agent_private_key": "` + pk + `",
 					"account_id": "acc-flat",
 					"chatgpt_user_id": "user-flat",
@@ -1405,7 +1405,7 @@ func TestParseImportJSONTokensAgentIdentityFlatCredentials(t *testing.T) {
 	if !tok.isAgentIdentity() {
 		t.Fatalf("token should be agent identity: %+v", tok)
 	}
-	if tok.agentRuntimeID != "rt-flat" || tok.accountID != "acc-flat" || tok.chatgptUserID != "user-flat" {
+	if tok.agentRuntimeID != "agent-flat" || tok.accountID != "acc-flat" || tok.chatgptUserID != "user-flat" {
 		t.Fatalf("agent identity fields mismatch: %+v", tok)
 	}
 	if tok.agentPrivateKey != pk {


### PR DESCRIPTION
## Summary
- enforce the documented `agent-` prefix and required Agent Identity fields across all import paths
- make the generic multipart JSON importer reuse the same validation as the dedicated endpoints
- deduplicate against both the runtime store and active database rows
- serialize runtime ID lookup and insertion to prevent concurrent duplicate creation
- add regression coverage for missing fields, database-only duplicates, and concurrent imports

## Validation
- `gofmt` applied
- `git diff --check` passed
- `go build ./admin` passed
- tests were added but not executed per request

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stronger validation for Agent Identity imports, including required fields, runtime ID format, and private key validity.
  * Added duplicate detection for individual and bulk imports, with clear skipped-item feedback.

* **Bug Fixes**
  * Prevented concurrent imports from creating duplicate Agent Identity accounts.
  * Improved handling of invalid or incomplete import tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->