### PR TITLE
feat(grok): 通过 GROK_OAUTH_CLIENT_ID 支持覆盖 OAuth client_id

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -92,3 +92,9 @@ REDIS_INSECURE_SKIP_VERIFY=false
 
 # ---- 时区 ----
 TZ=Asia/Shanghai
+
+# ---- Grok 上游 OAuth client_id（可选）----
+# 默认使用官方 Grok CLI 公开 client_id；留空即默认，默认行为零变化。
+# 用于多 client_id 部署、灰度对照或端点测试：设为自定义 client_id 即覆盖所有 Grok OAuth 落点
+# （浏览器授权、授权码兑换、refresh、device flow、SSO→Build 转换链）。
+# GROK_OAUTH_CLIENT_ID=

--- a/admin/grok_oauth.go
+++ b/admin/grok_oauth.go
@@ -289,7 +289,7 @@ func (h *Handler) createGrokOAuthAccount(ctx context.Context, in createGrokOAuth
 	if in.Token == nil {
 		return 0, "", fmt.Errorf("token 为空")
 	}
-	clientID := auth.GrokDefaultOAuthClientID
+	clientID := auth.EffectiveGrokOAuthClientID()
 	subject := strings.TrimSpace(in.Subject)
 	if subject == "" {
 		subject = auth.GrokSubjectFromAccessToken(in.Token.AccessToken)

--- a/auth/grok_account.go
+++ b/auth/grok_account.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -43,7 +44,20 @@ const (
 	GrokDefaultOAuthClientID    = "b1a00492-073a-47ea-816f-4c329264a828"
 	GrokDefaultOAuthScope       = "openid profile email offline_access grok-cli:access api:access"
 	GrokDefaultOAuthRedirectURI = "http://127.0.0.1:56121/callback"
+
+	// EnvGrokOAuthClientID 沿用既有 grokEnv 覆盖约定（类比 proxy 包的 GROK_CLIENT_VERSION / GROK_CLIENT_IDENTIFIER）：
+	// 留空回退到 GrokDefaultOAuthClientID，默认行为零变化。服务于多 client_id 部署、灰度对照与端点测试。
+	EnvGrokOAuthClientID = "GROK_OAUTH_CLIENT_ID"
 )
+
+// EffectiveGrokOAuthClientID 返回生效的 OAuth client_id：env GROK_OAUTH_CLIENT_ID 优先
+// （去空格后非空即用），留空回退到官方 Grok CLI 公开 id。未设 env 时仍是 GrokDefaultOAuthClientID。
+func EffectiveGrokOAuthClientID() string {
+	if v := strings.TrimSpace(os.Getenv(EnvGrokOAuthClientID)); v != "" {
+		return v
+	}
+	return GrokDefaultOAuthClientID
+}
 
 func (a *Account) isGrokAPILocked() bool {
 	if a == nil {
@@ -509,7 +523,7 @@ func BuildGrokAuthorizationURL(params GrokAuthURLParams) (string, error) {
 	}
 	clientID := strings.TrimSpace(params.ClientID)
 	if clientID == "" {
-		clientID = GrokDefaultOAuthClientID
+		clientID = EffectiveGrokOAuthClientID()
 	}
 	scope := strings.TrimSpace(params.Scope)
 	if scope == "" {
@@ -600,7 +614,7 @@ func ExchangeGrokAuthorizationCode(ctx context.Context, params GrokExchangeCodeP
 	}
 	clientID := strings.TrimSpace(params.ClientID)
 	if clientID == "" {
-		clientID = GrokDefaultOAuthClientID
+		clientID = EffectiveGrokOAuthClientID()
 	}
 	redirectURI := strings.TrimSpace(params.RedirectURI)
 	if redirectURI == "" {
@@ -817,7 +831,7 @@ func RefreshGrokAccessToken(ctx context.Context, params GrokRefreshParams) (*Gro
 	}
 	if strings.TrimSpace(params.ClientID) == "" {
 		// 浏览器授权链路默认使用 Grok CLI 公开 client_id
-		params.ClientID = GrokDefaultOAuthClientID
+		params.ClientID = EffectiveGrokOAuthClientID()
 	}
 
 	transport := http.DefaultTransport.(*http.Transport).Clone()

--- a/auth/grok_device.go
+++ b/auth/grok_device.go
@@ -84,7 +84,7 @@ func StartGrokDeviceFlow(ctx context.Context, proxyURL string) (*GrokDeviceCodeR
 		return nil, err
 	}
 	form := url.Values{
-		"client_id": {GrokDefaultOAuthClientID},
+		"client_id": {EffectiveGrokOAuthClientID()},
 		"scope":     {GrokDefaultOAuthScope},
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, discovery.DeviceAuthorizationEndpoint, strings.NewReader(form.Encode()))
@@ -146,7 +146,7 @@ func PollGrokDeviceToken(ctx context.Context, deviceCode, tokenEndpoint, proxyUR
 	form := url.Values{
 		"grant_type":  {GrokDeviceCodeGrantType},
 		"device_code": {deviceCode},
-		"client_id":   {GrokDefaultOAuthClientID},
+		"client_id":   {EffectiveGrokOAuthClientID()},
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenEndpoint, strings.NewReader(form.Encode()))
 	if err != nil {

--- a/auth/grok_oauth_client_id_test.go
+++ b/auth/grok_oauth_client_id_test.go
@@ -1,0 +1,27 @@
+package auth
+
+import "testing"
+
+// EffectiveGrokOAuthClientID 默认回退到 GrokDefaultOAuthClientID，设 env 后覆盖。
+// 这些用例直接钉住 PR 卖点：默认行为零变化 + env 非空即覆盖。
+func TestEffectiveGrokOAuthClientID_DefaultIsUnchanged(t *testing.T) {
+	t.Setenv(EnvGrokOAuthClientID, "")
+	if got := EffectiveGrokOAuthClientID(); got != GrokDefaultOAuthClientID {
+		t.Fatalf("default client_id drift: got %q, want %q", got, GrokDefaultOAuthClientID)
+	}
+}
+
+func TestEffectiveGrokOAuthClientID_EnvOverridesDefault(t *testing.T) {
+	t.Setenv(EnvGrokOAuthClientID, "test-client-id-1234")
+	if got := EffectiveGrokOAuthClientID(); got != "test-client-id-1234" {
+		t.Fatalf("env client_id not honored: got %q, want %q", got, "test-client-id-1234")
+	}
+}
+
+// env 为纯空白时同样回退默认，保持“非空即用”的契约。
+func TestEffectiveGrokOAuthClientID_WhitespaceFallsBack(t *testing.T) {
+	t.Setenv(EnvGrokOAuthClientID, "   \t  ")
+	if got := EffectiveGrokOAuthClientID(); got != GrokDefaultOAuthClientID {
+		t.Fatalf("whitespace-only client_id should fall back: got %q, want %q", got, GrokDefaultOAuthClientID)
+	}
+}

--- a/auth/grok_sso.go
+++ b/auth/grok_sso.go
@@ -176,7 +176,7 @@ func (f *grokSSOFlow) convert(ctx context.Context) (*GrokSSOBuildResult, error) 
 	}
 
 	// 2) 启动 device flow
-	form := url.Values{"client_id": {GrokDefaultOAuthClientID}, "scope": {GrokDefaultOAuthScope}}
+	form := url.Values{"client_id": {EffectiveGrokOAuthClientID()}, "scope": {GrokDefaultOAuthScope}}
 	status, _, body, err := f.do(ctx, http.MethodPost, grokSSODeviceURL, form)
 	if err != nil {
 		return nil, err
@@ -260,7 +260,7 @@ func (f *grokSSOFlow) pollToken(ctx context.Context, deviceCode string, interval
 	for {
 		status, _, body, err := f.do(ctx, http.MethodPost, GrokDefaultTokenURL, url.Values{
 			"grant_type":  {GrokDeviceCodeGrantType},
-			"client_id":   {GrokDefaultOAuthClientID},
+			"client_id":   {EffectiveGrokOAuthClientID()},
 			"device_code": {deviceCode},
 		})
 		if err != nil {


### PR DESCRIPTION
## 动机

为 Grok 的 OAuth `client_id` 增加一个 env 覆盖钩子，复用项目里已有的 `grokEnv` 约定（proxy 包里 `GROK_CLIENT_VERSION`、`GROK_CLIENT_IDENTIFIER` 等都是这个模式），将原本散落的硬编码 `GrokDefaultOAuthClientID` 收敛为单一可配置项。

**未设 env 时默认行为零变化**——仍使用内置的官方 Grok CLI 公开 `client_id`。这个钩子服务于多 `client_id` 部署、灰度对照与端点测试场景：把“换 `client_id`”从重编译降级到设环境变量，也就是在.env中直接填写。

## 改动内容

- **新增导出 helper** `auth.EffectiveGrokOAuthClientID()`：env `GROK_OAUTH_CLIENT_ID` 设值（去空格后非空）即用，否则回退到 `GrokDefaultOAuthClientID`。
- **8 处 `GrokDefaultOAuthClientID` 落点统一改走该 helper**，覆盖全部 OAuth 路径：
  - `auth/grok_account.go`：浏览器授权 URL 构造、授权码兑换、refresh token 刷新（3 处）
  - `auth/grok_sso.go`：SSO→Build 转换链的 device 启动与 token 兑换（2 处）
  - `auth/grok_device.go`：手动交互 device 流的启动与兑换（2 处）
  - `admin/grok_oauth.go`：创建 OAuth 账号时的默认 `client_id`（1 处）
- **`.env.example` 与既有环境变量文档同框**补一条 `GROK_OAUTH_CLIENT_ID` 占位说明。
- **新增单测** `auth/grok_oauth_client_id_test.go` 钉死三种行为：
  - 默认（未设 env）回退到 `GrokDefaultOAuthClientID`
  - env 设非空值即覆盖
  - env 为纯空白依旧回退默认

## 兼容性

- 默认行为零变化，不设 `GROK_OAUTH_CLIENT_ID` 时所有路径行为与改动前一致。
- 不涉及 DB schema、API 形状、前端、上游协议，纯运行时配置能力。

## 本地验证

限于本 PR 改动范围只覆盖 `auth` 与 `admin` 两个包，编译/静态分析/单测均针对这两个包跑：

```go
go build ./auth/ ./admin/
go vet ./auth/ ./admin/
go test -run TestEffectiveGrokOAuthClientID -v ./auth/
```

- 编译：`go build ./auth/ ./admin/` 零报错
- 静态分析：`go vet ./auth/ ./admin/` 零问题
- 新增单测：3 个用例全过（默认回退 / env 覆盖 / 纯空白回退）

> 说明：`go build ./...` 全量会因 `main.go` 对 `frontend/dist/*` 的 `//go:embed` 而需要先构前端（本仓库既有要求，与本 PR 无关）。`go test ./auth/` 全量另有 1 个 `store_scheduler_test.go` 的失败，与本 PR 改动域（Grok OAuth）无关，属仓库既有测试，本着不越界原则未在本次触及。

## 参考

- `proxy/grok_upstream.go` 已有的 `grokEnv("GROK_CLIENT_VERSION", ...)` 是本 env 钩子复用的模式来源。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional configuration for a custom Grok OAuth client ID.
  * Grok OAuth, device authorization, and SSO flows now use the configured client ID when provided, while preserving the existing default behavior otherwise.

* **Tests**
  * Added coverage for configured, unset, empty, and whitespace-only client ID settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->