### PR TITLE
fix(db): 修复 usage_logs 在 PostgreSQL 高并发下批量写入卡死

### DIFF
--- a/database/postgres.go
+++ b/database/postgres.go
@@ -232,9 +232,13 @@ const (
 	defaultUsageLogBatchSize            = 200
 	defaultUsageLogFlushIntervalSeconds = 5
 	minUsageLogBatchSize                = 1
-	maxUsageLogBatchSize                = 10000
+	maxUsageLogBatchSize                = 1000
 	minUsageLogFlushIntervalSeconds     = 1
 	maxUsageLogFlushIntervalSeconds     = 300
+
+	postgresMaxBindParams       = 65535
+	usageLogInsertColumnCount   = 45
+	maxUsageLogInsertRowsPerSQL = 1000
 )
 
 var ErrDuplicateAccountCredential = errors.New("duplicate account credential")
@@ -784,7 +788,7 @@ func (db *DB) migrate(ctx context.Context) error {
 	ALTER TABLE usage_logs ADD COLUMN IF NOT EXISTS reasoning_tokens INT DEFAULT 0;
 	ALTER TABLE usage_logs ADD COLUMN IF NOT EXISTS first_token_ms INT DEFAULT 0;
 	ALTER TABLE usage_logs ADD COLUMN IF NOT EXISTS ws_acquire_ms INT DEFAULT 0;
-	ALTER TABLE usage_logs ADD COLUMN IF NOT EXISTS reasoning_effort VARCHAR(20) DEFAULT '';
+	ALTER TABLE usage_logs ADD COLUMN IF NOT EXISTS reasoning_effort VARCHAR(100) DEFAULT '';
 	ALTER TABLE usage_logs ADD COLUMN IF NOT EXISTS via_websocket BOOLEAN DEFAULT FALSE;
 	ALTER TABLE usage_logs ADD COLUMN IF NOT EXISTS effective_model VARCHAR(100) DEFAULT '';
 	ALTER TABLE usage_logs ADD COLUMN IF NOT EXISTS inbound_endpoint VARCHAR(100) DEFAULT '';
@@ -792,10 +796,10 @@ func (db *DB) migrate(ctx context.Context) error {
 	ALTER TABLE usage_logs ADD COLUMN IF NOT EXISTS stream BOOLEAN DEFAULT false;
 	ALTER TABLE usage_logs ADD COLUMN IF NOT EXISTS compact BOOLEAN DEFAULT false;
 	ALTER TABLE usage_logs ADD COLUMN IF NOT EXISTS cached_tokens INT DEFAULT 0;
-	ALTER TABLE usage_logs ADD COLUMN IF NOT EXISTS service_tier VARCHAR(20) DEFAULT '';
-	ALTER TABLE usage_logs ADD COLUMN IF NOT EXISTS requested_service_tier VARCHAR(20) DEFAULT '';
-	ALTER TABLE usage_logs ADD COLUMN IF NOT EXISTS actual_service_tier VARCHAR(20) DEFAULT '';
-	ALTER TABLE usage_logs ADD COLUMN IF NOT EXISTS billing_service_tier VARCHAR(20) DEFAULT '';
+	ALTER TABLE usage_logs ADD COLUMN IF NOT EXISTS service_tier VARCHAR(100) DEFAULT '';
+	ALTER TABLE usage_logs ADD COLUMN IF NOT EXISTS requested_service_tier VARCHAR(100) DEFAULT '';
+	ALTER TABLE usage_logs ADD COLUMN IF NOT EXISTS actual_service_tier VARCHAR(100) DEFAULT '';
+	ALTER TABLE usage_logs ADD COLUMN IF NOT EXISTS billing_service_tier VARCHAR(100) DEFAULT '';
 	ALTER TABLE usage_logs ADD COLUMN IF NOT EXISTS api_key_id INT DEFAULT 0;
 	ALTER TABLE usage_logs ADD COLUMN IF NOT EXISTS api_key_name VARCHAR(255) DEFAULT '';
 	ALTER TABLE usage_logs ADD COLUMN IF NOT EXISTS api_key_masked VARCHAR(64) DEFAULT '';
@@ -807,7 +811,7 @@ func (db *DB) migrate(ctx context.Context) error {
 	ALTER TABLE usage_logs ADD COLUMN IF NOT EXISTS image_width INT DEFAULT 0;
 	ALTER TABLE usage_logs ADD COLUMN IF NOT EXISTS image_height INT DEFAULT 0;
 	ALTER TABLE usage_logs ADD COLUMN IF NOT EXISTS image_bytes INT DEFAULT 0;
-	ALTER TABLE usage_logs ADD COLUMN IF NOT EXISTS image_format VARCHAR(20) DEFAULT '';
+	ALTER TABLE usage_logs ADD COLUMN IF NOT EXISTS image_format VARCHAR(100) DEFAULT '';
 	ALTER TABLE usage_logs ADD COLUMN IF NOT EXISTS image_size VARCHAR(32) DEFAULT '';
 	ALTER TABLE usage_logs ADD COLUMN IF NOT EXISTS account_billed DOUBLE PRECISION DEFAULT 0;
 	ALTER TABLE usage_logs ADD COLUMN IF NOT EXISTS user_billed DOUBLE PRECISION DEFAULT 0;
@@ -817,6 +821,12 @@ func (db *DB) migrate(ctx context.Context) error {
 	ALTER TABLE usage_logs ADD COLUMN IF NOT EXISTS error_message TEXT DEFAULT '';
 	-- 上游渠道（codex/grok），写入时按调度账号固化，供仪表盘/用量分渠道聚合
 	ALTER TABLE usage_logs ADD COLUMN IF NOT EXISTS channel VARCHAR(16) DEFAULT '';
+	ALTER TABLE usage_logs ALTER COLUMN reasoning_effort TYPE VARCHAR(100);
+	ALTER TABLE usage_logs ALTER COLUMN service_tier TYPE VARCHAR(100);
+	ALTER TABLE usage_logs ALTER COLUMN requested_service_tier TYPE VARCHAR(100);
+	ALTER TABLE usage_logs ALTER COLUMN actual_service_tier TYPE VARCHAR(100);
+	ALTER TABLE usage_logs ALTER COLUMN billing_service_tier TYPE VARCHAR(100);
+	ALTER TABLE usage_logs ALTER COLUMN image_format TYPE VARCHAR(100);
 
 	CREATE INDEX IF NOT EXISTS idx_usage_logs_api_key_created_at ON usage_logs(api_key_id, created_at);
 	CREATE INDEX IF NOT EXISTS idx_usage_logs_channel_created_at ON usage_logs(channel, created_at);
@@ -2845,18 +2855,45 @@ func (db *DB) FlushUsageLogs() {
 	if db == nil {
 		return
 	}
-	db.flushLogs()
+	for db.flushLogBatch(true) {
+	}
 }
 
-// flushLogs 将缓冲中的日志批量写入 PG
+// flushLogs 将缓冲中的日志按配置批量写入 PG。
+// 高并发下 logBuf 可能在一个 flush 间隔内积累到数千条；这里每次只取
+// usage_log_batch_size，避免一次事务过大，也避免 PostgreSQL 65535 bind 参数上限。
 func (db *DB) flushLogs() {
+	db.flushLogBatch(false)
+}
+
+func (db *DB) flushLogBatch(drain bool) bool {
+	if db == nil {
+		return false
+	}
+	batchSize := db.GetUsageLogBatchSize()
+	if batchSize <= 0 {
+		batchSize = defaultUsageLogBatchSize
+	}
+
 	db.logMu.Lock()
 	if len(db.logBuf) == 0 {
 		db.logMu.Unlock()
-		return
+		return false
 	}
-	batch := db.logBuf
-	db.logBuf = make([]usageLogEntry, 0, db.GetUsageLogBatchSize())
+	take := len(db.logBuf)
+	if take > batchSize {
+		take = batchSize
+	}
+	batch := make([]usageLogEntry, take)
+	copy(batch, db.logBuf[:take])
+	remaining := len(db.logBuf) - take
+	if remaining == 0 {
+		db.logBuf = make([]usageLogEntry, 0, batchSize)
+	} else {
+		next := make([]usageLogEntry, remaining, remaining+batchSize)
+		copy(next, db.logBuf[take:])
+		db.logBuf = next
+	}
 	db.logMu.Unlock()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second) // 增加超时时间
@@ -2872,12 +2909,19 @@ func (db *DB) flushLogs() {
 	if err != nil {
 		log.Printf("批量写入日志失败，已重新放回缓冲区等待重试: %v", err)
 		db.requeueUsageLogBatch(batch)
-		return
+		return false
 	}
 
 	if storedLogCount := countStoredUsageLogs(batch); storedLogCount > 10 {
 		log.Printf("批量写入 %d 条使用日志", storedLogCount)
 	}
+	if remaining > 0 {
+		if drain {
+			return true
+		}
+		db.notifyLogFlush()
+	}
+	return false
 }
 
 func countStoredUsageLogs(batch []usageLogEntry) int {
@@ -2976,8 +3020,9 @@ func (db *DB) insertSQLiteUsageLogBatch(ctx context.Context, batch []usageLogEnt
 	return nil
 }
 
-// batchInsertLogs 使用 PostgreSQL 的批量插入优化
-// 分批处理以避免 PostgreSQL 65535 参数限制（每行 43 个参数）。
+// batchInsertLogs 使用 PostgreSQL 的批量插入优化。
+// PostgreSQL 单条语句最多 65535 个 bind 参数；usage_logs 当前每行 45 个参数，
+// 因此单条 INSERT 的行数必须稳定低于 floor(65535/45)=1456。
 func (db *DB) batchInsertLogs(ctx context.Context, batch []usageLogEntry) error {
 	if len(batch) == 0 {
 		return nil
@@ -2990,7 +3035,10 @@ func (db *DB) batchInsertLogs(ctx context.Context, batch []usageLogEntry) error 
 	defer tx.Rollback()
 
 	logsToStore := storedUsageLogs(batch)
-	const maxRowsPerBatch = 1500
+	maxRowsPerBatch := maxUsageLogInsertRowsPerSQL
+	if paramSafeRows := postgresMaxBindParams / usageLogInsertColumnCount; paramSafeRows > 0 && maxRowsPerBatch > paramSafeRows {
+		maxRowsPerBatch = paramSafeRows
+	}
 
 	// 分批处理
 	for start := 0; start < len(logsToStore); start += maxRowsPerBatch {
@@ -3024,7 +3072,6 @@ func (db *DB) batchInsertLogsChunk(ctx context.Context, execer sqlExecer, batch 
 
 	// 使用 COPY 或批量 VALUES 优化插入性能
 	valueStrings := make([]string, 0, len(batch))
-	const usageLogInsertColumnCount = 45
 	valueArgs := make([]interface{}, 0, len(batch)*usageLogInsertColumnCount)
 	argIdx := 1
 

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -2694,7 +2694,7 @@
     "usageLogErrors": "Errors Only",
     "usageLogOff": "Disabled",
     "usageLogBatchSize": "Log Batch Size",
-    "usageLogBatchSizeDesc": "Write logs to the database once the buffer reaches this size (1~10000).",
+    "usageLogBatchSizeDesc": "Write logs to the database once the buffer reaches this size (1~1000; 200~500 recommended for 5k RPM).",
     "usageLogFlushInterval": "Log Flush Interval",
     "usageLogFlushIntervalDesc": "When the batch size is not reached, write at least once every N seconds (1~300).",
     "billingTierPolicy": "Billing Tier Policy",

--- a/frontend/src/locales/zh.json
+++ b/frontend/src/locales/zh.json
@@ -2694,7 +2694,7 @@
     "usageLogErrors": "仅错误",
     "usageLogOff": "关闭写入",
     "usageLogBatchSize": "日志批量大小",
-    "usageLogBatchSizeDesc": "缓冲达到该条数后批量写入数据库（1~10000）。",
+    "usageLogBatchSizeDesc": "缓冲达到该条数后批量写入数据库（1~1000，5kRPM 建议 200~500）。",
     "usageLogFlushInterval": "日志刷新间隔",
     "usageLogFlushIntervalDesc": "未达到批量大小时，最多等待多少秒写入一次（1~300）。",
     "billingTierPolicy": "Tier 计费策略",

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -2668,7 +2668,7 @@ export default function Settings() {
                 <SettingField label={t('settings.usageLogBatchSize')} description={t('settings.usageLogBatchSizeDesc')}>
                   <DraftNumberInput
                     min={1}
-                    max={10000}
+                    max={1000}
                     value={settingsForm.usage_log_batch_size}
                     onValueChange={(value) => setSettingsForm(f => ({ ...f, usage_log_batch_size: value }))}
                   />


### PR DESCRIPTION
## 背景

这个 PR 修的是 `usage_logs` 在 PostgreSQL 模式下的一个高并发稳定性问题。

线上高 RPM 场景里已经踩到过：API 请求本身还在正常返回 200，但后台日志、RPM、QPS 会突然停止更新。App 日志里持续出现：

```text
pq: got 67500 parameters but PostgreSQL only supports 65535 parameters
批量写入日志失败，已重新放回缓冲区等待重试
```

这不是前端统计问题，而是 `usage_logs` 写入器卡住了。失败的 batch 会被重新塞回内存 buffer，下一轮继续失败，导致后续日志一起堵住。结果就是：

- `usage_logs` 不再新增
- Dashboard RPM/QPS 变成 0 或长时间不更新
- App 内存里的 log buffer 持续堆积
- API 表面上还活着，但运营统计已经失真
- 高并发下重启只能临时恢复，流量上来后还会复发

## 根因

当前 PostgreSQL 批量写入逻辑里有两个问题叠加在一起。

### 1. 单条 INSERT 参数数量超过 PostgreSQL 上限

`usage_logs` 每行现在有 45 个 bind 参数，但 `batchInsertLogs` 里硬编码了：

```go
const maxRowsPerBatch = 1500
```

所以单条 SQL 最多会变成：

```text
1500 * 45 = 67500 parameters
```

PostgreSQL 单条语句 bind 参数上限是：

```text
65535
```

也就是说当前这个上限本身已经超过 PostgreSQL 的硬限制。只要某次 flush 里有 1500 条以上要写入的 usage log，就会稳定触发这个错误。

### 2. usage_log_batch_size 没有真正限制单次 flush 的数据量

`usage_log_batch_size` 表面上是控制批量大小，但当前 `flushLogs()` 会一次性拿走整个 `logBuf`。

高并发下，`logBuf` 可能在一个 flush 间隔里堆到几千条。即使后台把 `usage_log_batch_size` 配成 200 或 500，flush 时仍然会把整个 buffer 一次拿走，然后内部再按 1500 切分，最后还是触发 PostgreSQL 参数上限。

所以单纯调小 `usage_log_batch_size` 并不能彻底解决这个问题。

## 一起修掉的另一个问题

线上还观察到另一个会让整批日志失败的问题：

```text
pq: value too long for type character varying(20)
```

目前这些字段是 `varchar(20)`：

- `reasoning_effort`
- `service_tier`
- `requested_service_tier`
- `actual_service_tier`
- `billing_service_tier`
- `image_format`

这些值来自请求或上游返回，长度不完全受服务端控制。只要某个值超过 20，整批日志都会失败，并进入同样的 requeue 重试循环。

这个 PR 把这些字段放宽到 `varchar(100)`，避免一个长字段把整批日志写入打挂。

## 修改内容

- `maxUsageLogBatchSize` 从 10000 限制到 1000
- `flushLogs()` 每次只取 `usage_log_batch_size` 条，剩余 buffer 继续分批刷
- `batchInsertLogs()` 内部按 PostgreSQL bind 参数上限保护，单条 INSERT 最高 1000 行
- `FlushUsageLogs()` 保持诊断/测试路径的“刷完当前 buffer”语义
- 放宽 `usage_logs` 部分 `varchar(20)` 字段到 `varchar(100)`
- 前端设置页把 `usage_log_batch_size` 最大值同步到 1000，并提示高 RPM 场景建议 200~500

## 为什么这个问题比较严重

这个问题比较隐蔽，因为它不是直接把 API 打挂。

实际表现是：

- API 继续正常响应
- 后台统计开始失真
- 日志不再落库
- buffer 在内存里不断重试
- 运营侧看到 RPM/QPS 异常
- 计费、排查、统计都会受到影响

在低流量环境里不容易触发，但在几千 RPM 的 PostgreSQL 部署里很容易出现。一旦触发，重启只能清掉当前内存 buffer，后面流量上来还会复发。

## 兼容性

这个 PR 只改 `usage_logs` 写入链路和设置页上限，没有改请求转发、账号调度、模型映射、鉴权、计费计算等核心逻辑。

表结构变更是放宽字段长度：

```text
varchar(20) -> varchar(100)
```

这是兼容变更，旧数据不受影响。

`usage_log_batch_size` 最大值从 10000 改为 1000。这个是有意限制，因为更大的值在 PostgreSQL 批量写入下本身就不安全。

## 验证

本地已跑：

```bash
go test ./auth ./proxy ./database ./admin
npm --prefix frontend run typecheck
```

线上高并发实例验证过：

```text
usage_log_mode = full
usage_log_batch_size = 500
usage_log_flush_interval_seconds = 1
```

修复前：

```text
pq: got 67500 parameters but PostgreSQL only supports 65535 parameters
pq: value too long for type character varying(20)
usage_logs 停止新增
RPM/QPS 归零或长时间不更新
```

修复后观察：

```text
usage_logs 正常新增
RPM/QPS 恢复
log buffer 没有持续堆积
未再出现 65535 parameters 错误
未再出现 varchar(20) value too long 错误
```

## 备注

这里没有引入新的异步队列或复杂逻辑，只是让现有 `usage_logs` 写入器真正按 batch size 分批工作，并把 PostgreSQL 的硬限制纳入保护。

这个问题建议尽快合并，因为它会在高 RPM PostgreSQL 部署里造成日志系统卡死，而且表面上 API 仍然可用，排查时很容易误判成前端统计或 Redis/PG 性能问题。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved usage log processing for larger workloads and PostgreSQL limits.
  * Expanded supported field lengths for usage log details.

* **Bug Fixes**
  * Improved reliability when flushing pending usage logs.
  * Prevented oversized database insert batches.

* **Settings**
  * Reduced the maximum usage log batch size from 10,000 to 1,000.
  * Updated guidance to recommend batch sizes of 200–500 for high-throughput environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->