### PR TITLE
fix(auth): restore groups after account reload

### DIFF
--- a/admin/import_json_test.go
+++ b/admin/import_json_test.go
@@ -3,6 +3,7 @@ package admin
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"mime/multipart"
@@ -1419,6 +1420,21 @@ func TestMergeRefreshedDuplicateIntoExisting(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Insert old: %v", err)
 	}
+	groupID, err := db.CreateAccountGroup(
+		context.Background(),
+		"repair-target",
+		"",
+		"",
+		0,
+		0,
+		sql.NullInt64{},
+	)
+	if err != nil {
+		t.Fatalf("CreateAccountGroup: %v", err)
+	}
+	if err := db.SetAccountGroups(context.Background(), oldID, []int64{groupID}); err != nil {
+		t.Fatalf("SetAccountGroups old: %v", err)
+	}
 
 	// 新导入的 RT 账号：刷新完成后身份与旧账号相同
 	newID, err := db.InsertAccountWithCredentials(context.Background(), "rt-later", map[string]interface{}{
@@ -1448,6 +1464,13 @@ func TestMergeRefreshedDuplicateIntoExisting(t *testing.T) {
 	}
 	if got := oldRow.GetCredential("codex_7d_used_percent"); got != "42.5" {
 		t.Fatalf("codex_7d_used_percent = %q, want 42.5 (用量统计必须保留)", got)
+	}
+	runtimeOld := store.FindByID(oldID)
+	if runtimeOld == nil {
+		t.Fatal("merged survivor missing from runtime store")
+	}
+	if got := runtimeOld.GroupIDSnapshot(); len(got) != 1 || got[0] != groupID {
+		t.Fatalf("survivor runtime groups = %v, want [%d]", got, groupID)
 	}
 
 	rows, err := db.ListActive(context.Background())

--- a/auth/store.go
+++ b/auth/store.go
@@ -4554,6 +4554,16 @@ func (s *Store) LoadAccountByID(ctx context.Context, dbID int64) error {
 	if account == nil {
 		return fmt.Errorf("账号 %d 缺少可用凭据", dbID)
 	}
+	// Full startup applies group memberships after loading all accounts.
+	// Single-account reloads need the same state before entering the runtime pool.
+	groupIDs, err := s.db.GetAccountGroupIDs(ctx, dbID)
+	if err != nil {
+		return fmt.Errorf("加载账号 %d 分组失败: %w", dbID, err)
+	}
+	account.mu.Lock()
+	account.GroupIDs = cloneInt64Slice(groupIDs)
+	account.recomputeEffectiveAutoPause(s)
+	account.mu.Unlock()
 	s.AddAccount(account)
 	return nil
 }


### PR DESCRIPTION
## What changed

Load an account's group memberships when `LoadAccountByID` rebuilds a single runtime account.

A regression test now covers the RT refresh/merge path and checks that the surviving account keeps its groups in the runtime store.

## Why

The full startup path loads group memberships after all accounts are built, but the single-account reload path only rebuilt the account from its credential row.

This shows up when an imported refresh token is refreshed asynchronously and then merged into an existing OAuth account. The memberships remain in `account_group_members`, but the surviving runtime account comes back with an empty `GroupIDs` slice. Until the next restart or a manual group edit, the admin API reports no groups and scheduling treats the account as ungrouped.

Fetching the memberships before `AddAccount` keeps the hot-reload path consistent with a full startup.

## Test

- `go test ./admin -run TestMergeRefreshedDuplicateIntoExisting -count=1`
- `git diff --check upstream/main...HEAD`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Account group memberships are now restored when accounts are loaded.
  * Effective auto-pause settings are recalculated using the account’s group context.
  * Account merges now preserve the surviving account’s group association in the runtime store.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->