### PR TITLE
fix(grok): increase max files for batch import and max tokens for ref…

### DIFF
--- a/admin/grok_accounts.go
+++ b/admin/grok_accounts.go
@@ -419,7 +419,7 @@ type grokBatchImportItem struct {
 	Error string `json:"error,omitempty"`
 }
 
-const grokBatchImportMaxFiles = 500
+const grokBatchImportMaxFiles = 5000
 
 // BatchImportGrokAccounts 批量导入 Grok 凭据文件（POST /api/admin/accounts/grok/import）。
 // 每个文件独立解析入库，按 subject / refresh_token 去重（批内 + 与现有账号）。

--- a/admin/grok_sso.go
+++ b/admin/grok_sso.go
@@ -199,7 +199,7 @@ type importGrokRefreshReq struct {
 }
 
 const (
-	grokRefreshImportMaxTokens = 200
+	grokRefreshImportMaxTokens = 5000
 	grokRefreshImportPerToken  = 30 * time.Second
 )
 


### PR DESCRIPTION
批量导入 Grok 凭据文件数量限制改为5000

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Increased the maximum number of Grok credential files that can be imported in one batch from 500 to 5,000.
  * Increased the maximum number of Grok refresh tokens that can be imported in one request from 200 to 5,000.
  * Import validation messages now reflect the updated file limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->