### PR TITLE
fix(prompt-filter): expose CY cooldown controls

### DIFF
--- a/admin/prompt_conversation_lock.go
+++ b/admin/prompt_conversation_lock.go
@@ -14,6 +14,7 @@ import (
 
 type unlockPromptConversationRequest struct {
 	Reason string `json:"reason"`
+	Scope  string `json:"scope"`
 }
 
 func (h *Handler) UnlockPromptConversation(c *gin.Context) {
@@ -33,8 +34,48 @@ func (h *Handler) UnlockPromptConversation(c *gin.Context) {
 	if request.Reason == "" {
 		request.Reason = "管理员主动解锁"
 	}
+	request.Scope = strings.ToLower(strings.TrimSpace(request.Scope))
+	if request.Scope == "" {
+		request.Scope = database.PromptConversationRestrictionScopeConversation
+	}
+	if request.Scope != database.PromptConversationRestrictionScopeConversation && request.Scope != database.PromptConversationRestrictionScopeUserCooldown {
+		writeError(c, http.StatusBadRequest, "解锁作用域无效")
+		return
+	}
 	ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)
 	defer cancel()
+	if request.Scope == database.PromptConversationRestrictionScopeUserCooldown {
+		current, err := h.db.GetPromptConversationLock(ctx, lockKey)
+		if errors.Is(err, sql.ErrNoRows) {
+			writeError(c, http.StatusNotFound, "用户冷却记录不存在")
+			return
+		}
+		if err != nil {
+			writeInternalError(c, err)
+			return
+		}
+		keys, err := h.db.UnlockPromptConversationUserCooldown(ctx, current.Platform, current.NewAPIUserID, request.Reason)
+		if errors.Is(err, sql.ErrNoRows) {
+			writeError(c, http.StatusNotFound, "活动用户冷却不存在或已经解除")
+			return
+		}
+		if err != nil {
+			writeInternalError(c, err)
+			return
+		}
+		if h.cache != nil {
+			for _, key := range keys {
+				_ = h.cache.DeleteRuntime(ctx, database.PromptConversationLockCacheNamespace, key)
+			}
+		}
+		item, err := h.db.GetPromptConversationLock(ctx, lockKey)
+		if err != nil {
+			writeInternalError(c, err)
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"lock": item, "scope": request.Scope, "unlocked_count": len(keys)})
+		return
+	}
 	item, err := h.db.UnlockPromptConversation(ctx, lockKey, request.Reason)
 	if errors.Is(err, sql.ErrNoRows) {
 		writeError(c, http.StatusNotFound, "活动会话锁不存在或已经解锁")
@@ -47,5 +88,5 @@ func (h *Handler) UnlockPromptConversation(c *gin.Context) {
 	if h.cache != nil {
 		_ = h.cache.DeleteRuntime(ctx, database.PromptConversationLockCacheNamespace, lockKey)
 	}
-	c.JSON(http.StatusOK, gin.H{"lock": item})
+	c.JSON(http.StatusOK, gin.H{"lock": item, "scope": request.Scope, "unlocked_count": 1})
 }

--- a/admin/prompt_conversation_lock_test.go
+++ b/admin/prompt_conversation_lock_test.go
@@ -55,3 +55,83 @@ func TestAdminCanUnlockPromptConversationAndInvalidateCache(t *testing.T) {
 		t.Fatalf("cache after unlock found=%t err=%v", found, err)
 	}
 }
+
+func TestAdminCanReleaseVerifiedUserCooldownAndInvalidateAllSessionCaches(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	db, err := database.New("sqlite", filepath.Join(t.TempDir(), "admin-user-cooldown.db"))
+	if err != nil {
+		t.Fatalf("database.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	lockKeys := []string{
+		"1111111111111111111111111111111111111111111111111111111111111111",
+		"2222222222222222222222222222222222222222222222222222222222222222",
+	}
+	tokenCache := cache.NewMemory(1)
+	for index, lockKey := range lockKeys {
+		item, _, err := db.LockPromptConversation(t.Context(), database.PromptConversationLockInput{
+			LockKey: lockKey, Platform: "newapi", NewAPIUserID: "42",
+			SessionFingerprint: []string{"11111111111111111111111111111111", "22222222222222222222222222222222"}[index],
+			SessionHash:        []string{"session-a", "session-b"}[index], DecisionID: "decision-" + string(rune('a'+index)),
+			ReasonCode: "upstream_cyber_policy",
+		})
+		if err != nil {
+			t.Fatalf("LockPromptConversation: %v", err)
+		}
+		raw, _ := json.Marshal(item)
+		if err := tokenCache.SetRuntime(t.Context(), database.PromptConversationLockCacheNamespace, lockKey, raw, time.Minute); err != nil {
+			t.Fatalf("SetRuntime: %v", err)
+		}
+	}
+	store := auth.NewStore(db, tokenCache, &database.SystemSettings{MaxConcurrency: 2, TestConcurrency: 1})
+	handler := NewHandler(store, db, tokenCache, nil, "")
+	router := gin.New()
+	router.POST("/api/admin/prompt-policy/conversation-locks/:lock_key/unlock", handler.UnlockPromptConversation)
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/api/admin/prompt-policy/conversation-locks/"+lockKeys[0]+"/unlock", bytes.NewBufferString(`{"reason":"reviewed","scope":"user_cooldown"}`))
+	request.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("unlock status=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+	var response struct {
+		Scope         string `json:"scope"`
+		UnlockedCount int    `json:"unlocked_count"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil || response.Scope != "user_cooldown" || response.UnlockedCount != 2 {
+		t.Fatalf("unlock response=%+v err=%v body=%s", response, err, recorder.Body.String())
+	}
+	for _, lockKey := range lockKeys {
+		if _, found, err := tokenCache.GetRuntime(t.Context(), database.PromptConversationLockCacheNamespace, lockKey); err != nil || found {
+			t.Fatalf("cache %s after user cooldown release found=%t err=%v", lockKey, found, err)
+		}
+	}
+}
+
+func TestRiskProfileShowsUserCooldownWithManualReleaseMetadata(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	db, err := database.New("sqlite", filepath.Join(t.TempDir(), "admin-user-cooldown-profile.db"))
+	if err != nil {
+		t.Fatalf("database.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	_, _, err = db.LockPromptConversation(t.Context(), database.PromptConversationLockInput{
+		LockKey:  "3333333333333333333333333333333333333333333333333333333333333333",
+		Platform: "newapi", NewAPIUserID: "42", DecisionID: "decision-profile",
+		ReasonCode: "upstream_cyber_policy", LockedAt: time.Now().UTC(),
+	})
+	if err != nil {
+		t.Fatalf("LockPromptConversation: %v", err)
+	}
+	tokenCache := cache.NewMemory(1)
+	store := auth.NewStore(db, tokenCache, &database.SystemSettings{MaxConcurrency: 2, TestConcurrency: 1})
+	handler := NewHandler(store, db, tokenCache, nil, "")
+	profiles := []*database.PromptRiskProfile{{
+		SubjectType: database.PromptRiskSubjectNewAPIUser, Platform: "newapi", NewAPIUserID: "42",
+	}}
+	handler.attachPromptConversationLocks(t.Context(), profiles)
+	lock := profiles[0].ConversationLock
+	if lock == nil || lock.RestrictionScope != database.PromptConversationRestrictionScopeUserCooldown || lock.ExpiresAt == nil || lock.RemainingSeconds <= 0 {
+		t.Fatalf("user cooldown profile lock=%#v", lock)
+	}
+}

--- a/admin/prompt_risk_profile.go
+++ b/admin/prompt_risk_profile.go
@@ -230,13 +230,47 @@ func (h *Handler) attachPromptConversationLocks(ctx context.Context, profiles []
 		lockTTL = time.Duration(promptfilter.NormalizeAdvancedConfig(cfg.Advanced).Enforcement.ConversationLockTTLHours) * time.Hour
 	}
 	for _, profile := range profiles {
-		if profile == nil || profile.SubjectType != database.PromptRiskSubjectSession || strings.TrimSpace(profile.SubjectKey) == "" {
+		if profile == nil {
 			continue
 		}
-		item, err := h.db.GetActivePromptConversationLockBySessionHashWithTTL(ctx, profile.SubjectKey, lockTTL)
-		if err == nil {
-			profile.ConversationLock = item
+		switch profile.SubjectType {
+		case database.PromptRiskSubjectSession:
+			if strings.TrimSpace(profile.SubjectKey) == "" {
+				continue
+			}
+			item, err := h.db.GetActivePromptConversationLockBySessionHashWithTTL(ctx, profile.SubjectKey, lockTTL)
+			if err == nil {
+				decoratePromptConversationRestriction(item, database.PromptConversationRestrictionScopeConversation, lockTTL)
+				profile.ConversationLock = item
+			}
+		case database.PromptRiskSubjectNewAPIUser:
+			if strings.TrimSpace(profile.Platform) == "" || strings.TrimSpace(profile.NewAPIUserID) == "" {
+				continue
+			}
+			item, _, err := h.db.GetActivePromptConversationRestriction(
+				ctx, "", profile.Platform, profile.NewAPIUserID, lockTTL, database.PromptUserCyberCooldownTTL,
+			)
+			if err == nil {
+				decoratePromptConversationRestriction(item, database.PromptConversationRestrictionScopeUserCooldown, database.PromptUserCyberCooldownTTL)
+				profile.ConversationLock = item
+			}
 		}
+	}
+}
+
+func decoratePromptConversationRestriction(item *database.PromptConversationLock, scope string, ttl time.Duration) {
+	if item == nil {
+		return
+	}
+	item.RestrictionScope = scope
+	if ttl <= 0 || item.LockedAt.IsZero() {
+		return
+	}
+	expiresAt := item.LockedAt.UTC().Add(ttl)
+	item.ExpiresAt = &expiresAt
+	remaining := time.Until(expiresAt)
+	if remaining > 0 {
+		item.RemainingSeconds = int64((remaining + time.Second - 1) / time.Second)
 	}
 }
 

--- a/database/prompt_conversation_lock.go
+++ b/database/prompt_conversation_lock.go
@@ -11,9 +11,12 @@ import (
 )
 
 const (
-	PromptConversationLockStatusActive   = "active"
-	PromptConversationLockStatusUnlocked = "unlocked"
-	PromptConversationLockCacheNamespace = "prompt-conversation-lock"
+	PromptConversationLockStatusActive             = "active"
+	PromptConversationLockStatusUnlocked           = "unlocked"
+	PromptConversationLockCacheNamespace           = "prompt-conversation-lock"
+	PromptConversationRestrictionScopeConversation = "conversation"
+	PromptConversationRestrictionScopeUserCooldown = "user_cooldown"
+	PromptUserCyberCooldownTTL                     = 30 * time.Minute
 )
 
 type PromptConversationLock struct {
@@ -35,6 +38,9 @@ type PromptConversationLock struct {
 	LockedAt           time.Time  `json:"locked_at"`
 	UnlockedAt         *time.Time `json:"unlocked_at,omitempty"`
 	UnlockReason       string     `json:"unlock_reason,omitempty"`
+	RestrictionScope   string     `json:"restriction_scope,omitempty"`
+	ExpiresAt          *time.Time `json:"expires_at,omitempty"`
+	RemainingSeconds   int64      `json:"remaining_seconds,omitempty"`
 	CreatedAt          time.Time  `json:"created_at"`
 	UpdatedAt          time.Time  `json:"updated_at"`
 }
@@ -149,7 +155,9 @@ func normalizePromptConversationLockInput(input PromptConversationLockInput) (Pr
 	input.ReasonCode = truncateCandidateRunes(strings.TrimSpace(input.ReasonCode), 100)
 	input.Endpoint = truncateCandidateRunes(strings.TrimSpace(input.Endpoint), 255)
 	input.Model = truncateCandidateRunes(strings.TrimSpace(input.Model), 128)
-	if len(input.LockKey) != 64 || input.Platform == "" || input.NewAPIUserID == "" || len(input.SessionFingerprint) != 32 || input.DecisionID == "" {
+	if len(input.LockKey) != 64 || input.Platform == "" || input.NewAPIUserID == "" || input.DecisionID == "" ||
+		(input.SessionFingerprint == "" && input.SessionHash != "") ||
+		(input.SessionFingerprint != "" && len(input.SessionFingerprint) != 32) {
 		return PromptConversationLockInput{}, errors.New("invalid prompt conversation lock identity")
 	}
 	if input.LockedAt.IsZero() {
@@ -239,7 +247,7 @@ func (db *DB) GetActivePromptConversationRestriction(ctx context.Context, lockKe
 	lockKey = strings.ToLower(strings.TrimSpace(lockKey))
 	platform = strings.ToLower(strings.TrimSpace(platform))
 	newAPIUserID = strings.TrimSpace(newAPIUserID)
-	if len(lockKey) != 64 || platform == "" || newAPIUserID == "" {
+	if (lockKey != "" && len(lockKey) != 64) || platform == "" || newAPIUserID == "" {
 		return nil, false, sql.ErrNoRows
 	}
 	now := time.Now().UTC()
@@ -252,16 +260,16 @@ func (db *DB) GetActivePromptConversationRestriction(ctx context.Context, lockKe
 		userCutoff = now.Add(-userCooldown)
 	}
 	query := promptConversationLockSelect + ` WHERE status='active' AND (
-		(lock_key=$1 AND locked_at>$4) OR
+		($1<>'' AND lock_key=$1 AND locked_at>$4) OR
 		(platform=$2 AND newapi_user_id=$3 AND locked_at>$5)
-	) ORDER BY CASE WHEN lock_key=$1 THEN 0 ELSE 1 END, locked_at DESC LIMIT 1`
+	) ORDER BY CASE WHEN $1<>'' AND lock_key=$1 THEN 0 ELSE 1 END, locked_at DESC LIMIT 1`
 	item, err := scanPromptConversationLock(db.conn.QueryRowContext(ctx, query,
 		lockKey, platform, newAPIUserID, conversationCutoff, userCutoff,
 	))
 	if err != nil {
 		return nil, false, err
 	}
-	return item, item.LockKey == lockKey, nil
+	return item, lockKey != "" && item.LockKey == lockKey, nil
 }
 
 func (db *DB) GetActivePromptConversationLockBySessionHash(ctx context.Context, sessionHash string) (*PromptConversationLock, error) {
@@ -331,4 +339,48 @@ func (db *DB) UnlockPromptConversation(ctx context.Context, lockKey, reason stri
 		return nil, sql.ErrNoRows
 	}
 	return db.GetPromptConversationLock(ctx, lockKey)
+}
+
+// UnlockPromptConversationUserCooldown releases every active CYB restriction
+// for one verified platform user. Clearing the complete user scope prevents an
+// older active conversation row from immediately re-applying the cooldown.
+// The returned keys allow callers to invalidate any exact-session cache rows.
+func (db *DB) UnlockPromptConversationUserCooldown(ctx context.Context, platform, newAPIUserID, reason string) ([]string, error) {
+	if err := db.ensurePromptConversationLocksTable(ctx); err != nil {
+		return nil, err
+	}
+	platform = strings.ToLower(truncateCandidateRunes(strings.TrimSpace(platform), 100))
+	newAPIUserID = truncateCandidateRunes(strings.TrimSpace(newAPIUserID), 255)
+	reason = truncateCandidateRunes(strings.TrimSpace(reason), 1000)
+	if platform == "" || newAPIUserID == "" {
+		return nil, sql.ErrNoRows
+	}
+	if reason == "" {
+		reason = "管理员解除用户安全冷却"
+	}
+	now := time.Now().UTC()
+	rows, err := db.conn.QueryContext(ctx, `UPDATE prompt_conversation_locks SET
+		status='unlocked', unlock_count=unlock_count+1, unlocked_at=$3,
+		unlock_reason=$4, updated_at=$3
+		WHERE platform=$1 AND newapi_user_id=$2 AND status='active'
+		RETURNING lock_key`, platform, newAPIUserID, now, reason)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	keys := make([]string, 0, 4)
+	for rows.Next() {
+		var key string
+		if err := rows.Scan(&key); err != nil {
+			return nil, err
+		}
+		keys = append(keys, key)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if len(keys) == 0 {
+		return nil, sql.ErrNoRows
+	}
+	return keys, nil
 }

--- a/database/prompt_conversation_lock_test.go
+++ b/database/prompt_conversation_lock_test.go
@@ -104,6 +104,31 @@ func TestPromptConversationRestrictionUsesBoundedUserCooldownAcrossSessions(t *t
 	}
 }
 
+func TestPromptConversationRestrictionSupportsSessionlessUserCooldown(t *testing.T) {
+	db := newPromptPolicySQLiteTestDB(t)
+	ctx := context.Background()
+	input := PromptConversationLockInput{
+		LockKey:  "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210",
+		Platform: "newapi", NewAPIUserID: "42",
+		IncidentID: "incident-sessionless", DecisionID: "decision-sessionless", ReasonCode: "upstream_cyber_policy",
+		LockedAt: time.Now().UTC(),
+	}
+	stored, changed, err := db.LockPromptConversation(ctx, input)
+	if err != nil || !changed || stored.SessionFingerprint != "" || stored.SessionHash != "" {
+		t.Fatalf("sessionless cooldown lock = %#v changed=%t err=%v", stored, changed, err)
+	}
+
+	item, exact, err := db.GetActivePromptConversationRestriction(ctx, "", "newapi", "42", 24*time.Hour, 30*time.Minute)
+	if err != nil || exact || item.DecisionID != input.DecisionID {
+		t.Fatalf("sessionless user cooldown restriction = %#v exact=%t err=%v", item, exact, err)
+	}
+	otherSessionKey := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	item, exact, err = db.GetActivePromptConversationRestriction(ctx, otherSessionKey, "newapi", "42", 24*time.Hour, 30*time.Minute)
+	if err != nil || exact || item.DecisionID != input.DecisionID {
+		t.Fatalf("sessionless cooldown did not cover later session = %#v exact=%t err=%v", item, exact, err)
+	}
+}
+
 func TestPromptConversationLockCreatesUserCooldownIndex(t *testing.T) {
 	db := newPromptPolicySQLiteTestDB(t)
 	if err := db.ensurePromptConversationLocksTable(t.Context()); err != nil {
@@ -113,5 +138,49 @@ func TestPromptConversationLockCreatesUserCooldownIndex(t *testing.T) {
 	err := db.conn.QueryRowContext(t.Context(), `SELECT name FROM sqlite_master WHERE type='index' AND name=$1`, "idx_prompt_conversation_locks_user_cooldown").Scan(&name)
 	if err != nil || name != "idx_prompt_conversation_locks_user_cooldown" {
 		t.Fatalf("user cooldown index = %q err=%v", name, err)
+	}
+}
+
+func TestUnlockPromptConversationUserCooldownClearsEveryActiveLockForVerifiedUser(t *testing.T) {
+	db := newPromptPolicySQLiteTestDB(t)
+	ctx := t.Context()
+	locks := []PromptConversationLockInput{
+		{
+			LockKey:  "1111111111111111111111111111111111111111111111111111111111111111",
+			Platform: "newapi", NewAPIUserID: "42", SessionFingerprint: "11111111111111111111111111111111",
+			SessionHash: "session-a", DecisionID: "decision-a", ReasonCode: "upstream_cyber_policy",
+		},
+		{
+			LockKey:  "2222222222222222222222222222222222222222222222222222222222222222",
+			Platform: "newapi", NewAPIUserID: "42", SessionFingerprint: "22222222222222222222222222222222",
+			SessionHash: "session-b", DecisionID: "decision-b", ReasonCode: "upstream_cyber_policy",
+		},
+		{
+			LockKey:  "3333333333333333333333333333333333333333333333333333333333333333",
+			Platform: "newapi", NewAPIUserID: "43", SessionFingerprint: "33333333333333333333333333333333",
+			SessionHash: "session-c", DecisionID: "decision-c", ReasonCode: "upstream_cyber_policy",
+		},
+	}
+	for _, input := range locks {
+		if _, _, err := db.LockPromptConversation(ctx, input); err != nil {
+			t.Fatalf("LockPromptConversation(%s): %v", input.DecisionID, err)
+		}
+	}
+
+	keys, err := db.UnlockPromptConversationUserCooldown(ctx, "newapi", "42", "confirmed false positive")
+	if err != nil || len(keys) != 2 {
+		t.Fatalf("user cooldown unlock keys=%v err=%v", keys, err)
+	}
+	for _, input := range locks[:2] {
+		if _, err := db.GetActivePromptConversationLock(ctx, input.LockKey); !errors.Is(err, sql.ErrNoRows) {
+			t.Fatalf("same-user lock %s remained active: %v", input.LockKey, err)
+		}
+		stored, err := db.GetPromptConversationLock(ctx, input.LockKey)
+		if err != nil || stored.UnlockReason != "confirmed false positive" || stored.UnlockCount != 1 {
+			t.Fatalf("unlocked row=%#v err=%v", stored, err)
+		}
+	}
+	if _, err := db.GetActivePromptConversationLock(ctx, locks[2].LockKey); err != nil {
+		t.Fatalf("different user lock was cleared: %v", err)
 	}
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1075,8 +1075,8 @@ export const api = {
 		request<{ policy: import('./types').PromptRiskTrustPolicy }>(`/prompt-policy/risk-profiles/${encodeURIComponent(subjectType)}/${encodeURIComponent(subjectKey)}/trust`, { method: 'PUT', body: JSON.stringify(data) }),
 	revokePromptRiskTrust: (subjectType: string, subjectKey: string) =>
 		request<{ policy: import('./types').PromptRiskTrustPolicy }>(`/prompt-policy/risk-profiles/${encodeURIComponent(subjectType)}/${encodeURIComponent(subjectKey)}/trust`, { method: 'DELETE' }),
-	unlockPromptConversation: (lockKey: string, reason = '管理员主动解锁') =>
-		request<{ lock: import('./types').PromptConversationLock }>(`/prompt-policy/conversation-locks/${encodeURIComponent(lockKey)}/unlock`, { method: 'POST', body: JSON.stringify({ reason }) }),
+	unlockPromptConversation: (lockKey: string, reason = '管理员主动解锁', scope: 'conversation' | 'user_cooldown' = 'conversation') =>
+		request<{ lock: import('./types').PromptConversationLock; scope: string; unlocked_count: number }>(`/prompt-policy/conversation-locks/${encodeURIComponent(lockKey)}/unlock`, { method: 'POST', body: JSON.stringify({ reason, scope }) }),
   testPromptFilter: (data: { text: string; endpoint?: string; model?: string }) =>
     request<PromptFilterTestResponse>('/prompt-filter/test', { method: 'POST', body: JSON.stringify(data) }),
   testPromptReview: (data: PromptReviewTestRequest) =>

--- a/frontend/src/lib/promptRiskProfileView.test.mjs
+++ b/frontend/src/lib/promptRiskProfileView.test.mjs
@@ -71,12 +71,17 @@ test('risk page separates people from environment subjects', () => {
   assert.match(zh.promptFilter.risk.nonPersonHint, /環境|环境/)
 })
 
-test('active CYB conversation locks are visible and manually unlockable', () => {
+test('active CYB conversation locks and user cooldowns are visible and manually unlockable', () => {
   assert.match(types, /PromptConversationLock/)
   assert.match(types, /conversation_lock\?: PromptConversationLock/)
   assert.match(api, /unlockPromptConversation/)
   assert.match(api, /conversation-locks\/\$\{encodeURIComponent\(lockKey\)\}\/unlock/)
   assert.match(source, /conversation_lock\?\.status === 'active'/)
-  assert.match(source, /unlockPromptConversation\(lock\.lock_key\)/)
+  assert.match(source, /unlockPromptConversation\(lock\.lock_key[\s\S]*scope\)/)
+  assert.match(source, /user_cooldown/)
+  assert.match(source, /confirmUserCooldown/)
+  assert.match(source, /remaining_seconds/)
+  assert.match(types, /restriction_scope\?: 'conversation' \| 'user_cooldown'/)
   assert.match(zh.promptFilter.risk.conversationLock.description, /不会再次累计处罚/)
+  assert.match(zh.promptFilter.risk.conversationLock.userCooldownDescription, /所有会话/)
 })

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1884,7 +1884,17 @@
         "unlock": "Unlock conversation",
         "confirm": "Unlock this conversation? Its original context remains present, so do this only after confirming a false positive.",
         "unlocked": "Conversation unlocked",
+        "conversationUnlockReason": "Conversation manually unlocked after administrator review",
+        "userCooldownTitle": "CYB user safety cooldown",
+        "userCooldownActive": "User in cooldown",
+        "userCooldownDescription": "This verified user recently received an upstream CYB response. All sessions are rejected locally without adding duplicate penalties; releasing the cooldown clears every currently active CY lock for this user.",
+        "unlockUserCooldown": "Release user cooldown",
+        "confirmUserCooldown": "Release this user's safety cooldown? This also clears every currently active CY conversation lock for the user. Do this only after confirming a false positive or completing manual review.",
+        "userCooldownUnlocked": "User safety cooldown released; {{count}} active locks cleared",
+        "userCooldownUnlockReason": "User safety cooldown released after administrator review",
         "lockedAt": "Locked at",
+        "expiresAt": "Automatic release",
+        "remaining": "Time remaining",
         "reason": "Lock reason"
       },
       "trust": {

--- a/frontend/src/locales/zh-TW.json
+++ b/frontend/src/locales/zh-TW.json
@@ -271,7 +271,17 @@
         "unlock": "解鎖此對話",
         "confirm": "確認解鎖此對話？原視窗中的上下文仍會保留，僅應在確認誤判後操作。",
         "unlocked": "對話已解鎖",
+        "conversationUnlockReason": "管理員確認後手動解鎖會話",
+        "userCooldownTitle": "CYB 使用者安全冷卻",
+        "userCooldownActive": "使用者冷卻中",
+        "userCooldownDescription": "此可信使用者近期收到過上游 CYB。冷卻期間其所有會話都會被本地拒絕且不會重複累計處罰；解除操作會一次清除該使用者目前全部活動 CY 鎖。",
+        "unlockUserCooldown": "解除使用者冷卻",
+        "confirmUserCooldown": "確認解除該使用者的安全冷卻？這會同時清除該使用者目前全部活動 CY 會話鎖，僅應在確認誤判或完成人工審核後操作。",
+        "userCooldownUnlocked": "使用者安全冷卻已解除，共清除 {{count}} 條活動鎖",
+        "userCooldownUnlockReason": "管理員人工審核後解除使用者安全冷卻",
         "lockedAt": "鎖定時間",
+        "expiresAt": "自動解除時間",
+        "remaining": "剩餘時間",
         "reason": "鎖定原因"
       },
       "trust": {

--- a/frontend/src/locales/zh.json
+++ b/frontend/src/locales/zh.json
@@ -1884,7 +1884,17 @@
         "unlock": "解锁此对话",
         "confirm": "确认解锁此对话？原窗口中的上下文仍会保留，仅应在确认误判后操作。",
         "unlocked": "对话已解锁",
+        "conversationUnlockReason": "管理员确认后手动解锁会话",
+        "userCooldownTitle": "CYB 用户安全冷却",
+        "userCooldownActive": "用户冷却中",
+        "userCooldownDescription": "该可信用户近期收到过上游 CYB。冷却期间其所有会话都会被本地拒绝且不会重复累计处罚；解除操作会一次清除该用户当前全部活动 CY 锁。",
+        "unlockUserCooldown": "解除用户冷却",
+        "confirmUserCooldown": "确认解除该用户的安全冷却？这会同时清除该用户当前全部活动 CY 会话锁，仅应在确认误判或已经完成人工审核后操作。",
+        "userCooldownUnlocked": "用户安全冷却已解除，共清除 {{count}} 条活动锁",
+        "userCooldownUnlockReason": "管理员人工审核后解除用户安全冷却",
         "lockedAt": "锁定时间",
+        "expiresAt": "自动解除时间",
+        "remaining": "剩余时间",
         "reason": "锁定原因"
       },
       "trust": {

--- a/frontend/src/pages/PromptFilter.tsx
+++ b/frontend/src/pages/PromptFilter.tsx
@@ -4022,6 +4022,16 @@ function promptRiskIdentityPrimary(profile: Pick<PromptRiskProfile, 'subject_dis
   return profile.newapi_user_name || profile.newapi_user_email || profile.subject_display || '-'
 }
 
+function formatPromptRestrictionRemaining(seconds?: number) {
+  const total = Math.max(0, Math.ceil(Number(seconds) || 0))
+  if (total <= 0) return '-'
+  const minutes = Math.ceil(total / 60)
+  if (minutes < 60) return `${minutes}m`
+  const hours = Math.floor(minutes / 60)
+  const remainder = minutes % 60
+  return remainder > 0 ? `${hours}h ${remainder}m` : `${hours}h`
+}
+
 function RiskProfilesTable({ profiles }: { profiles: PromptRiskProfile[] }) {
   const { t } = useTranslation()
   return (
@@ -4041,7 +4051,7 @@ function RiskProfilesTable({ profiles }: { profiles: PromptRiskProfile[] }) {
             <TableCell>
               <div className="flex items-center gap-2"><Users className="size-4 text-muted-foreground" /><span className="font-medium">{promptRiskIdentityPrimary(profile)}</span></div>
               {profile.newapi_user_id || profile.newapi_user_email ? <div className="mt-1 text-xs text-muted-foreground">{profile.newapi_user_id ? `${t('promptFilter.risk.userId')} #${profile.newapi_user_id}` : ''}{profile.newapi_user_id && profile.newapi_user_email ? ' · ' : ''}{profile.newapi_user_email || ''}</div> : null}
-              <div className="mt-1 flex flex-wrap gap-1"><Badge variant={profile.is_person ? 'default' : 'outline'}>{profile.is_person ? t('promptFilter.risk.person') : t('promptFilter.risk.nonPerson')}</Badge><Badge variant={profile.has_activity ? 'secondary' : 'outline'}>{t(profile.has_activity ? 'promptFilter.risk.activeProfile' : 'promptFilter.risk.identityOnly')}</Badge><Badge variant="outline">{t(`promptFilter.risk.subjects.${profile.subject_type}`)}</Badge>{profile.platform ? <Badge variant="secondary">{profile.platform}</Badge> : null}{profile.newapi_user_group ? <Badge variant="secondary">{t('promptFilter.risk.userGroup')}: {profile.newapi_user_group}</Badge> : null}{profile.trust_policy ? <Badge variant={profile.trust_policy.status === 'active' ? 'default' : 'outline'}>{t(`promptFilter.risk.trust.status.${profile.trust_policy.status}`, { defaultValue: profile.trust_policy.status })}</Badge> : null}{profile.conversation_lock?.status === 'active' ? <Badge variant="destructive">{t('promptFilter.risk.conversationLock.active')}</Badge> : null}</div>
+              <div className="mt-1 flex flex-wrap gap-1"><Badge variant={profile.is_person ? 'default' : 'outline'}>{profile.is_person ? t('promptFilter.risk.person') : t('promptFilter.risk.nonPerson')}</Badge><Badge variant={profile.has_activity ? 'secondary' : 'outline'}>{t(profile.has_activity ? 'promptFilter.risk.activeProfile' : 'promptFilter.risk.identityOnly')}</Badge><Badge variant="outline">{t(`promptFilter.risk.subjects.${profile.subject_type}`)}</Badge>{profile.platform ? <Badge variant="secondary">{profile.platform}</Badge> : null}{profile.newapi_user_group ? <Badge variant="secondary">{t('promptFilter.risk.userGroup')}: {profile.newapi_user_group}</Badge> : null}{profile.trust_policy ? <Badge variant={profile.trust_policy.status === 'active' ? 'default' : 'outline'}>{t(`promptFilter.risk.trust.status.${profile.trust_policy.status}`, { defaultValue: profile.trust_policy.status })}</Badge> : null}{profile.conversation_lock?.status === 'active' ? <Badge variant="destructive">{t(profile.conversation_lock.restriction_scope === 'user_cooldown' ? 'promptFilter.risk.conversationLock.userCooldownActive' : 'promptFilter.risk.conversationLock.active')}</Badge> : null}</div>
               <div className="mt-1 font-mono text-[11px] text-muted-foreground">{profile.subject_key.slice(0, 18)}</div>
             </TableCell>
             <TableCell><div className="flex items-center gap-2"><span className="font-mono text-lg font-semibold">{profile.risk_score}</span><Badge className={promptRiskBadgeClass(profile.risk_level)}>{t(`promptFilter.risk.levels.${profile.risk_level}`)}</Badge></div><div className="text-xs text-muted-foreground">{t('promptFilter.risk.identityConfidence')} {profile.identity_confidence}%</div></TableCell>
@@ -4121,11 +4131,13 @@ function PromptRiskProfileDetailButton({ profile }: { profile: PromptRiskProfile
   }
   const unlockConversation = async () => {
     const lock = item.conversation_lock
-    if (!lock || !window.confirm(t('promptFilter.risk.conversationLock.confirm'))) return
+    const userCooldown = lock?.restriction_scope === 'user_cooldown' || item.subject_type === 'newapi_user'
+    const scope = userCooldown ? 'user_cooldown' : 'conversation'
+    if (!lock || !window.confirm(t(userCooldown ? 'promptFilter.risk.conversationLock.confirmUserCooldown' : 'promptFilter.risk.conversationLock.confirm'))) return
     setUnlockingConversation(true)
     try {
-      await api.unlockPromptConversation(lock.lock_key)
-      showToast(t('promptFilter.risk.conversationLock.unlocked'))
+      const result = await api.unlockPromptConversation(lock.lock_key, userCooldown ? t('promptFilter.risk.conversationLock.userCooldownUnlockReason') : t('promptFilter.risk.conversationLock.conversationUnlockReason'), scope)
+      showToast(t(userCooldown ? 'promptFilter.risk.conversationLock.userCooldownUnlocked' : 'promptFilter.risk.conversationLock.unlocked', { count: result.unlocked_count }))
       await loadDetail()
     } catch (err) {
       showToast(getErrorMessage(err), 'error')
@@ -4133,6 +4145,8 @@ function PromptRiskProfileDetailButton({ profile }: { profile: PromptRiskProfile
       setUnlockingConversation(false)
     }
   }
+  const activeRestriction = item.conversation_lock
+  const isUserCooldown = activeRestriction?.restriction_scope === 'user_cooldown' || item.subject_type === 'newapi_user'
   return <>
     <Button size="sm" variant="outline" onClick={() => { setEventPage(1); setTrustEventPage(1); setOpen(true) }}>{t('promptFilter.cyberDetail')}</Button>
     <Dialog open={open} onOpenChange={setOpen}>
@@ -4142,10 +4156,10 @@ function PromptRiskProfileDetailButton({ profile }: { profile: PromptRiskProfile
           <div className="rounded-lg border border-[hsl(var(--warning))]/30 bg-[hsl(var(--warning-bg))] p-3 text-sm text-[hsl(var(--warning))]">{detail?.guardrail || t('promptFilter.risk.guardrail')}</div>
           {item.conversation_lock?.status === 'active' ? <div className="rounded-lg border border-destructive/35 bg-destructive/5 p-4">
             <div className="flex flex-wrap items-start justify-between gap-3">
-              <div><div className="flex items-center gap-2 font-semibold text-destructive"><ShieldAlert className="size-4" />{t('promptFilter.risk.conversationLock.title')}<Badge variant="destructive">{t('promptFilter.risk.conversationLock.active')}</Badge></div><p className="mt-1 text-xs leading-5 text-muted-foreground">{t('promptFilter.risk.conversationLock.description')}</p></div>
-              <Button size="sm" variant="destructive" disabled={unlockingConversation} onClick={() => void unlockConversation()}>{t('promptFilter.risk.conversationLock.unlock')}</Button>
+              <div><div className="flex items-center gap-2 font-semibold text-destructive"><ShieldAlert className="size-4" />{t(isUserCooldown ? 'promptFilter.risk.conversationLock.userCooldownTitle' : 'promptFilter.risk.conversationLock.title')}<Badge variant="destructive">{t(isUserCooldown ? 'promptFilter.risk.conversationLock.userCooldownActive' : 'promptFilter.risk.conversationLock.active')}</Badge></div><p className="mt-1 text-xs leading-5 text-muted-foreground">{t(isUserCooldown ? 'promptFilter.risk.conversationLock.userCooldownDescription' : 'promptFilter.risk.conversationLock.description')}</p></div>
+              <Button size="sm" variant="destructive" disabled={unlockingConversation} onClick={() => void unlockConversation()}>{t(isUserCooldown ? 'promptFilter.risk.conversationLock.unlockUserCooldown' : 'promptFilter.risk.conversationLock.unlock')}</Button>
             </div>
-            <div className="mt-3 grid gap-2 sm:grid-cols-2 lg:grid-cols-4"><PromptPolicyDetailField label={t('promptFilter.risk.conversationLock.lockedAt')} value={formatBeijingTime(item.conversation_lock.locked_at)} /><PromptPolicyDetailField label={t('promptFilter.risk.conversationLock.reason')} value={item.conversation_lock.reason_code} /><PromptPolicyDetailField label={t('promptFilter.colEndpoint')} value={item.conversation_lock.endpoint || '-'} /><PromptPolicyDetailField label={t('promptFilter.reviewModel')} value={item.conversation_lock.model || '-'} /></div>
+            <div className="mt-3 grid gap-2 sm:grid-cols-2 lg:grid-cols-4"><PromptPolicyDetailField label={t('promptFilter.risk.conversationLock.lockedAt')} value={formatBeijingTime(item.conversation_lock.locked_at)} /><PromptPolicyDetailField label={t('promptFilter.risk.conversationLock.expiresAt')} value={item.conversation_lock.expires_at ? formatBeijingTime(item.conversation_lock.expires_at) : '-'} /><PromptPolicyDetailField label={t('promptFilter.risk.conversationLock.remaining')} value={formatPromptRestrictionRemaining(item.conversation_lock.remaining_seconds)} /><PromptPolicyDetailField label={t('promptFilter.risk.conversationLock.reason')} value={isUserCooldown ? 'user_cyber_cooldown' : 'conversation_cyber_locked'} /><PromptPolicyDetailField label={t('promptFilter.colEndpoint')} value={item.conversation_lock.endpoint || '-'} /><PromptPolicyDetailField label={t('promptFilter.reviewModel')} value={item.conversation_lock.model || '-'} /></div>
           </div> : null}
           <div className="rounded-lg border bg-muted/20 p-4">
             <div className="flex flex-wrap items-start justify-between gap-3">

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1604,6 +1604,9 @@ export interface PromptConversationLock {
   locked_at: ISODateString
   unlocked_at?: ISODateString
   unlock_reason?: string
+  restriction_scope?: 'conversation' | 'user_cooldown'
+  expires_at?: ISODateString
+  remaining_seconds?: number
   created_at: ISODateString
   updated_at: ISODateString
 }

--- a/proxy/prompt_conversation_lock.go
+++ b/proxy/prompt_conversation_lock.go
@@ -7,8 +7,10 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -20,12 +22,22 @@ import (
 
 const (
 	promptConversationLockedReasonCode = "conversation_cyber_locked"
-	promptConversationLockedMessage    = "此对话因触发网络安全策略（CYB）已被锁定，请新建对话后继续。本次锁定拦截不会重复累计；在新对话中再次触发 CYB 可能会停用账号。如果确认是误判，请联系管理员解锁。"
+	promptConversationLockedMessage    = "当前对话因上游 CYB 已被锁定。本次锁定拦截不会重复累计处罚；可等待自动到期，或由管理员在「Prompt 检查 → 风险画像 → 会话详情」手动解锁。解除后再次触发 CYB 可能会停用账号。"
 	promptUserCyberCooldownReasonCode  = "user_cyber_cooldown"
-	promptUserCyberCooldownMessage     = "该用户刚刚触发网络安全策略（CYB），现处于 30 分钟安全冷却期。冷却期间的新请求不会继续转发，也不会重复累计处罚；如确认是误判，请联系管理员处理。"
+	promptUserCyberCooldownMessage     = "该用户因上游 CYB 现处于 30 分钟安全冷却期。冷却期间的新请求不会继续转发，也不会重复累计处罚；可等待自动到期，或由管理员在「Prompt 检查 → 风险画像 → 用户详情」手动解除冷却。"
 	promptConversationLockCacheTTL     = 30 * time.Second
-	promptUserCyberCooldownTTL         = 30 * time.Minute
+	promptUserCyberCooldownTTL         = database.PromptUserCyberCooldownTTL
 )
+
+type promptCyberRestriction struct {
+	ReasonCode        string
+	Message           string
+	Scope             string
+	LockedAt          time.Time
+	ExpiresAt         time.Time
+	RetryAfterSeconds int64
+	IncidentID        string
+}
 
 type promptConversationLockIdentity struct {
 	LockKey            string
@@ -33,6 +45,21 @@ type promptConversationLockIdentity struct {
 	NewAPIUserID       string
 	SessionFingerprint string
 	SessionHash        string
+}
+
+func verifiedPromptUserCooldownIdentity(c *gin.Context, policyContext verifiedNewAPIPolicyContext) (promptConversationLockIdentity, bool) {
+	if c == nil || !policyContext.MetaVerified {
+		return promptConversationLockIdentity{}, false
+	}
+	platform := normalizedNewAPIPlatform(policyContext.Platform)
+	userID := strings.TrimSpace(policyContext.Identity.UserID)
+	if platform == "" || userID == "" {
+		return promptConversationLockIdentity{}, false
+	}
+	digest := sha256.Sum256([]byte("prompt-user-cooldown-v1\x00" + platform + "\x00" + userID))
+	return promptConversationLockIdentity{
+		LockKey: hex.EncodeToString(digest[:]), Platform: platform, NewAPIUserID: userID,
+	}, true
 }
 
 func verifiedPromptConversationLockIdentity(c *gin.Context, policyContext verifiedNewAPIPolicyContext) (promptConversationLockIdentity, bool) {
@@ -61,11 +88,113 @@ func promptConversationLockExpired(item *database.PromptConversationLock, ttl ti
 	return item == nil || (ttl > 0 && !item.LockedAt.After(time.Now().UTC().Add(-ttl)))
 }
 
-func promptCyberRestrictionDecision(item *database.PromptConversationLock) (string, string) {
-	if item != nil && item.ReasonCode == promptUserCyberCooldownReasonCode {
-		return promptUserCyberCooldownReasonCode, promptUserCyberCooldownMessage
+func promptCyberRestrictionDecision(item *database.PromptConversationLock, cfg promptfilter.Config) promptCyberRestriction {
+	result := promptCyberRestriction{
+		ReasonCode: promptConversationLockedReasonCode,
+		Message:    promptConversationLockedMessage,
+		Scope:      database.PromptConversationRestrictionScopeConversation,
 	}
-	return promptConversationLockedReasonCode, promptConversationLockedMessage
+	ttl := promptConversationLockTTL(cfg)
+	if item != nil {
+		result.LockedAt = item.LockedAt.UTC()
+		result.IncidentID = strings.TrimSpace(item.IncidentID)
+		if item.ReasonCode == promptUserCyberCooldownReasonCode {
+			result.ReasonCode = promptUserCyberCooldownReasonCode
+			result.Message = promptUserCyberCooldownMessage
+			result.Scope = database.PromptConversationRestrictionScopeUserCooldown
+			ttl = promptUserCyberCooldownTTL
+		}
+	}
+	if !result.LockedAt.IsZero() && ttl > 0 {
+		result.ExpiresAt = result.LockedAt.Add(ttl)
+		remaining := time.Until(result.ExpiresAt)
+		if remaining > 0 {
+			result.RetryAfterSeconds = int64((remaining + time.Second - 1) / time.Second)
+		}
+	}
+	remainingText := promptCyberRestrictionRemainingText(result.RetryAfterSeconds)
+	if result.Scope == database.PromptConversationRestrictionScopeUserCooldown {
+		result.Message = fmt.Sprintf("该用户因上游 CYB 进入安全冷却，剩余约 %s；冷却期间所有新请求均不会转发，也不会重复累计处罚。管理员可在「Prompt 检查 → 风险画像 → 用户详情」解除冷却。错误码：%s。", remainingText, result.ReasonCode)
+	} else {
+		result.Message = fmt.Sprintf("当前对话因上游 CYB 已锁定，剩余约 %s；后续请求不会转发或重复累计处罚。管理员可在「Prompt 检查 → 风险画像 → 会话详情」手动解锁。错误码：%s。", remainingText, result.ReasonCode)
+	}
+	return result
+}
+
+func promptCyberRestrictionRemainingText(seconds int64) string {
+	if seconds <= 0 {
+		return "不到 1 分钟"
+	}
+	minutes := (seconds + 59) / 60
+	if minutes < 60 {
+		return fmt.Sprintf("%d 分钟", minutes)
+	}
+	hours := minutes / 60
+	remainingMinutes := minutes % 60
+	if remainingMinutes == 0 {
+		return fmt.Sprintf("%d 小时", hours)
+	}
+	return fmt.Sprintf("%d 小时 %d 分钟", hours, remainingMinutes)
+}
+
+func promptCyberRestrictionDetails(restriction promptCyberRestriction, signedDetails gin.H) gin.H {
+	details := gin.H{}
+	for key, value := range signedDetails {
+		details[key] = value
+	}
+	details["reason_code"] = restriction.ReasonCode
+	details["restriction_scope"] = restriction.Scope
+	details["retry_after_seconds"] = restriction.RetryAfterSeconds
+	details["manual_unlock_path"] = "/admin/prompt-filter/profiles"
+	if !restriction.LockedAt.IsZero() {
+		details["locked_at"] = restriction.LockedAt.Format(time.RFC3339)
+	}
+	if !restriction.ExpiresAt.IsZero() {
+		details["expires_at"] = restriction.ExpiresAt.Format(time.RFC3339)
+	}
+	if restriction.IncidentID != "" {
+		details["incident_id"] = restriction.IncidentID
+	}
+	return details
+}
+
+func promptCyberRestrictionAPIError(restriction promptCyberRestriction, signedDetails gin.H) *api.APIError {
+	return api.NewAPIErrorWithDetails(
+		api.ErrorCode(restriction.ReasonCode), restriction.Message,
+		api.ErrorTypeInvalidRequest, promptCyberRestrictionDetails(restriction, signedDetails),
+	)
+}
+
+func writePromptCyberRestrictionHeaders(c *gin.Context, restriction promptCyberRestriction) {
+	if c == nil {
+		return
+	}
+	c.Header("X-Codex2API-Policy-Restriction-Scope", restriction.Scope)
+	if restriction.RetryAfterSeconds > 0 {
+		c.Header("Retry-After", strconv.FormatInt(restriction.RetryAfterSeconds, 10))
+	}
+	if !restriction.ExpiresAt.IsZero() {
+		c.Header("X-Codex2API-Policy-Restriction-Expires-At", restriction.ExpiresAt.Format(time.RFC3339))
+	}
+}
+
+func (h *Handler) sendNewAPIPromptCyberRestriction(c *gin.Context, cfg promptfilter.Config, decision promptfilter.Decision, verdict promptfilter.Verdict, body []byte, endpoint, model string, signedBody []byte, restriction promptCyberRestriction) bool {
+	policyContext, verified := h.verifyNewAPIPolicyContext(c, cfg.Advanced.NewAPI, signedBody)
+	if !verified {
+		return false
+	}
+	metadata := buildNewAPIPolicyDecisionMetadataWithSecret(policyContext.Identity, decision, verdict, cfg, body, endpoint, model, "", policyContext.VerificationSecret)
+	writeNewAPIPolicyDecisionHeaders(c, metadata)
+	writePromptCyberRestrictionHeaders(c, restriction)
+	apiErr := promptCyberRestrictionAPIError(restriction, newAPIPolicyDecisionDetails(metadata))
+	if requestUsesAnthropicErrorEnvelope(c) {
+		c.JSON(http.StatusBadRequest, gin.H{"type": "error", "error": gin.H{
+			"type": string(apiErr.Type), "message": apiErr.Message, "details": apiErr.Details,
+		}})
+		return true
+	}
+	api.SendErrorWithStatus(c, apiErr, http.StatusBadRequest)
+	return true
 }
 
 func promptCyberRestrictionLock(item *database.PromptConversationLock, exactConversation bool) *database.PromptConversationLock {
@@ -89,31 +218,36 @@ func (h *Handler) activePromptConversationLock(c *gin.Context, cfg promptfilter.
 	if !verified {
 		return nil, false
 	}
-	identity, ok := verifiedPromptConversationLockIdentity(c, policyContext)
+	userIdentity, ok := verifiedPromptUserCooldownIdentity(c, policyContext)
 	if !ok {
 		return nil, false
 	}
+	conversationIdentity, hasConversationIdentity := verifiedPromptConversationLockIdentity(c, policyContext)
+	lockKey := ""
+	if hasConversationIdentity {
+		lockKey = conversationIdentity.LockKey
+	}
 	lockTTL := promptConversationLockTTL(cfg)
-	if h.cache != nil {
-		if raw, found, err := h.cache.GetRuntime(c.Request.Context(), database.PromptConversationLockCacheNamespace, identity.LockKey); err == nil && found {
+	if hasConversationIdentity && h.cache != nil {
+		if raw, found, err := h.cache.GetRuntime(c.Request.Context(), database.PromptConversationLockCacheNamespace, conversationIdentity.LockKey); err == nil && found {
 			var item database.PromptConversationLock
 			if json.Unmarshal(raw, &item) == nil && item.Status == database.PromptConversationLockStatusActive && !promptConversationLockExpired(&item, lockTTL) {
 				return promptCyberRestrictionLock(&item, true), true
 			}
-			_ = h.cache.DeleteRuntime(c.Request.Context(), database.PromptConversationLockCacheNamespace, identity.LockKey)
+			_ = h.cache.DeleteRuntime(c.Request.Context(), database.PromptConversationLockCacheNamespace, conversationIdentity.LockKey)
 		}
 	}
 	ctx, cancel := context.WithTimeout(c.Request.Context(), 2*time.Second)
 	defer cancel()
 	item, exactConversation, err := h.db.GetActivePromptConversationRestriction(
-		ctx, identity.LockKey, identity.Platform, identity.NewAPIUserID,
+		ctx, lockKey, userIdentity.Platform, userIdentity.NewAPIUserID,
 		lockTTL, promptUserCyberCooldownTTL,
 	)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, false
 	}
 	if err != nil {
-		log.Printf("check prompt conversation lock failed key=%s: %v", identity.LockKey[:12], err)
+		log.Printf("check prompt conversation restriction failed identity=%s: %v", userIdentity.LockKey[:12], err)
 		return nil, false
 	}
 	if exactConversation {
@@ -154,9 +288,14 @@ func (h *Handler) lockPromptConversationAfterUpstreamCYB(c *gin.Context, endpoin
 	if !verified {
 		return false
 	}
-	identity, ok := verifiedPromptConversationLockIdentity(c, policyContext)
+	userIdentity, ok := verifiedPromptUserCooldownIdentity(c, policyContext)
 	if !ok {
 		return false
+	}
+	identity := userIdentity
+	conversationIdentity, hasConversationIdentity := verifiedPromptConversationLockIdentity(c, policyContext)
+	if hasConversationIdentity {
+		identity = conversationIdentity
 	}
 	ctx, cancel := context.WithTimeout(c.Request.Context(), 3*time.Second)
 	defer cancel()
@@ -170,6 +309,9 @@ func (h *Handler) lockPromptConversationAfterUpstreamCYB(c *gin.Context, endpoin
 		log.Printf("persist prompt conversation lock failed decision=%s: %v", metadata.DecisionID, err)
 		return false
 	}
+	if !hasConversationIdentity {
+		return false
+	}
 	h.cachePromptConversationLock(c.Request.Context(), item, promptConversationLockTTL(cfg))
 	return item != nil && item.Status == database.PromptConversationLockStatusActive
 }
@@ -179,7 +321,7 @@ func (h *Handler) rejectLockedPromptConversation(c *gin.Context, cfg promptfilte
 	if !locked {
 		return false
 	}
-	reasonCode, message := promptCyberRestrictionDecision(item)
+	restriction := promptCyberRestrictionDecision(item, cfg)
 	profile := strings.ToLower(strings.TrimSpace(cfg.Advanced.Guard.DefaultProfile))
 	switch profile {
 	case promptfilter.GuardProfileBalanced, promptfilter.GuardProfileStrict, promptfilter.GuardProfileResearch:
@@ -188,16 +330,20 @@ func (h *Handler) rejectLockedPromptConversation(c *gin.Context, cfg promptfilte
 	}
 	decision := promptfilter.Decision{
 		Action: promptfilter.ActionBlock, Profile: profile,
-		ReasonCode: reasonCode, StrikeEligible: false, Terminal: true,
+		ReasonCode: restriction.ReasonCode, StrikeEligible: false, Terminal: true,
 	}
-	verdict := promptfilter.Verdict{Action: promptfilter.ActionBlock, Reason: message, FullText: reasonCode}
-	if h.sendNewAPIPolicyDecision(c, cfg, decision, verdict, responseBody, endpoint, model, signedBody) {
+	verdict := promptfilter.Verdict{Action: promptfilter.ActionBlock, Reason: restriction.Message, FullText: restriction.ReasonCode}
+	if h.sendNewAPIPromptCyberRestriction(c, cfg, decision, verdict, responseBody, endpoint, model, signedBody, restriction) {
 		return true
 	}
+	writePromptCyberRestrictionHeaders(c, restriction)
+	apiErr := promptCyberRestrictionAPIError(restriction, nil)
 	if requestUsesAnthropicErrorEnvelope(c) {
-		sendAnthropicError(c, http.StatusBadRequest, "invalid_request_error", message)
+		c.JSON(http.StatusBadRequest, gin.H{"type": "error", "error": gin.H{
+			"type": string(apiErr.Type), "message": apiErr.Message, "details": apiErr.Details,
+		}})
 		return true
 	}
-	api.SendErrorWithStatus(c, api.NewAPIError(api.ErrorCode(reasonCode), message, api.ErrorTypeInvalidRequest), http.StatusBadRequest)
+	api.SendErrorWithStatus(c, apiErr, http.StatusBadRequest)
 	return true
 }

--- a/proxy/prompt_conversation_lock_test.go
+++ b/proxy/prompt_conversation_lock_test.go
@@ -4,14 +4,20 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"net/http/httptest"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/codex2api/auth"
 	"github.com/codex2api/cache"
 	"github.com/codex2api/database"
+	"github.com/gin-gonic/gin"
+	"github.com/tidwall/gjson"
 )
 
 func newPromptConversationLockTestHandler(t *testing.T) (*Handler, *database.DB) {
@@ -33,6 +39,17 @@ func newPromptConversationLockTestHandler(t *testing.T) (*Handler, *database.DB)
 	handler := NewHandler(store, db, nil, nil)
 	handler.SetRuntimeCache(cache.NewMemory(1))
 	return handler, db
+}
+
+func signedBoundPromptConversationContextWithRecorder(t *testing.T, requestID string, identity newAPIIdentity, body []byte, fingerprint string) (*gin.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	c, recorder := signedNewAPIPolicyContextWithSecret(t, requestID, identity, "/v1/responses", body, "gateway-a-secret")
+	c.Set(contextAPIKeyID, int64(101))
+	addSignedNewAPIPolicyMetaWithSecret(t, c, newAPIPolicyMeta{
+		PlatformID: "gateway-a", Profile: "balanced", Mode: "enforce",
+		Provider: "openai", Protocol: "responses", SessionFingerprint: fingerprint,
+	}, true, "gateway-a-secret")
+	return c, recorder
 }
 
 func TestExplicitUpstreamCYBLocksOnlyTheSignedConversation(t *testing.T) {
@@ -65,7 +82,7 @@ func TestExplicitUpstreamCYBLocksOnlyTheSignedConversation(t *testing.T) {
 		t.Fatalf("active lock = %#v err=%v", lock, err)
 	}
 
-	repeat := signedBoundNewAPIPolicyContext(t, "cyb-lock-repeat", identity, body, 101, "gateway-a", "gateway-a-secret", fingerprint)
+	repeat, repeatRecorder := signedBoundPromptConversationContextWithRecorder(t, "cyb-lock-repeat", identity, body, fingerprint)
 	setIngressRequestBodyIfAbsent(repeat, body)
 	if blocked := handler.inspectPromptFilterOpenAI(repeat, body, "/v1/responses", "gpt-5.5"); !blocked {
 		t.Fatal("locked conversation was forwarded")
@@ -76,6 +93,21 @@ func TestExplicitUpstreamCYBLocksOnlyTheSignedConversation(t *testing.T) {
 	}
 	if message := newAPIPolicyDecisionAPIError(repeatMetadata).Message; !strings.Contains(message, "不会重复累计") || !strings.Contains(message, "再次触发 CYB 可能会停用账号") {
 		t.Fatalf("locked retry message = %q", message)
+	}
+	if got := gjson.GetBytes(repeatRecorder.Body.Bytes(), "error.code").String(); got != promptConversationLockedReasonCode {
+		t.Fatalf("locked retry error code=%q body=%s", got, repeatRecorder.Body.String())
+	}
+	if got := gjson.GetBytes(repeatRecorder.Body.Bytes(), "error.details.restriction_scope").String(); got != database.PromptConversationRestrictionScopeConversation {
+		t.Fatalf("locked retry scope=%q body=%s", got, repeatRecorder.Body.String())
+	}
+	if got := gjson.GetBytes(repeatRecorder.Body.Bytes(), "error.details.retry_after_seconds").Int(); got <= 0 {
+		t.Fatalf("locked retry remaining=%d body=%s", got, repeatRecorder.Body.String())
+	}
+	if retryAfter := repeat.Writer.Header().Get("Retry-After"); retryAfter == "" {
+		t.Fatalf("locked retry missing Retry-After header: %v", repeat.Writer.Header())
+	}
+	if message := gjson.GetBytes(repeatRecorder.Body.Bytes(), "error.message").String(); !strings.Contains(message, "会话详情") || !strings.Contains(message, promptConversationLockedReasonCode) {
+		t.Fatalf("locked retry actionable message=%q", message)
 	}
 	lock, err = db.GetActivePromptConversationLock(t.Context(), lockIdentity.LockKey)
 	if err != nil || lock.TriggerCount != 1 {
@@ -98,7 +130,7 @@ func TestUpstreamCYBCoolsVerifiedUserAcrossSessionChurn(t *testing.T) {
 	setIngressRequestBodyIfAbsent(first, body)
 	handler.logUpstreamCyberPolicy(first, "/v1/responses", "gpt-5.5", []byte(`{"error":{"code":"cyber_policy"}}`))
 
-	churned := signedBoundNewAPIPolicyContext(t, "cyb-cooldown-churned", identity, body, 101, "gateway-a", "gateway-a-secret", "fedcba9876543210fedcba9876543210")
+	churned, churnedRecorder := signedBoundPromptConversationContextWithRecorder(t, "cyb-cooldown-churned", identity, body, "fedcba9876543210fedcba9876543210")
 	setIngressRequestBodyIfAbsent(churned, body)
 	if blocked := handler.inspectPromptFilterOpenAI(churned, body, "/v1/responses", "gpt-5.5"); !blocked {
 		t.Fatal("verified user bypassed CYB cooldown by changing session fingerprint")
@@ -109,6 +141,95 @@ func TestUpstreamCYBCoolsVerifiedUserAcrossSessionChurn(t *testing.T) {
 	}
 	if message := newAPIPolicyDecisionAPIError(metadata).Message; !strings.Contains(message, "30 分钟安全冷却期") || !strings.Contains(message, "不会重复累计处罚") {
 		t.Fatalf("user cooldown message = %q", message)
+	}
+	if got := gjson.GetBytes(churnedRecorder.Body.Bytes(), "error.code").String(); got != promptUserCyberCooldownReasonCode {
+		t.Fatalf("user cooldown error code=%q body=%s", got, churnedRecorder.Body.String())
+	}
+	if got := gjson.GetBytes(churnedRecorder.Body.Bytes(), "error.details.restriction_scope").String(); got != database.PromptConversationRestrictionScopeUserCooldown {
+		t.Fatalf("user cooldown scope=%q body=%s", got, churnedRecorder.Body.String())
+	}
+	if got := gjson.GetBytes(churnedRecorder.Body.Bytes(), "error.details.retry_after_seconds").Int(); got <= 0 || got > int64(promptUserCyberCooldownTTL/time.Second) {
+		t.Fatalf("user cooldown remaining=%d body=%s", got, churnedRecorder.Body.String())
+	}
+	if message := gjson.GetBytes(churnedRecorder.Body.Bytes(), "error.message").String(); !strings.Contains(message, "用户详情") || !strings.Contains(message, promptUserCyberCooldownReasonCode) {
+		t.Fatalf("user cooldown actionable message=%q", message)
+	}
+}
+
+func TestUpstreamCYBCoolsVerifiedUserWithoutSessionFingerprint(t *testing.T) {
+	handler, db := newPromptConversationLockTestHandler(t)
+	body := []byte(`{"model":"gpt-5.5","input":"ordinary request"}`)
+	identity := newAPIIdentity{UserID: "42", ClientIP: "203.0.113.8"}
+	first := signedBoundNewAPIPolicyContext(t, "cyb-cooldown-no-session-first", identity, body, 101, "gateway-a", "gateway-a-secret", "")
+	setIngressRequestBodyIfAbsent(first, body)
+	handler.logUpstreamCyberPolicy(first, "/v1/responses", "gpt-5.5", []byte(`{"error":{"code":"cyber_policy"}}`))
+
+	metadata, delegated := newAPIUpstreamCyberPolicyDecision(first)
+	if !delegated || metadata.ConversationLocked {
+		t.Fatalf("CYB without session response metadata = %+v delegated=%t", metadata, delegated)
+	}
+	item, exact, err := db.GetActivePromptConversationRestriction(t.Context(), "", "gateway-a", "42", 24*time.Hour, 30*time.Minute)
+	if err != nil || exact || item.NewAPIUserID != "42" || item.SessionFingerprint != "" || item.SessionHash != "" {
+		t.Fatalf("sessionless user cooldown = %#v exact=%t err=%v", item, exact, err)
+	}
+
+	repeat := signedBoundNewAPIPolicyContext(t, "cyb-cooldown-no-session-repeat", identity, body, 101, "gateway-a", "gateway-a-secret", "")
+	setIngressRequestBodyIfAbsent(repeat, body)
+	if blocked := handler.inspectPromptFilterOpenAI(repeat, body, "/v1/responses", "gpt-5.5"); !blocked {
+		t.Fatal("verified user without session bypassed CYB cooldown")
+	}
+	repeatMetadata := policyDecisionMetadataFromHeaders(repeat.Writer.Header())
+	if repeatMetadata.ReasonCode != promptUserCyberCooldownReasonCode || repeatMetadata.StrikeEligible {
+		t.Fatalf("sessionless user cooldown metadata = %+v", repeatMetadata)
+	}
+
+	withSession := signedBoundNewAPIPolicyContext(t, "cyb-cooldown-session-after-sessionless", identity, body, 101, "gateway-a", "gateway-a-secret", "0123456789abcdef0123456789abcdef")
+	setIngressRequestBodyIfAbsent(withSession, body)
+	if blocked := handler.inspectPromptFilterOpenAI(withSession, body, "/v1/responses", "gpt-5.5"); !blocked {
+		t.Fatal("verified user escaped sessionless CYB cooldown by later adding a session fingerprint")
+	}
+}
+
+func TestSessionlessUserCooldownBlocksConcurrentRetriesWithoutNewCYIncidents(t *testing.T) {
+	handler, db := newPromptConversationLockTestHandler(t)
+	body := []byte(`{"model":"gpt-5.5","input":"ordinary request"}`)
+	identity := newAPIIdentity{UserID: "42", ClientIP: "203.0.113.8"}
+	first := signedBoundNewAPIPolicyContext(t, "cyb-sessionless-concurrent-first", identity, body, 101, "gateway-a", "gateway-a-secret", "")
+	setIngressRequestBodyIfAbsent(first, body)
+	handler.logUpstreamCyberPolicy(first, "/v1/responses", "gpt-5.5", []byte(`{"error":{"code":"cyber_policy"}}`))
+	waitPromptFilterAuditIdle(t, db)
+
+	_, incidentTotalBefore, err := db.ListPromptPolicyIncidentsPage(t.Context(), database.PromptPolicyIncidentQuery{Page: 1, PageSize: 10})
+	if err != nil || incidentTotalBefore != 1 {
+		t.Fatalf("initial CY incidents total=%d err=%v", incidentTotalBefore, err)
+	}
+
+	const retries = 64
+	requests := make([]*gin.Context, 0, retries)
+	for index := 0; index < retries; index++ {
+		request := signedBoundNewAPIPolicyContext(t, "cyb-sessionless-concurrent-"+strconv.Itoa(index), identity, body, 101, "gateway-a", "gateway-a-secret", "")
+		setIngressRequestBodyIfAbsent(request, body)
+		requests = append(requests, request)
+	}
+	var blocked atomic.Int64
+	var wg sync.WaitGroup
+	for _, request := range requests {
+		wg.Add(1)
+		go func(c *gin.Context) {
+			defer wg.Done()
+			if handler.inspectPromptFilterOpenAI(c, body, "/v1/responses", "gpt-5.5") {
+				blocked.Add(1)
+			}
+		}(request)
+	}
+	wg.Wait()
+	if got := blocked.Load(); got != retries {
+		t.Fatalf("blocked concurrent retries=%d, want %d", got, retries)
+	}
+	waitPromptFilterAuditIdle(t, db)
+	_, incidentTotalAfter, err := db.ListPromptPolicyIncidentsPage(t.Context(), database.PromptPolicyIncidentQuery{Page: 1, PageSize: 10})
+	if err != nil || incidentTotalAfter != incidentTotalBefore {
+		t.Fatalf("concurrent retries created new CY incidents: before=%d after=%d err=%v", incidentTotalBefore, incidentTotalAfter, err)
 	}
 }
 

--- a/proxy/responses_ws.go
+++ b/proxy/responses_ws.go
@@ -1092,22 +1092,23 @@ func (h *Handler) inspectPromptFilterOpenAIForWebSocket(c *gin.Context, conn *we
 	}
 	cfg := h.promptFilterConfigForRequest(c)
 	if item, locked := h.activePromptConversationLock(c, cfg, nil); locked {
-		reasonCode, message := promptCyberRestrictionDecision(item)
+		restriction := promptCyberRestrictionDecision(item, cfg)
 		profile := strings.ToLower(strings.TrimSpace(cfg.Advanced.Guard.DefaultProfile))
 		switch profile {
 		case promptfilter.GuardProfileBalanced, promptfilter.GuardProfileStrict, promptfilter.GuardProfileResearch:
 		default:
 			profile = promptfilter.GuardProfileBalanced
 		}
-		decision := promptfilter.Decision{Action: promptfilter.ActionBlock, Profile: profile, ReasonCode: reasonCode, Terminal: true}
-		verdict := promptfilter.Verdict{Action: promptfilter.ActionBlock, Reason: message, FullText: reasonCode}
+		decision := promptfilter.Decision{Action: promptfilter.ActionBlock, Profile: profile, ReasonCode: restriction.ReasonCode, Terminal: true}
+		verdict := promptfilter.Verdict{Action: promptfilter.ActionBlock, Reason: restriction.Message, FullText: restriction.ReasonCode}
 		if policyContext, verified := h.verifyNewAPIPolicyContext(c, cfg.Advanced.NewAPI, nil); verified {
 			metadata := buildNewAPIPolicyDecisionMetadataWithSecret(policyContext.Identity, decision, verdict, cfg, rawBody, endpoint, model, policyEventID, policyContext.VerificationSecret)
 			writeNewAPIPolicyDecisionHeaders(c, metadata)
-			_ = writeResponsesWSError(conn, newAPIPolicyDecisionAPIError(metadata))
+			writePromptCyberRestrictionHeaders(c, restriction)
+			_ = writeResponsesWSError(conn, promptCyberRestrictionAPIError(restriction, newAPIPolicyDecisionDetails(metadata)))
 			return true, true
 		}
-		_ = writeResponsesWSError(conn, api.NewAPIError(api.ErrorCode(reasonCode), message, api.ErrorTypeInvalidRequest))
+		_ = writeResponsesWSError(conn, promptCyberRestrictionAPIError(restriction, nil))
 		return true, false
 	}
 	// Keep disabled filters off the WebSocket request-body hot path too.


### PR DESCRIPTION
## Summary

- return explicit conversation/user cooldown errors with retry metadata across HTTP, signed NewAPI, Anthropic and Responses WebSocket paths
- expose active user cooldowns in risk-profile details and allow administrators to release all active CY locks for a verified user
- keep exact-session unlock behavior backward compatible while adding restriction scope, expiry and remaining-time metadata
- add localized UI states, confirmation copy and regression coverage for bulk unlock, cache invalidation and response headers

## User impact

After an upstream CY event, follow-up requests now receive a clear error code, restriction scope, remaining time and manual-unlock location instead of a generic rejection. Operators can release either one conversation or the verified user cooldown from Prompt Check > Risk Profiles.

## Validation

- `go test ./...`
- `go build ./...`
- targeted `go test -race` for database/admin/proxy cooldown flows
- frontend 103 tests
- frontend typecheck
- frontend production build
- GitNexus staged impact: MEDIUM, 5 expected risk-profile processes

## Compatibility

The existing conversation unlock API remains the default. `scope=user_cooldown` is additive, and legacy clients keep exact-session behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added user-level safety cooldowns that can apply across sessions.
  - Admins can release either a single conversation restriction or all active cooldowns for a verified user.
  - Risk profiles now show restriction scope, expiration time, and remaining duration.
  - Blocked requests provide clearer restriction details, retry timing, and actionable messages across API and WebSocket responses.
  - Added localized support in English, Simplified Chinese, and Traditional Chinese.

- **Bug Fixes**
  - Ensured cooldowns persist across session changes and concurrent retries without creating duplicate incidents.
  - Improved cache invalidation after restrictions are released.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->