### PR TITLE
feat(prompt-filter): unify policy audit and per-key review control

### DIFF
--- a/admin/prompt_filter_newapi_bindings.go
+++ b/admin/prompt_filter_newapi_bindings.go
@@ -28,6 +28,7 @@ type promptFilterNewAPIBindingCreateRequest struct {
 	PlatformName          string `json:"platform_name"`
 	Enabled               *bool  `json:"enabled"`
 	RequireSignedIdentity *bool  `json:"require_signed_identity"`
+	PromptFilterScope     string `json:"prompt_filter_scope"`
 }
 
 type promptFilterNewAPIBindingUpdateRequest struct {
@@ -35,6 +36,7 @@ type promptFilterNewAPIBindingUpdateRequest struct {
 	PlatformName          *string `json:"platform_name"`
 	Enabled               *bool   `json:"enabled"`
 	RequireSignedIdentity *bool   `json:"require_signed_identity"`
+	PromptFilterScope     *string `json:"prompt_filter_scope"`
 }
 
 type promptFilterNewAPIBindingSecretRequest struct {
@@ -48,6 +50,7 @@ type promptFilterNewAPIBindingResponse struct {
 	PlatformName            string     `json:"platform_name"`
 	Enabled                 bool       `json:"enabled"`
 	RequireSignedIdentity   bool       `json:"require_signed_identity"`
+	PromptFilterScope       string     `json:"prompt_filter_scope"`
 	SecretConfigured        bool       `json:"secret_configured"`
 	SecretMasked            string     `json:"secret_masked"`
 	PreviousSecretActive    bool       `json:"previous_secret_active"`
@@ -115,7 +118,15 @@ func (h *Handler) CreatePromptFilterNewAPIBinding(c *gin.Context) {
 	if req.RequireSignedIdentity != nil {
 		requireSigned = *req.RequireSignedIdentity
 	}
-	binding := &database.PromptFilterNewAPIBinding{APIKeyID: req.APIKeyID, PlatformCode: code, PlatformName: name, Secret: secret, Enabled: enabled, RequireSignedIdentity: requireSigned}
+	scope, validScope := database.NormalizePromptFilterScope(req.PromptFilterScope)
+	if !validScope {
+		writeError(c, http.StatusBadRequest, "Prompt 检查范围仅支持 inherit、local_only 或 off")
+		return
+	}
+	binding := &database.PromptFilterNewAPIBinding{
+		APIKeyID: req.APIKeyID, PlatformCode: code, PlatformName: name, Secret: secret,
+		Enabled: enabled, RequireSignedIdentity: requireSigned, PromptFilterScope: scope,
+	}
 	mutationCtx, cancelMutation := promptFilterBindingMutationContext(c)
 	defer cancelMutation()
 	h.settingsUpdateMu.Lock()
@@ -171,6 +182,15 @@ func (h *Handler) UpdatePromptFilterNewAPIBinding(c *gin.Context) {
 	}
 	if req.RequireSignedIdentity != nil {
 		binding.RequireSignedIdentity = *req.RequireSignedIdentity
+	}
+	if req.PromptFilterScope != nil {
+		scope, validScope := database.NormalizePromptFilterScope(*req.PromptFilterScope)
+		if !validScope {
+			h.settingsUpdateMu.Unlock()
+			writeError(c, http.StatusBadRequest, "Prompt 检查范围仅支持 inherit、local_only 或 off")
+			return
+		}
+		binding.PromptFilterScope = scope
 	}
 	binding.PlatformCode, binding.PlatformName, ok = validatePromptFilterBindingFields(c, binding.PlatformCode, binding.PlatformName)
 	if !ok {
@@ -374,7 +394,7 @@ func newPromptFilterNewAPIBindingResponse(binding *database.PromptFilterNewAPIBi
 	previousActive := binding.PreviousSecret != "" && binding.PreviousSecretExpiresAt != nil && binding.PreviousSecretExpiresAt.After(time.Now())
 	return promptFilterNewAPIBindingResponse{
 		APIKeyID: binding.APIKeyID, PlatformCode: binding.PlatformCode, PlatformName: binding.PlatformName,
-		Enabled: binding.Enabled, RequireSignedIdentity: binding.RequireSignedIdentity,
+		Enabled: binding.Enabled, RequireSignedIdentity: binding.RequireSignedIdentity, PromptFilterScope: binding.PromptFilterScope,
 		SecretConfigured: binding.Secret != "", SecretMasked: maskPromptFilterBindingSecret(binding.Secret),
 		PreviousSecretActive: previousActive, PreviousSecretExpiresAt: binding.PreviousSecretExpiresAt,
 		UpdatedAt: binding.UpdatedAt, Secret: reveal,

--- a/admin/prompt_filter_newapi_bindings_test.go
+++ b/admin/prompt_filter_newapi_bindings_test.go
@@ -46,7 +46,7 @@ func TestPromptFilterNewAPIBindingAdminLifecycleMasksSecretsAndReloadsStore(t *t
 		t.Fatalf("overlong platform code response=%d body=%s", invalid.Code, invalid.Body.String())
 	}
 
-	createBody := `{"api_key_id":` + jsonNumber(apiKeyID) + `,"platform_code":"gateway-a","platform_name":"示例平台 NewAPI"}`
+	createBody := `{"api_key_id":` + jsonNumber(apiKeyID) + `,"platform_code":"gateway-a","platform_name":"示例平台 NewAPI","prompt_filter_scope":"local_only"}`
 	created := do(http.MethodPost, "/api/admin/prompt-filter/newapi-bindings", createBody)
 	if created.Code != http.StatusCreated {
 		t.Fatalf("create status=%d body=%s", created.Code, created.Body.String())
@@ -61,6 +61,9 @@ func TestPromptFilterNewAPIBindingAdminLifecycleMasksSecretsAndReloadsStore(t *t
 	if createResponse.RequireSignedIdentity {
 		t.Fatal("create default require_signed_identity = true, want safe migration default false")
 	}
+	if createResponse.PromptFilterScope != database.PromptFilterScopeLocalOnly {
+		t.Fatalf("create prompt filter scope = %q", createResponse.PromptFilterScope)
+	}
 	runtimeBinding, ok := store.GetPromptFilterNewAPIBinding(apiKeyID)
 	if !ok || runtimeBinding.Secret != createResponse.Secret {
 		t.Fatalf("runtime create binding=%#v ok=%v", runtimeBinding, ok)
@@ -74,12 +77,17 @@ func TestPromptFilterNewAPIBindingAdminLifecycleMasksSecretsAndReloadsStore(t *t
 		t.Fatalf("list leaked secret: %s", listed.Body.String())
 	}
 
-	patched := do(http.MethodPatch, "/api/admin/prompt-filter/newapi-bindings/"+jsonNumber(apiKeyID), `{"platform_name":"示例平台生产站","enabled":false}`)
+	invalidScope := do(http.MethodPatch, "/api/admin/prompt-filter/newapi-bindings/"+jsonNumber(apiKeyID), `{"prompt_filter_scope":"remote_only"}`)
+	if invalidScope.Code != http.StatusBadRequest {
+		t.Fatalf("invalid scope status=%d body=%s", invalidScope.Code, invalidScope.Body.String())
+	}
+
+	patched := do(http.MethodPatch, "/api/admin/prompt-filter/newapi-bindings/"+jsonNumber(apiKeyID), `{"platform_name":"示例平台生产站","enabled":false,"prompt_filter_scope":"off"}`)
 	if patched.Code != http.StatusOK {
 		t.Fatalf("patch status=%d body=%s", patched.Code, patched.Body.String())
 	}
 	runtimeBinding, _ = store.GetPromptFilterNewAPIBinding(apiKeyID)
-	if runtimeBinding.PlatformName != "示例平台生产站" || runtimeBinding.Enabled {
+	if runtimeBinding.PlatformName != "示例平台生产站" || runtimeBinding.Enabled || runtimeBinding.PromptFilterScope != database.PromptFilterScopeOff {
 		t.Fatalf("runtime patch binding=%#v", runtimeBinding)
 	}
 	if strings.Contains(patched.Body.String(), "policy_mode") || strings.Contains(patched.Body.String(), "policy_profile") {

--- a/database/prompt_filter_newapi_binding.go
+++ b/database/prompt_filter_newapi_binding.go
@@ -21,6 +21,10 @@ const (
 	PromptFilterPolicyProfileBalanced = "balanced"
 	PromptFilterPolicyProfileStrict   = "strict"
 	PromptFilterPolicyProfileResearch = "research"
+
+	PromptFilterScopeInherit   = "inherit"
+	PromptFilterScopeLocalOnly = "local_only"
+	PromptFilterScopeOff       = "off"
 )
 
 var ErrPromptFilterNewAPIBindingConflict = errors.New("prompt filter NewAPI binding conflict")
@@ -34,6 +38,7 @@ const sqlitePromptFilterNewAPIBindingsDDL = `CREATE TABLE IF NOT EXISTS prompt_f
 	secret TEXT NOT NULL,
 	enabled INTEGER NOT NULL DEFAULT 1,
 	require_signed_identity INTEGER NOT NULL DEFAULT 0,
+	prompt_filter_scope TEXT NOT NULL DEFAULT 'inherit',
 	policy_mode TEXT NOT NULL DEFAULT 'inherit',
 	policy_profile TEXT NOT NULL DEFAULT 'inherit',
 	previous_secret TEXT NOT NULL DEFAULT '',
@@ -48,6 +53,7 @@ const postgresPromptFilterNewAPIBindingsDDL = `CREATE TABLE IF NOT EXISTS prompt
 	secret TEXT NOT NULL,
 	enabled BOOLEAN NOT NULL DEFAULT TRUE,
 	require_signed_identity BOOLEAN NOT NULL DEFAULT FALSE,
+	prompt_filter_scope VARCHAR(16) NOT NULL DEFAULT 'inherit',
 	policy_mode VARCHAR(16) NOT NULL DEFAULT 'inherit',
 	policy_profile VARCHAR(16) NOT NULL DEFAULT 'inherit',
 	previous_secret TEXT NOT NULL DEFAULT '',
@@ -65,6 +71,7 @@ type PromptFilterNewAPIBinding struct {
 	Secret                  string     `json:"-"`
 	Enabled                 bool       `json:"enabled"`
 	RequireSignedIdentity   bool       `json:"require_signed_identity"`
+	PromptFilterScope       string     `json:"prompt_filter_scope"`
 	PolicyMode              string     `json:"policy_mode"`
 	PolicyProfile           string     `json:"policy_profile"`
 	PreviousSecret          string     `json:"-"`
@@ -80,11 +87,33 @@ func (db *DB) ensurePromptFilterNewAPIBindingsTable(ctx context.Context) error {
 	if _, err := db.conn.ExecContext(ctx, ddl); err != nil {
 		return err
 	}
+	if db.isSQLite() {
+		if err := db.ensureSQLiteColumn(ctx, "prompt_filter_newapi_bindings", "prompt_filter_scope", "TEXT NOT NULL DEFAULT 'inherit'"); err != nil {
+			return err
+		}
+	} else if _, err := db.conn.ExecContext(ctx, `ALTER TABLE prompt_filter_newapi_bindings ADD COLUMN IF NOT EXISTS prompt_filter_scope VARCHAR(16) NOT NULL DEFAULT 'inherit'`); err != nil {
+		return err
+	}
 	// Binding-level policy overrides were retired. Keep the legacy columns for
 	// a low-risk rolling migration, but neutralize all stored values so an old
 	// shadow/off row cannot silently override the unified GuardPipeline.
-	_, err := db.conn.ExecContext(ctx, `UPDATE prompt_filter_newapi_bindings SET policy_mode='inherit', policy_profile='inherit' WHERE policy_mode<>'inherit' OR policy_profile<>'inherit'`)
+	_, err := db.conn.ExecContext(ctx, `UPDATE prompt_filter_newapi_bindings
+		SET policy_mode='inherit', policy_profile='inherit',
+			prompt_filter_scope=CASE WHEN prompt_filter_scope IN ('inherit','local_only','off') THEN prompt_filter_scope ELSE 'inherit' END
+		WHERE policy_mode<>'inherit' OR policy_profile<>'inherit' OR prompt_filter_scope NOT IN ('inherit','local_only','off')`)
 	return err
+}
+
+func NormalizePromptFilterScope(value string) (string, bool) {
+	value = strings.ToLower(strings.TrimSpace(value))
+	switch value {
+	case "", PromptFilterScopeInherit:
+		return PromptFilterScopeInherit, true
+	case PromptFilterScopeLocalOnly, PromptFilterScopeOff:
+		return value, true
+	default:
+		return "", false
+	}
 }
 
 func NormalizePromptFilterPolicyMode(value string) (string, bool) {
@@ -120,7 +149,7 @@ func NormalizePromptFilterPlatformCode(value string) (string, bool) {
 }
 
 func (db *DB) ListPromptFilterNewAPIBindings(ctx context.Context) ([]*PromptFilterNewAPIBinding, error) {
-	rows, err := db.conn.QueryContext(ctx, `SELECT api_key_id, platform_code, platform_name, secret, enabled, require_signed_identity, policy_mode, policy_profile, previous_secret, previous_secret_expires_at, updated_at FROM prompt_filter_newapi_bindings ORDER BY api_key_id`)
+	rows, err := db.conn.QueryContext(ctx, `SELECT api_key_id, platform_code, platform_name, secret, enabled, require_signed_identity, prompt_filter_scope, policy_mode, policy_profile, previous_secret, previous_secret_expires_at, updated_at FROM prompt_filter_newapi_bindings ORDER BY api_key_id`)
 	if err != nil {
 		return nil, err
 	}
@@ -137,7 +166,7 @@ func (db *DB) ListPromptFilterNewAPIBindings(ctx context.Context) ([]*PromptFilt
 }
 
 func (db *DB) GetPromptFilterNewAPIBinding(ctx context.Context, apiKeyID int64) (*PromptFilterNewAPIBinding, error) {
-	return scanPromptFilterNewAPIBinding(db.conn.QueryRowContext(ctx, `SELECT api_key_id, platform_code, platform_name, secret, enabled, require_signed_identity, policy_mode, policy_profile, previous_secret, previous_secret_expires_at, updated_at FROM prompt_filter_newapi_bindings WHERE api_key_id = $1`, apiKeyID))
+	return scanPromptFilterNewAPIBinding(db.conn.QueryRowContext(ctx, `SELECT api_key_id, platform_code, platform_name, secret, enabled, require_signed_identity, prompt_filter_scope, policy_mode, policy_profile, previous_secret, previous_secret_expires_at, updated_at FROM prompt_filter_newapi_bindings WHERE api_key_id = $1`, apiKeyID))
 }
 
 func (db *DB) CreatePromptFilterNewAPIBinding(ctx context.Context, binding *PromptFilterNewAPIBinding) error {
@@ -157,10 +186,15 @@ func (db *DB) CreatePromptFilterNewAPIBinding(ctx context.Context, binding *Prom
 	}
 	mode := PromptFilterPolicyModeInherit
 	profile := PromptFilterPolicyProfileInherit
+	scope, ok := NormalizePromptFilterScope(binding.PromptFilterScope)
+	if !ok {
+		return errors.New("prompt_filter_scope must be inherit, local_only, or off")
+	}
+	binding.PromptFilterScope = scope
 	binding.PolicyMode = mode
 	binding.PolicyProfile = profile
 	return db.withSQLiteWriteLock(ctx, func() error {
-		_, err := db.conn.ExecContext(ctx, `INSERT INTO prompt_filter_newapi_bindings (api_key_id, platform_code, platform_name, secret, enabled, require_signed_identity, policy_mode, policy_profile, previous_secret, previous_secret_expires_at, updated_at) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, '', NULL, CURRENT_TIMESTAMP)`, binding.APIKeyID, platformCode, strings.TrimSpace(binding.PlatformName), secret, binding.Enabled, binding.RequireSignedIdentity, mode, profile)
+		_, err := db.conn.ExecContext(ctx, `INSERT INTO prompt_filter_newapi_bindings (api_key_id, platform_code, platform_name, secret, enabled, require_signed_identity, prompt_filter_scope, policy_mode, policy_profile, previous_secret, previous_secret_expires_at, updated_at) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, '', NULL, CURRENT_TIMESTAMP)`, binding.APIKeyID, platformCode, strings.TrimSpace(binding.PlatformName), secret, binding.Enabled, binding.RequireSignedIdentity, scope, mode, profile)
 		if isPromptFilterNewAPIBindingConflict(err) {
 			return fmt.Errorf("%w: %v", ErrPromptFilterNewAPIBindingConflict, err)
 		}
@@ -181,10 +215,15 @@ func (db *DB) UpdatePromptFilterNewAPIBinding(ctx context.Context, binding *Prom
 	}
 	mode := PromptFilterPolicyModeInherit
 	profile := PromptFilterPolicyProfileInherit
+	scope, ok := NormalizePromptFilterScope(binding.PromptFilterScope)
+	if !ok {
+		return errors.New("prompt_filter_scope must be inherit, local_only, or off")
+	}
+	binding.PromptFilterScope = scope
 	binding.PolicyMode = mode
 	binding.PolicyProfile = profile
 	return db.withSQLiteWriteLock(ctx, func() error {
-		result, err := db.conn.ExecContext(ctx, `UPDATE prompt_filter_newapi_bindings SET platform_code=$1, platform_name=$2, enabled=$3, require_signed_identity=$4, policy_mode=$5, policy_profile=$6, updated_at=CURRENT_TIMESTAMP WHERE api_key_id=$7`, platformCode, strings.TrimSpace(binding.PlatformName), binding.Enabled, binding.RequireSignedIdentity, mode, profile, binding.APIKeyID)
+		result, err := db.conn.ExecContext(ctx, `UPDATE prompt_filter_newapi_bindings SET platform_code=$1, platform_name=$2, enabled=$3, require_signed_identity=$4, prompt_filter_scope=$5, policy_mode=$6, policy_profile=$7, updated_at=CURRENT_TIMESTAMP WHERE api_key_id=$8`, platformCode, strings.TrimSpace(binding.PlatformName), binding.Enabled, binding.RequireSignedIdentity, scope, mode, profile, binding.APIKeyID)
 		if isPromptFilterNewAPIBindingConflict(err) {
 			return fmt.Errorf("%w: %v", ErrPromptFilterNewAPIBindingConflict, err)
 		}
@@ -245,8 +284,13 @@ func (db *DB) DeletePromptFilterNewAPIBinding(ctx context.Context, apiKeyID int6
 func scanPromptFilterNewAPIBinding(scanner interface{ Scan(...interface{}) error }) (*PromptFilterNewAPIBinding, error) {
 	binding := &PromptFilterNewAPIBinding{}
 	var previousExpiryRaw, updatedAtRaw interface{}
-	if err := scanner.Scan(&binding.APIKeyID, &binding.PlatformCode, &binding.PlatformName, &binding.Secret, &binding.Enabled, &binding.RequireSignedIdentity, &binding.PolicyMode, &binding.PolicyProfile, &binding.PreviousSecret, &previousExpiryRaw, &updatedAtRaw); err != nil {
+	if err := scanner.Scan(&binding.APIKeyID, &binding.PlatformCode, &binding.PlatformName, &binding.Secret, &binding.Enabled, &binding.RequireSignedIdentity, &binding.PromptFilterScope, &binding.PolicyMode, &binding.PolicyProfile, &binding.PreviousSecret, &previousExpiryRaw, &updatedAtRaw); err != nil {
 		return nil, err
+	}
+	if normalized, ok := NormalizePromptFilterScope(binding.PromptFilterScope); ok {
+		binding.PromptFilterScope = normalized
+	} else {
+		binding.PromptFilterScope = PromptFilterScopeInherit
 	}
 	previousExpiry, err := parseDBNullTimeValue(previousExpiryRaw)
 	if err != nil {

--- a/database/prompt_filter_newapi_binding_test.go
+++ b/database/prompt_filter_newapi_binding_test.go
@@ -82,7 +82,8 @@ func TestPromptFilterNewAPIBindingCRUDAndSecretRotationSQLite(t *testing.T) {
 	binding := &PromptFilterNewAPIBinding{
 		APIKeyID: apiKeyID, PlatformCode: "gateway-a", PlatformName: "示例平台 NewAPI",
 		Secret: "01234567890123456789012345678901", Enabled: true, RequireSignedIdentity: true,
-		PolicyMode: PromptFilterPolicyModeEnforce, PolicyProfile: PromptFilterPolicyProfileBalanced,
+		PromptFilterScope: PromptFilterScopeLocalOnly,
+		PolicyMode:        PromptFilterPolicyModeEnforce, PolicyProfile: PromptFilterPolicyProfileBalanced,
 	}
 	if err := db.CreatePromptFilterNewAPIBinding(ctx, binding); err != nil {
 		t.Fatalf("Create binding: %v", err)
@@ -91,7 +92,7 @@ func TestPromptFilterNewAPIBindingCRUDAndSecretRotationSQLite(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Get binding: %v", err)
 	}
-	if got.PlatformCode != "gateway-a" || got.Secret != binding.Secret || !got.Enabled || !got.RequireSignedIdentity {
+	if got.PlatformCode != "gateway-a" || got.Secret != binding.Secret || !got.Enabled || !got.RequireSignedIdentity || got.PromptFilterScope != PromptFilterScopeLocalOnly {
 		t.Fatalf("binding = %#v", got)
 	}
 	if got.PolicyMode != PromptFilterPolicyModeInherit || got.PolicyProfile != PromptFilterPolicyProfileInherit {
@@ -115,6 +116,7 @@ func TestPromptFilterNewAPIBindingCRUDAndSecretRotationSQLite(t *testing.T) {
 	got.PlatformName = "示例平台生产站"
 	got.PolicyMode = PromptFilterPolicyModeWarn
 	got.PolicyProfile = PromptFilterPolicyProfileStrict
+	got.PromptFilterScope = PromptFilterScopeOff
 	got.Enabled = false
 	if err := db.UpdatePromptFilterNewAPIBinding(ctx, got); err != nil {
 		t.Fatalf("Update binding: %v", err)
@@ -125,6 +127,9 @@ func TestPromptFilterNewAPIBindingCRUDAndSecretRotationSQLite(t *testing.T) {
 	}
 	if updated.PolicyMode != PromptFilterPolicyModeInherit || updated.PolicyProfile != PromptFilterPolicyProfileInherit {
 		t.Fatalf("update retained retired policy override: %#v", updated)
+	}
+	if updated.PromptFilterScope != PromptFilterScopeOff {
+		t.Fatalf("update lost prompt filter scope: %#v", updated)
 	}
 
 	newSecret := "abcdefghijklmnopqrstuvwxyzABCDEF"
@@ -200,8 +205,8 @@ func TestPromptFilterNewAPIBindingPostgresMigrationDDL(t *testing.T) {
 	promptFilterBindingDDLQueryMu.Lock()
 	queries := append([]string(nil), promptFilterBindingDDLQueries...)
 	promptFilterBindingDDLQueryMu.Unlock()
-	if len(queries) != 2 {
-		t.Fatalf("ensure executed %d statements, want DDL plus override retirement", len(queries))
+	if len(queries) != 3 {
+		t.Fatalf("ensure executed %d statements, want DDL, scope migration, and override retirement", len(queries))
 	}
 	query := queries[0]
 	for _, fragment := range []string{
@@ -209,14 +214,18 @@ func TestPromptFilterNewAPIBindingPostgresMigrationDDL(t *testing.T) {
 		"api_key_id INT PRIMARY KEY",
 		"platform_code VARCHAR(32) NOT NULL UNIQUE",
 		"require_signed_identity BOOLEAN NOT NULL DEFAULT FALSE",
+		"prompt_filter_scope VARCHAR(16) NOT NULL DEFAULT 'inherit'",
 		"previous_secret_expires_at TIMESTAMPTZ NULL",
 	} {
 		if !strings.Contains(query, fragment) {
 			t.Fatalf("postgres DDL missing %q: %s", fragment, query)
 		}
 	}
-	if !strings.Contains(queries[1], "SET policy_mode='inherit', policy_profile='inherit'") {
-		t.Fatalf("postgres migration did not retire binding policy overrides: %s", queries[1])
+	if !strings.Contains(queries[1], "ADD COLUMN IF NOT EXISTS prompt_filter_scope") {
+		t.Fatalf("postgres migration did not add prompt filter scope: %s", queries[1])
+	}
+	if !strings.Contains(queries[2], "SET policy_mode='inherit', policy_profile='inherit'") || !strings.Contains(queries[2], "prompt_filter_scope IN ('inherit','local_only','off')") {
+		t.Fatalf("postgres migration did not retire policy overrides and preserve valid scopes: %s", queries[2])
 	}
 }
 
@@ -236,7 +245,7 @@ func TestPromptFilterNewAPIBindingMigrationNeutralizesLegacyPolicyOverrides(t *t
 	}); err != nil {
 		t.Fatalf("Create binding: %v", err)
 	}
-	if _, err := db.conn.ExecContext(ctx, `UPDATE prompt_filter_newapi_bindings SET policy_mode='shadow', policy_profile='research' WHERE api_key_id=?`, apiKeyID); err != nil {
+	if _, err := db.conn.ExecContext(ctx, `UPDATE prompt_filter_newapi_bindings SET policy_mode='shadow', policy_profile='research', prompt_filter_scope='invalid' WHERE api_key_id=?`, apiKeyID); err != nil {
 		t.Fatalf("seed legacy policy override: %v", err)
 	}
 	if err := db.ensurePromptFilterNewAPIBindingsTable(ctx); err != nil {
@@ -248,6 +257,9 @@ func TestPromptFilterNewAPIBindingMigrationNeutralizesLegacyPolicyOverrides(t *t
 	}
 	if got.PolicyMode != PromptFilterPolicyModeInherit || got.PolicyProfile != PromptFilterPolicyProfileInherit {
 		t.Fatalf("legacy policy override survived migration: %#v", got)
+	}
+	if got.PromptFilterScope != PromptFilterScopeInherit {
+		t.Fatalf("invalid prompt filter scope survived migration: %#v", got)
 	}
 }
 

--- a/frontend/src/components/AccountDetailSheet.tsx
+++ b/frontend/src/components/AccountDetailSheet.tsx
@@ -1,10 +1,12 @@
 import type { ReactNode } from "react";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import {
   AlertTriangle,
   BarChart3,
+  Check,
   ChevronLeft,
   ChevronRight,
+  Copy,
   ExternalLink,
   FileJson,
   FlaskConical,
@@ -59,6 +61,59 @@ function getRateLimitWindow(account: AccountRow): "5h" | "7d" | null {
       return "7d";
   }
   return null;
+}
+
+// 复制邮箱按钮。navigator.clipboard 在非安全上下文（局域网 http 访问）下不存在，
+// 回退到隐藏 textarea + execCommand，否则内网部署里这个按钮会静默失效。
+async function copyTextToClipboard(text: string): Promise<void> {
+  if (navigator.clipboard?.writeText) {
+    await navigator.clipboard.writeText(text);
+    return;
+  }
+  const ta = document.createElement("textarea");
+  ta.value = text;
+  ta.style.position = "fixed";
+  ta.style.left = "-9999px";
+  document.body.appendChild(ta);
+  ta.select();
+  document.execCommand("copy");
+  document.body.removeChild(ta);
+}
+
+function CopyValueButton({ value, label }: { value: string; label: string }) {
+  const { t } = useTranslation();
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (!copied) return;
+    const timer = window.setTimeout(() => setCopied(false), 1500);
+    return () => window.clearTimeout(timer);
+  }, [copied]);
+
+  const handleCopy = async () => {
+    try {
+      await copyTextToClipboard(value);
+      setCopied(true);
+    } catch {
+      // 剪贴板权限被拒时不打断查看详情，保持静默。
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={() => void handleCopy()}
+      title={copied ? t("common.copied") : label}
+      aria-label={label}
+      className="inline-flex size-6 shrink-0 items-center justify-center rounded-md border border-transparent text-muted-foreground transition-colors hover:border-border hover:bg-muted hover:text-foreground"
+    >
+      {copied ? (
+        <Check className="size-3.5 text-emerald-600 dark:text-emerald-400" />
+      ) : (
+        <Copy className="size-3.5" />
+      )}
+    </button>
+  );
 }
 
 function Section({
@@ -172,6 +227,10 @@ export default function AccountDetailSheet({
       ? account.name || account.email || `#${account.id}`
       : account.email || account.name || `#${account.id}`
     : "";
+  // 标题退化成 "#12" 这种 id 兜底时没有复制价值（旁边就有 ID 徽章），不显示按钮。
+  const copyableName = Boolean(
+    account && displayName && displayName !== `#${account.id}`,
+  );
   const rateWindow = account ? getRateLimitWindow(account) : null;
   const isGrok = Boolean(account?.grok_api);
   // Grok API Key 无 refresh_token；Codex AT-only / Responses 也不走 AT 刷新。
@@ -256,9 +315,23 @@ export default function AccountDetailSheet({
                     </span>
                   )}
                 </div>
-                <SheetTitle className="break-all text-[17px] leading-snug">
-                  {displayName}
-                </SheetTitle>
+                <div className="flex items-start gap-1.5">
+                  <SheetTitle className="break-all text-[17px] leading-snug">
+                    {displayName}
+                  </SheetTitle>
+                  {copyableName && (
+                    <span className="mt-0.5">
+                      <CopyValueButton
+                        value={displayName}
+                        label={
+                          displayName.includes("@")
+                            ? t("accounts.detailCopyEmail")
+                            : t("common.copy")
+                        }
+                      />
+                    </span>
+                  )}
+                </div>
                 {account.chatgpt_account_id ? (
                   <SheetDescription className="mt-1 break-all font-mono text-[11px]">
                     {account.chatgpt_account_id}

--- a/frontend/src/components/PromptFilterNewAPIBindings.tsx
+++ b/frontend/src/components/PromptFilterNewAPIBindings.tsx
@@ -17,6 +17,7 @@ import { useToast } from '../hooks/useToast'
 import type {
   APIKeyRow,
   PromptFilterNewAPIBinding,
+  PromptFilterScope,
 } from '../types'
 import { getErrorMessage } from '../utils/error'
 import { formatBeijingTime } from '../utils/time'
@@ -40,6 +41,7 @@ type BindingForm = {
   platformName: string
   enabled: boolean
   requireSignedIdentity: boolean
+  promptFilterScope: PromptFilterScope
 }
 
 const emptyBindingForm: BindingForm = {
@@ -48,6 +50,7 @@ const emptyBindingForm: BindingForm = {
   platformName: '',
   enabled: true,
   requireSignedIdentity: false,
+  promptFilterScope: 'inherit',
 }
 
 function apiKeyLabel(apiKey: APIKeyRow): string {
@@ -140,6 +143,21 @@ function BindingFormFields({
           onCheckedChange={(requireSignedIdentity) => setForm({ ...form, requireSignedIdentity })}
         />
       </div>
+      <label className="block space-y-1.5 rounded-lg border border-border/70 bg-muted/20 p-3">
+        <span className="text-sm font-medium">该 Key 的 Prompt 检查范围</span>
+        <Select
+          value={form.promptFilterScope}
+          onValueChange={(promptFilterScope) => setForm({ ...form, promptFilterScope: promptFilterScope as PromptFilterScope })}
+          options={[
+            { value: 'inherit', label: '继承全局：本地检测 + 远程模型复核' },
+            { value: 'local_only', label: '仅本地检测：跳过远程模型复核' },
+            { value: 'off', label: '完全跳过：不执行 Prompt 检查' },
+          ]}
+        />
+        <span className="block text-xs leading-5 text-muted-foreground">
+          “仅本地检测”仍会执行高危规则、会话关联、审计记录与风险画像；“完全跳过”只保留 API Key 和签名身份校验，适合明确受控的内部调用方。
+        </span>
+      </label>
     </div>
   )
 }
@@ -201,6 +219,7 @@ export default function PromptFilterNewAPIBindings() {
       platformName: binding.platform_name,
       enabled: binding.enabled,
       requireSignedIdentity: binding.require_signed_identity,
+      promptFilterScope: binding.prompt_filter_scope || 'inherit',
     })
     setEditing(binding)
   }
@@ -220,6 +239,15 @@ export default function PromptFilterNewAPIBindings() {
       showToast('请选择 Codex2API Key，并填写调用方代码。', 'error')
       return
     }
+    if (createForm.promptFilterScope === 'off') {
+      const approved = await confirm({
+        title: '确认让该 Key 跳过全部 Prompt 检查？',
+        description: '该 Key 的请求将不执行本地高危规则和远程模型复核。API Key 鉴权及可选的 NewAPI 签名身份校验仍会保留。',
+        confirmText: '确认完全跳过',
+        tone: 'warning',
+      })
+      if (!approved) return
+    }
     setSaving(true)
     try {
       const result = await api.createPromptFilterNewAPIBinding({
@@ -228,6 +256,7 @@ export default function PromptFilterNewAPIBindings() {
         platform_name: createForm.platformName.trim(),
         enabled: createForm.enabled,
         require_signed_identity: createForm.requireSignedIdentity,
+        prompt_filter_scope: createForm.promptFilterScope,
       })
       setCreateOpen(false)
       await load()
@@ -254,6 +283,15 @@ export default function PromptFilterNewAPIBindings() {
       })
       if (!approved) return
     }
+    if (editing.prompt_filter_scope !== 'off' && editForm.promptFilterScope === 'off') {
+      const approved = await confirm({
+        title: '确认让该 Key 跳过全部 Prompt 检查？',
+        description: '保存后，该 Key 将不再执行本地高危规则和远程模型复核。API Key 鉴权及可选的 NewAPI 签名身份校验仍会保留。',
+        confirmText: '确认完全跳过',
+        tone: 'warning',
+      })
+      if (!approved) return
+    }
     setSaving(true)
     try {
       await api.updatePromptFilterNewAPIBinding(editing.api_key_id, {
@@ -261,6 +299,7 @@ export default function PromptFilterNewAPIBindings() {
         platform_name: editForm.platformName.trim(),
         enabled: editForm.enabled,
         require_signed_identity: editForm.requireSignedIdentity,
+        prompt_filter_scope: editForm.promptFilterScope,
       })
       setEditing(null)
       await load()
@@ -346,7 +385,8 @@ export default function PromptFilterNewAPIBindings() {
               <h4 id="newapi-key-bindings-title" className="text-sm font-semibold">按 Codex2API Key 绑定审计身份</h4>
             </div>
             <p className="mt-1 text-sm leading-6 text-muted-foreground">
-              将签名身份与实际请求使用的 Codex2API Key 对应起来。绑定只负责身份校验，拦截模式和审核档位统一由 GuardPipeline 管理。
+              将签名身份与实际请求使用的 Codex2API Key 对应起来，并可为指定 Key 缩小 Prompt 检查范围。
+              全局阈值和审核档位仍由 GuardPipeline 管理，调用方不能通过请求头或元数据修改此策略。
             </p>
           </div>
           <div className="flex gap-2">
@@ -425,6 +465,13 @@ export default function PromptFilterNewAPIBindings() {
                             <Badge variant={binding.require_signed_identity ? 'default' : 'outline'}>
                               {binding.require_signed_identity ? '强制签名' : '未强制签名'}
                             </Badge>
+                            <Badge variant={binding.prompt_filter_scope === 'off' ? 'destructive' : 'outline'}>
+                              {binding.prompt_filter_scope === 'local_only'
+                                ? '仅本地检测'
+                                : binding.prompt_filter_scope === 'off'
+                                  ? '跳过 Prompt 检查'
+                                  : '继承全局审核'}
+                            </Badge>
                           </div>
                         </td>
                         <td className="px-3 py-3">
@@ -479,7 +526,7 @@ export default function PromptFilterNewAPIBindings() {
         <DialogContent className="sm:max-w-2xl">
           <DialogHeader>
             <DialogTitle>编辑审计身份绑定</DialogTitle>
-            <DialogDescription>此处只管理调用方身份；拦截模式和审核档位请在统一 GuardPipeline 中设置。</DialogDescription>
+            <DialogDescription>管理调用方身份及该 Key 的检查范围；全局拦截阈值和审核档位仍由统一 GuardPipeline 管理。</DialogDescription>
           </DialogHeader>
           <BindingFormFields form={editForm} setForm={setEditForm} apiKeys={apiKeys.filter((key) => key.id === editing?.api_key_id)} editing />
           <DialogFooter>

--- a/frontend/src/lib/promptFilterNewAPIBindings.test.mjs
+++ b/frontend/src/lib/promptFilterNewAPIBindings.test.mjs
@@ -7,17 +7,21 @@ const pageSource = readFileSync(new URL('../pages/PromptFilter.tsx', import.meta
 const apiSource = readFileSync(new URL('../api.ts', import.meta.url), 'utf8')
 const typesSource = readFileSync(new URL('../types.ts', import.meta.url), 'utf8')
 
-test('identity binding cannot override the unified GuardPipeline policy', () => {
+test('identity binding only narrows prompt scope without overriding GuardPipeline thresholds', () => {
   assert.equal(componentSource.includes('requireSignedIdentity: false'), true)
-  assert.equal(componentSource.includes('拦截模式和审核档位统一由 GuardPipeline 管理'), true)
+  assert.equal(componentSource.includes('全局阈值和审核档位仍由 GuardPipeline 管理'), true)
+  for (const fragment of ['promptFilterScope', "'inherit'", "'local_only'", "'off'", '仅本地检测：跳过远程模型复核']) {
+    assert.equal(componentSource.includes(fragment), true, `binding editor missing prompt scope control: ${fragment}`)
+  }
   for (const fragment of ['policyMode', 'policyProfile', 'policy_mode', 'policy_profile', '策略模式']) {
     assert.equal(componentSource.includes(fragment), false, `binding editor still exposes policy control: ${fragment}`)
   }
-	  const bindingStart = typesSource.indexOf('export interface PromptFilterNewAPIBinding')
-	  const bindingEnd = typesSource.indexOf('export interface CreateAPIKeyRequest')
-	  assert.ok(bindingStart >= 0, 'missing PromptFilterNewAPIBinding interface')
-	  assert.ok(bindingEnd > bindingStart, 'missing CreateAPIKeyRequest boundary after PromptFilterNewAPIBinding')
-	  const bindingTypes = typesSource.slice(bindingStart, bindingEnd)
+  const bindingStart = typesSource.indexOf('export interface PromptFilterNewAPIBinding')
+  const bindingEnd = typesSource.indexOf('export interface CreateAPIKeyRequest')
+  assert.ok(bindingStart >= 0, 'missing PromptFilterNewAPIBinding interface')
+  assert.ok(bindingEnd > bindingStart, 'missing CreateAPIKeyRequest boundary after PromptFilterNewAPIBinding')
+  const bindingTypes = typesSource.slice(bindingStart, bindingEnd)
+  assert.equal(bindingTypes.includes('prompt_filter_scope'), true)
   assert.equal(bindingTypes.includes('policy_mode'), false)
   assert.equal(bindingTypes.includes('policy_profile'), false)
 })
@@ -50,11 +54,11 @@ test('key bindings are embedded in an optional NewAPI adapter panel', () => {
   assert.equal(componentSource.includes('<Card'), false, 'embedded binding editor must not create a second top-level card')
   assert.equal(pageSource.includes('getPromptFilterNewAPISecret'), false)
   assert.equal(pageSource.includes("setBool('newapi', 'enabled'"), false)
-	  const recommendedPresetStart = pageSource.indexOf('const applyRecommendedProtection')
-	  const recommendedPresetEnd = pageSource.indexOf('\n\n  return (', recommendedPresetStart)
-	  assert.ok(recommendedPresetStart >= 0, 'missing applyRecommendedProtection')
-	  assert.ok(recommendedPresetEnd > recommendedPresetStart, 'missing PromptFilter render boundary')
-	  const recommendedPreset = pageSource.slice(recommendedPresetStart, recommendedPresetEnd)
+  const recommendedPresetStart = pageSource.indexOf('const applyRecommendedProtection')
+  const recommendedPresetEnd = pageSource.indexOf('\n\n  return (', recommendedPresetStart)
+  assert.ok(recommendedPresetStart >= 0, 'missing applyRecommendedProtection')
+  assert.ok(recommendedPresetEnd > recommendedPresetStart, 'missing PromptFilter render boundary')
+  const recommendedPreset = pageSource.slice(recommendedPresetStart, recommendedPresetEnd)
   for (const fragment of [
     "recommendedStrength === 'penalty'",
     "t('promptFilter.penaltyRequiresNewAPI')",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -839,6 +839,7 @@
     "detailBaseUrl": "Base URL",
     "detailProxy": "Proxy",
     "modelCooldown": "model {{model}}",
+    "detailCopyEmail": "Copy email",
     "detailPrev": "Previous account",
     "detailNext": "Next account",
     "openDetail": "View details",

--- a/frontend/src/locales/zh.json
+++ b/frontend/src/locales/zh.json
@@ -839,6 +839,7 @@
     "detailBaseUrl": "Base URL",
     "detailProxy": "代理",
     "modelCooldown": "模型 {{model}}",
+    "detailCopyEmail": "复制邮箱",
     "detailPrev": "上一个账号",
     "detailNext": "下一个账号",
     "openDetail": "查看详情",

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2263,12 +2263,15 @@ export interface APIKeyRow {
 
 export type APIKeysResponse = ApiListResponse<'keys', APIKeyRow>
 
+export type PromptFilterScope = 'inherit' | 'local_only' | 'off'
+
 export interface PromptFilterNewAPIBinding {
   api_key_id: number
   platform_code: string
   platform_name: string
   enabled: boolean
   require_signed_identity: boolean
+  prompt_filter_scope: PromptFilterScope
   secret_configured: boolean
   secret_masked: string
   previous_secret_active: boolean
@@ -2288,6 +2291,7 @@ export interface CreatePromptFilterNewAPIBindingRequest {
   platform_name: string
   enabled?: boolean
   require_signed_identity?: boolean
+  prompt_filter_scope?: PromptFilterScope
 }
 
 export type UpdatePromptFilterNewAPIBindingRequest = Partial<

--- a/proxy/newapi_policy_test.go
+++ b/proxy/newapi_policy_test.go
@@ -531,6 +531,40 @@ func TestNewAPIIdentitySecretsDoNotFallbackForUnboundKeyInBindingMode(t *testing
 	}
 }
 
+func TestPromptFilterBindingScopeControlsOnlyItsAPIKey(t *testing.T) {
+	cfg := promptGuardTestConfig()
+	cfg.Enabled = true
+	cfg.Review.Enabled = true
+	handler := newPromptFilterBindingTestHandler(t, cfg, []database.PromptFilterNewAPIBinding{
+		{APIKeyID: 101, PlatformCode: "full-review", Secret: "full-review-secret", Enabled: true, PromptFilterScope: database.PromptFilterScopeInherit},
+		{APIKeyID: 202, PlatformCode: "local-only", Secret: "local-only-secret", Enabled: true, PromptFilterScope: database.PromptFilterScopeLocalOnly},
+		{APIKeyID: 303, PlatformCode: "prompt-off", Secret: "prompt-off-secret", Enabled: true, PromptFilterScope: database.PromptFilterScopeOff},
+	})
+	requestConfig := func(apiKeyID int64) promptfilter.Config {
+		c, _ := gin.CreateTestContext(httptest.NewRecorder())
+		c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+		c.Set(contextAPIKeyID, apiKeyID)
+		return handler.promptFilterConfigForRequest(c)
+	}
+
+	inherit := requestConfig(101)
+	if !inherit.Enabled || !inherit.Review.Enabled {
+		t.Fatalf("inherit scope changed global review: enabled=%v review=%v", inherit.Enabled, inherit.Review.Enabled)
+	}
+	localOnly := requestConfig(202)
+	if !localOnly.Enabled || localOnly.Review.Enabled || !localOnly.Advanced.NewAPI.Enabled {
+		t.Fatalf("local-only scope=%+v", localOnly)
+	}
+	off := requestConfig(303)
+	if off.Enabled || !off.Advanced.NewAPI.Enabled {
+		t.Fatalf("off scope disabled identity or retained prompt checks: enabled=%v newapi=%v", off.Enabled, off.Advanced.NewAPI.Enabled)
+	}
+	unbound := requestConfig(404)
+	if !unbound.Enabled || !unbound.Review.Enabled || unbound.Advanced.NewAPI.Enabled {
+		t.Fatalf("unbound key inherited wrong config: enabled=%v review=%v newapi=%v", unbound.Enabled, unbound.Review.Enabled, unbound.Advanced.NewAPI.Enabled)
+	}
+}
+
 func TestUnboundWebSocketIsNotRevokedByAnotherKeysBinding(t *testing.T) {
 	handler := newPromptFilterBindingTestHandler(t, promptGuardTestConfig(), []database.PromptFilterNewAPIBinding{{
 		APIKeyID: 101, PlatformCode: "gateway-a", Secret: "gateway-a-secret", Enabled: true,
@@ -559,7 +593,8 @@ func TestUnboundWebSocketIsNotRevokedByAnotherKeysBinding(t *testing.T) {
 func TestBindingSnapshotRefreshesPolicyAndRevokesObsoleteWebSocketIdentity(t *testing.T) {
 	oldBinding := database.PromptFilterNewAPIBinding{
 		APIKeyID: 101, PlatformCode: "gateway-a", Secret: "old-secret", Enabled: true, RequireSignedIdentity: true,
-		PolicyMode: database.PromptFilterPolicyModeWarn, PolicyProfile: database.PromptFilterPolicyProfileResearch,
+		PromptFilterScope: database.PromptFilterScopeInherit,
+		PolicyMode:        database.PromptFilterPolicyModeWarn, PolicyProfile: database.PromptFilterPolicyProfileResearch,
 	}
 	handler := newPromptFilterBindingTestHandler(t, promptGuardTestConfig(), []database.PromptFilterNewAPIBinding{oldBinding})
 	newConnection := func() *gin.Context {
@@ -581,7 +616,8 @@ func TestBindingSnapshotRefreshesPolicyAndRevokesObsoleteWebSocketIdentity(t *te
 	rotated := database.PromptFilterNewAPIBinding{
 		APIKeyID: 101, PlatformCode: "gateway-a", Secret: "new-secret", PreviousSecret: "old-secret", PreviousSecretExpiresAt: &expiresAt,
 		Enabled: true, RequireSignedIdentity: true,
-		PolicyMode: database.PromptFilterPolicyModeEnforce, PolicyProfile: database.PromptFilterPolicyProfileStrict,
+		PromptFilterScope: database.PromptFilterScopeLocalOnly,
+		PolicyMode:        database.PromptFilterPolicyModeEnforce, PolicyProfile: database.PromptFilterPolicyProfileStrict,
 	}
 	handler.store.ReplacePromptFilterNewAPIBindings([]*database.PromptFilterNewAPIBinding{&rotated})
 	if apiErr := handler.refreshNewAPIWebSocketBinding(c, time.Now()); apiErr != nil {
@@ -595,6 +631,9 @@ func TestBindingSnapshotRefreshesPolicyAndRevokesObsoleteWebSocketIdentity(t *te
 	currentCfg := handler.promptFilterConfigForRequest(c)
 	if currentCfg.Advanced.Guard.Mode != promptfilter.GuardModeInherit || currentCfg.Advanced.Guard.DefaultProfile != promptfilter.GuardProfileBalanced {
 		t.Fatalf("binding changed unified policy: mode=%q profile=%q", currentCfg.Advanced.Guard.Mode, currentCfg.Advanced.Guard.DefaultProfile)
+	}
+	if currentCfg.Review.Enabled {
+		t.Fatal("websocket frame did not hot-refresh local-only review scope")
 	}
 
 	for _, tc := range []struct {

--- a/proxy/prompt_request_context.go
+++ b/proxy/prompt_request_context.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"strings"
 
+	"github.com/codex2api/database"
 	"github.com/codex2api/security/promptfilter"
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -69,10 +70,21 @@ func (h *Handler) promptFilterConfigForRequest(c *gin.Context) promptfilter.Conf
 	// binding. Ignore any retired persisted enablement value.
 	state.config.Advanced.NewAPI.Enabled = false
 	if binding, bound := h.resolvePromptFilterNewAPIBinding(c); bound {
-		// A key binding is only the identity isolation boundary. Prompt filtering
-		// mode and profile remain owned by the unified GuardPipeline configuration;
-		// an identity binding must never weaken or strengthen request enforcement.
 		state.config.Advanced.NewAPI.Enabled = binding.Enabled
+		if binding.Enabled {
+			switch binding.PromptFilterScope {
+			case database.PromptFilterScopeLocalOnly:
+				// Keep the deterministic local GuardPipeline, session correlation,
+				// audit evidence and risk profiling, but remove the synchronous
+				// remote model hop for this API key.
+				state.config.Review.Enabled = false
+			case database.PromptFilterScopeOff:
+				// This explicit admin-side API-key exception disables Prompt checks
+				// only. NewAPI signature verification remains enabled above and API
+				// key authentication is enforced before this request-local snapshot.
+				state.config.Enabled = false
+			}
+		}
 	}
 	state.configOwner = h
 	state.configReady = true


### PR DESCRIPTION
## Summary

This PR unifies Prompt policy auditing across local decisions, upstream `cyber_policy` incidents, usage logs, rule-learning evidence, and risk profiles. It also adds a per-API-key Prompt inspection scope so trusted integrations can retain deterministic local high-risk checks without paying the latency cost of remote model review on every request.

## Main changes

- Add durable Prompt policy incidents with exact request/attempt correlation instead of time-window inference.
- Preserve nullable scoring semantics so “not evaluated” is distinct from a real zero score.
- Link incidents, usage logs, candidate evidence, identities, API keys, accounts, and risk profiles.
- Add searchable/paginated CY incidents, model-review history, local audit logs, learning records, and profile-event history.
- Persist AI analysis results and close the attribution/application lifecycle.
- Add adaptive risk-profile review with auditable temporary trust rather than a permanent whitelist.
- Add per-key Prompt inspection scope:
  - `inherit`: local GuardPipeline plus configured remote review.
  - `local_only`: keep local rules, session correlation, audit, and risk profiling; skip remote model review.
  - `off`: skip Prompt inspection for the bound API key, with explicit UI confirmation.
- Apply per-key scope consistently to HTTP, SSE, and WebSocket request flows, including hot refresh for logical WebSocket frames.
- Keep NewAPI signed identity validation independent from Prompt inspection scope.
- Consolidate Prompt Filter administration and improve Chinese/English/TW UI copy, filters, pagination, and local refresh behavior.
- Include upstream v2.7.0 changes and the latest account-detail copy-email improvement.

## Safety properties

- A request cannot select or override its own scope through headers or body fields.
- Scope applies only to an enabled server-side API-key binding.
- `local_only` does not disable deterministic high-risk rules, session correlation, audit persistence, or risk-profile updates.
- Other API keys continue to inherit global review settings.
- Existing bindings migrate to `inherit`.
- No raw authorization credentials or unredacted secrets are exposed by the API or UI.

## Verification

- `go test ./... -count=1`
- `npm test -- --run`
- `npm run typecheck`
- `npm run build`
- SQLite and PostgreSQL binding migration tests
- Per-key isolation tests
- HTTP and WebSocket hot-refresh policy tests
- GitNexus change detection and blast-radius review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-binding prompt-check scopes: inherited, local-only, or disabled.
  * Added scope controls, status indicators, and confirmation warnings when disabling checks.
  * Scope changes now apply to API-key traffic and refresh active WebSocket policies.
  * Added one-click copying for account email addresses and display names, with localized labels.

* **Bug Fixes**
  * Invalid or legacy scope values are normalized to the inherited setting.
  * Local-only and disabled modes preserve authentication and required identity checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->