### PR TITLE
fix(proxy): preserve response continuation affinity

### DIFF
--- a/auth/session_affinity_test.go
+++ b/auth/session_affinity_test.go
@@ -208,6 +208,42 @@ func TestBindSessionAffinityUsesConfigurableTTL(t *testing.T) {
 	}
 }
 
+func TestNextForContinuationPreservesBoundedAffinity(t *testing.T) {
+	bound := &Account{DBID: 1, AccessToken: "tok-1"}
+	fallback := &Account{DBID: 2, AccessToken: "tok-2"}
+	fallback.SetSchedulerPriority(20)
+	store := &Store{
+		accounts:       []*Account{bound, fallback},
+		maxConcurrency: 2,
+	}
+	store.bindSessionAffinity("conversation-1", bound, "")
+
+	store.sessionMu.Lock()
+	binding := store.sessionBindings["conversation-1"]
+	binding.boundAt = time.Now().Add(-defaultMaxAffinityDuration - time.Minute)
+	binding.requestCount = defaultMaxAffinityRequests
+	store.sessionBindings["conversation-1"] = binding
+	store.sessionMu.Unlock()
+
+	acc, _ := store.NextForContinuationWithFilter("conversation-1", 0, nil, nil)
+	if acc == nil || acc.DBID != bound.DBID {
+		t.Fatalf("continuation account = %#v, want bound account %d", acc, bound.DBID)
+	}
+	store.Release(acc)
+
+	acc, _ = store.NextForContinuationWithFilter("conversation-1", 0, map[int64]bool{bound.DBID: true}, nil)
+	if acc != nil {
+		store.Release(acc)
+		t.Fatalf("continuation fell through to account %d when bound account was excluded", acc.DBID)
+	}
+
+	acc, _ = store.NextForSessionWithFilter("conversation-1", 0, nil, nil)
+	if acc == nil || acc.DBID != fallback.DBID {
+		t.Fatalf("ordinary bounded request account = %#v, want fallback account %d", acc, fallback.DBID)
+	}
+	store.Release(acc)
+}
+
 func TestNextForSessionFallsBackWhenBoundAccountExcluded(t *testing.T) {
 	store := &Store{
 		accounts: []*Account{

--- a/auth/store.go
+++ b/auth/store.go
@@ -5219,6 +5219,17 @@ func (s *Store) NextForSession(key string, apiKeyID int64, exclude map[int64]boo
 // 解除发生时绕过 binding 走完整挑号策略(NextExcludingWithFilter),后续 BindSessionAffinity
 // 会重新建立绑定。
 func (s *Store) NextForSessionWithFilter(key string, apiKeyID int64, exclude map[int64]bool, filter AccountFilter) (*Account, string) {
+	return s.nextForSessionWithFilter(key, apiKeyID, exclude, filter, false)
+}
+
+// NextForContinuationWithFilter preserves an existing account binding for a
+// stateful upstream continuation. A previous_response_id belongs to the OAuth
+// account that created it, so bounded-affinity escape must not rotate accounts.
+func (s *Store) NextForContinuationWithFilter(key string, apiKeyID int64, exclude map[int64]bool, filter AccountFilter) (*Account, string) {
+	return s.nextForSessionWithFilter(key, apiKeyID, exclude, filter, true)
+}
+
+func (s *Store) nextForSessionWithFilter(key string, apiKeyID int64, exclude map[int64]bool, filter AccountFilter, preserveBinding bool) (*Account, string) {
 	if s == nil {
 		return nil, ""
 	}
@@ -5239,12 +5250,15 @@ func (s *Store) NextForSessionWithFilter(key string, apiKeyID int64, exclude map
 			mode = override
 		}
 	}
-	if mode == AffinityModeOff {
+	if mode == AffinityModeOff && !preserveBinding {
 		return s.NextExcludingWithFilter(apiKeyID, exclude, filter), ""
 	}
 
 	if ok {
 		if !s.affinityProxyStillValid(binding.accountID, binding.proxyURL) {
+			if preserveBinding {
+				return s.takeByIDExcluding(binding.accountID, apiKeyID, exclude, filter), ""
+			}
 			s.UnbindSessionAffinity(key, binding.accountID)
 			ok = false
 		}
@@ -5253,7 +5267,7 @@ func (s *Store) NextForSessionWithFilter(key string, apiKeyID int64, exclude map
 		expired := !binding.expiresAt.After(now)
 		// bounded 模式下追加逃逸条件检查
 		escape := false
-		if mode == AffinityModeBounded {
+		if mode == AffinityModeBounded && !preserveBinding {
 			if binding.requestCount >= defaultMaxAffinityRequests {
 				escape = true
 			} else if !binding.boundAt.IsZero() && now.Sub(binding.boundAt) >= defaultMaxAffinityDuration {
@@ -5274,10 +5288,15 @@ func (s *Store) NextForSessionWithFilter(key string, apiKeyID int64, exclude map
 			}
 			s.sessionMu.Unlock()
 			return acc, binding.proxyURL
+		} else if preserveBinding {
+			return nil, ""
 		}
 	}
 	if binding, ok := s.getCachedSessionAffinity(key); ok {
 		if !s.affinityProxyStillValid(binding.accountID, binding.proxyURL) {
+			if preserveBinding {
+				return s.takeByIDExcluding(binding.accountID, apiKeyID, exclude, filter), ""
+			}
 			s.UnbindSessionAffinity(key, binding.accountID)
 			return s.nextAccountForFreshAffinity(key, apiKeyID, exclude, filter), ""
 		}
@@ -5286,7 +5305,7 @@ func (s *Store) NextForSessionWithFilter(key string, apiKeyID int64, exclude map
 		if override := s.resolveGrokAffinityOverride(binding.accountID); override != "" {
 			cacheMode = override
 		}
-		if cacheMode == AffinityModeBounded && !s.affinityAccountStillHealthy(binding.accountID) {
+		if cacheMode == AffinityModeBounded && !preserveBinding && !s.affinityAccountStillHealthy(binding.accountID) {
 			// 不复用,落到完整挑号
 		} else if acc := s.takeByIDExcluding(binding.accountID, apiKeyID, exclude, filter); acc != nil {
 			s.sessionMu.Lock()
@@ -5296,6 +5315,8 @@ func (s *Store) NextForSessionWithFilter(key string, apiKeyID int64, exclude map
 			s.sessionBindings[key] = binding
 			s.sessionMu.Unlock()
 			return acc, binding.proxyURL
+		} else if preserveBinding {
+			return nil, ""
 		}
 	}
 
@@ -5600,6 +5621,16 @@ func (s *Store) hasDispatchCandidateWithFilter(apiKeyID int64, exclude map[int64
 
 // WaitForSessionAvailableWithFilter waits for an account that satisfies the request-level filter.
 func (s *Store) WaitForSessionAvailableWithFilter(ctx context.Context, key string, timeout time.Duration, apiKeyID int64, exclude map[int64]bool, filter AccountFilter) (*Account, string) {
+	return s.waitForSessionAvailableWithFilter(ctx, key, timeout, apiKeyID, exclude, filter, false)
+}
+
+// WaitForContinuationAvailableWithFilter waits for the account already bound
+// to a stateful continuation instead of falling through to another account.
+func (s *Store) WaitForContinuationAvailableWithFilter(ctx context.Context, key string, timeout time.Duration, apiKeyID int64, exclude map[int64]bool, filter AccountFilter) (*Account, string) {
+	return s.waitForSessionAvailableWithFilter(ctx, key, timeout, apiKeyID, exclude, filter, true)
+}
+
+func (s *Store) waitForSessionAvailableWithFilter(ctx context.Context, key string, timeout time.Duration, apiKeyID int64, exclude map[int64]bool, filter AccountFilter, preserveBinding bool) (*Account, string) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -5627,7 +5658,13 @@ func (s *Store) WaitForSessionAvailableWithFilter(ctx context.Context, key strin
 		case <-deadline.C:
 			return nil, ""
 		default:
-			acc, proxyURL := s.NextForSessionWithFilter(key, apiKeyID, exclude, filter)
+			var acc *Account
+			var proxyURL string
+			if preserveBinding {
+				acc, proxyURL = s.NextForContinuationWithFilter(key, apiKeyID, exclude, filter)
+			} else {
+				acc, proxyURL = s.NextForSessionWithFilter(key, apiKeyID, exclude, filter)
+			}
 			if acc != nil {
 				return acc, proxyURL
 			}

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -500,6 +500,96 @@ func TestResponsesWebSocketForwardsResponsesEvents(t *testing.T) {
 	}
 }
 
+func TestResponsesWebSocketContinuationKeepsBoundAccountPastBoundedLimit(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	previousExec := WebsocketExecuteFunc
+	t.Cleanup(func() {
+		WebsocketExecuteFunc = previousExec
+	})
+
+	var store *auth.Store
+	var mu sync.Mutex
+	responseOwners := make(map[string]int64)
+	responseSequence := 0
+	WebsocketExecuteFunc = func(ctx context.Context, account *auth.Account, requestBody []byte, sessionID string, proxyOverride string, apiKey string, deviceCfg *DeviceProfileConfig, headers http.Header, poolRouteKey string) (*http.Response, error) {
+		mu.Lock()
+		defer mu.Unlock()
+
+		previousResponseID := gjson.GetBytes(requestBody, "previous_response_id").String()
+		if ownerID := responseOwners[previousResponseID]; previousResponseID != "" && ownerID != account.ID() {
+			body := fmt.Sprintf(`{"error":{"type":"invalid_request_error","code":"previous_response_not_found","message":"Previous response with id '%s' not found."}}`, previousResponseID)
+			return &http.Response{
+				StatusCode: http.StatusBadRequest,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(body)),
+			}, nil
+		}
+
+		responseSequence++
+		responseID := fmt.Sprintf("resp_%d", responseSequence)
+		responseOwners[responseID] = account.ID()
+		if responseSequence == 1 {
+			priority := int64(20)
+			if !store.ApplyAccountSchedulerPriority(2, &priority) {
+				t.Fatal("failed to raise fallback account scheduler priority")
+			}
+		}
+		sse := fmt.Sprintf(`data: {"type":"response.completed","response":{"id":"%s","usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}}`+"\n\n", responseID)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(sse)),
+		}, nil
+	}
+
+	store = auth.NewStore(nil, nil, &database.SystemSettings{MaxConcurrency: 2, TestConcurrency: 1, TestModel: "gpt-5.4"})
+	primary := &auth.Account{DBID: 1, AccessToken: "at-1", PlanType: "plus", AccountID: "acct-1"}
+	primary.SetSchedulerPriority(10)
+	store.AddAccount(primary)
+	store.AddAccount(&auth.Account{DBID: 2, AccessToken: "at-2", PlanType: "plus", AccountID: "acct-2"})
+	handler := NewHandler(store, nil, &config.Config{AllowAnonymousV1: true}, nil)
+
+	router := gin.New()
+	handler.RegisterRoutes(router)
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/v1/responses"
+	conn, resp, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		if resp != nil {
+			t.Fatalf("dial websocket failed: %v status=%d", err, resp.StatusCode)
+		}
+		t.Fatalf("dial websocket failed: %v", err)
+	}
+	defer conn.Close()
+
+	previousResponseID := ""
+	for turn := 1; turn <= 52; turn++ {
+		payload := fmt.Sprintf(`{"type":"response.create","model":"gpt-5.4","prompt_cache_key":"conversation-1","input":"turn-%d"}`, turn)
+		if previousResponseID != "" {
+			payload = fmt.Sprintf(`{"type":"response.create","model":"gpt-5.4","prompt_cache_key":"conversation-1","previous_response_id":"%s","input":"turn-%d"}`, previousResponseID, turn)
+		}
+		if err := conn.WriteMessage(websocket.TextMessage, []byte(payload)); err != nil {
+			t.Fatalf("turn %d write request: %v", turn, err)
+		}
+
+		_ = conn.SetReadDeadline(time.Now().Add(time.Second))
+		_, event, err := conn.ReadMessage()
+		if err != nil {
+			t.Fatalf("turn %d read event: %v", turn, err)
+		}
+		if eventType := gjson.GetBytes(event, "type").String(); eventType != "response.completed" {
+			t.Fatalf("turn %d event type = %q, want response.completed; body=%s", turn, eventType, event)
+		}
+		previousResponseID = gjson.GetBytes(event, "response.id").String()
+		if previousResponseID == "" {
+			t.Fatalf("turn %d response.id missing: %s", turn, event)
+		}
+	}
+}
+
 func TestResponsesWebSocketSuccessPreservesNewerUsageLimitCooldown(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/proxy/responses_ws.go
+++ b/proxy/responses_ws.go
@@ -249,6 +249,7 @@ func (h *Handler) forwardResponsesWebSocketTurn(c *gin.Context, conn *websocket.
 	sessionIdentity := resolveRequestSessionIdentity(c.Request.Header, rawBody)
 	apiKeyID := requestAPIKeyID(c)
 	affinityKey := sessionAffinityKey(sessionIdentity.affinityID, apiKeyID)
+	hasPreviousResponse := strings.TrimSpace(gjson.GetBytes(rawBody, "previous_response_id").String()) != ""
 	respCacheOwner := responseCacheOwner(apiKeyID)
 	ruleIdentity := h.payloadRuleIdentity(c)
 	// 上下文压缩轮豁免首字超时看门狗（issue #381）：压缩首帧天然慢，超时换号无益。
@@ -324,7 +325,11 @@ func (h *Handler) forwardResponsesWebSocketTurn(c *gin.Context, conn *websocket.
 	for attempt := 0; ; attempt++ {
 		account, stickyProxyURL, retainedHTTPFallback := wsHTTPFallback.Take()
 		if !retainedHTTPFallback {
-			account, stickyProxyURL = h.nextRetryAccountForSession(c.Request.Context(), affinityKey, apiKeyID, retryExclusions, accountFilter)
+			if hasPreviousResponse {
+				account, stickyProxyURL = h.nextRetryAccountForContinuation(c.Request.Context(), affinityKey, apiKeyID, retryExclusions, accountFilter)
+			} else {
+				account, stickyProxyURL = h.nextRetryAccountForSession(c.Request.Context(), affinityKey, apiKeyID, retryExclusions, accountFilter)
+			}
 		}
 		if account == nil {
 			if lastRetryableUpstreamErr != nil {
@@ -414,7 +419,7 @@ func (h *Handler) forwardResponsesWebSocketTurn(c *gin.Context, conn *websocket.
 				h.store.ReportRequestFailure(account, kind, time.Duration(durationMs)*time.Millisecond)
 			}
 			h.store.Release(account)
-			if !stickyRetry {
+			if !stickyRetry && !hasPreviousResponse {
 				h.store.UnbindSessionAffinity(affinityKey, account.ID())
 			}
 			if timedOut && shouldRetry {
@@ -471,7 +476,9 @@ func (h *Handler) forwardResponsesWebSocketTurn(c *gin.Context, conn *websocket.
 					}
 					log.Printf("Responses WebSocket upstream rejected encrypted_content, stripped encrypted reasoning context and retried once (attempt %d)", attempt+1)
 					h.store.Release(account)
-					h.store.UnbindSessionAffinity(affinityKey, account.ID())
+					if !hasPreviousResponse {
+						h.store.UnbindSessionAffinity(affinityKey, account.ID())
+					}
 					continue
 				}
 			}
@@ -481,7 +488,9 @@ func (h *Handler) forwardResponsesWebSocketTurn(c *gin.Context, conn *websocket.
 			}
 			SyncCodexUsageState(h.store, account, resp)
 			h.store.Release(account)
-			h.store.UnbindSessionAffinity(affinityKey, account.ID())
+			if !hasPreviousResponse {
+				h.store.UnbindSessionAffinity(affinityKey, account.ID())
+			}
 			retryExclusions.MarkHard(account.ID())
 
 			log.Printf("Responses WebSocket upstream returned error (attempt %d, status %d): %s", attempt+1, resp.StatusCode, upstreamErrorConsoleBody(errBody))
@@ -543,7 +552,7 @@ func (h *Handler) forwardResponsesWebSocketTurn(c *gin.Context, conn *websocket.
 		if wsHTTPFallback.ForceHTTP() && !useWebsocket {
 			fallbackLog = &wsHTTPFallback
 		}
-		if err := h.streamResponsesWSUpstream(c, conn, resp, account, proxyURL, affinityKey, logModel, effectiveModel, logEffectiveModel, reasoningEffort, serviceTier, respCacheOwner, expandedInputRaw, start, ttftGuard, silentRetryEnabled, hideUpstreamErrors, useWebsocket, fallbackLog, attempt+1, options); err != nil {
+		if err := h.streamResponsesWSUpstream(c, conn, resp, account, proxyURL, affinityKey, hasPreviousResponse, logModel, effectiveModel, logEffectiveModel, reasoningEffort, serviceTier, respCacheOwner, expandedInputRaw, start, ttftGuard, silentRetryEnabled, hideUpstreamErrors, useWebsocket, fallbackLog, attempt+1, options); err != nil {
 			var retryErr *responsesWSRetryableStreamError
 			if errors.As(err, &retryErr) {
 				lastRetryableUpstreamErr = api.NewAPIError(api.ErrCodeUpstreamError, retryErr.outcome.failureMessage, api.ErrorTypeUpstream)
@@ -574,7 +583,7 @@ func (h *Handler) forwardResponsesWebSocketTurn(c *gin.Context, conn *websocket.
 			if errors.Is(err, errResponsesWSClientGone) {
 				return err
 			}
-			if shouldRetryErr, ok := err.(*responsesWSCloseError); ok && shouldRetryErr.code == websocket.CloseTryAgainLater {
+			if shouldRetryErr, ok := err.(*responsesWSCloseError); ok && shouldRetryErr.code == websocket.CloseTryAgainLater && !hasPreviousResponse {
 				h.store.UnbindSessionAffinity(affinityKey, account.ID())
 			}
 			return err
@@ -590,6 +599,7 @@ func (h *Handler) streamResponsesWSUpstream(
 	account *auth.Account,
 	proxyURL string,
 	affinityKey string,
+	preserveAffinity bool,
 	model string,
 	effectiveModel string,
 	logEffectiveModel string,
@@ -820,7 +830,9 @@ func (h *Handler) streamResponsesWSUpstream(
 			h.reportStreamOutcomeFailure(account, outcome, time.Duration(totalDuration)*time.Millisecond)
 		}
 		h.store.Release(account)
-		h.store.UnbindSessionAffinity(affinityKey, account.ID())
+		if !preserveAffinity {
+			h.store.UnbindSessionAffinity(affinityKey, account.ID())
+		}
 		return &responsesWSRetryableStreamError{outcome: outcome}
 	}
 	if outcome.logStatusCode != http.StatusOK {
@@ -880,7 +892,9 @@ func (h *Handler) streamResponsesWSUpstream(
 	if outcome.penalize {
 		recyclePooledClient(account, proxyURL)
 		h.reportStreamOutcomeFailure(account, outcome, time.Duration(totalDuration)*time.Millisecond)
-		h.store.UnbindSessionAffinity(affinityKey, account.ID())
+		if !preserveAffinity {
+			h.store.UnbindSessionAffinity(affinityKey, account.ID())
+		}
 	} else if outcome.logStatusCode == http.StatusOK {
 		h.store.ClearModelCooldown(account, effectiveModel)
 		h.store.ConfirmResponsesAvailableSince(account, start)

--- a/proxy/retry_exclusions.go
+++ b/proxy/retry_exclusions.go
@@ -159,16 +159,34 @@ func (r *retryAccountExclusions) ForSelection() map[int64]bool {
 }
 
 func (h *Handler) nextRetryAccountForSession(ctx context.Context, affinityKey string, apiKeyID int64, exclusions *retryAccountExclusions, filter auth.AccountFilter) (*auth.Account, string) {
+	return h.nextRetryAccount(ctx, affinityKey, apiKeyID, exclusions, filter, false)
+}
+
+func (h *Handler) nextRetryAccountForContinuation(ctx context.Context, affinityKey string, apiKeyID int64, exclusions *retryAccountExclusions, filter auth.AccountFilter) (*auth.Account, string) {
+	return h.nextRetryAccount(ctx, affinityKey, apiKeyID, exclusions, filter, true)
+}
+
+func (h *Handler) nextRetryAccount(ctx context.Context, affinityKey string, apiKeyID int64, exclusions *retryAccountExclusions, filter auth.AccountFilter, preserveBinding bool) (*auth.Account, string) {
 	if h == nil || h.store == nil {
 		return nil, ""
 	}
 	for {
 		exclude := exclusions.ForSelection()
-		account, stickyProxyURL := h.nextAccountForSessionWithFilter(affinityKey, apiKeyID, exclude, filter)
+		var account *auth.Account
+		var stickyProxyURL string
+		if preserveBinding {
+			account, stickyProxyURL = h.store.NextForContinuationWithFilter(affinityKey, apiKeyID, exclude, filter)
+		} else {
+			account, stickyProxyURL = h.nextAccountForSessionWithFilter(affinityKey, apiKeyID, exclude, filter)
+		}
 		if account != nil {
 			return account, stickyProxyURL
 		}
-		account, stickyProxyURL = h.store.WaitForSessionAvailableWithFilter(ctx, affinityKey, 30*time.Second, apiKeyID, exclude, filter)
+		if preserveBinding {
+			account, stickyProxyURL = h.store.WaitForContinuationAvailableWithFilter(ctx, affinityKey, 30*time.Second, apiKeyID, exclude, filter)
+		} else {
+			account, stickyProxyURL = h.store.WaitForSessionAvailableWithFilter(ctx, affinityKey, 30*time.Second, apiKeyID, exclude, filter)
+		}
 		if account != nil {
 			return account, stickyProxyURL
 		}


### PR DESCRIPTION
## Summary

- keep WebSocket `previous_response_id` continuations on the OAuth account that created the response
- preserve that binding across retryable request and stream failures
- keep ordinary requests on the existing bounded-affinity behavior
- add store-level and 52-turn WebSocket regression coverage
- A fix for #400 

## Root cause

Bounded affinity intentionally rotates an account after 50 requests or five minutes. Responses continuations are stateful and their response IDs are scoped to the creating OAuth account, so that rotation causes `previous_response_not_found`.

## Validation

- `go test ./auth ./proxy -count=1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebSocket continuation handling so requests remain routed to the originally assigned account across extended interactions.
  * Preserved session affinity through retries, streaming responses, upstream failures, and temporary account unavailability.
  * Prevented bounded scheduling limits or priority changes from unexpectedly switching continuation requests to another account.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->