### PR TITLE
feat: 分离 API relay 与 OAuth 的模型冷却策略

### DIFF
--- a/admin/batch_test_test.go
+++ b/admin/batch_test_test.go
@@ -341,7 +341,7 @@ func TestRunSingleBatchTestResponseFailedMarksReadyAccountError(t *testing.T) {
 	}
 }
 
-func TestRunSingleBatchTestUsageLimitResponseFailedMarksRateLimited(t *testing.T) {
+func TestRunSingleBatchTestRelayUsageLimitDoesNotPersistAccountCooldown(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
 		w.WriteHeader(http.StatusOK)
@@ -366,8 +366,8 @@ func TestRunSingleBatchTestUsageLimitResponseFailedMarksRateLimited(t *testing.T
 	if status != "rate_limited" {
 		t.Fatalf("status = %q, message = %q, want rate_limited", status, msg)
 	}
-	if got := account.RuntimeStatus(); got != "rate_limited" {
-		t.Fatalf("RuntimeStatus() = %q, want rate_limited", got)
+	if got := account.RuntimeStatus(); got != "active" {
+		t.Fatalf("RuntimeStatus() = %q, want active for direct API upstream", got)
 	}
 }
 

--- a/admin/handler.go
+++ b/admin/handler.go
@@ -603,6 +603,9 @@ func (h *Handler) RegisterRoutes(r *gin.Engine) {
 	api.PATCH("/accounts/:id/note", h.UpdateAccountNote)
 	api.POST("/accounts/:id/lock", h.ToggleAccountLock)
 	api.POST("/accounts/:id/reset-status", h.ResetAccountStatus)
+	api.PATCH("/accounts/:id/model-cooldown-policy", h.UpdateAccountModelCooldownPolicy)
+	api.DELETE("/accounts/:id/model-cooldowns", h.ClearAllAccountModelCooldowns)
+	api.DELETE("/accounts/:id/model-cooldowns/:model", h.ClearAccountModelCooldown)
 	api.POST("/accounts/:id/reset-credits", h.ResetCredits)
 	api.GET("/accounts/:id/reset-credits", h.GetResetCredits)
 	api.POST("/accounts/:id/invite", h.SendInvite)
@@ -944,84 +947,90 @@ type accountResponse struct {
 	CreditSkipUsageWindow bool   `json:"credit_skip_usage_window"`
 	// UsingCredits 是与 Status 并列的独立信号：用量窗口已打满但积分顶着，
 	// 状态仍是 active（可调度），前端据此在状态徽章旁并列一个「使用积分」徽章。
-	UsingCredits               bool                        `json:"using_credits,omitempty"`
-	SkipWarmTier               bool                        `json:"skip_warm_tier"`
-	AccountType                string                      `json:"account_type,omitempty"`
-	AccessTokenType            string                      `json:"access_token_type,omitempty"`
-	OpenAIResponsesAPI         bool                        `json:"openai_responses_api,omitempty"`
-	GrokAPI                    bool                        `json:"grok_api,omitempty"`
-	AgentIdentity              bool                        `json:"agent_identity,omitempty"`
-	GrokAuthKind               string                      `json:"grok_auth_kind,omitempty"`
-	GrokPlan                   *auth.GrokPlan              `json:"grok_plan,omitempty"`
-	GrokBilling                json.RawMessage             `json:"grok_billing,omitempty"`
-	GrokRateLimit              *auth.GrokRateLimitSnapshot `json:"grok_rate_limit,omitempty"`
-	GrokFreeQuota              *auth.GrokFreeQuotaSnapshot `json:"grok_free_quota,omitempty"`
-	BaseURL                    string                      `json:"base_url,omitempty"`
-	Models                     []string                    `json:"models,omitempty"`
-	ModelMapping               string                      `json:"model_mapping,omitempty"`
-	CodexClientMetadataMode    string                      `json:"codex_client_metadata_mode,omitempty"`
-	CustomHeaders              map[string]string           `json:"custom_headers,omitempty"`
-	HealthTier                 string                      `json:"health_tier"`
-	SchedulerScore             float64                     `json:"scheduler_score"`
-	DispatchScore              float64                     `json:"dispatch_score"`
-	ScoreBiasOverride          *int64                      `json:"score_bias_override"`
-	ScoreBiasEffective         int64                       `json:"score_bias_effective"`
-	BaseConcurrencyOverride    *int64                      `json:"base_concurrency_override"`
-	BaseConcurrencyEffective   int64                       `json:"base_concurrency_effective"`
-	ConcurrencyCap             int64                       `json:"dynamic_concurrency_limit"`
-	ProxyURL                   string                      `json:"proxy_url"`
-	CreatedAt                  string                      `json:"created_at"`
-	UpdatedAt                  string                      `json:"updated_at"`
-	CodexUsageUpdatedAt        string                      `json:"codex_usage_updated_at,omitempty"`
-	Codex5HUsageUpdatedAt      string                      `json:"codex_5h_usage_updated_at,omitempty"`
-	ActiveRequests             int64                       `json:"active_requests"`
-	TotalRequests              int64                       `json:"total_requests"`
-	LastUsedAt                 string                      `json:"last_used_at"`
-	SuccessRequests            int64                       `json:"success_requests"`
-	ErrorRequests              int64                       `json:"error_requests"`
-	RetryErrorRequests         int64                       `json:"retry_error_requests"`
-	RateLimitAttempts          int64                       `json:"rate_limit_attempts"`
-	UsagePercent7d             *float64                    `json:"usage_percent_7d"`
-	UsagePercent5h             *float64                    `json:"usage_percent_5h"`
-	RateLimitResetCredits      *int                        `json:"rate_limit_reset_credits"`
-	ApplicableResetCredits     *int                        `json:"applicable_reset_credits"`
-	CreditsBalance             *string                     `json:"credits_balance"`
-	CreditsHasCredits          *bool                       `json:"credits_has_credits"`
-	CreditsUnlimited           *bool                       `json:"credits_unlimited"`
-	CreditsOverageLimitReached *bool                       `json:"credits_overage_limit_reached"`
-	AutoPause5hThreshold       *float64                    `json:"auto_pause_5h_threshold"`
-	AutoPause7dThreshold       *float64                    `json:"auto_pause_7d_threshold"`
-	AutoPause5hDisabled        bool                        `json:"auto_pause_5h_disabled"`
-	AutoPause7dDisabled        bool                        `json:"auto_pause_7d_disabled"`
-	UsageLimitOverride         *bool                       `json:"ignore_usage_limit_status_override"`
-	UsageLimitEffective        bool                        `json:"ignore_usage_limit_status_effective"`
-	DispatchCountLimit         *int64                      `json:"dispatch_count_limit"`
-	DispatchCountUsed          int64                       `json:"dispatch_count_used,omitempty"`
-	DispatchCountResetAt       string                      `json:"dispatch_count_reset_at,omitempty"`
-	DispatchCountLimited       bool                        `json:"dispatch_count_limited,omitempty"`
-	SchedulerPriority          *int64                      `json:"scheduler_priority"`
-	Usage5hDetail              *accountUsageWindow         `json:"usage_5h_detail,omitempty"`
-	Usage7dDetail              *accountUsageWindow         `json:"usage_7d_detail,omitempty"`
-	Reset5hAt                  string                      `json:"reset_5h_at,omitempty"`
-	Reset7dAt                  string                      `json:"reset_7d_at,omitempty"`
-	Window7dKind               string                      `json:"usage_window_7d_kind,omitempty"`    // "monthly"(team 月窗)/"weekly"/""；供前端标「30天」而非误标「7天」
-	Window7dSeconds            *int64                      `json:"usage_window_7d_seconds,omitempty"` // 长窗口真实周期秒数
-	Billed5h                   *float64                    `json:"billed_5h"`
-	Billed7d                   *float64                    `json:"billed_7d"`
-	ScoreBreakdown             schedulerBreakdownResponse  `json:"scheduler_breakdown"`
-	LastUnauthorizedAt         string                      `json:"last_unauthorized_at,omitempty"`
-	LastRateLimitedAt          string                      `json:"last_rate_limited_at,omitempty"`
-	LastTimeoutAt              string                      `json:"last_timeout_at,omitempty"`
-	LastServerErrorAt          string                      `json:"last_server_error_at,omitempty"`
-	CooldownReason             string                      `json:"cooldown_reason,omitempty"`
-	CooldownUntil              string                      `json:"cooldown_until,omitempty"`
-	ModelCooldowns             []modelCooldownResponse     `json:"model_cooldowns,omitempty"`
-	Enabled                    bool                        `json:"enabled"`
-	Locked                     bool                        `json:"locked"`
-	AllowedAPIKeyIDs           []int64                     `json:"allowed_api_key_ids"`
-	Tags                       []string                    `json:"tags"`
-	GroupIDs                   []int64                     `json:"group_ids"`
-	Note                       string                      `json:"note"`
+	UsingCredits                  bool                        `json:"using_credits,omitempty"`
+	SkipWarmTier                  bool                        `json:"skip_warm_tier"`
+	AccountType                   string                      `json:"account_type,omitempty"`
+	AccessTokenType               string                      `json:"access_token_type,omitempty"`
+	OpenAIResponsesAPI            bool                        `json:"openai_responses_api,omitempty"`
+	GrokAPI                       bool                        `json:"grok_api,omitempty"`
+	AgentIdentity                 bool                        `json:"agent_identity,omitempty"`
+	GrokAuthKind                  string                      `json:"grok_auth_kind,omitempty"`
+	GrokPlan                      *auth.GrokPlan              `json:"grok_plan,omitempty"`
+	GrokBilling                   json.RawMessage             `json:"grok_billing,omitempty"`
+	GrokRateLimit                 *auth.GrokRateLimitSnapshot `json:"grok_rate_limit,omitempty"`
+	GrokFreeQuota                 *auth.GrokFreeQuotaSnapshot `json:"grok_free_quota,omitempty"`
+	BaseURL                       string                      `json:"base_url,omitempty"`
+	Models                        []string                    `json:"models,omitempty"`
+	ModelMapping                  string                      `json:"model_mapping,omitempty"`
+	CodexClientMetadataMode       string                      `json:"codex_client_metadata_mode,omitempty"`
+	CustomHeaders                 map[string]string           `json:"custom_headers,omitempty"`
+	HealthTier                    string                      `json:"health_tier"`
+	SchedulerScore                float64                     `json:"scheduler_score"`
+	DispatchScore                 float64                     `json:"dispatch_score"`
+	ScoreBiasOverride             *int64                      `json:"score_bias_override"`
+	ScoreBiasEffective            int64                       `json:"score_bias_effective"`
+	BaseConcurrencyOverride       *int64                      `json:"base_concurrency_override"`
+	BaseConcurrencyEffective      int64                       `json:"base_concurrency_effective"`
+	ConcurrencyCap                int64                       `json:"dynamic_concurrency_limit"`
+	ProxyURL                      string                      `json:"proxy_url"`
+	CreatedAt                     string                      `json:"created_at"`
+	UpdatedAt                     string                      `json:"updated_at"`
+	CodexUsageUpdatedAt           string                      `json:"codex_usage_updated_at,omitempty"`
+	Codex5HUsageUpdatedAt         string                      `json:"codex_5h_usage_updated_at,omitempty"`
+	ActiveRequests                int64                       `json:"active_requests"`
+	TotalRequests                 int64                       `json:"total_requests"`
+	LastUsedAt                    string                      `json:"last_used_at"`
+	SuccessRequests               int64                       `json:"success_requests"`
+	ErrorRequests                 int64                       `json:"error_requests"`
+	RetryErrorRequests            int64                       `json:"retry_error_requests"`
+	RateLimitAttempts             int64                       `json:"rate_limit_attempts"`
+	UsagePercent7d                *float64                    `json:"usage_percent_7d"`
+	UsagePercent5h                *float64                    `json:"usage_percent_5h"`
+	RateLimitResetCredits         *int                        `json:"rate_limit_reset_credits"`
+	ApplicableResetCredits        *int                        `json:"applicable_reset_credits"`
+	CreditsBalance                *string                     `json:"credits_balance"`
+	CreditsHasCredits             *bool                       `json:"credits_has_credits"`
+	CreditsUnlimited              *bool                       `json:"credits_unlimited"`
+	CreditsOverageLimitReached    *bool                       `json:"credits_overage_limit_reached"`
+	AutoPause5hThreshold          *float64                    `json:"auto_pause_5h_threshold"`
+	AutoPause7dThreshold          *float64                    `json:"auto_pause_7d_threshold"`
+	AutoPause5hDisabled           bool                        `json:"auto_pause_5h_disabled"`
+	AutoPause7dDisabled           bool                        `json:"auto_pause_7d_disabled"`
+	UsageLimitOverride            *bool                       `json:"ignore_usage_limit_status_override"`
+	UsageLimitEffective           bool                        `json:"ignore_usage_limit_status_effective"`
+	DispatchCountLimit            *int64                      `json:"dispatch_count_limit"`
+	DispatchCountUsed             int64                       `json:"dispatch_count_used,omitempty"`
+	DispatchCountResetAt          string                      `json:"dispatch_count_reset_at,omitempty"`
+	DispatchCountLimited          bool                        `json:"dispatch_count_limited,omitempty"`
+	SchedulerPriority             *int64                      `json:"scheduler_priority"`
+	Usage5hDetail                 *accountUsageWindow         `json:"usage_5h_detail,omitempty"`
+	Usage7dDetail                 *accountUsageWindow         `json:"usage_7d_detail,omitempty"`
+	Reset5hAt                     string                      `json:"reset_5h_at,omitempty"`
+	Reset7dAt                     string                      `json:"reset_7d_at,omitempty"`
+	Window7dKind                  string                      `json:"usage_window_7d_kind,omitempty"`    // "monthly"(team 月窗)/"weekly"/""；供前端标「30天」而非误标「7天」
+	Window7dSeconds               *int64                      `json:"usage_window_7d_seconds,omitempty"` // 长窗口真实周期秒数
+	Billed5h                      *float64                    `json:"billed_5h"`
+	Billed7d                      *float64                    `json:"billed_7d"`
+	ScoreBreakdown                schedulerBreakdownResponse  `json:"scheduler_breakdown"`
+	LastUnauthorizedAt            string                      `json:"last_unauthorized_at,omitempty"`
+	LastRateLimitedAt             string                      `json:"last_rate_limited_at,omitempty"`
+	LastTimeoutAt                 string                      `json:"last_timeout_at,omitempty"`
+	LastServerErrorAt             string                      `json:"last_server_error_at,omitempty"`
+	CooldownReason                string                      `json:"cooldown_reason,omitempty"`
+	CooldownUntil                 string                      `json:"cooldown_until,omitempty"`
+	ModelCooldowns                []modelCooldownResponse     `json:"model_cooldowns,omitempty"`
+	ModelCooldownModeOverride     *string                     `json:"model_cooldown_mode_override"`
+	ModelCooldownSecondsOverride  *int                        `json:"model_cooldown_seconds_override"`
+	ModelCooldownBackoffOverride  *bool                       `json:"model_cooldown_backoff_override"`
+	ModelCooldownModeEffective    string                      `json:"model_cooldown_mode_effective"`
+	ModelCooldownSecondsEffective int                         `json:"model_cooldown_seconds_effective"`
+	ModelCooldownBackoffEffective bool                        `json:"model_cooldown_backoff_effective"`
+	Enabled                       bool                        `json:"enabled"`
+	Locked                        bool                        `json:"locked"`
+	AllowedAPIKeyIDs              []int64                     `json:"allowed_api_key_ids"`
+	Tags                          []string                    `json:"tags"`
+	GroupIDs                      []int64                     `json:"group_ids"`
+	Note                          string                      `json:"note"`
 	// 图片配额信息
 	ImageQuotaRemaining *int   `json:"image_quota_remaining,omitempty"`
 	ImageQuotaTotal     *int   `json:"image_quota_total,omitempty"`
@@ -1221,6 +1230,11 @@ func (h *Handler) ListAccounts(c *gin.Context) {
 		resp.DispatchCountLimit = accountDispatchCountLimit(row)
 		resp.SchedulerPriority = accountSchedulerPriority(row)
 		if acc, ok := accountMap[row.ID]; ok {
+			resp.ModelCooldownModeOverride, resp.ModelCooldownSecondsOverride, resp.ModelCooldownBackoffOverride = acc.GetModelCooldownPolicyOverride()
+			effectiveCooldownPolicy := h.store.ResolveModelCooldownPolicy(acc)
+			resp.ModelCooldownModeEffective = effectiveCooldownPolicy.Mode
+			resp.ModelCooldownSecondsEffective = effectiveCooldownPolicy.Seconds
+			resp.ModelCooldownBackoffEffective = effectiveCooldownPolicy.BackoffEnabled
 			resp.UsageLimitOverride = acc.GetIgnoreUsageLimitStatusOverride()
 			resp.UsageLimitEffective = acc.IgnoresUsageLimitStatus()
 			if isGrokAccount {
@@ -5546,6 +5560,7 @@ func (h *Handler) ResetAccountStatus(c *gin.Context) {
 	}
 
 	h.store.ClearCooldown(acc)
+	h.store.ClearAllModelCooldowns(acc)
 	acc.ClearUsageCache()
 	h.syncAccountPlanAfterReset(c.Request.Context(), acc)
 	writeMessage(c, http.StatusOK, "账号状态已重置")
@@ -5570,6 +5585,7 @@ func (h *Handler) BatchResetStatus(c *gin.Context) {
 			continue
 		}
 		h.store.ClearCooldown(acc)
+		h.store.ClearAllModelCooldowns(acc)
 		acc.ClearUsageCache()
 		h.syncAccountPlanAfterReset(c.Request.Context(), acc)
 		success++
@@ -5579,6 +5595,146 @@ func (h *Handler) BatchResetStatus(c *gin.Context) {
 		"message": fmt.Sprintf("已重置 %d 个账号状态", success),
 		"success": success,
 		"failed":  fail,
+	})
+}
+
+func (h *Handler) UpdateAccountModelCooldownPolicy(c *gin.Context) {
+	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil {
+		writeError(c, http.StatusBadRequest, "无效的账号 ID")
+		return
+	}
+	acc := h.store.FindByID(id)
+	if acc == nil {
+		writeError(c, http.StatusNotFound, "账号不存在")
+		return
+	}
+
+	var raw map[string]json.RawMessage
+	decoder := json.NewDecoder(c.Request.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&raw); err != nil {
+		writeError(c, http.StatusBadRequest, "请求格式错误")
+		return
+	}
+	allowed := map[string]bool{
+		"mode": true, "seconds": true, "backoff_enabled": true,
+	}
+	for key := range raw {
+		if !allowed[key] {
+			writeError(c, http.StatusBadRequest, "未知字段: "+key)
+			return
+		}
+	}
+	if len(raw) == 0 {
+		writeError(c, http.StatusBadRequest, "至少提供一个策略字段")
+		return
+	}
+
+	currentMode, currentSeconds, currentBackoff := acc.GetModelCooldownPolicyOverride()
+	mode, seconds, backoff := currentMode, currentSeconds, currentBackoff
+	updates := make(map[string]interface{})
+	if value, ok := raw["mode"]; ok {
+		if string(value) == "null" {
+			mode = nil
+			updates["model_cooldown_mode_override"] = nil
+		} else {
+			var parsed string
+			if json.Unmarshal(value, &parsed) != nil || !database.IsValidModelCooldownMode(parsed) {
+				writeError(c, http.StatusBadRequest, "mode 必须是 off、fixed、adaptive 或 null")
+				return
+			}
+			parsed = database.NormalizeModelCooldownMode(parsed, database.ModelCooldownModeAdaptive)
+			mode = &parsed
+			updates["model_cooldown_mode_override"] = parsed
+		}
+	}
+	if value, ok := raw["seconds"]; ok {
+		if string(value) == "null" {
+			seconds = nil
+			updates["model_cooldown_seconds_override"] = nil
+		} else {
+			var parsed int
+			if json.Unmarshal(value, &parsed) != nil || parsed < 1 || parsed > database.MaxModelCooldownSeconds {
+				writeError(c, http.StatusBadRequest, fmt.Sprintf("seconds 必须在 1-%d 之间或为 null", database.MaxModelCooldownSeconds))
+				return
+			}
+			seconds = &parsed
+			updates["model_cooldown_seconds_override"] = parsed
+		}
+	}
+	if value, ok := raw["backoff_enabled"]; ok {
+		if string(value) == "null" {
+			backoff = nil
+			updates["model_cooldown_backoff_override"] = nil
+		} else {
+			var parsed bool
+			if json.Unmarshal(value, &parsed) != nil {
+				writeError(c, http.StatusBadRequest, "backoff_enabled 必须是布尔值或 null")
+				return
+			}
+			backoff = &parsed
+			updates["model_cooldown_backoff_override"] = parsed
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)
+	defer cancel()
+	if err := h.db.UpdateCredentials(ctx, id, updates); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			writeError(c, http.StatusNotFound, "账号不存在")
+			return
+		}
+		writeError(c, http.StatusInternalServerError, "保存模型冷却策略失败: "+err.Error())
+		return
+	}
+	h.store.ApplyAccountModelCooldownPolicyOverride(id, mode, seconds, backoff)
+	effective := h.store.ResolveModelCooldownPolicy(acc)
+	c.JSON(http.StatusOK, gin.H{
+		"message":                   "模型冷却策略已更新",
+		"mode_override":             mode,
+		"seconds_override":          seconds,
+		"backoff_enabled_override":  backoff,
+		"mode_effective":            effective.Mode,
+		"seconds_effective":         effective.Seconds,
+		"backoff_enabled_effective": effective.BackoffEnabled,
+	})
+}
+
+func (h *Handler) ClearAccountModelCooldown(c *gin.Context) {
+	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil {
+		writeError(c, http.StatusBadRequest, "无效的账号 ID")
+		return
+	}
+	acc := h.store.FindByID(id)
+	if acc == nil {
+		writeError(c, http.StatusNotFound, "账号不存在")
+		return
+	}
+	model := strings.TrimSpace(c.Param("model"))
+	if model == "" {
+		writeError(c, http.StatusBadRequest, "模型不能为空")
+		return
+	}
+	h.store.ClearModelCooldown(acc, model)
+	writeMessage(c, http.StatusOK, "模型冷却已清除")
+}
+
+func (h *Handler) ClearAllAccountModelCooldowns(c *gin.Context) {
+	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil {
+		writeError(c, http.StatusBadRequest, "无效的账号 ID")
+		return
+	}
+	acc := h.store.FindByID(id)
+	if acc == nil {
+		writeError(c, http.StatusNotFound, "账号不存在")
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"message": "账号全部模型冷却已清除",
+		"cleared": h.store.ClearAllModelCooldowns(acc),
 	})
 }
 
@@ -7265,6 +7421,12 @@ type settingsResponse struct {
 	ResponseCacheLocalMaxEntryBytes    int64                            `json:"response_cache_local_max_entry_bytes"`
 	ResponseCacheReconstructMaxBytes   int64                            `json:"response_cache_reconstruct_max_bytes"`
 	ResponseCacheConfigGeneration      int64                            `json:"response_cache_config_generation"`
+	RelayModelCooldownMode             string                           `json:"relay_model_cooldown_mode"`
+	RelayModelCooldownSeconds          int                              `json:"relay_model_cooldown_seconds"`
+	RelayModelCooldownBackoffEnabled   bool                             `json:"relay_model_cooldown_backoff_enabled"`
+	OAuthModelCooldownMode             string                           `json:"oauth_model_cooldown_mode"`
+	OAuthModelCooldownSeconds          int                              `json:"oauth_model_cooldown_seconds"`
+	OAuthModelCooldownBackoffEnabled   bool                             `json:"oauth_model_cooldown_backoff_enabled"`
 }
 
 type rawJSON = json.RawMessage
@@ -7391,6 +7553,12 @@ type updateSettingsReq struct {
 	ResponseCacheLocalMaxEntryBytes     *int64   `json:"response_cache_local_max_entry_bytes"`
 	ResponseCacheReconstructMaxBytes    *int64   `json:"response_cache_reconstruct_max_bytes"`
 	ResponseCacheConfigGeneration       rawJSON  `json:"response_cache_config_generation"`
+	RelayModelCooldownMode              *string  `json:"relay_model_cooldown_mode"`
+	RelayModelCooldownSeconds           *int     `json:"relay_model_cooldown_seconds"`
+	RelayModelCooldownBackoffEnabled    *bool    `json:"relay_model_cooldown_backoff_enabled"`
+	OAuthModelCooldownMode              *string  `json:"oauth_model_cooldown_mode"`
+	OAuthModelCooldownSeconds           *int     `json:"oauth_model_cooldown_seconds"`
+	OAuthModelCooldownBackoffEnabled    *bool    `json:"oauth_model_cooldown_backoff_enabled"`
 }
 
 func updateSettingsHasFieldsOtherThanCustomPatterns(req updateSettingsReq) bool {
@@ -7971,6 +8139,7 @@ func (h *Handler) GetSettings(c *gin.Context) {
 	if dbSettings != nil {
 		bgCfg = decodeBackgroundConfig(dbSettings.BackgroundConfig)
 	}
+	modelCooldownSettings := h.store.GetModelCooldownSettings()
 	c.JSON(http.StatusOK, settingsResponse{
 		SiteName:                            branding.SiteName,
 		SiteLogo:                            branding.SiteLogo,
@@ -7988,6 +8157,12 @@ func (h *Handler) GetSettings(c *gin.Context) {
 		ResponseCacheLocalMaxEntryBytes:     responseCacheSettings.LocalMaxEntryBytes,
 		ResponseCacheReconstructMaxBytes:    responseCacheSettings.ReconstructMaxBytes,
 		ResponseCacheConfigGeneration:       responseCacheSettings.Generation,
+		RelayModelCooldownMode:              modelCooldownSettings.RelayMode,
+		RelayModelCooldownSeconds:           modelCooldownSettings.RelaySeconds,
+		RelayModelCooldownBackoffEnabled:    modelCooldownSettings.RelayBackoffEnabled,
+		OAuthModelCooldownMode:              modelCooldownSettings.OAuthMode,
+		OAuthModelCooldownSeconds:           modelCooldownSettings.OAuthSeconds,
+		OAuthModelCooldownBackoffEnabled:    modelCooldownSettings.OAuthBackoffEnabled,
 		BackgroundRefreshIntervalMinutes:    h.store.GetBackgroundRefreshIntervalMinutes(),
 		UsageProbeMaxAgeMinutes:             h.store.GetUsageProbeMaxAgeMinutes(),
 		UsageProbeConcurrency:               h.store.GetUsageProbeConcurrency(),
@@ -8226,6 +8401,29 @@ func (h *Handler) UpdateSettings(c *gin.Context) {
 	if req.ResponseCacheConfigGeneration != nil {
 		writeError(c, http.StatusBadRequest, "response_cache_config_generation 为只读字段")
 		return
+	}
+	modelCooldownUpdateRequested := req.RelayModelCooldownMode != nil ||
+		req.RelayModelCooldownSeconds != nil ||
+		req.RelayModelCooldownBackoffEnabled != nil ||
+		req.OAuthModelCooldownMode != nil ||
+		req.OAuthModelCooldownSeconds != nil ||
+		req.OAuthModelCooldownBackoffEnabled != nil
+	if req.RelayModelCooldownMode != nil && !database.IsValidModelCooldownMode(*req.RelayModelCooldownMode) {
+		writeError(c, http.StatusBadRequest, "relay_model_cooldown_mode 必须是 off、fixed 或 adaptive")
+		return
+	}
+	if req.OAuthModelCooldownMode != nil && !database.IsValidModelCooldownMode(*req.OAuthModelCooldownMode) {
+		writeError(c, http.StatusBadRequest, "oauth_model_cooldown_mode 必须是 off、fixed 或 adaptive")
+		return
+	}
+	for field, value := range map[string]*int{
+		"relay_model_cooldown_seconds": req.RelayModelCooldownSeconds,
+		"oauth_model_cooldown_seconds": req.OAuthModelCooldownSeconds,
+	} {
+		if value != nil && (*value < 1 || *value > database.MaxModelCooldownSeconds) {
+			writeError(c, http.StatusBadRequest, fmt.Sprintf("%s 必须在 1-%d 之间", field, database.MaxModelCooldownSeconds))
+			return
+		}
 	}
 	var submittedPromptFilterCustomPatterns []promptfilter.PatternConfig
 	var promptFilterPatternQuarantines []promptfilter.PatternQuarantine
@@ -9307,6 +9505,10 @@ func (h *Handler) UpdateSettings(c *gin.Context) {
 	})
 	if err != nil {
 		log.Printf("无法持久化保存设置: %v", err)
+		if modelCooldownUpdateRequested {
+			writeError(c, http.StatusInternalServerError, "保存模型冷却设置前无法持久化系统设置")
+			return
+		}
 		if responseCacheUpdateRequested {
 			writeError(c, http.StatusInternalServerError, "保存响应缓存设置前无法持久化系统设置")
 			return
@@ -9358,6 +9560,22 @@ func (h *Handler) UpdateSettings(c *gin.Context) {
 		}
 	}
 
+	if modelCooldownUpdateRequested {
+		committed, updateErr := h.db.UpdateModelCooldownSettings(c.Request.Context(), database.ModelCooldownSettingsUpdate{
+			RelayMode:           req.RelayModelCooldownMode,
+			RelaySeconds:        req.RelayModelCooldownSeconds,
+			RelayBackoffEnabled: req.RelayModelCooldownBackoffEnabled,
+			OAuthMode:           req.OAuthModelCooldownMode,
+			OAuthSeconds:        req.OAuthModelCooldownSeconds,
+			OAuthBackoffEnabled: req.OAuthModelCooldownBackoffEnabled,
+		})
+		if updateErr != nil {
+			writeError(c, http.StatusInternalServerError, updateErr.Error())
+			return
+		}
+		h.store.SetModelCooldownSettings(committed)
+	}
+
 	if responseCacheUpdateRequested {
 		committed, updateErr := cacheSettingsStore.UpdateResponseCacheSettings(
 			c.Request.Context(),
@@ -9394,6 +9612,7 @@ func (h *Handler) UpdateSettings(c *gin.Context) {
 	if adminAuthSource == "env" {
 		adminSecretForDisplay = ""
 	}
+	modelCooldownSettings := h.store.GetModelCooldownSettings()
 
 	c.JSON(http.StatusOK, settingsResponse{
 		SiteName:                            siteName,
@@ -9412,6 +9631,12 @@ func (h *Handler) UpdateSettings(c *gin.Context) {
 		ResponseCacheLocalMaxEntryBytes:     responseCacheSettings.LocalMaxEntryBytes,
 		ResponseCacheReconstructMaxBytes:    responseCacheSettings.ReconstructMaxBytes,
 		ResponseCacheConfigGeneration:       responseCacheSettings.Generation,
+		RelayModelCooldownMode:              modelCooldownSettings.RelayMode,
+		RelayModelCooldownSeconds:           modelCooldownSettings.RelaySeconds,
+		RelayModelCooldownBackoffEnabled:    modelCooldownSettings.RelayBackoffEnabled,
+		OAuthModelCooldownMode:              modelCooldownSettings.OAuthMode,
+		OAuthModelCooldownSeconds:           modelCooldownSettings.OAuthSeconds,
+		OAuthModelCooldownBackoffEnabled:    modelCooldownSettings.OAuthBackoffEnabled,
 		BackgroundRefreshIntervalMinutes:    h.store.GetBackgroundRefreshIntervalMinutes(),
 		UsageProbeMaxAgeMinutes:             h.store.GetUsageProbeMaxAgeMinutes(),
 		UsageProbeConcurrency:               h.store.GetUsageProbeConcurrency(),

--- a/auth/cooldown_cache_test.go
+++ b/auth/cooldown_cache_test.go
@@ -143,3 +143,27 @@ func TestCooldownCacheWritesAndDeletes(t *testing.T) {
 		t.Fatalf("model cooldown runtime cache after clear ok=%v err=%v, want miss", ok, err)
 	}
 }
+
+func TestModelCooldownFixedModeDoesNotBackoff(t *testing.T) {
+	store := NewStore(nil, nil, nil)
+	acc := &Account{DBID: 11}
+
+	first := store.MarkModelCooldownWithBackoff(acc, "gpt-5.6-sol", 2*time.Second, "rate_limited_model", false)
+	second := store.MarkModelCooldownWithBackoff(acc, "gpt-5.6-sol", 2*time.Second, "rate_limited_model", false)
+
+	if first.Model == "" || second.Model == "" {
+		t.Fatal("expected cooldown records")
+	}
+	if second.BackoffLevel != 0 {
+		t.Fatalf("BackoffLevel = %d, want 0", second.BackoffLevel)
+	}
+	if remaining := time.Until(second.ResetAt); remaining < time.Second || remaining > 3*time.Second {
+		t.Fatalf("remaining = %v, want fixed ~2s", remaining)
+	}
+	if cleared := store.ClearAllModelCooldowns(acc); cleared != 1 {
+		t.Fatalf("ClearAllModelCooldowns() = %d, want 1", cleared)
+	}
+	if acc.IsModelRateLimited("gpt-5.6-sol") {
+		t.Fatal("model cooldown should be cleared")
+	}
+}

--- a/auth/store.go
+++ b/auth/store.go
@@ -248,6 +248,9 @@ type Account struct {
 	Tags                           []string
 	GroupIDs                       []int64
 	ModelCooldowns                 map[string]ModelCooldown
+	ModelCooldownModeOverride      *string
+	ModelCooldownSecondsOverride   *int
+	ModelCooldownBackoffOverride   *bool
 
 	SubscriptionExpiresAt time.Time
 }
@@ -2434,6 +2437,50 @@ func (a *Account) ClearModelCooldown(model string) bool {
 	return true
 }
 
+func (a *Account) ClearAllModelCooldowns() []string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if len(a.ModelCooldowns) == 0 {
+		return nil
+	}
+	models := make([]string, 0, len(a.ModelCooldowns))
+	for model := range a.ModelCooldowns {
+		models = append(models, model)
+	}
+	clear(a.ModelCooldowns)
+	sort.Strings(models)
+	return models
+}
+
+func (a *Account) SetModelCooldownPolicyOverride(mode *string, seconds *int, backoff *bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.ModelCooldownModeOverride = mode
+	a.ModelCooldownSecondsOverride = seconds
+	a.ModelCooldownBackoffOverride = backoff
+}
+
+func (a *Account) GetModelCooldownPolicyOverride() (*string, *int, *bool) {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	var mode *string
+	var seconds *int
+	var backoff *bool
+	if a.ModelCooldownModeOverride != nil {
+		value := *a.ModelCooldownModeOverride
+		mode = &value
+	}
+	if a.ModelCooldownSecondsOverride != nil {
+		value := *a.ModelCooldownSecondsOverride
+		seconds = &value
+	}
+	if a.ModelCooldownBackoffOverride != nil {
+		value := *a.ModelCooldownBackoffOverride
+		backoff = &value
+	}
+	return mode, seconds, backoff
+}
+
 // GetDynamicConcurrencyLimit 获取当前动态并发上限
 func (a *Account) GetDynamicConcurrencyLimit() int64 {
 	a.mu.RLock()
@@ -2784,6 +2831,7 @@ type Store struct {
 	grokProbeEnabled      atomic.Bool  // 定期探测 Grok 账号状态是否开启（默认关）
 	grokProbeIntervalMin  atomic.Int64 // 定期探测间隔（分钟，默认 30，下限 grokProbeMinIntervalMinutes）
 	grokMaxRateLimitRetry atomic.Int64 // Grok 请求限流(429)专属换号重试上限（0=跟随全局）
+	modelCooldownSettings atomic.Value // database.ModelCooldownSettings
 	promptFilterConfig    atomic.Value // promptFilterConfigState
 	sessionMu             sync.RWMutex
 	sessionBindings       map[string]sessionAffinity
@@ -3299,6 +3347,14 @@ func NewStore(db *database.DB, tc cache.TokenCache, settings *database.SystemSet
 	s.ignoreUsageLimitStatus.Store(settings.IgnoreUsageLimitStatus)
 	s.retryIntervalMS.Store(int64(normalizeRetryIntervalMS(settings.RetryIntervalMS)))
 	s.transportRetryPolicy.Store(database.NormalizeTransportRetryPolicy(settings.TransportRetryPolicy))
+	s.SetModelCooldownSettings(database.ModelCooldownSettings{
+		RelayMode:           settings.RelayModelCooldownMode,
+		RelaySeconds:        settings.RelayModelCooldownSeconds,
+		RelayBackoffEnabled: settings.RelayModelCooldownBackoffEnabled,
+		OAuthMode:           settings.OAuthModelCooldownMode,
+		OAuthSeconds:        settings.OAuthModelCooldownSeconds,
+		OAuthBackoffEnabled: settings.OAuthModelCooldownBackoffEnabled,
+	})
 
 	s.globalAutoPause5hThreshold = normalizeQuotaAutoPauseThreshold(settings.AutoPause5hThreshold)
 	s.globalAutoPause7dThreshold = normalizeQuotaAutoPauseThreshold(settings.AutoPause7dThreshold)
@@ -4223,6 +4279,19 @@ func (s *Store) buildAccountFromRow(ctx context.Context, row *database.AccountRo
 	account.CreditEnabled = row.CreditEnabled
 	account.CreditSkipUsageWindow = row.CreditSkipUsageWindow
 	account.IgnoreUsageLimitStatusOverride = row.GetCredentialOptionalBool("ignore_usage_limit_status_override")
+	if rawMode := strings.TrimSpace(row.GetCredential("model_cooldown_mode_override")); rawMode != "" {
+		if database.IsValidModelCooldownMode(rawMode) {
+			mode := database.NormalizeModelCooldownMode(rawMode, database.ModelCooldownModeAdaptive)
+			account.ModelCooldownModeOverride = &mode
+		}
+	}
+	if seconds, ok := row.GetCredentialInt64("model_cooldown_seconds_override"); ok {
+		if seconds >= 1 && seconds <= database.MaxModelCooldownSeconds {
+			value := int(seconds)
+			account.ModelCooldownSecondsOverride = &value
+		}
+	}
+	account.ModelCooldownBackoffOverride = row.GetCredentialOptionalBool("model_cooldown_backoff_override")
 	account.recomputeEffectiveIgnoreUsageLimitStatus(s.IgnoreUsageLimitStatus())
 	account.SkipWarmTier = row.SkipWarmTier
 	if row.Status == "error" {
@@ -6972,6 +7041,10 @@ func (s *Store) markCooldown(acc *Account, duration time.Duration, reason string
 }
 
 func (s *Store) MarkModelCooldown(acc *Account, model string, duration time.Duration, reason string) ModelCooldown {
+	return s.MarkModelCooldownWithBackoff(acc, model, duration, reason, true)
+}
+
+func (s *Store) MarkModelCooldownWithBackoff(acc *Account, model string, duration time.Duration, reason string, backoffEnabled bool) ModelCooldown {
 	if acc == nil {
 		return ModelCooldown{}
 	}
@@ -6993,7 +7066,7 @@ func (s *Store) MarkModelCooldown(acc *Account, model string, duration time.Dura
 	}
 	current := acc.ModelCooldowns[key]
 	level := current.BackoffLevel
-	if current.ResetAt.After(now) {
+	if backoffEnabled && current.ResetAt.After(now) {
 		level++
 		duration *= 2
 		for i := 0; i < level-1; i++ {
@@ -7002,6 +7075,8 @@ func (s *Store) MarkModelCooldown(acc *Account, model string, duration time.Dura
 		if duration > 30*time.Minute {
 			duration = 30 * time.Minute
 		}
+	} else if !backoffEnabled {
+		level = 0
 	}
 	resetAt := now.Add(duration)
 	if reason == "" {
@@ -7092,6 +7167,92 @@ func (s *Store) ClearModelCooldown(acc *Account, model string) {
 	if err := s.db.ClearModelCooldown(ctx, acc.DBID, key); err != nil {
 		log.Printf("[账号 %d] 清理模型冷却失败 model=%s: %v", acc.DBID, key, err)
 	}
+}
+
+func (s *Store) ClearAllModelCooldowns(acc *Account) int {
+	if acc == nil {
+		return 0
+	}
+	models := acc.ClearAllModelCooldowns()
+	for _, model := range models {
+		s.deleteCachedModelCooldown(acc.DBID, model)
+	}
+	s.fastSchedulerUpdate(acc)
+	if s.db != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		if err := s.db.ClearAllModelCooldowns(ctx, acc.DBID); err != nil {
+			log.Printf("[账号 %d] 清理全部模型冷却失败: %v", acc.DBID, err)
+		}
+	}
+	return len(models)
+}
+
+type ModelCooldownPolicy struct {
+	Mode           string
+	Seconds        int
+	BackoffEnabled bool
+	Source         string
+}
+
+func (s *Store) SetModelCooldownSettings(settings database.ModelCooldownSettings) {
+	if s == nil {
+		return
+	}
+	s.modelCooldownSettings.Store(database.NormalizeModelCooldownSettings(settings))
+}
+
+func (s *Store) GetModelCooldownSettings() database.ModelCooldownSettings {
+	if s == nil {
+		return database.DefaultModelCooldownSettings()
+	}
+	if value := s.modelCooldownSettings.Load(); value != nil {
+		if settings, ok := value.(database.ModelCooldownSettings); ok {
+			return database.NormalizeModelCooldownSettings(settings)
+		}
+	}
+	return database.DefaultModelCooldownSettings()
+}
+
+func (s *Store) ResolveModelCooldownPolicy(acc *Account) ModelCooldownPolicy {
+	settings := s.GetModelCooldownSettings()
+	policy := ModelCooldownPolicy{
+		Mode:           settings.OAuthMode,
+		Seconds:        settings.OAuthSeconds,
+		BackoffEnabled: settings.OAuthBackoffEnabled,
+		Source:         "oauth",
+	}
+	if acc != nil && acc.IsRelayStyle() && !acc.IsGrokAPI() {
+		policy.Mode = settings.RelayMode
+		policy.Seconds = settings.RelaySeconds
+		policy.BackoffEnabled = settings.RelayBackoffEnabled
+		policy.Source = "relay"
+	}
+	if acc != nil {
+		mode, seconds, backoff := acc.GetModelCooldownPolicyOverride()
+		if mode != nil {
+			policy.Mode = database.NormalizeModelCooldownMode(*mode, policy.Mode)
+			policy.Source = "account"
+		}
+		if seconds != nil {
+			policy.Seconds = database.NormalizeModelCooldownSeconds(*seconds, policy.Seconds)
+			policy.Source = "account"
+		}
+		if backoff != nil {
+			policy.BackoffEnabled = *backoff
+			policy.Source = "account"
+		}
+	}
+	return policy
+}
+
+func (s *Store) ApplyAccountModelCooldownPolicyOverride(dbID int64, mode *string, seconds *int, backoff *bool) bool {
+	acc := s.FindByID(dbID)
+	if acc == nil {
+		return false
+	}
+	acc.SetModelCooldownPolicyOverride(mode, seconds, backoff)
+	return true
 }
 
 // MarkError 标记账号为错误状态，并持久化到数据库。

--- a/database/model_cooldown_settings.go
+++ b/database/model_cooldown_settings.go
@@ -1,0 +1,187 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+)
+
+const (
+	ModelCooldownModeOff      = "off"
+	ModelCooldownModeFixed    = "fixed"
+	ModelCooldownModeAdaptive = "adaptive"
+
+	DefaultRelayModelCooldownSeconds = 2
+	DefaultOAuthModelCooldownSeconds = 300
+	MaxModelCooldownSeconds          = 1800
+)
+
+// ModelCooldownSettings separates transient API/relay throttling from OAuth
+// account-pool throttling. Relay defaults intentionally avoid persistent
+// cooldowns because an isolated upstream 429 is normal load-shedding, not an
+// account health failure.
+type ModelCooldownSettings struct {
+	RelayMode           string
+	RelaySeconds        int
+	RelayBackoffEnabled bool
+	OAuthMode           string
+	OAuthSeconds        int
+	OAuthBackoffEnabled bool
+}
+
+type ModelCooldownSettingsUpdate struct {
+	RelayMode           *string
+	RelaySeconds        *int
+	RelayBackoffEnabled *bool
+	OAuthMode           *string
+	OAuthSeconds        *int
+	OAuthBackoffEnabled *bool
+}
+
+func DefaultModelCooldownSettings() ModelCooldownSettings {
+	return ModelCooldownSettings{
+		RelayMode:           ModelCooldownModeOff,
+		RelaySeconds:        DefaultRelayModelCooldownSeconds,
+		RelayBackoffEnabled: false,
+		OAuthMode:           ModelCooldownModeAdaptive,
+		OAuthSeconds:        DefaultOAuthModelCooldownSeconds,
+		OAuthBackoffEnabled: true,
+	}
+}
+
+func NormalizeModelCooldownMode(value, fallback string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case ModelCooldownModeOff:
+		return ModelCooldownModeOff
+	case ModelCooldownModeFixed:
+		return ModelCooldownModeFixed
+	case ModelCooldownModeAdaptive:
+		return ModelCooldownModeAdaptive
+	default:
+		switch fallback {
+		case ModelCooldownModeOff, ModelCooldownModeFixed, ModelCooldownModeAdaptive:
+			return fallback
+		default:
+			return ModelCooldownModeAdaptive
+		}
+	}
+}
+
+func IsValidModelCooldownMode(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case ModelCooldownModeOff, ModelCooldownModeFixed, ModelCooldownModeAdaptive:
+		return true
+	default:
+		return false
+	}
+}
+
+func NormalizeModelCooldownSeconds(value, fallback int) int {
+	if fallback < 0 {
+		fallback = 0
+	}
+	if fallback > MaxModelCooldownSeconds {
+		fallback = MaxModelCooldownSeconds
+	}
+	if value < 0 {
+		return fallback
+	}
+	if value > MaxModelCooldownSeconds {
+		return MaxModelCooldownSeconds
+	}
+	return value
+}
+
+func NormalizeModelCooldownSettings(value ModelCooldownSettings) ModelCooldownSettings {
+	defaults := DefaultModelCooldownSettings()
+	value.RelayMode = NormalizeModelCooldownMode(value.RelayMode, defaults.RelayMode)
+	if value.RelaySeconds <= 0 {
+		value.RelaySeconds = defaults.RelaySeconds
+	}
+	value.RelaySeconds = NormalizeModelCooldownSeconds(value.RelaySeconds, defaults.RelaySeconds)
+	value.OAuthMode = NormalizeModelCooldownMode(value.OAuthMode, defaults.OAuthMode)
+	if value.OAuthSeconds <= 0 {
+		value.OAuthSeconds = defaults.OAuthSeconds
+	}
+	value.OAuthSeconds = NormalizeModelCooldownSeconds(value.OAuthSeconds, defaults.OAuthSeconds)
+	return value
+}
+
+func (db *DB) GetModelCooldownSettings(ctx context.Context) (ModelCooldownSettings, error) {
+	defaults := DefaultModelCooldownSettings()
+	value := defaults
+	err := db.conn.QueryRowContext(ctx, `
+		SELECT
+			COALESCE(NULLIF(TRIM(relay_model_cooldown_mode), ''), $1),
+			COALESCE(relay_model_cooldown_seconds, $2),
+			COALESCE(relay_model_cooldown_backoff_enabled, $3),
+			COALESCE(NULLIF(TRIM(oauth_model_cooldown_mode), ''), $4),
+			COALESCE(oauth_model_cooldown_seconds, $5),
+			COALESCE(oauth_model_cooldown_backoff_enabled, $6)
+		FROM system_settings
+		WHERE id = 1
+	`, defaults.RelayMode, defaults.RelaySeconds, defaults.RelayBackoffEnabled,
+		defaults.OAuthMode, defaults.OAuthSeconds, defaults.OAuthBackoffEnabled,
+	).Scan(
+		&value.RelayMode,
+		&value.RelaySeconds,
+		&value.RelayBackoffEnabled,
+		&value.OAuthMode,
+		&value.OAuthSeconds,
+		&value.OAuthBackoffEnabled,
+	)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return defaults, nil
+		}
+		return defaults, fmt.Errorf("读取模型冷却设置失败: %w", err)
+	}
+	return NormalizeModelCooldownSettings(value), nil
+}
+
+func (db *DB) UpdateModelCooldownSettings(ctx context.Context, update ModelCooldownSettingsUpdate) (ModelCooldownSettings, error) {
+	current, err := db.GetModelCooldownSettings(ctx)
+	if err != nil {
+		return ModelCooldownSettings{}, err
+	}
+	if update.RelayMode != nil {
+		current.RelayMode = NormalizeModelCooldownMode(*update.RelayMode, current.RelayMode)
+	}
+	if update.RelaySeconds != nil {
+		current.RelaySeconds = NormalizeModelCooldownSeconds(*update.RelaySeconds, current.RelaySeconds)
+	}
+	if update.RelayBackoffEnabled != nil {
+		current.RelayBackoffEnabled = *update.RelayBackoffEnabled
+	}
+	if update.OAuthMode != nil {
+		current.OAuthMode = NormalizeModelCooldownMode(*update.OAuthMode, current.OAuthMode)
+	}
+	if update.OAuthSeconds != nil {
+		current.OAuthSeconds = NormalizeModelCooldownSeconds(*update.OAuthSeconds, current.OAuthSeconds)
+	}
+	if update.OAuthBackoffEnabled != nil {
+		current.OAuthBackoffEnabled = *update.OAuthBackoffEnabled
+	}
+	current = NormalizeModelCooldownSettings(current)
+
+	if _, err := db.conn.ExecContext(ctx, `INSERT INTO system_settings (id) VALUES (1) ON CONFLICT(id) DO NOTHING`); err != nil {
+		return ModelCooldownSettings{}, fmt.Errorf("初始化模型冷却设置失败: %w", err)
+	}
+	_, err = db.conn.ExecContext(ctx, `
+		UPDATE system_settings SET
+			relay_model_cooldown_mode = $1,
+			relay_model_cooldown_seconds = $2,
+			relay_model_cooldown_backoff_enabled = $3,
+			oauth_model_cooldown_mode = $4,
+			oauth_model_cooldown_seconds = $5,
+			oauth_model_cooldown_backoff_enabled = $6
+		WHERE id = 1
+	`, current.RelayMode, current.RelaySeconds, current.RelayBackoffEnabled,
+		current.OAuthMode, current.OAuthSeconds, current.OAuthBackoffEnabled,
+	)
+	if err != nil {
+		return ModelCooldownSettings{}, fmt.Errorf("保存模型冷却设置失败: %w", err)
+	}
+	return current, nil
+}

--- a/database/postgres.go
+++ b/database/postgres.go
@@ -1244,6 +1244,12 @@ func (db *DB) migrate(ctx context.Context) error {
 	ALTER TABLE system_settings ADD COLUMN IF NOT EXISTS response_cache_local_max_entry_bytes BIGINT NOT NULL DEFAULT 8388608;
 	ALTER TABLE system_settings ADD COLUMN IF NOT EXISTS response_cache_reconstruct_max_bytes BIGINT NOT NULL DEFAULT 67108864;
 	ALTER TABLE system_settings ADD COLUMN IF NOT EXISTS response_cache_config_generation BIGINT NOT NULL DEFAULT 1;
+	ALTER TABLE system_settings ADD COLUMN IF NOT EXISTS relay_model_cooldown_mode VARCHAR(20) NOT NULL DEFAULT 'off';
+	ALTER TABLE system_settings ADD COLUMN IF NOT EXISTS relay_model_cooldown_seconds INT NOT NULL DEFAULT 2;
+	ALTER TABLE system_settings ADD COLUMN IF NOT EXISTS relay_model_cooldown_backoff_enabled BOOLEAN NOT NULL DEFAULT FALSE;
+	ALTER TABLE system_settings ADD COLUMN IF NOT EXISTS oauth_model_cooldown_mode VARCHAR(20) NOT NULL DEFAULT 'adaptive';
+	ALTER TABLE system_settings ADD COLUMN IF NOT EXISTS oauth_model_cooldown_seconds INT NOT NULL DEFAULT 300;
+	ALTER TABLE system_settings ADD COLUMN IF NOT EXISTS oauth_model_cooldown_backoff_enabled BOOLEAN NOT NULL DEFAULT TRUE;
 
 	ALTER TABLE account_groups ADD COLUMN IF NOT EXISTS auto_pause_5h_threshold DOUBLE PRECISION DEFAULT 0;
 	ALTER TABLE account_groups ADD COLUMN IF NOT EXISTS auto_pause_7d_threshold DOUBLE PRECISION DEFAULT 0;
@@ -2050,7 +2056,13 @@ type SystemSettings struct {
 	// custom/synced 覆盖代码默认；空为 "{}"。
 	ModelPricingOverrides string
 	// ModelPricingSyncURL 是「从 JSON URL 同步定价」的来源地址，空时用内置默认。
-	ModelPricingSyncURL string
+	ModelPricingSyncURL              string
+	RelayModelCooldownMode           string
+	RelayModelCooldownSeconds        int
+	RelayModelCooldownBackoffEnabled bool
+	OAuthModelCooldownMode           string
+	OAuthModelCooldownSeconds        int
+	OAuthModelCooldownBackoffEnabled bool
 
 	// PreservePromptFilterCustomPatterns is an update-only concurrency guard.
 	// When true, an existing row keeps its current custom-pattern value instead
@@ -5690,6 +5702,14 @@ func (db *DB) ClearModelCooldown(ctx context.Context, accountID int64, model str
 		return nil
 	}
 	_, err := db.conn.ExecContext(ctx, `DELETE FROM account_model_cooldowns WHERE account_id = $1 AND model = $2`, accountID, model)
+	return err
+}
+
+func (db *DB) ClearAllModelCooldowns(ctx context.Context, accountID int64) error {
+	if accountID == 0 {
+		return nil
+	}
+	_, err := db.conn.ExecContext(ctx, `DELETE FROM account_model_cooldowns WHERE account_id = $1`, accountID)
 	return err
 }
 

--- a/database/sqlite.go
+++ b/database/sqlite.go
@@ -280,7 +280,13 @@ func (db *DB) migrateSQLite(ctx context.Context) error {
 					response_cache_local_max_bytes INTEGER NOT NULL DEFAULT 67108864,
 					response_cache_local_max_entry_bytes INTEGER NOT NULL DEFAULT 8388608,
 					response_cache_reconstruct_max_bytes INTEGER NOT NULL DEFAULT 67108864,
-					response_cache_config_generation INTEGER NOT NULL DEFAULT 1
+					response_cache_config_generation INTEGER NOT NULL DEFAULT 1,
+					relay_model_cooldown_mode TEXT NOT NULL DEFAULT 'off',
+					relay_model_cooldown_seconds INTEGER NOT NULL DEFAULT 2,
+					relay_model_cooldown_backoff_enabled INTEGER NOT NULL DEFAULT 0,
+					oauth_model_cooldown_mode TEXT NOT NULL DEFAULT 'adaptive',
+					oauth_model_cooldown_seconds INTEGER NOT NULL DEFAULT 300,
+					oauth_model_cooldown_backoff_enabled INTEGER NOT NULL DEFAULT 1
 				);`,
 		`CREATE TABLE IF NOT EXISTS model_registry (
 			id TEXT PRIMARY KEY,
@@ -527,6 +533,12 @@ func (db *DB) migrateSQLite(ctx context.Context) error {
 		{"system_settings", "response_cache_local_max_entry_bytes", "INTEGER NOT NULL DEFAULT 8388608"},
 		{"system_settings", "response_cache_reconstruct_max_bytes", "INTEGER NOT NULL DEFAULT 67108864"},
 		{"system_settings", "response_cache_config_generation", "INTEGER NOT NULL DEFAULT 1"},
+		{"system_settings", "relay_model_cooldown_mode", "TEXT NOT NULL DEFAULT 'off'"},
+		{"system_settings", "relay_model_cooldown_seconds", "INTEGER NOT NULL DEFAULT 2"},
+		{"system_settings", "relay_model_cooldown_backoff_enabled", "INTEGER NOT NULL DEFAULT 0"},
+		{"system_settings", "oauth_model_cooldown_mode", "TEXT NOT NULL DEFAULT 'adaptive'"},
+		{"system_settings", "oauth_model_cooldown_seconds", "INTEGER NOT NULL DEFAULT 300"},
+		{"system_settings", "oauth_model_cooldown_backoff_enabled", "INTEGER NOT NULL DEFAULT 1"},
 		{"system_settings", "max_retries", "INTEGER DEFAULT 2"},
 		{"system_settings", "max_rate_limit_retries", "INTEGER DEFAULT 1"},
 		{"system_settings", "allow_remote_migration", "INTEGER DEFAULT 0"},

--- a/database/sqlite_test.go
+++ b/database/sqlite_test.go
@@ -1159,6 +1159,49 @@ func TestSQLiteModelCooldownPersistence(t *testing.T) {
 	}
 }
 
+func TestModelCooldownSettingsDefaultsAndUpdate(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "codex2api.db")
+	db, err := New("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("New(sqlite) 返回错误: %v", err)
+	}
+	defer db.Close()
+
+	defaults, err := db.GetModelCooldownSettings(ctx)
+	if err != nil {
+		t.Fatalf("GetModelCooldownSettings defaults: %v", err)
+	}
+	if defaults.RelayMode != ModelCooldownModeOff || defaults.RelaySeconds != 2 || defaults.RelayBackoffEnabled {
+		t.Fatalf("relay defaults = %#v", defaults)
+	}
+	if defaults.OAuthMode != ModelCooldownModeAdaptive || defaults.OAuthSeconds != 300 || !defaults.OAuthBackoffEnabled {
+		t.Fatalf("oauth defaults = %#v", defaults)
+	}
+
+	mode := ModelCooldownModeFixed
+	seconds := 7
+	backoff := false
+	updated, err := db.UpdateModelCooldownSettings(ctx, ModelCooldownSettingsUpdate{
+		RelayMode:           &mode,
+		RelaySeconds:        &seconds,
+		RelayBackoffEnabled: &backoff,
+	})
+	if err != nil {
+		t.Fatalf("UpdateModelCooldownSettings: %v", err)
+	}
+	if updated.RelayMode != mode || updated.RelaySeconds != seconds || updated.RelayBackoffEnabled {
+		t.Fatalf("updated relay settings = %#v", updated)
+	}
+	reloaded, err := db.GetModelCooldownSettings(ctx)
+	if err != nil {
+		t.Fatalf("GetModelCooldownSettings reload: %v", err)
+	}
+	if reloaded != updated {
+		t.Fatalf("reloaded = %#v, want %#v", reloaded, updated)
+	}
+}
+
 func TestAccountRequestCountsSeparateRetryAttempts(t *testing.T) {
 	ctx := context.Background()
 	dbPath := filepath.Join(t.TempDir(), "codex2api.db")

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -581,6 +581,31 @@ export const api = {
     request<{ message: string; success: number; failed: number }>('/accounts/batch-update', { method: 'POST', body: JSON.stringify(data) }),
   resetAccountStatus: (id: number) =>
     request<MessageResponse>(`/accounts/${id}/reset-status`, { method: 'POST' }),
+  updateAccountModelCooldownPolicy: (
+    id: number,
+    data: {
+      mode?: 'off' | 'fixed' | 'adaptive' | null
+      seconds?: number | null
+      backoff_enabled?: boolean | null
+    },
+  ) =>
+    request<{
+      message: string
+      mode_effective: 'off' | 'fixed' | 'adaptive'
+      seconds_effective: number
+      backoff_enabled_effective: boolean
+    }>(`/accounts/${id}/model-cooldown-policy`, {
+      method: 'PATCH',
+      body: JSON.stringify(data),
+    }),
+  clearAccountModelCooldown: (id: number, model: string) =>
+    request<MessageResponse>(`/accounts/${id}/model-cooldowns/${encodeURIComponent(model)}`, {
+      method: 'DELETE',
+    }),
+  clearAllAccountModelCooldowns: (id: number) =>
+    request<{ message: string; cleared: number }>(`/accounts/${id}/model-cooldowns`, {
+      method: 'DELETE',
+    }),
   // usage_refreshed 表示重置后的用量探针是否在响应前跑完；false 时调用方应稍后补刷一次。
   resetCredits: (id: number) =>
     request<{

--- a/frontend/src/components/AccountDetailSheet.tsx
+++ b/frontend/src/components/AccountDetailSheet.tsx
@@ -19,6 +19,7 @@ import {
   Timer,
   Trash2,
   Unlock,
+  X,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import type { AccountGroup, AccountHealthBucket, AccountRow } from "../types";
@@ -27,6 +28,9 @@ import ChannelLogo from "./ChannelLogo";
 import ModelLogo from "./ModelLogo";
 import StatusBadge from "./StatusBadge";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Select } from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
 import {
   Sheet,
   SheetBody,
@@ -176,6 +180,13 @@ export interface AccountDetailSheetProps {
   onToggleEnabled: () => void;
   onToggleLock: () => void;
   onResetStatus: () => void;
+  onSaveModelCooldownPolicy: (data: {
+    mode: "off" | "fixed" | "adaptive" | null;
+    seconds: number | null;
+    backoff_enabled: boolean | null;
+  }) => void;
+  onClearModelCooldown: (model: string) => void;
+  onClearAllModelCooldowns: () => void;
   onResetCredits: () => void;
   onDelete: () => void;
 }
@@ -201,11 +212,32 @@ export default function AccountDetailSheet({
   onToggleEnabled,
   onToggleLock,
   onResetStatus,
+  onSaveModelCooldownPolicy,
+  onClearModelCooldown,
+  onClearAllModelCooldowns,
   onResetCredits,
   onDelete,
 }: AccountDetailSheetProps) {
   const { t } = useTranslation();
   const open = Boolean(account);
+  const [cooldownMode, setCooldownMode] = useState<string>("inherit");
+  const [cooldownSeconds, setCooldownSeconds] = useState(300);
+  const [cooldownBackoff, setCooldownBackoff] = useState(true);
+
+  useEffect(() => {
+    if (!account) return;
+    setCooldownMode(account.model_cooldown_mode_override ?? "inherit");
+    setCooldownSeconds(
+      account.model_cooldown_seconds_override ??
+        account.model_cooldown_seconds_effective ??
+        300,
+    );
+    setCooldownBackoff(
+      account.model_cooldown_backoff_override ??
+        account.model_cooldown_backoff_effective ??
+        true,
+    );
+  }, [account]);
 
   useEffect(() => {
     if (!open) return;
@@ -441,6 +473,138 @@ export default function AccountDetailSheet({
                 ) : null}
               </div>
             </Section>
+
+            {!isGrok ? <Section
+              title={t("accounts.modelCooldownPolicy")}
+              action={
+                (account.model_cooldowns?.length ?? 0) > 0 ? (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="xs"
+                    onClick={onClearAllModelCooldowns}
+                    className="h-7 text-[11px] text-amber-700 dark:text-amber-300"
+                  >
+                    <X className="size-3" />
+                    {t("accounts.clearAllModelCooldowns")}
+                  </Button>
+                ) : null
+              }
+            >
+              <div className="space-y-3 rounded-xl border border-border bg-card p-3">
+                <div className="rounded-lg bg-muted/40 px-2.5 py-2 text-[11px] leading-relaxed text-muted-foreground">
+                  {t("accounts.modelCooldownEffective", {
+                    mode: t(
+                      `settings.modelCooldownMode${(
+                        account.model_cooldown_mode_effective ?? "adaptive"
+                      )
+                        .charAt(0)
+                        .toUpperCase()}${(
+                        account.model_cooldown_mode_effective ?? "adaptive"
+                      ).slice(1)}`,
+                    ),
+                    seconds: account.model_cooldown_seconds_effective ?? 0,
+                    backoff: account.model_cooldown_backoff_effective
+                      ? t("common.enabled")
+                      : t("common.disabled"),
+                  })}
+                </div>
+                <div className="grid grid-cols-2 gap-2">
+                  <div className="col-span-2">
+                    <label className="mb-1 block text-[11px] font-medium text-muted-foreground">
+                      {t("accounts.modelCooldownModeOverride")}
+                    </label>
+                    <Select
+                      value={cooldownMode}
+                      onValueChange={setCooldownMode}
+                      options={[
+                        { label: t("accounts.modelCooldownInherit"), value: "inherit" },
+                        { label: t("settings.modelCooldownModeOff"), value: "off" },
+                        { label: t("settings.modelCooldownModeFixed"), value: "fixed" },
+                        { label: t("settings.modelCooldownModeAdaptive"), value: "adaptive" },
+                      ]}
+                    />
+                  </div>
+                  <div>
+                    <label className="mb-1 block text-[11px] font-medium text-muted-foreground">
+                      {t("settings.modelCooldownSeconds")}
+                    </label>
+                    <Input
+                      type="number"
+                      min={1}
+                      max={1800}
+                      value={cooldownSeconds}
+                      disabled={cooldownMode === "off"}
+                      onChange={(event) =>
+                        setCooldownSeconds(
+                          Math.max(1, Math.min(1800, Number(event.target.value) || 1)),
+                        )
+                      }
+                    />
+                  </div>
+                  <div className="flex items-end">
+                    <div className="flex h-10 w-full items-center justify-between rounded-md border border-input px-3">
+                      <span className="text-xs text-muted-foreground">
+                        {t("settings.modelCooldownBackoff")}
+                      </span>
+                      <Switch
+                        checked={cooldownBackoff}
+                        disabled={cooldownMode !== "adaptive"}
+                        onCheckedChange={setCooldownBackoff}
+                      />
+                    </div>
+                  </div>
+                </div>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="w-full"
+                  onClick={() =>
+                    onSaveModelCooldownPolicy({
+                      mode:
+                        cooldownMode === "inherit"
+                          ? null
+                          : (cooldownMode as "off" | "fixed" | "adaptive"),
+                      seconds:
+                        cooldownMode === "inherit" ? null : cooldownSeconds,
+                      backoff_enabled:
+                        cooldownMode === "inherit" ? null : cooldownBackoff,
+                    })
+                  }
+                >
+                  {t("accounts.saveModelCooldownPolicy")}
+                </Button>
+                {(account.model_cooldowns?.length ?? 0) > 0 ? (
+                  <div className="space-y-1.5 border-t border-border pt-3">
+                    {account.model_cooldowns?.map((cooldown) => (
+                      <div
+                        key={cooldown.model}
+                        className="flex items-center justify-between gap-2 rounded-lg bg-amber-500/10 px-2.5 py-2 text-xs"
+                      >
+                        <div className="min-w-0">
+                          <div className="truncate font-medium text-amber-800 dark:text-amber-200">
+                            {cooldown.model}
+                          </div>
+                          <div className="text-[10px] text-muted-foreground">
+                            {cooldown.reason} · {cooldown.remaining_seconds}s
+                          </div>
+                        </div>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon-sm"
+                          onClick={() => onClearModelCooldown(cooldown.model)}
+                          title={t("accounts.clearModelCooldown")}
+                        >
+                          <X className="size-3.5" />
+                        </Button>
+                      </div>
+                    ))}
+                  </div>
+                ) : null}
+              </div>
+            </Section> : null}
 
             <Section
               title={t("accounts.usage")}

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1258,7 +1258,18 @@
     "billed": "Cost",
     "importGroupsLabel": "Bind to account groups",
     "importGroupsPlaceholder": "Pick groups (optional)",
-    "importGroupsHint": "Accounts created by this run join the selected groups. Existing accounts matched as duplicates keep their current groups. Leave empty to skip binding."
+    "importGroupsHint": "Accounts created by this run join the selected groups. Existing accounts matched as duplicates keep their current groups. Leave empty to skip binding.",
+    "modelCooldownPolicy": "Model cooldown policy",
+    "clearAllModelCooldowns": "Clear all",
+    "modelCooldownEffective": "Effective: {{mode}} · {{seconds}} sec · backoff {{backoff}}",
+    "modelCooldownModeOverride": "Account override",
+    "modelCooldownInherit": "Inherit system default",
+    "saveModelCooldownPolicy": "Save cooldown policy",
+    "clearModelCooldown": "Clear this model cooldown",
+    "modelCooldownPolicySaved": "Account model cooldown policy saved",
+    "modelCooldownPolicySaveFailed": "Failed to save model cooldown policy: {{error}}",
+    "modelCooldownCleared": "Cleared model cooldown for {{model}}",
+    "allModelCooldownsCleared": "Cleared {{count}} model cooldowns"
   },
   "invite": {
     "entry": "Codex Invite",
@@ -3377,7 +3388,22 @@
     "codexPreflightSSEPassthrough": "Preflight SSE Passthrough (Legacy Compat)",
     "codexPreflightSSEPassthroughDesc": "Forward pre-content upstream metadata events (codex.rate_limits / codex.response.metadata / response.metadata) to the downstream immediately instead of buffering them until the first real content event. For multi-tier gateways that treat the first SSE data frame as time-to-first-response.",
     "codexPreflightSSEPassthroughEnabled": "Enable immediate passthrough",
-    "codexPreflightSSEPassthroughEnabledDesc": "Warning: legacy compatibility mode, off by default. When enabled, HTTP 200 is committed before the first content event; upstream failures in that window can only be delivered as 200 + SSE failed frames — real HTTP error codes, pre-first-token silent account rotation, and overflow auto-compact are all unavailable in that window. Hot-reloads without restart."
+    "codexPreflightSSEPassthroughEnabledDesc": "Warning: legacy compatibility mode, off by default. When enabled, HTTP 200 is committed before the first content event; upstream failures in that window can only be delivered as 200 + SSE failed frames — real HTTP error codes, pre-first-token silent account rotation, and overflow auto-compact are all unavailable in that window. Hot-reloads without restart.",
+    "modelCooldownTitle": "Model 429 cooldown policy",
+    "modelCooldownDesc": "Control model-level 429 cooldowns separately for direct API upstreams and OAuth account pools. Explicit 5h/7d usage windows still follow their real reset times.",
+    "relayModelCooldownTitle": "API plan / direct upstream",
+    "relayModelCooldownDesc": "Persistent model cooldown is off by default. Transient 429s rotate upstreams and return a standard 429 only after retries are exhausted.",
+    "oauthModelCooldownTitle": "OAuth / subscription pool",
+    "oauthModelCooldownDesc": "Keep account-pool protection while allowing cooldowns to be disabled, fixed, or adaptive.",
+    "modelCooldownMode": "Cooldown mode",
+    "modelCooldownModeDesc": "Off stores no model cooldown; fixed uses a constant duration; adaptive can back off on repeated 429s.",
+    "modelCooldownModeOff": "Off",
+    "modelCooldownModeFixed": "Fixed",
+    "modelCooldownModeAdaptive": "Adaptive",
+    "modelCooldownSeconds": "Base duration",
+    "modelCooldownSecondsDesc": "Base model cooldown duration from 1 to 1800 seconds.",
+    "modelCooldownBackoff": "Exponential backoff",
+    "modelCooldownBackoffDesc": "Adaptive mode only. Repeated 429s extend the cooldown up to 30 minutes."
   },
   "proxies": {
     "description": "Manage the proxy pool for round-robin use, or bind a proxy to accounts in the account pool",

--- a/frontend/src/locales/zh-TW.json
+++ b/frontend/src/locales/zh-TW.json
@@ -1,5 +1,35 @@
 {
-  "common": {"success":"成功","failed":"失敗"},
+  "common": {"success":"成功","failed":"失敗","enabled":"開啟","disabled":"關閉"},
+  "accounts": {
+    "modelCooldownPolicy": "模型冷卻策略",
+    "clearAllModelCooldowns": "清除全部",
+    "modelCooldownEffective": "目前生效：{{mode}} · {{seconds}} 秒 · 退避{{backoff}}",
+    "modelCooldownModeOverride": "帳號覆蓋模式",
+    "modelCooldownInherit": "跟隨系統預設",
+    "saveModelCooldownPolicy": "儲存帳號冷卻策略",
+    "clearModelCooldown": "清除此模型冷卻",
+    "modelCooldownPolicySaved": "帳號模型冷卻策略已儲存",
+    "modelCooldownPolicySaveFailed": "儲存模型冷卻策略失敗：{{error}}",
+    "modelCooldownCleared": "已清除 {{model}} 的模型冷卻",
+    "allModelCooldownsCleared": "已清除 {{count}} 條模型冷卻"
+  },
+  "settings": {
+    "modelCooldownTitle": "模型 429 冷卻策略",
+    "modelCooldownDesc": "分別控制 API 直連上游與 OAuth 帳號池的模型級 429 冷卻。",
+    "relayModelCooldownTitle": "API 計畫 / 直連上游",
+    "relayModelCooldownDesc": "預設關閉持久化模型冷卻，偶發 429 只做換上游重試。",
+    "oauthModelCooldownTitle": "OAuth / 訂閱帳號池",
+    "oauthModelCooldownDesc": "可關閉、固定時長或使用指數退避。",
+    "modelCooldownMode": "冷卻模式",
+    "modelCooldownModeDesc": "關閉、固定或自適應。",
+    "modelCooldownModeOff": "關閉",
+    "modelCooldownModeFixed": "固定",
+    "modelCooldownModeAdaptive": "自適應",
+    "modelCooldownSeconds": "基礎時長",
+    "modelCooldownSecondsDesc": "範圍 1–1800 秒。",
+    "modelCooldownBackoff": "指數退避",
+    "modelCooldownBackoffDesc": "僅自適應模式生效。"
+  },
   "promptFilter": {
     "views": {"profiles":"風險畫像","intelligence":"CY 學習審核"},
     "coverageTitle": "目前防護涵蓋",

--- a/frontend/src/locales/zh.json
+++ b/frontend/src/locales/zh.json
@@ -1258,7 +1258,18 @@
     "billed": "成本",
     "importGroupsLabel": "绑定账号分组",
     "importGroupsPlaceholder": "选择要绑定的分组（可不选）",
-    "importGroupsHint": "本次新增的账号会直接进入所选分组；命中重复的已有账号分组保持不变。不选则不绑定。"
+    "importGroupsHint": "本次新增的账号会直接进入所选分组；命中重复的已有账号分组保持不变。不选则不绑定。",
+    "modelCooldownPolicy": "模型冷却策略",
+    "clearAllModelCooldowns": "清除全部",
+    "modelCooldownEffective": "当前生效：{{mode}} · {{seconds}} 秒 · 退避{{backoff}}",
+    "modelCooldownModeOverride": "账号覆盖模式",
+    "modelCooldownInherit": "跟随系统默认",
+    "saveModelCooldownPolicy": "保存账号冷却策略",
+    "clearModelCooldown": "清除此模型冷却",
+    "modelCooldownPolicySaved": "账号模型冷却策略已保存",
+    "modelCooldownPolicySaveFailed": "保存模型冷却策略失败：{{error}}",
+    "modelCooldownCleared": "已清除 {{model}} 的模型冷却",
+    "allModelCooldownsCleared": "已清除 {{count}} 条模型冷却"
   },
   "invite": {
     "entry": "Codex 邀请",
@@ -3377,7 +3388,22 @@
     "codexPreflightSSEPassthrough": "前置元数据事件立即透传（旧版兼容）",
     "codexPreflightSSEPassthroughDesc": "把内容生成前的上游元数据事件（codex.rate_limits / codex.response.metadata / response.metadata）立即转发给下游，而不是缓冲到首个真实内容事件。适配把“首条 SSE 数据帧”当作首响应时间的多层网关。",
     "codexPreflightSSEPassthroughEnabled": "启用立即透传",
-    "codexPreflightSSEPassthroughEnabledDesc": "警告：旧版兼容模式，默认关闭。开启后首个内容事件之前就会提交 HTTP 200，此窗口内的上游失败只能以 200 + SSE failed 帧下发——真实 HTTP 错误码、首包前静默换号重试、超窗自动压缩在该窗口内全部失效。热更新即时生效，无需重启。"
+    "codexPreflightSSEPassthroughEnabledDesc": "警告：旧版兼容模式，默认关闭。开启后首个内容事件之前就会提交 HTTP 200，此窗口内的上游失败只能以 200 + SSE failed 帧下发——真实 HTTP 错误码、首包前静默换号重试、超窗自动压缩在该窗口内全部失效。热更新即时生效，无需重启。",
+    "modelCooldownTitle": "模型 429 冷却策略",
+    "modelCooldownDesc": "分别控制 API 直连上游与 OAuth 账号池的模型级 429 冷却。明确的 5h/7d 用量窗口仍按真实重置时间处理。",
+    "relayModelCooldownTitle": "API 计划 / 直连上游",
+    "relayModelCooldownDesc": "默认关闭持久化模型冷却。偶发 429 会换上游重试，重试耗尽后向客户端返回标准 429。",
+    "oauthModelCooldownTitle": "OAuth / 订阅账号池",
+    "oauthModelCooldownDesc": "保留账号池保护，但允许关闭、固定时长或使用指数退避。",
+    "modelCooldownMode": "冷却模式",
+    "modelCooldownModeDesc": "关闭不写入模型冷却；固定使用恒定时长；自适应可按重复 429 退避。",
+    "modelCooldownModeOff": "关闭",
+    "modelCooldownModeFixed": "固定",
+    "modelCooldownModeAdaptive": "自适应",
+    "modelCooldownSeconds": "基础时长",
+    "modelCooldownSecondsDesc": "模型冷却基础秒数，范围 1–1800 秒。",
+    "modelCooldownBackoff": "指数退避",
+    "modelCooldownBackoffDesc": "仅自适应模式生效；重复 429 会逐步延长，最长 30 分钟。"
   },
   "proxies": {
     "description": "管理代理池，支持轮询分配给账号使用；也可将指定代理绑定到账号池中的账号",

--- a/frontend/src/pages/Accounts.tsx
+++ b/frontend/src/pages/Accounts.tsx
@@ -3362,6 +3362,53 @@ export default function Accounts() {
     }
   };
 
+  const handleSaveModelCooldownPolicy = async (
+    account: AccountRow,
+    data: {
+      mode: "off" | "fixed" | "adaptive" | null;
+      seconds: number | null;
+      backoff_enabled: boolean | null;
+    },
+  ) => {
+    try {
+      await api.updateAccountModelCooldownPolicy(account.id, data);
+      showToast(t("accounts.modelCooldownPolicySaved"));
+      void reloadSilently();
+    } catch (error) {
+      showToast(
+        t("accounts.modelCooldownPolicySaveFailed", {
+          error: getErrorMessage(error),
+        }),
+        "error",
+      );
+    }
+  };
+
+  const handleClearModelCooldown = async (
+    account: AccountRow,
+    model: string,
+  ) => {
+    try {
+      await api.clearAccountModelCooldown(account.id, model);
+      showToast(t("accounts.modelCooldownCleared", { model }));
+      void reloadSilently();
+    } catch (error) {
+      showToast(getErrorMessage(error), "error");
+    }
+  };
+
+  const handleClearAllModelCooldowns = async (account: AccountRow) => {
+    try {
+      const result = await api.clearAllAccountModelCooldowns(account.id);
+      showToast(
+        t("accounts.allModelCooldownsCleared", { count: result.cleared }),
+      );
+      void reloadSilently();
+    } catch (error) {
+      showToast(getErrorMessage(error), "error");
+    }
+  };
+
   // 主动重置额度：消耗 1 次「主动重置次数」立即重置该账号额度（带二次确认）。
   const handleResetCredits = async (account: AccountRow) => {
     const confirmed = await confirm({
@@ -7263,6 +7310,18 @@ export default function Accounts() {
             onResetStatus={() => {
               if (!detailAccount) return;
               void handleResetStatus(detailAccount);
+            }}
+            onSaveModelCooldownPolicy={(data) => {
+              if (!detailAccount) return;
+              void handleSaveModelCooldownPolicy(detailAccount, data);
+            }}
+            onClearModelCooldown={(model) => {
+              if (!detailAccount) return;
+              void handleClearModelCooldown(detailAccount, model);
+            }}
+            onClearAllModelCooldowns={() => {
+              if (!detailAccount) return;
+              void handleClearAllModelCooldowns(detailAccount);
             }}
             onResetCredits={() => {
               if (!detailAccount) return;

--- a/frontend/src/pages/GrokAccounts.tsx
+++ b/frontend/src/pages/GrokAccounts.tsx
@@ -2763,6 +2763,47 @@ export default function GrokAccounts({
           if (!detailAccount) return;
           void handleResetStatus(detailAccount);
         }}
+        onSaveModelCooldownPolicy={(data) => {
+          if (!detailAccount) return;
+          void api
+            .updateAccountModelCooldownPolicy(detailAccount.id, data)
+            .then(() => {
+              showToast(t("accounts.modelCooldownPolicySaved"));
+              return reload();
+            })
+            .catch((error) =>
+              showToast(
+                t("accounts.modelCooldownPolicySaveFailed", {
+                  error: getErrorMessage(error),
+                }),
+                "error",
+              ),
+            );
+        }}
+        onClearModelCooldown={(model) => {
+          if (!detailAccount) return;
+          void api
+            .clearAccountModelCooldown(detailAccount.id, model)
+            .then(() => {
+              showToast(t("accounts.modelCooldownCleared", { model }));
+              return reload();
+            })
+            .catch((error) => showToast(getErrorMessage(error), "error"));
+        }}
+        onClearAllModelCooldowns={() => {
+          if (!detailAccount) return;
+          void api
+            .clearAllAccountModelCooldowns(detailAccount.id)
+            .then((result) => {
+              showToast(
+                t("accounts.allModelCooldownsCleared", {
+                  count: result.cleared,
+                }),
+              );
+              return reload();
+            })
+            .catch((error) => showToast(getErrorMessage(error), "error"));
+        }}
         onResetCredits={() => {
           // Grok 无额度券；Sheet 内已隐藏。
         }}

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -71,6 +71,7 @@ import {
   Save,
   Shield,
   Trash2,
+  Timer,
   Upload,
   Wifi,
   Wrench,
@@ -1121,6 +1122,11 @@ export default function Settings() {
     { label: t('settings.transportRetryPolicyRotate'), value: 'rotate' },
     { label: t('settings.transportRetryPolicySticky'), value: 'sticky' },
   ]
+  const modelCooldownModeOptions = [
+    { label: t('settings.modelCooldownModeOff'), value: 'off' },
+    { label: t('settings.modelCooldownModeFixed'), value: 'fixed' },
+    { label: t('settings.modelCooldownModeAdaptive'), value: 'adaptive' },
+  ]
   const affinityModeOptions = [
     { label: t('settings.affinityModeBounded'), value: 'bounded' },
     { label: t('settings.affinityModeOff'), value: 'off' },
@@ -1241,6 +1247,12 @@ export default function Settings() {
     response_cache_local_max_entry_bytes: DEFAULT_RESPONSE_CACHE_ENTRY_BYTES,
     response_cache_reconstruct_max_bytes: DEFAULT_RESPONSE_CACHE_RECONSTRUCT_BYTES,
     response_cache_config_generation: 0,
+    relay_model_cooldown_mode: 'off',
+    relay_model_cooldown_seconds: 2,
+    relay_model_cooldown_backoff_enabled: false,
+    oauth_model_cooldown_mode: 'adaptive',
+    oauth_model_cooldown_seconds: 300,
+    oauth_model_cooldown_backoff_enabled: true,
     model_mapping: '{}',
     codex_model_mapping: '{}',
     payload_rules: '{}',
@@ -2112,6 +2124,104 @@ export default function Settings() {
               </div>
             </SettingsCard>
           </div>
+
+          <SettingsCard
+            title={t('settings.modelCooldownTitle')}
+            description={t('settings.modelCooldownDesc')}
+            icon={<Timer className="size-4" />}
+          >
+            <div className="grid gap-4 lg:grid-cols-2">
+              <div className="space-y-3 rounded-xl border border-emerald-500/20 bg-emerald-500/5 p-3.5">
+                <div>
+                  <h3 className="text-sm font-semibold">{t('settings.relayModelCooldownTitle')}</h3>
+                  <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+                    {t('settings.relayModelCooldownDesc')}
+                  </p>
+                </div>
+                <div className={SETTINGS_FIELD_GRID}>
+                  <SettingField label={t('settings.modelCooldownMode')} description={t('settings.modelCooldownModeDesc')}>
+                    <Select
+                      value={settingsForm.relay_model_cooldown_mode}
+                      onValueChange={(value) => autoSaveStringField('relay_model_cooldown_mode', value)}
+                      options={modelCooldownModeOptions}
+                    />
+                  </SettingField>
+                  <SettingField
+                    label={t('settings.modelCooldownSeconds')}
+                    description={t('settings.modelCooldownSecondsDesc')}
+                    suffix={t('settings.unit.sec')}
+                    className={cn(settingsForm.relay_model_cooldown_mode === 'off' && 'opacity-60')}
+                  >
+                    <DraftNumberInput
+                      min={1}
+                      max={1800}
+                      disabled={settingsForm.relay_model_cooldown_mode === 'off'}
+                      value={settingsForm.relay_model_cooldown_seconds}
+                      onValueChange={(value) => setSettingsForm(f => ({ ...f, relay_model_cooldown_seconds: value }))}
+                      onValueCommit={(value) => void autoSaveSettingsPatch({ relay_model_cooldown_seconds: value })}
+                    />
+                  </SettingField>
+                </div>
+                <SettingField
+                  label={t('settings.modelCooldownBackoff')}
+                  description={t('settings.modelCooldownBackoffDesc')}
+                  layout="switch"
+                  className={cn(settingsForm.relay_model_cooldown_mode !== 'adaptive' && 'opacity-60')}
+                >
+                  <Switch
+                    checked={settingsForm.relay_model_cooldown_backoff_enabled}
+                    disabled={settingsForm.relay_model_cooldown_mode !== 'adaptive'}
+                    onCheckedChange={(checked) => autoSaveBooleanField('relay_model_cooldown_backoff_enabled', checked)}
+                  />
+                </SettingField>
+              </div>
+
+              <div className="space-y-3 rounded-xl border border-amber-500/20 bg-amber-500/5 p-3.5">
+                <div>
+                  <h3 className="text-sm font-semibold">{t('settings.oauthModelCooldownTitle')}</h3>
+                  <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+                    {t('settings.oauthModelCooldownDesc')}
+                  </p>
+                </div>
+                <div className={SETTINGS_FIELD_GRID}>
+                  <SettingField label={t('settings.modelCooldownMode')} description={t('settings.modelCooldownModeDesc')}>
+                    <Select
+                      value={settingsForm.oauth_model_cooldown_mode}
+                      onValueChange={(value) => autoSaveStringField('oauth_model_cooldown_mode', value)}
+                      options={modelCooldownModeOptions}
+                    />
+                  </SettingField>
+                  <SettingField
+                    label={t('settings.modelCooldownSeconds')}
+                    description={t('settings.modelCooldownSecondsDesc')}
+                    suffix={t('settings.unit.sec')}
+                    className={cn(settingsForm.oauth_model_cooldown_mode === 'off' && 'opacity-60')}
+                  >
+                    <DraftNumberInput
+                      min={1}
+                      max={1800}
+                      disabled={settingsForm.oauth_model_cooldown_mode === 'off'}
+                      value={settingsForm.oauth_model_cooldown_seconds}
+                      onValueChange={(value) => setSettingsForm(f => ({ ...f, oauth_model_cooldown_seconds: value }))}
+                      onValueCommit={(value) => void autoSaveSettingsPatch({ oauth_model_cooldown_seconds: value })}
+                    />
+                  </SettingField>
+                </div>
+                <SettingField
+                  label={t('settings.modelCooldownBackoff')}
+                  description={t('settings.modelCooldownBackoffDesc')}
+                  layout="switch"
+                  className={cn(settingsForm.oauth_model_cooldown_mode !== 'adaptive' && 'opacity-60')}
+                >
+                  <Switch
+                    checked={settingsForm.oauth_model_cooldown_backoff_enabled}
+                    disabled={settingsForm.oauth_model_cooldown_mode !== 'adaptive'}
+                    onCheckedChange={(checked) => autoSaveBooleanField('oauth_model_cooldown_backoff_enabled', checked)}
+                  />
+                </SettingField>
+              </div>
+            </div>
+          </SettingsCard>
 
           <SettingsCard
             title={t('settings.autoResetCreditsTitle')}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -8,6 +8,7 @@ export interface ToastState {
 
 export type AccountStatus = 'active' | 'ready' | 'cooldown' | 'error' | 'refreshing' | 'paused' | 'quota_paused' | string
 export type CodexClientMetadataMode = 'auto' | 'always' | 'off'
+export type ModelCooldownMode = 'off' | 'fixed' | 'adaptive'
 
 export interface StatsChannelCounts {
   total: number
@@ -185,6 +186,12 @@ export interface AccountRow {
     reset_at: ISODateString
     remaining_seconds: number
   }>
+  model_cooldown_mode_override?: ModelCooldownMode | null
+  model_cooldown_seconds_override?: number | null
+  model_cooldown_backoff_override?: boolean | null
+  model_cooldown_mode_effective?: ModelCooldownMode
+  model_cooldown_seconds_effective?: number
+  model_cooldown_backoff_effective?: boolean
   enabled?: boolean
   locked?: boolean
   credit_enabled?: boolean
@@ -1007,6 +1014,12 @@ export interface SystemSettings {
   response_cache_local_max_entry_bytes: number
   response_cache_reconstruct_max_bytes: number
   readonly response_cache_config_generation: number
+  relay_model_cooldown_mode: ModelCooldownMode
+  relay_model_cooldown_seconds: number
+  relay_model_cooldown_backoff_enabled: boolean
+  oauth_model_cooldown_mode: ModelCooldownMode
+  oauth_model_cooldown_seconds: number
+  oauth_model_cooldown_backoff_enabled: boolean
   expired_cleaned?: number
   model_mapping: string
   codex_model_mapping: string

--- a/main.go
+++ b/main.go
@@ -173,6 +173,19 @@ func main() {
 		log.Printf("已加载持久化业务设置: ProxyURL=%s, MaxConcurrency=%d, GlobalRPM=%d, PgMaxConns=%d, RedisPoolSize=%d",
 			settings.ProxyURL, settings.MaxConcurrency, settings.GlobalRPM, settings.PgMaxConns, settings.RedisPoolSize)
 	}
+	modelCooldownCtx, modelCooldownCancel := context.WithTimeout(context.Background(), 3*time.Second)
+	modelCooldownSettings, modelCooldownErr := db.GetModelCooldownSettings(modelCooldownCtx)
+	modelCooldownCancel()
+	if modelCooldownErr != nil {
+		log.Printf("警告: 读取模型冷却设置失败，将采用安全默认值: %v", modelCooldownErr)
+		modelCooldownSettings = database.DefaultModelCooldownSettings()
+	}
+	settings.RelayModelCooldownMode = modelCooldownSettings.RelayMode
+	settings.RelayModelCooldownSeconds = modelCooldownSettings.RelaySeconds
+	settings.RelayModelCooldownBackoffEnabled = modelCooldownSettings.RelayBackoffEnabled
+	settings.OAuthModelCooldownMode = modelCooldownSettings.OAuthMode
+	settings.OAuthModelCooldownSeconds = modelCooldownSettings.OAuthSeconds
+	settings.OAuthModelCooldownBackoffEnabled = modelCooldownSettings.OAuthBackoffEnabled
 	if envPolicy := strings.TrimSpace(os.Getenv("CODEX_BILLING_TIER_POLICY")); envPolicy != "" {
 		settings.BillingTierPolicy = proxy.NormalizeBillingTierPolicy(envPolicy)
 	}

--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -5139,6 +5139,37 @@ func Apply429Cooldown(store *auth.Store, account *auth.Account, body []byte, res
 	if account != nil && account.IsGrokAPI() {
 		return applyGrokCooldown(store, account, http.StatusTooManyRequests, body, resp, model)
 	}
+	// OpenAI Responses/API relay 是直连上游，不是 OAuth 订阅账号。裸 429 通常只是
+	// 瞬时负载抑制，默认不应写入 Redis/DB 并把整个模型摘掉 5~30 分钟。
+	if account != nil && account.IsRelayStyle() {
+		reason := "rate_limited_model"
+		if isCodexModelCapacityError(body) {
+			reason = "model_capacity"
+		}
+		decision := codex429Decision{
+			Scope:  rateLimitScopeModel,
+			Reason: reason,
+			Model:  strings.TrimSpace(model),
+		}
+		if store == nil || decision.Model == "" {
+			return decision
+		}
+		policy := store.ResolveModelCooldownPolicy(account)
+		if policy.Mode == database.ModelCooldownModeOff || policy.Seconds <= 0 {
+			return decision
+		}
+		backoff := policy.Mode == database.ModelCooldownModeAdaptive && policy.BackoffEnabled
+		cooldown := store.MarkModelCooldownWithBackoff(
+			account,
+			decision.Model,
+			time.Duration(policy.Seconds)*time.Second,
+			decision.Reason,
+			backoff,
+		)
+		decision.ResetAt = cooldown.ResetAt
+		decision.Cooldown = time.Until(cooldown.ResetAt)
+		return decision
+	}
 	decision := classify429RateLimit(account, body, resp, time.Now(), model)
 	if store == nil || account == nil {
 		return decision
@@ -5147,7 +5178,20 @@ func Apply429Cooldown(store *auth.Store, account *auth.Account, body []byte, res
 		store.ApplyUsageLimitMetadata(account, details.planType, decision.ResetAt)
 	}
 	if decision.Scope == rateLimitScopeModel {
-		cooldown := store.MarkModelCooldown(account, decision.Model, decision.Cooldown, decision.Reason)
+		policy := store.ResolveModelCooldownPolicy(account)
+		if policy.Mode == database.ModelCooldownModeOff || policy.Seconds <= 0 {
+			decision.ResetAt = time.Time{}
+			decision.Cooldown = 0
+			return decision
+		}
+		backoff := policy.Mode == database.ModelCooldownModeAdaptive && policy.BackoffEnabled
+		cooldown := store.MarkModelCooldownWithBackoff(
+			account,
+			decision.Model,
+			time.Duration(policy.Seconds)*time.Second,
+			decision.Reason,
+			backoff,
+		)
 		decision.ResetAt = cooldown.ResetAt
 		decision.Cooldown = time.Until(cooldown.ResetAt)
 		return decision
@@ -5194,7 +5238,11 @@ func (h *Handler) applyCooldownForModel(account *auth.Account, statusCode int, b
 	case http.StatusTooManyRequests:
 		decision := Apply429Cooldown(h.store, account, body, resp, model)
 		if decision.Scope == rateLimitScopeModel {
-			log.Printf("账号 %d 模型 %s 触发短时限流 (reason=%s)，冷却到 %s", account.ID(), decision.Model, decision.Reason, decision.ResetAt.Format(time.RFC3339))
+			if decision.ResetAt.IsZero() {
+				log.Printf("账号 %d 模型 %s 触发短时限流 (reason=%s)，按策略不持久化冷却", account.ID(), decision.Model, decision.Reason)
+			} else {
+				log.Printf("账号 %d 模型 %s 触发短时限流 (reason=%s)，冷却到 %s", account.ID(), decision.Model, decision.Reason, decision.ResetAt.Format(time.RFC3339))
+			}
 			return decision
 		}
 		log.Printf("账号 %d 被限速 (plan=%s, reason=%s)，冷却到 %s", account.ID(), account.GetPlanType(), decision.Reason, decision.ResetAt.Format(time.RFC3339))
@@ -5561,6 +5609,12 @@ func (h *Handler) sendFinalUpstreamError(c *gin.Context, statusCode int, body []
 			},
 		})
 		return
+	}
+
+	if statusCode == http.StatusTooManyRequests && c.Writer.Header().Get("Retry-After") == "" {
+		// 上游偶发 429 在重试池耗尽后仍应以标准限流语义返回，不能伪装成
+		// no_available_account/503。没有明确 reset 信息时给客户端一个最小退避提示。
+		c.Header("Retry-After", "1")
 	}
 
 	h.sendUpstreamError(c, statusCode, body)

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -3092,8 +3092,8 @@ func TestSendFinalUpstreamError_FallsBackForNonUsageLimit(t *testing.T) {
 	if recorder.Code != http.StatusTooManyRequests {
 		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusTooManyRequests)
 	}
-	if got := recorder.Header().Get("Retry-After"); got != "" {
-		t.Fatalf("Retry-After = %q, want empty", got)
+	if got := recorder.Header().Get("Retry-After"); got != "1" {
+		t.Fatalf("Retry-After = %q, want 1", got)
 	}
 }
 
@@ -3565,6 +3565,35 @@ func TestApply429CooldownUnknown429UsesModelCooldown(t *testing.T) {
 	}
 	if !account.IsModelRateLimited("gpt-5.4") {
 		t.Fatal("expected model cooldown")
+	}
+}
+
+func TestApply429CooldownRelayDefaultDoesNotPersistCooldown(t *testing.T) {
+	store := auth.NewStore(nil, nil, nil)
+	account := &auth.Account{
+		DBID:         103,
+		UpstreamType: auth.UpstreamOpenAIResponses,
+		BaseURL:      "https://api.example.test",
+		APIKey:       "test-key",
+		PlanType:     "api",
+	}
+
+	decision := Apply429Cooldown(
+		store,
+		account,
+		[]byte(`{"detail":"Rate limit exceeded"}`),
+		&http.Response{Header: make(http.Header)},
+		"gpt-5.6-sol",
+	)
+
+	if decision.Scope != rateLimitScopeModel || decision.Reason != "rate_limited_model" {
+		t.Fatalf("decision = %#v, want non-persistent model rate limit", decision)
+	}
+	if !decision.ResetAt.IsZero() || decision.Cooldown != 0 {
+		t.Fatalf("decision cooldown = %v reset=%v, want no persistent cooldown", decision.Cooldown, decision.ResetAt)
+	}
+	if account.IsModelRateLimited("gpt-5.6-sol") {
+		t.Fatal("relay account should remain schedulable after a transient 429")
 	}
 }
 


### PR DESCRIPTION
## 说明

Responses API 中转遇到临时 429 时，目前会沿用 Codex OAuth 账号的模型冷却逻辑。对于直连 API 上游，这类 429 很常见，持久化几分钟的模型冷却反而容易把仍可重试的上游提前摘掉。

这个 PR 把 relay 和 OAuth 的模型冷却策略拆开：

- relay 默认关闭持久模型冷却；重试耗尽后保留 HTTP 429，并补 `Retry-After`
- OAuth 默认保持 300 秒自适应冷却，5h/7d 用量窗口的处理不变
- 两类策略都支持 `off`、`fixed`、`adaptive`
- 支持系统默认和单账号覆盖
- 账号详情可以查看当前生效策略，并清除单模型或全部模型冷却
- 重置账号状态时一并清除模型冷却
- Grok 继续使用现有的独立限流逻辑

设置写入 `system_settings`，SQLite 和 PostgreSQL 都包含兼容迁移。账号覆盖仍放在 credentials 中，不需要新增账号表字段。

## 验证

- `go test ./...`
- `go vet ./...`
- `npm run typecheck`
- `npm test`（93 tests）
- `npm run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable model cooldown policies for relay and OAuth connections, including off, fixed, and adaptive modes.
  * Added account-level cooldown overrides and controls to clear individual or all model cooldowns.
  * Added system settings for cooldown duration and adaptive backoff behavior.
* **Bug Fixes**
  * Direct upstream rate limits no longer incorrectly persist account cooldown status.
  * Rate-limited responses now include a minimum `Retry-After` value when unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->