### PR TITLE
fix(grok): support Codex custom and dynamic tools

### DIFF
--- a/auth/grok_account.go
+++ b/auth/grok_account.go
@@ -360,9 +360,9 @@ func (a *Account) GrokChannelSupportsModel(model string) bool {
 	// confused with "catalog has never been fetched" and reopen defaults.
 	if len(candidates) == 0 && (a.grokRouting == nil || !a.grokRouting.CatalogKnown) {
 		if a.GrokAuthKindLocked() == GrokAuthKindAPIKey {
-			candidates = []string{"grok-4.5", "grok-4", "grok-3-fast", "grok-3", "grok-2"}
+			candidates = []string{"grok-4.6", "grok-4.5", "grok-4", "grok-3-fast", "grok-3", "grok-2"}
 		} else {
-			candidates = []string{"grok-4.5"}
+			candidates = []string{"grok-4.6", "grok-4.5"}
 		}
 	}
 	for _, candidate := range candidates {

--- a/proxy/grok_namespace_tools.go
+++ b/proxy/grok_namespace_tools.go
@@ -27,6 +27,24 @@ type grokNsIdentity struct {
 
 type grokAliasRegister func(namespace, name string, custom, toolSearch bool) string
 
+func newGrokAliasRegister() (grokAliasRegister, map[string]grokNsIdentity) {
+	aliases := make(map[string]grokNsIdentity)
+	registered := make(map[string]grokNsIdentity)
+	register := func(namespace, name string, custom, toolSearch bool) string {
+		alias := grokNamespaceAliasName(namespace, name)
+		if existing, ok := registered[alias]; ok && (existing.Namespace != namespace || existing.Name != name || existing.Custom != custom || existing.ToolSearch != toolSearch) {
+			alias = grokDisambiguatedAlias(alias, namespace, name)
+		}
+		identity := grokNsIdentity{Namespace: namespace, Name: name, Custom: custom, ToolSearch: toolSearch}
+		registered[alias] = identity
+		if custom || toolSearch || namespace != "" || alias != name {
+			aliases[alias] = identity
+		}
+		return alias
+	}
+	return register, aliases
+}
+
 const grokToolSearchProxyName = "tool_search"
 const grokToolCallHardLimitBytes = 128 * 1024
 
@@ -278,23 +296,9 @@ func normalizeGrokUpstreamTools(body []byte) ([]byte, map[string]grokNsIdentity)
 		return body, nil
 	}
 
-	aliases := make(map[string]grokNsIdentity)
-	registered := make(map[string]grokNsIdentity)
+	register, aliases := newGrokAliasRegister()
 	changed := false
 	webSearchDropped := false
-
-	register := func(namespace, name string, custom, toolSearch bool) string {
-		alias := grokNamespaceAliasName(namespace, name)
-		if existing, ok := registered[alias]; ok && (existing.Namespace != namespace || existing.Name != name || existing.Custom != custom || existing.ToolSearch != toolSearch) {
-			alias = grokDisambiguatedAlias(alias, namespace, name)
-		}
-		identity := grokNsIdentity{Namespace: namespace, Name: name, Custom: custom, ToolSearch: toolSearch}
-		registered[alias] = identity
-		if custom || toolSearch || namespace != "" || alias != name {
-			aliases[alias] = identity
-		}
-		return alias
-	}
 
 	// 1) tools[]：展平 namespace，归一 web_search。
 	if rawTools, ok := payload["tools"].([]any); ok {
@@ -700,6 +704,11 @@ type grokStreamReverser struct {
 }
 
 func (r *grokStreamReverser) rewriteLine(line []byte) []byte {
+	if !bytes.Contains(line, []byte(`"function_call"`)) &&
+		!bytes.Contains(line, []byte(`"response.function_call_arguments.`)) &&
+		!bytes.Contains(line, []byte(`"response.completed"`)) {
+		return line
+	}
 	trimmed := bytes.TrimRight(line, "\r\n")
 	suffix := line[len(trimmed):]
 	idx := bytes.Index(trimmed, []byte("data:"))
@@ -760,11 +769,13 @@ func (r *grokStreamReverser) rewriteLine(line []byte) []byte {
 		if itemID == "" {
 			itemID = grokNsStringField(event, "call_id")
 		}
-		if n := len(grokNsStringField(event, "arguments")); n > r.inputBytes[itemID] {
-			r.inputBytes[itemID] = n
-		}
-		if r.inputBytes[itemID] > grokToolCallHardLimitBytes {
-			return r.failureLine(head, gap, suffix, event, itemID)
+		if r.customItems[itemID] || r.toolSearchItems[itemID] {
+			if n := len(grokNsStringField(event, "arguments")); n > r.inputBytes[itemID] {
+				r.inputBytes[itemID] = n
+			}
+			if r.inputBytes[itemID] > grokToolCallHardLimitBytes {
+				return r.failureLine(head, gap, suffix, event, itemID)
+			}
 		}
 		if r.toolSearchItems[itemID] {
 			return nil

--- a/proxy/grok_namespace_tools.go
+++ b/proxy/grok_namespace_tools.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"io"
+	"reflect"
 	"strconv"
 	"strings"
 )
@@ -82,6 +83,30 @@ func grokFunctionToolForCustom(tool map[string]any, name string) map[string]any 
 	}
 	if description, ok := tool["description"].(string); ok {
 		converted["description"] = description
+	}
+	return converted
+}
+
+func normalizeGrokFunctionTool(tool map[string]any, name string) map[string]any {
+	converted := make(map[string]any, len(tool))
+	for key, value := range tool {
+		converted[key] = value
+	}
+	converted["type"] = "function"
+	converted["name"] = name
+	if _, ok := converted["parameters"]; !ok {
+		if schema, exists := converted["inputSchema"]; exists {
+			converted["parameters"] = schema
+		} else if schema, exists := converted["input_schema"]; exists {
+			converted["parameters"] = schema
+		}
+	}
+	for _, key := range []string{
+		"inputSchema", "input_schema", "deferLoading", "defer_loading",
+		"allowedCallers", "allowed_callers", "outputSchema", "output_schema",
+		"metadata", "x_provider",
+	} {
+		delete(converted, key)
 	}
 	return converted
 }
@@ -274,16 +299,30 @@ func normalizeGrokUpstreamTools(body []byte) ([]byte, map[string]grokNsIdentity)
 	// 1) tools[]：展平 namespace，归一 web_search。
 	if rawTools, ok := payload["tools"].([]any); ok {
 		newTools := make([]any, 0, len(rawTools))
+		emittedFunctions := make(map[string]bool)
+		appendTool := func(tool any) {
+			if object, ok := tool.(map[string]any); ok && grokNsStringField(object, "type") == "function" {
+				name := strings.TrimSpace(grokNsStringField(object, "name"))
+				if name != "" && emittedFunctions[name] {
+					changed = true
+					return
+				}
+				if name != "" {
+					emittedFunctions[name] = true
+				}
+			}
+			newTools = append(newTools, tool)
+		}
 		for _, rt := range rawTools {
 			tool, ok := rt.(map[string]any)
 			if !ok {
-				newTools = append(newTools, rt)
+				appendTool(rt)
 				continue
 			}
 			kind := grokNsStringField(tool, "type")
 			if kind == "tool_search" {
 				alias := register("", grokToolSearchProxyName, false, true)
-				newTools = append(newTools, grokFunctionToolForToolSearch(alias))
+				appendTool(grokFunctionToolForToolSearch(alias))
 				changed = true
 				continue
 			}
@@ -294,13 +333,17 @@ func normalizeGrokUpstreamTools(body []byte) ([]byte, map[string]grokNsIdentity)
 					tool["name"] = registered
 					changed = true
 				}
-				newTools = append(newTools, tool)
+				normalized := normalizeGrokFunctionTool(tool, registered)
+				if !reflect.DeepEqual(tool, normalized) {
+					changed = true
+				}
+				appendTool(normalized)
 				continue
 			}
 			if kind == "custom" {
 				name := strings.TrimSpace(grokNsStringField(tool, "name"))
 				alias := register("", name, true, false)
-				newTools = append(newTools, grokFunctionToolForCustom(tool, alias))
+				appendTool(grokFunctionToolForCustom(tool, alias))
 				changed = true
 				continue
 			}
@@ -310,14 +353,14 @@ func normalizeGrokUpstreamTools(body []byte) ([]byte, map[string]grokNsIdentity)
 					changed = true
 				}
 				if keep {
-					newTools = append(newTools, converted)
+					appendTool(converted)
 				} else {
 					webSearchDropped = true
 				}
 				continue
 			}
 			if kind != "namespace" {
-				newTools = append(newTools, tool)
+				appendTool(tool)
 				continue
 			}
 			namespace := strings.TrimSpace(grokNsStringField(tool, "name"))
@@ -336,10 +379,9 @@ func normalizeGrokUpstreamTools(body []byte) ([]byte, map[string]grokNsIdentity)
 				if childType == "custom" {
 					child = grokFunctionToolForCustom(child, alias)
 				} else {
-					child["name"] = alias
+					child = normalizeGrokFunctionTool(child, alias)
 				}
-				delete(child, "defer_loading")
-				newTools = append(newTools, child)
+				appendTool(child)
 			}
 			changed = true
 		}

--- a/proxy/grok_namespace_tools.go
+++ b/proxy/grok_namespace_tools.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"io"
+	"strconv"
 	"strings"
 )
 
@@ -17,8 +18,90 @@ import (
 // 逻辑对齐参考实现：请求侧展平 + 响应侧恢复的完整往返。
 
 type grokNsIdentity struct {
-	Namespace string
-	Name      string
+	Namespace  string
+	Name       string
+	Custom     bool
+	ToolSearch bool
+}
+
+type grokAliasRegister func(namespace, name string, custom, toolSearch bool) string
+
+const grokToolSearchProxyName = "tool_search"
+const grokToolCallHardLimitBytes = 128 * 1024
+
+func grokFunctionToolForToolSearch(name string) map[string]any {
+	return map[string]any{
+		"type": "function", "name": name,
+		"description": "Search and load Codex tools, plugins, connectors, and MCP namespaces for the current task.",
+		"parameters": map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"query": map[string]any{"type": "string"},
+				"limit": map[string]any{"type": "integer"},
+			},
+			"required": []string{"query"},
+		},
+	}
+}
+
+func grokJSONString(value any) string {
+	if text, ok := value.(string); ok {
+		return text
+	}
+	if value == nil {
+		return "{}"
+	}
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return "{}"
+	}
+	return string(encoded)
+}
+
+func grokToolSearchArguments(value any) any {
+	text := strings.TrimSpace(grokJSONString(value))
+	var decoded any
+	if text != "" && json.Unmarshal([]byte(text), &decoded) == nil {
+		return decoded
+	}
+	return text
+}
+
+func grokFunctionToolForCustom(tool map[string]any, name string) map[string]any {
+	converted := map[string]any{
+		"type": "function",
+		"name": name,
+		"parameters": map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"input": map[string]any{"type": "string"},
+			},
+			"required":             []string{"input"},
+			"additionalProperties": false,
+		},
+	}
+	if description, ok := tool["description"].(string); ok {
+		converted["description"] = description
+	}
+	return converted
+}
+
+func marshalGrokCustomToolArguments(input string) string {
+	encoded, err := json.Marshal(map[string]string{"input": input})
+	if err != nil {
+		return `{"input":""}`
+	}
+	return string(encoded)
+}
+
+func unwrapGrokCustomToolArguments(arguments string) string {
+	var decoded struct {
+		Input string `json:"input"`
+	}
+	if json.Unmarshal([]byte(arguments), &decoded) == nil {
+		return decoded.Input
+	}
+	return arguments
 }
 
 // grokNamespaceAliasName 生成扁平化后的函数名：namespace + name（命名空间已以 "__" 结尾时不再补分隔符）。
@@ -74,7 +157,7 @@ var grokNativeHistoryFields = map[string][]string{
 // rebuildGrokHistoryItem 把单个 input[] 历史项重建为 Grok 原生字段集：只保留白名单字段、丢弃 null，
 // function_call 携带 namespace 的改写成扁平名，外来 compaction 项换成边界消息。
 // 返回 (重建后的项, 是否发生改写)；未知类型原样返回不改。
-func rebuildGrokHistoryItem(item map[string]any, register func(namespace, name string) string) (map[string]any, bool) {
+func rebuildGrokHistoryItem(item map[string]any, register grokAliasRegister) (map[string]any, bool) {
 	itemType := grokNsStringField(item, "type")
 	if itemType == "" && grokNsStringField(item, "role") != "" {
 		itemType = "message" // Codex 可能省略带 role 消息的 type
@@ -83,6 +166,45 @@ func rebuildGrokHistoryItem(item map[string]any, register func(namespace, name s
 		// 外来 compaction 密文 Grok 解不了，直接换成边界消息。
 		return grokBoundaryMessage(), true
 	}
+	if itemType == "custom_tool_call" {
+		name := strings.TrimSpace(grokNsStringField(item, "name"))
+		namespace := strings.TrimSpace(grokNsStringField(item, "namespace"))
+		alias := register(namespace, name, true, false)
+		return map[string]any{
+			"type":      "function_call",
+			"call_id":   grokNsStringField(item, "call_id"),
+			"name":      alias,
+			"arguments": marshalGrokCustomToolArguments(grokNsStringField(item, "input")),
+		}, true
+	}
+	if itemType == "custom_tool_call_output" {
+		output := item["output"]
+		if output == nil {
+			output = ""
+		}
+		return map[string]any{
+			"type":    "function_call_output",
+			"call_id": grokNsStringField(item, "call_id"),
+			"output":  output,
+		}, true
+	}
+	if itemType == "tool_search_call" {
+		alias := register("", grokToolSearchProxyName, false, true)
+		return map[string]any{
+			"type": "function_call", "call_id": grokNsStringField(item, "call_id"),
+			"name": alias, "arguments": grokJSONString(item["arguments"]),
+		}, true
+	}
+	if itemType == "tool_search_output" || itemType == "tool_search_call_output" {
+		output := item["output"]
+		if output == nil {
+			output = item["tools"]
+		}
+		return map[string]any{
+			"type": "function_call_output", "call_id": grokNsStringField(item, "call_id"),
+			"output": grokJSONString(output),
+		}, true
+	}
 	fields, known := grokNativeHistoryFields[itemType]
 	if !known {
 		return item, false
@@ -90,7 +212,7 @@ func rebuildGrokHistoryItem(item map[string]any, register func(namespace, name s
 	// function_call 的 namespace 引用改写成扁平名，匹配已展平的工具声明。
 	if itemType == "function_call" {
 		if ns := strings.TrimSpace(grokNsStringField(item, "namespace")); ns != "" {
-			item["name"] = register(ns, strings.TrimSpace(grokNsStringField(item, "name")))
+			item["name"] = register(ns, strings.TrimSpace(grokNsStringField(item, "name")), false, false)
 		}
 	}
 	allowed := make(map[string]struct{}, len(fields))
@@ -132,15 +254,20 @@ func normalizeGrokUpstreamTools(body []byte) ([]byte, map[string]grokNsIdentity)
 	}
 
 	aliases := make(map[string]grokNsIdentity)
+	registered := make(map[string]grokNsIdentity)
 	changed := false
 	webSearchDropped := false
 
-	register := func(namespace, name string) string {
+	register := func(namespace, name string, custom, toolSearch bool) string {
 		alias := grokNamespaceAliasName(namespace, name)
-		if existing, ok := aliases[alias]; ok && (existing.Namespace != namespace || existing.Name != name) {
+		if existing, ok := registered[alias]; ok && (existing.Namespace != namespace || existing.Name != name || existing.Custom != custom || existing.ToolSearch != toolSearch) {
 			alias = grokDisambiguatedAlias(alias, namespace, name)
 		}
-		aliases[alias] = grokNsIdentity{Namespace: namespace, Name: name}
+		identity := grokNsIdentity{Namespace: namespace, Name: name, Custom: custom, ToolSearch: toolSearch}
+		registered[alias] = identity
+		if custom || toolSearch || namespace != "" || alias != name {
+			aliases[alias] = identity
+		}
 		return alias
 	}
 
@@ -154,6 +281,29 @@ func normalizeGrokUpstreamTools(body []byte) ([]byte, map[string]grokNsIdentity)
 				continue
 			}
 			kind := grokNsStringField(tool, "type")
+			if kind == "tool_search" {
+				alias := register("", grokToolSearchProxyName, false, true)
+				newTools = append(newTools, grokFunctionToolForToolSearch(alias))
+				changed = true
+				continue
+			}
+			if kind == "function" {
+				name := strings.TrimSpace(grokNsStringField(tool, "name"))
+				registered := register("", name, false, false)
+				if registered != name {
+					tool["name"] = registered
+					changed = true
+				}
+				newTools = append(newTools, tool)
+				continue
+			}
+			if kind == "custom" {
+				name := strings.TrimSpace(grokNsStringField(tool, "name"))
+				alias := register("", name, true, false)
+				newTools = append(newTools, grokFunctionToolForCustom(tool, alias))
+				changed = true
+				continue
+			}
 			if _, isWebSearch := grokWebSearchTypes[kind]; isWebSearch {
 				converted, keep, toolChanged := normalizeGrokWebSearchTool(tool)
 				if toolChanged {
@@ -174,11 +324,20 @@ func normalizeGrokUpstreamTools(body []byte) ([]byte, map[string]grokNsIdentity)
 			children, _ := tool["tools"].([]any)
 			for _, rc := range children {
 				child, ok := rc.(map[string]any)
-				if !ok || grokNsStringField(child, "type") != "function" {
+				if !ok {
+					continue
+				}
+				childType := grokNsStringField(child, "type")
+				if childType != "function" && childType != "custom" {
 					continue
 				}
 				name := strings.TrimSpace(grokNsStringField(child, "name"))
-				child["name"] = register(namespace, name)
+				alias := register(namespace, name, childType == "custom", false)
+				if childType == "custom" {
+					child = grokFunctionToolForCustom(child, alias)
+				} else {
+					child["name"] = alias
+				}
 				delete(child, "defer_loading")
 				newTools = append(newTools, child)
 			}
@@ -200,10 +359,21 @@ func normalizeGrokUpstreamTools(body []byte) ([]byte, map[string]grokNsIdentity)
 
 	// 2) tool_choice：{type:function,name,namespace} → {type:function,name:alias}。
 	if tc, ok := payload["tool_choice"].(map[string]any); ok {
-		if grokNsStringField(tc, "type") == "function" {
+		kind := grokNsStringField(tc, "type")
+		if kind == "custom" {
+			name := strings.TrimSpace(grokNsStringField(tc, "name"))
+			tc["type"] = "function"
+			tc["name"] = register(strings.TrimSpace(grokNsStringField(tc, "namespace")), name, true, false)
+			delete(tc, "namespace")
+			changed = true
+		} else if kind == "tool_search" {
+			tc["type"] = "function"
+			tc["name"] = register("", grokToolSearchProxyName, false, true)
+			changed = true
+		} else if kind == "function" {
 			if namespace := strings.TrimSpace(grokNsStringField(tc, "namespace")); namespace != "" {
 				name := strings.TrimSpace(grokNsStringField(tc, "name"))
-				tc["name"] = register(namespace, name)
+				tc["name"] = register(namespace, name, false, false)
 				delete(tc, "namespace")
 				changed = true
 			}
@@ -271,6 +441,7 @@ func grokWebSearchAllowedDomains(tool map[string]any) []any {
 // "Could not decode the compaction blob"。密文有两种载体：
 //   - reasoning 项的 encrypted_content（最常见）；
 //   - remote_compaction_v2 的 type:"compaction" 压缩项（内含 encrypted_content）。
+//
 // 处理：删掉 reasoning 等历史项的 encrypted_content（密文非回放前置条件，保留明文
 // summary/content 即可续接）；去密文后无可回放内容的 reasoning 项、以及整条 compaction 项，
 // 替换成一条纯文本边界消息。优雅降级，对齐参考实现对外来密文的处理。
@@ -372,6 +543,17 @@ func reverseGrokNamespaceValue(value any, aliases map[string]grokNsIdentity) boo
 				} else {
 					delete(typed, "namespace")
 				}
+				if identity.ToolSearch {
+					typed["type"] = "tool_search_call"
+					typed["execution"] = "client"
+					typed["arguments"] = grokToolSearchArguments(typed["arguments"])
+					delete(typed, "name")
+					delete(typed, "namespace")
+				} else if identity.Custom {
+					typed["type"] = "custom_tool_call"
+					typed["input"] = unwrapGrokCustomToolArguments(grokNsStringField(typed, "arguments"))
+					delete(typed, "arguments")
+				}
 				changed = true
 			}
 		}
@@ -442,12 +624,16 @@ func newGrokNamespaceReverser(body io.ReadCloser, streaming bool, aliases map[st
 			_ = pw.Close()
 			return
 		}
+		reverser := &grokStreamReverser{aliases: aliases, customItems: make(map[string]bool), toolSearchItems: make(map[string]bool), inputBytes: make(map[string]int)}
 		reader := bufio.NewReader(body)
 		for {
 			line, err := reader.ReadBytes('\n')
 			if len(line) > 0 {
-				if _, werr := pw.Write(reverseGrokNamespaceSSELine(line, aliases)); werr != nil {
-					return
+				rewritten := reverser.rewriteLine(line)
+				if len(rewritten) > 0 {
+					if _, werr := pw.Write(rewritten); werr != nil {
+						return
+					}
 				}
 			}
 			if err != nil {
@@ -461,4 +647,125 @@ func newGrokNamespaceReverser(body io.ReadCloser, streaming bool, aliases map[st
 		_ = pw.Close()
 	}()
 	return pr
+}
+
+type grokStreamReverser struct {
+	aliases         map[string]grokNsIdentity
+	customItems     map[string]bool
+	toolSearchItems map[string]bool
+	inputBytes      map[string]int
+	failed          bool
+}
+
+func (r *grokStreamReverser) rewriteLine(line []byte) []byte {
+	trimmed := bytes.TrimRight(line, "\r\n")
+	suffix := line[len(trimmed):]
+	idx := bytes.Index(trimmed, []byte("data:"))
+	if idx < 0 {
+		return line
+	}
+	head := trimmed[:idx+len("data:")]
+	payload := bytes.TrimLeft(trimmed[idx+len("data:"):], " ")
+	gap := trimmed[idx+len("data:") : len(trimmed)-len(payload)]
+	if len(payload) == 0 || payload[0] != '{' {
+		return line
+	}
+	var event map[string]any
+	if json.Unmarshal(payload, &event) != nil {
+		return line
+	}
+	eventType := grokNsStringField(event, "type")
+	if r.failed {
+		return nil
+	}
+	switch eventType {
+	case "response.output_item.added", "response.output_item.done":
+		if item, ok := event["item"].(map[string]any); ok {
+			name := grokNsStringField(item, "name")
+			identity, bridged := r.aliases[name]
+			if bridged && identity.Custom {
+				if id := grokNsStringField(item, "id"); id != "" {
+					r.customItems[id] = true
+				}
+				if callID := grokNsStringField(item, "call_id"); callID != "" {
+					r.customItems[callID] = true
+				}
+			}
+			if bridged && identity.ToolSearch {
+				if id := grokNsStringField(item, "id"); id != "" {
+					r.toolSearchItems[id] = true
+				}
+				if callID := grokNsStringField(item, "call_id"); callID != "" {
+					r.toolSearchItems[callID] = true
+				}
+			}
+			reverseGrokNamespaceValue(item, r.aliases)
+		}
+	case "response.function_call_arguments.delta":
+		itemID := grokNsStringField(event, "item_id")
+		if itemID == "" {
+			itemID = grokNsStringField(event, "call_id")
+		}
+		if r.customItems[itemID] || r.toolSearchItems[itemID] {
+			r.inputBytes[itemID] += len(grokNsStringField(event, "delta"))
+			if r.inputBytes[itemID] > grokToolCallHardLimitBytes {
+				return r.failureLine(head, gap, suffix, event, itemID)
+			}
+			return nil
+		}
+	case "response.function_call_arguments.done":
+		itemID := grokNsStringField(event, "item_id")
+		if itemID == "" {
+			itemID = grokNsStringField(event, "call_id")
+		}
+		if n := len(grokNsStringField(event, "arguments")); n > r.inputBytes[itemID] {
+			r.inputBytes[itemID] = n
+		}
+		if r.inputBytes[itemID] > grokToolCallHardLimitBytes {
+			return r.failureLine(head, gap, suffix, event, itemID)
+		}
+		if r.toolSearchItems[itemID] {
+			return nil
+		}
+		if r.customItems[itemID] {
+			event["type"] = "response.custom_tool_call_input.done"
+			event["input"] = unwrapGrokCustomToolArguments(grokNsStringField(event, "arguments"))
+			delete(event, "arguments")
+		}
+	case "response.completed":
+		if response, ok := event["response"].(map[string]any); ok {
+			reverseGrokNamespaceValue(response, r.aliases)
+		}
+	}
+	rewritten, err := json.Marshal(event)
+	if err != nil {
+		return line
+	}
+	out := make([]byte, 0, len(head)+len(gap)+len(rewritten)+len(suffix))
+	out = append(out, head...)
+	out = append(out, gap...)
+	out = append(out, rewritten...)
+	out = append(out, suffix...)
+	return out
+}
+
+func (r *grokStreamReverser) failureLine(head, gap, suffix []byte, source map[string]any, itemID string) []byte {
+	r.failed = true
+	failure := map[string]any{
+		"type": "response.failed",
+		"response": map[string]any{
+			"object": "response", "status": "failed", "status_code": 400,
+			"output": []any{},
+			"error": map[string]any{
+				"type": "invalid_request_error", "code": "invalid_prompt", "param": "tools", "status_code": 400,
+				"message": "tool_input_too_large: codex2api stopped an oversized tool call after " + strconv.Itoa(r.inputBytes[itemID]) + " bytes (limit " + strconv.Itoa(grokToolCallHardLimitBytes) + "). Split the work into smaller batches.",
+			},
+		},
+	}
+	if sequence, ok := source["sequence_number"]; ok {
+		failure["sequence_number"] = sequence
+	}
+	encoded, _ := json.Marshal(failure)
+	out := append(append(append(append([]byte{}, head...), gap...), encoded...), suffix...)
+	return out
 }

--- a/proxy/grok_namespace_tools_test.go
+++ b/proxy/grok_namespace_tools_test.go
@@ -153,6 +153,60 @@ func TestGrokAdditionalToolsAndToolSearchMatrix(t *testing.T) {
 	}
 }
 
+func TestGrokToolSearchOutputInjectsDynamicTools(t *testing.T) {
+	body := []byte(`{
+		"model":"grok-4.6",
+		"tools":[
+			{"type":"tool_search"},
+			{"type":"namespace","name":"codex_app","tools":[{"type":"function","name":"load_workspace_dependencies","inputSchema":{"type":"object","properties":{},"additionalProperties":false},"deferLoading":true}]}
+		],
+		"input":[
+			{"type":"tool_search_call","call_id":"ts_1","execution":"client","arguments":{"query":"workspace dependencies"}},
+			{"type":"tool_search_output","call_id":"ts_1","tools":[
+				{"type":"namespace","name":"codex_app","tools":[
+					{"type":"function","name":"load_workspace_dependencies","inputSchema":{"type":"object","properties":{},"additionalProperties":false},"deferLoading":true},
+					{"type":"custom","name":"dynamic_patch","description":"dynamic custom tool","defer_loading":true}
+				]}
+			]},
+			{"type":"additional_tools","tools":[{"type":"namespace","name":"codex_app","tools":[{"type":"function","name":"load_workspace_dependencies","input_schema":{"type":"object","properties":{}}}]}]},
+			{"type":"message","role":"user","content":"use the loaded tool"}
+		]
+	}`)
+	result := prepareGrokUpstreamBody(body)
+	if gjson.GetBytes(result.Body, `input.#(type=="additional_tools")`).Exists() {
+		t.Fatalf("additional_tools leaked upstream: %s", result.Body)
+	}
+	if got := gjson.GetBytes(result.Body, "input.1.type").String(); got != "function_call_output" {
+		t.Fatalf("tool_search output history type = %q; body=%s", got, result.Body)
+	}
+	loadedCount := 0
+	customCount := 0
+	for _, raw := range gjson.GetBytes(result.Body, "tools").Array() {
+		name := raw.Get("name").String()
+		identity := result.Aliases[name]
+		if identity.Namespace == "codex_app" && identity.Name == "load_workspace_dependencies" {
+			loadedCount++
+			if raw.Get("parameters.type").String() != "object" {
+				t.Fatalf("dynamic function inputSchema was not normalized: %s", raw.Raw)
+			}
+			for _, field := range []string{"inputSchema", "input_schema", "deferLoading", "defer_loading"} {
+				if raw.Get(field).Exists() {
+					t.Fatalf("dynamic function leaked %s: %s", field, raw.Raw)
+				}
+			}
+		}
+		if identity.Namespace == "codex_app" && identity.Name == "dynamic_patch" && identity.Custom {
+			customCount++
+		}
+	}
+	if loadedCount != 1 {
+		t.Fatalf("loaded dynamic function count = %d, want 1; aliases=%#v body=%s", loadedCount, result.Aliases, result.Body)
+	}
+	if customCount != 1 {
+		t.Fatalf("loaded dynamic custom count = %d, want 1; aliases=%#v body=%s", customCount, result.Aliases, result.Body)
+	}
+}
+
 func TestGrokGiantCustomToolGuard(t *testing.T) {
 	body := []byte(`{"model":"grok-4.6","tools":[{"type":"custom","name":"apply_patch"}],"input":"patch"}`)
 	result := prepareGrokUpstreamBody(body)

--- a/proxy/grok_namespace_tools_test.go
+++ b/proxy/grok_namespace_tools_test.go
@@ -2,10 +2,212 @@ package proxy
 
 import (
 	"encoding/json"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/tidwall/gjson"
 )
+
+func TestGrokCustomToolCompatibilityMatrix(t *testing.T) {
+	body := []byte(`{
+		"model":"grok-4.6",
+		"tools":[
+			{"type":"custom","name":"apply_patch","description":"patch files","format":{"type":"grammar","syntax":"lark","definition":"start: /.+/"}},
+			{"type":"namespace","name":"computer","tools":[{"type":"custom","name":"operate","description":"use computer"}]}
+		],
+		"tool_choice":{"type":"custom","name":"operate","namespace":"computer"},
+		"input":[
+			{"type":"custom_tool_call","call_id":"call_1","name":"apply_patch","input":"*** Begin Patch"},
+			{"type":"custom_tool_call_output","call_id":"call_1","output":null}
+		]
+	}`)
+
+	result := prepareGrokUpstreamBody(body)
+	if strings.Contains(string(result.Body), `"type":"custom"`) || strings.Contains(string(result.Body), `"type":"namespace"`) {
+		t.Fatalf("Codex-only tool variants leaked upstream: %s", result.Body)
+	}
+	if got := gjson.GetBytes(result.Body, "tools.0.type").String(); got != "function" {
+		t.Fatalf("top-level custom type = %q", got)
+	}
+	if got := gjson.GetBytes(result.Body, "tools.0.parameters.required.0").String(); got != "input" {
+		t.Fatalf("custom wrapper schema did not require input: %s", result.Body)
+	}
+	if got := gjson.GetBytes(result.Body, "tool_choice.type").String(); got != "function" {
+		t.Fatalf("custom tool_choice type = %q", got)
+	}
+	choiceName := gjson.GetBytes(result.Body, "tool_choice.name").String()
+	identity, ok := result.Aliases[choiceName]
+	if !ok || !identity.Custom || identity.Namespace != "computer" || identity.Name != "operate" {
+		t.Fatalf("custom tool_choice alias = %q %#v", choiceName, identity)
+	}
+	if got := gjson.GetBytes(result.Body, "input.0.type").String(); got != "function_call" {
+		t.Fatalf("custom history call type = %q", got)
+	}
+	if got := gjson.GetBytes(result.Body, "input.0.arguments").String(); got != `{"input":"*** Begin Patch"}` {
+		t.Fatalf("custom history arguments = %q", got)
+	}
+	if got := gjson.GetBytes(result.Body, "input.1.output").String(); got != "" {
+		t.Fatalf("nil custom output = %q", got)
+	}
+}
+
+func TestGrokCustomAndFunctionNameCollision(t *testing.T) {
+	body := []byte(`{"tools":[{"type":"function","name":"same","parameters":{"type":"object"}},{"type":"custom","name":"same"}],"input":"x"}`)
+	result := prepareGrokUpstreamBody(body)
+	first := gjson.GetBytes(result.Body, "tools.0.name").String()
+	second := gjson.GetBytes(result.Body, "tools.1.name").String()
+	if first == second {
+		t.Fatalf("function/custom collision reused alias %q: %s", first, result.Body)
+	}
+	if result.Aliases[first].Custom || !result.Aliases[second].Custom {
+		t.Fatalf("alias identities lost function/custom distinction: %#v", result.Aliases)
+	}
+}
+
+func TestGrokCustomResponseRestoration(t *testing.T) {
+	aliases := map[string]grokNsIdentity{"apply_patch": {Name: "apply_patch", Custom: true}}
+	nonStream := reverseGrokNamespaceJSON([]byte(`{"output":[{"type":"function_call","id":"fc_1","call_id":"call_1","name":"apply_patch","arguments":"{\"input\":\"patch text\"}"}]}`), aliases)
+	if got := gjson.GetBytes(nonStream, "output.0.type").String(); got != "custom_tool_call" {
+		t.Fatalf("non-stream type = %q; body=%s", got, nonStream)
+	}
+	if got := gjson.GetBytes(nonStream, "output.0.input").String(); got != "patch text" {
+		t.Fatalf("non-stream input = %q; body=%s", got, nonStream)
+	}
+
+	r := &grokStreamReverser{aliases: aliases, customItems: map[string]bool{}, toolSearchItems: map[string]bool{}, inputBytes: map[string]int{}}
+	added := r.rewriteLine([]byte("data: {\"type\":\"response.output_item.added\",\"item\":{\"type\":\"function_call\",\"id\":\"fc_1\",\"call_id\":\"call_1\",\"name\":\"apply_patch\",\"arguments\":\"\"}}\n"))
+	if got := gjson.GetBytes(bytesAfterSSEData(added), "item.type").String(); got != "custom_tool_call" {
+		t.Fatalf("stream added type = %q; line=%s", got, added)
+	}
+	delta := r.rewriteLine([]byte("data: {\"type\":\"response.function_call_arguments.delta\",\"item_id\":\"fc_1\",\"delta\":\"{\"}\n"))
+	if delta != nil {
+		t.Fatalf("custom function delta leaked: %s", delta)
+	}
+	done := r.rewriteLine([]byte("data: {\"type\":\"response.function_call_arguments.done\",\"item_id\":\"fc_1\",\"arguments\":\"{\\\"input\\\":\\\"patch text\\\"}\"}\n"))
+	if got := gjson.GetBytes(bytesAfterSSEData(done), "type").String(); got != "response.custom_tool_call_input.done" {
+		t.Fatalf("stream done type = %q; line=%s", got, done)
+	}
+	if got := gjson.GetBytes(bytesAfterSSEData(done), "input").String(); got != "patch text" {
+		t.Fatalf("stream done input = %q; line=%s", got, done)
+	}
+}
+
+func TestGrokAdditionalToolsAndToolSearchMatrix(t *testing.T) {
+	body := []byte(`{
+		"model":"grok-4.6",
+		"input":[
+			{"type":"additional_tools","tools":[{"type":"tool_search"},{"type":"namespace","name":"deferred","tools":[{"type":"custom","name":"run"}]}]},
+			{"type":"message","role":"user","content":"find and run a tool"},
+			{"type":"tool_search_call","call_id":"ts_1","execution":"client","arguments":{"query":"github","limit":3}},
+			{"type":"tool_search_output","call_id":"ts_1","tools":[{"name":"github"}]}
+		],
+		"tool_choice":{"type":"tool_search"}
+	}`)
+	result := prepareGrokUpstreamBody(body)
+	if gjson.GetBytes(result.Body, `input.#(type=="additional_tools")`).Exists() {
+		t.Fatalf("additional_tools carrier leaked upstream: %s", result.Body)
+	}
+	if strings.Contains(string(result.Body), `"type":"tool_search"`) || strings.Contains(string(result.Body), `"type":"namespace"`) {
+		t.Fatalf("Codex-only tool declaration leaked upstream: %s", result.Body)
+	}
+	proxyName := ""
+	for alias, metadata := range result.Aliases {
+		if metadata.ToolSearch {
+			proxyName = alias
+			break
+		}
+	}
+	identity, ok := result.Aliases[proxyName]
+	if !ok || !identity.ToolSearch {
+		t.Fatalf("tool_search proxy identity missing: name=%q aliases=%#v body=%s", proxyName, result.Aliases, result.Body)
+	}
+	if got := gjson.GetBytes(result.Body, "input.1.type").String(); got != "function_call" {
+		t.Fatalf("tool_search history call type = %q; body=%s", got, result.Body)
+	}
+	if got := gjson.GetBytes(result.Body, "input.2.type").String(); got != "function_call_output" {
+		t.Fatalf("tool_search output type = %q; body=%s", got, result.Body)
+	}
+	if got := gjson.GetBytes(result.Body, "tool_choice.name").String(); got != proxyName {
+		t.Fatalf("tool_search choice name = %q, want %q", got, proxyName)
+	}
+
+	nonStream := reverseGrokNamespaceJSON([]byte(`{"output":[{"type":"function_call","id":"fc_ts","call_id":"ts_2","name":"`+proxyName+`","arguments":"{\"query\":\"github\"}"}]}`), result.Aliases)
+	if got := gjson.GetBytes(nonStream, "output.0.type").String(); got != "tool_search_call" {
+		t.Fatalf("restored tool_search type = %q; body=%s", got, nonStream)
+	}
+	if got := gjson.GetBytes(nonStream, "output.0.arguments.query").String(); got != "github" {
+		t.Fatalf("restored tool_search query = %q; body=%s", got, nonStream)
+	}
+
+	r := &grokStreamReverser{aliases: result.Aliases, customItems: map[string]bool{}, toolSearchItems: map[string]bool{}, inputBytes: map[string]int{}}
+	added := r.rewriteLine([]byte("data: {\"type\":\"response.output_item.added\",\"item\":{\"type\":\"function_call\",\"id\":\"fc_ts\",\"call_id\":\"ts_2\",\"name\":\"" + proxyName + "\",\"arguments\":\"\"}}\n"))
+	if got := gjson.GetBytes(bytesAfterSSEData(added), "item.type").String(); got != "tool_search_call" {
+		t.Fatalf("stream tool_search added type = %q; line=%s", got, added)
+	}
+	if leaked := r.rewriteLine([]byte("data: {\"type\":\"response.function_call_arguments.delta\",\"item_id\":\"fc_ts\",\"delta\":\"{}\"}\n")); leaked != nil {
+		t.Fatalf("tool_search argument delta leaked: %s", leaked)
+	}
+	if leaked := r.rewriteLine([]byte("data: {\"type\":\"response.function_call_arguments.done\",\"item_id\":\"fc_ts\",\"arguments\":\"{}\"}\n")); leaked != nil {
+		t.Fatalf("tool_search argument done leaked: %s", leaked)
+	}
+}
+
+func TestGrokGiantCustomToolGuard(t *testing.T) {
+	body := []byte(`{"model":"grok-4.6","tools":[{"type":"custom","name":"apply_patch"}],"input":"patch"}`)
+	result := prepareGrokUpstreamBody(body)
+	if !strings.Contains(gjson.GetBytes(result.Body, "instructions").String(), grokGiantToolInstructionMarker) {
+		t.Fatalf("apply_patch guard instructions missing: %s", result.Body)
+	}
+	aliases := result.Aliases
+	r := &grokStreamReverser{aliases: aliases, customItems: map[string]bool{}, toolSearchItems: map[string]bool{}, inputBytes: map[string]int{}}
+	_ = r.rewriteLine([]byte("data: {\"type\":\"response.output_item.added\",\"item\":{\"type\":\"function_call\",\"id\":\"fc_big\",\"name\":\"apply_patch\"}}\n"))
+	large := strings.Repeat("x", grokToolCallHardLimitBytes+1)
+	line := []byte("data: " + string(mustJSON(t, map[string]any{"type": "response.function_call_arguments.delta", "item_id": "fc_big", "delta": large})) + "\n")
+	failure := r.rewriteLine(line)
+	if got := gjson.GetBytes(bytesAfterSSEData(failure), "type").String(); got != "response.failed" {
+		t.Fatalf("oversized custom call did not fail: type=%q line=%s", got, failure)
+	}
+	if got := gjson.GetBytes(bytesAfterSSEData(failure), "response.error.code").String(); got != "invalid_prompt" {
+		t.Fatalf("oversized custom error code = %q", got)
+	}
+}
+
+func mustJSON(t *testing.T, value any) []byte {
+	t.Helper()
+	out, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return out
+}
+
+func TestGrokToolMappingsAreRequestLocal(t *testing.T) {
+	const workers = 32
+	errCh := make(chan string, workers)
+	for i := 0; i < workers; i++ {
+		go func(i int) {
+			name := "custom_" + strconv.Itoa(i)
+			body := []byte(`{"tools":[{"type":"custom","name":"` + name + `"}],"input":"x"}`)
+			result := prepareGrokUpstreamBody(body)
+			if len(result.Aliases) != 1 || !result.Aliases[name].Custom {
+				errCh <- name
+				return
+			}
+			errCh <- ""
+		}(i)
+	}
+	for i := 0; i < workers; i++ {
+		if name := <-errCh; name != "" {
+			t.Fatalf("request-local mapping lost for %s", name)
+		}
+	}
+}
+
+func bytesAfterSSEData(line []byte) []byte {
+	trimmed := strings.TrimSpace(string(line))
+	return []byte(strings.TrimSpace(strings.TrimPrefix(trimmed, "data:")))
+}
 
 func TestFlattenGrokNamespaceTools(t *testing.T) {
 	body := []byte(`{
@@ -204,7 +406,7 @@ func TestReverseGrokNamespaceSSELine(t *testing.T) {
 }
 
 func TestRebuildGrokHistoryToNativeContract(t *testing.T) {
-	reg := func(ns, name string) string { return ns + "__" + name }
+	reg := func(ns, name string, _, _ bool) string { return ns + "__" + name }
 	// Codex 发的历史项带扩展字段/null；重建后应只剩 Grok 原生字段。
 	cases := []struct {
 		name   string

--- a/proxy/grok_namespace_tools_test.go
+++ b/proxy/grok_namespace_tools_test.go
@@ -227,6 +227,49 @@ func TestGrokGiantCustomToolGuard(t *testing.T) {
 	}
 }
 
+func TestGrokGiantToolGuardIsCaseInsensitiveAndPreservesNumbers(t *testing.T) {
+	body := []byte(`{"seed":9007199254740993,"tools":[{"type":"custom","name":"APPLY_PATCH"}],"input":"patch"}`)
+	guarded, changed := addGrokGiantToolInstructions(body)
+	if !changed {
+		t.Fatal("case-insensitive apply_patch name did not enable guard")
+	}
+	if !strings.Contains(string(guarded), `"seed":9007199254740993`) {
+		t.Fatalf("large integer changed during guard injection: %s", guarded)
+	}
+}
+
+func TestGrokAdditionalToolsPreservesNumbers(t *testing.T) {
+	body := []byte(`{"seed":9007199254740993,"input":[{"type":"additional_tools","tools":[{"type":"function","name":"lookup","parameters":{"type":"object"}}]}]}`)
+	lifted, changed := liftGrokAdditionalTools(body)
+	if !changed {
+		t.Fatal("additional_tools carrier was not lifted")
+	}
+	if !strings.Contains(string(lifted), `"seed":9007199254740993`) {
+		t.Fatalf("large integer changed while lifting tools: %s", lifted)
+	}
+}
+
+func TestGrokPlainFunctionDoneBypassesBridgedSizeLimit(t *testing.T) {
+	r := &grokStreamReverser{aliases: map[string]grokNsIdentity{}, customItems: map[string]bool{}, toolSearchItems: map[string]bool{}, inputBytes: map[string]int{}}
+	arguments := strings.Repeat("x", grokToolCallHardLimitBytes+1)
+	line := []byte("data: " + string(mustJSON(t, map[string]any{"type": "response.function_call_arguments.done", "item_id": "plain", "arguments": arguments})) + "\n")
+	got := r.rewriteLine(line)
+	if string(got) != string(line) {
+		t.Fatalf("plain function call was rewritten or rejected: %s", got)
+	}
+}
+
+func TestGrokStreamFastPathIncludesFunctionArgumentsEvents(t *testing.T) {
+	r := &grokStreamReverser{aliases: map[string]grokNsIdentity{}, customItems: map[string]bool{"custom": true}, toolSearchItems: map[string]bool{}, inputBytes: map[string]int{}}
+	line := []byte("data: {\"type\":\"response.function_call_arguments.delta\",\"item_id\":\"custom\",\"delta\":\"{}\"}\n")
+	if got := r.rewriteLine(line); got != nil {
+		t.Fatalf("bridged arguments delta bypassed stream handling: %s", got)
+	}
+	if r.inputBytes["custom"] != 2 {
+		t.Fatalf("bridged arguments delta was not accounted: %d", r.inputBytes["custom"])
+	}
+}
+
 func mustJSON(t *testing.T, value any) []byte {
 	t.Helper()
 	out, err := json.Marshal(value)

--- a/proxy/grok_preflight.go
+++ b/proxy/grok_preflight.go
@@ -42,6 +42,12 @@ var grokDroppedTopLevelFields = map[string]struct{}{
 // 钳制、无工具时撤掉 tool_choice，并顺带算出轮次序号与模型名。
 // 请求体非法 JSON 或顶层不是对象时原样返回，交由上游报错。
 func prepareGrokUpstreamBody(body []byte) grokPreflightResult {
+	if lifted, changed := liftGrokAdditionalTools(body); changed {
+		return prepareGrokUpstreamBody(lifted)
+	}
+	if guarded, changed := addGrokGiantToolInstructions(body); changed {
+		return prepareGrokUpstreamBody(guarded)
+	}
 	result := grokPreflightResult{Body: body, TurnIndex: 1}
 	if !gjson.ValidBytes(body) {
 		return result
@@ -56,12 +62,17 @@ func prepareGrokUpstreamBody(body []byte) grokPreflightResult {
 	}
 
 	aliases := make(map[string]grokNsIdentity)
-	register := func(namespace, name string) string {
+	registered := make(map[string]grokNsIdentity)
+	register := func(namespace, name string, custom, toolSearch bool) string {
 		alias := grokNamespaceAliasName(namespace, name)
-		if existing, ok := aliases[alias]; ok && (existing.Namespace != namespace || existing.Name != name) {
+		if existing, ok := registered[alias]; ok && (existing.Namespace != namespace || existing.Name != name || existing.Custom != custom || existing.ToolSearch != toolSearch) {
 			alias = grokDisambiguatedAlias(alias, namespace, name)
 		}
-		aliases[alias] = grokNsIdentity{Namespace: namespace, Name: name}
+		identity := grokNsIdentity{Namespace: namespace, Name: name, Custom: custom, ToolSearch: toolSearch}
+		registered[alias] = identity
+		if custom || toolSearch || namespace != "" || alias != name {
+			aliases[alias] = identity
+		}
 		return alias
 	}
 
@@ -160,6 +171,88 @@ func prepareGrokUpstreamBody(body []byte) grokPreflightResult {
 	return result
 }
 
+const grokGiantToolInstructionMarker = "[codex2api giant-tool-call guard]"
+
+func addGrokGiantToolInstructions(body []byte) ([]byte, bool) {
+	if !bytes.Contains(body, []byte(`"apply_patch"`)) || bytes.Contains(body, []byte(grokGiantToolInstructionMarker)) {
+		return body, false
+	}
+	var request map[string]any
+	if json.Unmarshal(body, &request) != nil || !grokBodyHasNamedTool(request, "apply_patch") {
+		return body, false
+	}
+	guidance := grokGiantToolInstructionMarker + "\nWhen using apply_patch or another code-writing tool, modify at most 2 files per call and keep each tool input below 96 KiB. Split larger work into verified batches."
+	existing := strings.TrimSpace(grokNsStringField(request, "instructions"))
+	if existing != "" {
+		guidance = existing + "\n\n" + guidance
+	}
+	request["instructions"] = guidance
+	out, err := json.Marshal(request)
+	return out, err == nil
+}
+
+func grokBodyHasNamedTool(request map[string]any, want string) bool {
+	var scan func([]any) bool
+	scan = func(tools []any) bool {
+		for _, raw := range tools {
+			tool, ok := raw.(map[string]any)
+			if !ok {
+				continue
+			}
+			if strings.EqualFold(strings.TrimSpace(grokNsStringField(tool, "name")), want) {
+				return true
+			}
+			if nested, ok := tool["tools"].([]any); ok && scan(nested) {
+				return true
+			}
+		}
+		return false
+	}
+	tools, _ := request["tools"].([]any)
+	return scan(tools)
+}
+
+func liftGrokAdditionalTools(body []byte) ([]byte, bool) {
+	if !bytes.Contains(body, []byte(`"additional_tools"`)) {
+		return body, false
+	}
+	var request map[string]any
+	if json.Unmarshal(body, &request) != nil {
+		return body, false
+	}
+	input, ok := request["input"].([]any)
+	if !ok {
+		return body, false
+	}
+	tools, _ := request["tools"].([]any)
+	filtered := make([]any, 0, len(input))
+	changed := false
+	for _, raw := range input {
+		item, itemOK := raw.(map[string]any)
+		if !itemOK || strings.TrimSpace(grokNsStringField(item, "type")) != "additional_tools" {
+			filtered = append(filtered, raw)
+			continue
+		}
+		additional, toolsOK := item["tools"].([]any)
+		if !toolsOK {
+			filtered = append(filtered, raw)
+			continue
+		}
+		tools = append(tools, additional...)
+		changed = true
+	}
+	if !changed {
+		return body, false
+	}
+	request["input"] = filtered
+	request["tools"] = tools
+	out, err := json.Marshal(request)
+	if err != nil {
+		return body, false
+	}
+	return out, true
+}
+
 // grokWriteObjectKey 写出 JSON 对象里的 `"key":`，必要时补上分隔逗号。
 func grokWriteObjectKey(out *bytes.Buffer, first *bool, key gjson.Result) {
 	if !*first {
@@ -180,7 +273,7 @@ func grokWriteObjectKey(out *bytes.Buffer, first *bool, key gjson.Result) {
 // 降级为上游接受的最小形态，其余工具原样拷贝。
 // 返回 (新数组 JSON, 是否改写, 归一后是否等同于"没有工具", 是否移除过 web_search)。
 // "没有工具"含 tools 缺失与归一后空数组两种——两者都让 tool_choice 失去意义。
-func grokNormalizeToolsRaw(tools gjson.Result, register func(namespace, name string) string) (raw []byte, changed, empty, webSearchDropped bool) {
+func grokNormalizeToolsRaw(tools gjson.Result, register grokAliasRegister) (raw []byte, changed, empty, webSearchDropped bool) {
 	if !tools.Exists() {
 		return nil, false, true, false
 	}
@@ -222,6 +315,39 @@ func grokNormalizeToolsRaw(tools gjson.Result, register func(namespace, name str
 			return true
 		}
 		kind := tool.Get("type").String()
+		if kind == "tool_search" {
+			writeObject(grokFunctionToolForToolSearch(register("", grokToolSearchProxyName, false, true)))
+			changed = true
+			return true
+		}
+		if kind == "function" {
+			name := strings.TrimSpace(tool.Get("name").String())
+			registered := register("", name, false, false)
+			if registered == name {
+				writeRaw(tool.Raw)
+				return true
+			}
+			decoded, ok := grokDecodeObject(tool.Raw)
+			if !ok {
+				writeRaw(tool.Raw)
+				return true
+			}
+			decoded["name"] = registered
+			writeObject(decoded)
+			changed = true
+			return true
+		}
+		if kind == "custom" {
+			decoded, ok := grokDecodeObject(tool.Raw)
+			if !ok {
+				writeRaw(tool.Raw)
+				return true
+			}
+			name := strings.TrimSpace(grokNsStringField(decoded, "name"))
+			writeObject(grokFunctionToolForCustom(decoded, register("", name, true, false)))
+			changed = true
+			return true
+		}
 		if _, isWebSearch := grokWebSearchTypes[kind]; isWebSearch {
 			decoded, ok := grokDecodeObject(tool.Raw)
 			if !ok {
@@ -247,16 +373,22 @@ func grokNormalizeToolsRaw(tools gjson.Result, register func(namespace, name str
 		}
 		namespace := strings.TrimSpace(tool.Get("name").String())
 		tool.Get("tools").ForEach(func(_, child gjson.Result) bool {
-			if !child.IsObject() || child.Get("type").String() != "function" {
+			childType := child.Get("type").String()
+			if !child.IsObject() || (childType != "function" && childType != "custom") {
 				return true
 			}
 			decoded, ok := grokDecodeObject(child.Raw)
 			if !ok {
 				return true
 			}
-			decoded["name"] = register(namespace, strings.TrimSpace(grokNsStringField(decoded, "name")))
-			delete(decoded, "defer_loading")
-			writeObject(decoded)
+			alias := register(namespace, strings.TrimSpace(grokNsStringField(decoded, "name")), childType == "custom", false)
+			if childType == "custom" {
+				writeObject(grokFunctionToolForCustom(decoded, alias))
+			} else {
+				decoded["name"] = alias
+				delete(decoded, "defer_loading")
+				writeObject(decoded)
+			}
 			return true
 		})
 		changed = true
@@ -271,7 +403,7 @@ func grokNormalizeToolsRaw(tools gjson.Result, register func(namespace, name str
 // tool_choice 但 tools 为空"硬校验 400）。
 // 判定顺序与逐步改写实现一致：先 web_search 撤销、再 namespace 改写、最后空工具撤销，
 // 使 namespace 别名的注册时机不受影响。
-func grokNormalizeToolChoiceRaw(choice gjson.Result, toolsEmpty, webSearchDropped bool, register func(namespace, name string) string) (raw []byte, changed, dropped bool) {
+func grokNormalizeToolChoiceRaw(choice gjson.Result, toolsEmpty, webSearchDropped bool, register grokAliasRegister) (raw []byte, changed, dropped bool) {
 	if !choice.Exists() {
 		return nil, false, false
 	}
@@ -282,10 +414,23 @@ func grokNormalizeToolChoiceRaw(choice gjson.Result, toolsEmpty, webSearchDroppe
 				return nil, false, true
 			}
 		}
-		if kind == "function" {
+		if kind == "custom" {
+			if decoded, ok := grokDecodeObject(choice.Raw); ok {
+				decoded["type"] = "function"
+				decoded["name"] = register(strings.TrimSpace(choice.Get("namespace").String()), strings.TrimSpace(choice.Get("name").String()), true, false)
+				delete(decoded, "namespace")
+				if encoded, err := json.Marshal(decoded); err == nil {
+					raw, changed = encoded, true
+				}
+			}
+		} else if kind == "tool_search" {
+			if encoded, err := json.Marshal(map[string]any{"type": "function", "name": register("", grokToolSearchProxyName, false, true)}); err == nil {
+				raw, changed = encoded, true
+			}
+		} else if kind == "function" {
 			if namespace := strings.TrimSpace(choice.Get("namespace").String()); namespace != "" {
 				if decoded, ok := grokDecodeObject(choice.Raw); ok {
-					decoded["name"] = register(namespace, strings.TrimSpace(grokNsStringField(decoded, "name")))
+					decoded["name"] = register(namespace, strings.TrimSpace(grokNsStringField(decoded, "name")), false, false)
 					delete(decoded, "namespace")
 					if encoded, err := json.Marshal(decoded); err == nil {
 						raw, changed = encoded, true
@@ -303,7 +448,7 @@ func grokNormalizeToolChoiceRaw(choice gjson.Result, toolsEmpty, webSearchDroppe
 // grokWriteRebuiltInput 逐项处理 input[] 并直接写入 out：干净项原样拷贝 raw 字节，
 // 只有需要重建的项才走重写。顺带数出 user 消息数作为轮次序号，
 // 省掉一趟独立的全量遍历。
-func grokWriteRebuiltInput(out *bytes.Buffer, input gjson.Result, register func(namespace, name string) string) (changed bool, turns int) {
+func grokWriteRebuiltInput(out *bytes.Buffer, input gjson.Result, register grokAliasRegister) (changed bool, turns int) {
 	out.WriteByte('[')
 	first := true
 	input.ForEach(func(_, item gjson.Result) bool {
@@ -326,7 +471,7 @@ func grokWriteRebuiltInput(out *bytes.Buffer, input gjson.Result, register func(
 
 // grokWriteHistoryItem 把单个历史项写入 out，返回 (是否改写, 是否计入轮次)。
 // 无需改写时原样拷贝 raw 字节。
-func grokWriteHistoryItem(out *bytes.Buffer, item gjson.Result, register func(namespace, name string) string) (bool, bool) {
+func grokWriteHistoryItem(out *bytes.Buffer, item gjson.Result, register grokAliasRegister) (bool, bool) {
 	verbatim := func() (bool, bool) {
 		out.WriteString(item.Raw)
 		return false, grokRawItemIsUserMessage(item)
@@ -344,6 +489,22 @@ func grokWriteHistoryItem(out *bytes.Buffer, item gjson.Result, register func(na
 		out.Write(encoded)
 		return true, false
 	}
+	if itemType == "custom_tool_call" || itemType == "custom_tool_call_output" || itemType == "tool_search_call" || itemType == "tool_search_output" || itemType == "tool_search_call_output" {
+		decoded, ok := grokDecodeObject(item.Raw)
+		if !ok {
+			return verbatim()
+		}
+		rebuilt, changed := rebuildGrokHistoryItem(decoded, register)
+		if !changed {
+			return verbatim()
+		}
+		encoded, err := json.Marshal(rebuilt)
+		if err != nil {
+			return verbatim()
+		}
+		out.Write(encoded)
+		return true, false
+	}
 	fields, known := grokNativeHistoryFields[itemType]
 	if !known {
 		return verbatim() // 未知类型原样透传
@@ -354,7 +515,7 @@ func grokWriteHistoryItem(out *bytes.Buffer, item gjson.Result, register func(na
 	aliasName := ""
 	if itemType == "function_call" {
 		if namespace := strings.TrimSpace(grokRawStringField(item, "namespace")); namespace != "" {
-			aliasName = register(namespace, strings.TrimSpace(grokRawStringField(item, "name")))
+			aliasName = register(namespace, strings.TrimSpace(grokRawStringField(item, "name")), false, false)
 		}
 	}
 	if aliasName == "" && grokHistoryItemFieldsAreNative(item, fields) {

--- a/proxy/grok_preflight.go
+++ b/proxy/grok_preflight.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"bytes"
 	"encoding/json"
+	"reflect"
 	"slices"
 	"strings"
 
@@ -213,7 +214,7 @@ func grokBodyHasNamedTool(request map[string]any, want string) bool {
 }
 
 func liftGrokAdditionalTools(body []byte) ([]byte, bool) {
-	if !bytes.Contains(body, []byte(`"additional_tools"`)) {
+	if !bytes.Contains(body, []byte(`"additional_tools"`)) && !bytes.Contains(body, []byte(`"tool_search_output"`)) && !bytes.Contains(body, []byte(`"tool_search_call_output"`)) {
 		return body, false
 	}
 	var request map[string]any
@@ -229,17 +230,27 @@ func liftGrokAdditionalTools(body []byte) ([]byte, bool) {
 	changed := false
 	for _, raw := range input {
 		item, itemOK := raw.(map[string]any)
-		if !itemOK || strings.TrimSpace(grokNsStringField(item, "type")) != "additional_tools" {
+		if !itemOK {
 			filtered = append(filtered, raw)
 			continue
 		}
+		itemType := strings.TrimSpace(grokNsStringField(item, "type"))
 		additional, toolsOK := item["tools"].([]any)
-		if !toolsOK {
+		if !toolsOK || (itemType != "additional_tools" && itemType != "tool_search_output" && itemType != "tool_search_call_output") {
 			filtered = append(filtered, raw)
 			continue
 		}
 		tools = append(tools, additional...)
 		changed = true
+		if itemType != "additional_tools" {
+			output := item["output"]
+			if output == nil {
+				output = additional
+			}
+			item["output"] = output
+			delete(item, "tools")
+			filtered = append(filtered, raw)
+		}
 	}
 	if !changed {
 		return body, false
@@ -286,6 +297,7 @@ func grokNormalizeToolsRaw(tools gjson.Result, register grokAliasRegister) (raw 
 	buf.WriteByte('[')
 	first := true
 	kept := 0
+	emittedFunctions := make(map[string]bool)
 
 	writeRaw := func(value string) {
 		if !first {
@@ -296,6 +308,16 @@ func grokNormalizeToolsRaw(tools gjson.Result, register grokAliasRegister) (raw 
 		kept++
 	}
 	writeObject := func(value map[string]any) bool {
+		if grokNsStringField(value, "type") == "function" {
+			name := strings.TrimSpace(grokNsStringField(value, "name"))
+			if name != "" && emittedFunctions[name] {
+				changed = true
+				return true
+			}
+			if name != "" {
+				emittedFunctions[name] = true
+			}
+		}
 		encoded, err := json.Marshal(value)
 		if err != nil {
 			return false
@@ -323,18 +345,16 @@ func grokNormalizeToolsRaw(tools gjson.Result, register grokAliasRegister) (raw 
 		if kind == "function" {
 			name := strings.TrimSpace(tool.Get("name").String())
 			registered := register("", name, false, false)
-			if registered == name {
-				writeRaw(tool.Raw)
-				return true
-			}
 			decoded, ok := grokDecodeObject(tool.Raw)
 			if !ok {
 				writeRaw(tool.Raw)
 				return true
 			}
-			decoded["name"] = registered
-			writeObject(decoded)
-			changed = true
+			normalized := normalizeGrokFunctionTool(decoded, registered)
+			writeObject(normalized)
+			if registered != name || !reflect.DeepEqual(decoded, normalized) {
+				changed = true
+			}
 			return true
 		}
 		if kind == "custom" {
@@ -385,9 +405,7 @@ func grokNormalizeToolsRaw(tools gjson.Result, register grokAliasRegister) (raw 
 			if childType == "custom" {
 				writeObject(grokFunctionToolForCustom(decoded, alias))
 			} else {
-				decoded["name"] = alias
-				delete(decoded, "defer_loading")
-				writeObject(decoded)
+				writeObject(normalizeGrokFunctionTool(decoded, alias))
 			}
 			return true
 		})

--- a/proxy/grok_preflight.go
+++ b/proxy/grok_preflight.go
@@ -62,20 +62,7 @@ func prepareGrokUpstreamBody(body []byte) grokPreflightResult {
 		result.Model = model.String()
 	}
 
-	aliases := make(map[string]grokNsIdentity)
-	registered := make(map[string]grokNsIdentity)
-	register := func(namespace, name string, custom, toolSearch bool) string {
-		alias := grokNamespaceAliasName(namespace, name)
-		if existing, ok := registered[alias]; ok && (existing.Namespace != namespace || existing.Name != name || existing.Custom != custom || existing.ToolSearch != toolSearch) {
-			alias = grokDisambiguatedAlias(alias, namespace, name)
-		}
-		identity := grokNsIdentity{Namespace: namespace, Name: name, Custom: custom, ToolSearch: toolSearch}
-		registered[alias] = identity
-		if custom || toolSearch || namespace != "" || alias != name {
-			aliases[alias] = identity
-		}
-		return alias
-	}
+	register, aliases := newGrokAliasRegister()
 
 	// tools 先处理：input 与 tool_choice 的 namespace 引用要改写成同一份别名，
 	// 处理顺序必须与逐步改写实现一致，否则别名撞名时的消歧结果会不同。
@@ -175,13 +162,15 @@ func prepareGrokUpstreamBody(body []byte) grokPreflightResult {
 const grokGiantToolInstructionMarker = "[codex2api giant-tool-call guard]"
 
 func addGrokGiantToolInstructions(body []byte) ([]byte, bool) {
-	if !bytes.Contains(body, []byte(`"apply_patch"`)) || bytes.Contains(body, []byte(grokGiantToolInstructionMarker)) {
+	if !bytes.Contains(bytes.ToLower(body), []byte(`"apply_patch"`)) || bytes.Contains(body, []byte(grokGiantToolInstructionMarker)) {
 		return body, false
 	}
 	var request map[string]any
-	if json.Unmarshal(body, &request) != nil || !grokBodyHasNamedTool(request, "apply_patch") {
+	if decodeGrokJSONPreservingNumbers(body, &request) != nil || !grokBodyHasNamedTool(request, "apply_patch") {
 		return body, false
 	}
+	// The 96 KiB guidance leaves deliberate headroom below the 128 KiB hard stop
+	// for wrapper JSON and escaping overhead.
 	guidance := grokGiantToolInstructionMarker + "\nWhen using apply_patch or another code-writing tool, modify at most 2 files per call and keep each tool input below 96 KiB. Split larger work into verified batches."
 	existing := strings.TrimSpace(grokNsStringField(request, "instructions"))
 	if existing != "" {
@@ -218,7 +207,7 @@ func liftGrokAdditionalTools(body []byte) ([]byte, bool) {
 		return body, false
 	}
 	var request map[string]any
-	if json.Unmarshal(body, &request) != nil {
+	if decodeGrokJSONPreservingNumbers(body, &request) != nil {
 		return body, false
 	}
 	input, ok := request["input"].([]any)
@@ -262,6 +251,12 @@ func liftGrokAdditionalTools(body []byte) ([]byte, bool) {
 		return body, false
 	}
 	return out, true
+}
+
+func decodeGrokJSONPreservingNumbers(body []byte, target any) error {
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.UseNumber()
+	return decoder.Decode(target)
 }
 
 // grokWriteObjectKey 写出 JSON 对象里的 `"key":`，必要时补上分隔逗号。

--- a/proxy/grok_preflight_diff_test.go
+++ b/proxy/grok_preflight_diff_test.go
@@ -244,7 +244,7 @@ func TestGrokPreflightPreservesUntouchedBody(t *testing.T) {
 // TestGrokPrepareHistoryItemMatchesMapRebuild 逐项守护 raw 拼接重建与 map 版
 // rebuildGrokHistoryItem 的等价性：改写与否的判定必须一致，改写结果必须语义相同。
 func TestGrokPrepareHistoryItemMatchesMapRebuild(t *testing.T) {
-	register := func(ns, name string) string { return ns + "__" + name }
+	register := func(ns, name string, _, _ bool) string { return ns + "__" + name }
 	for _, tc := range grokDiffCorpus() {
 		input := gjson.Get(tc.body, "input")
 		if !input.IsArray() {


### PR DESCRIPTION
## Summary

Bridge Codex Responses tool extensions onto the upstream Grok/xAI Responses platform while preserving the existing Grok account, OAuth/API-key, routing, billing, catalog, and native-protocol control plane.

This fixes Codex requests failing before generation with HTTP 422:

```
unknown variant `custom`, expected one of `function`, ...
```

## Changes

- convert top-level Codex `custom` tools into reversible function wrappers
- flatten function/custom namespace children with deterministic collision-safe aliases
- convert custom and namespaced `tool_choice`
- convert historical `custom_tool_call` and output items
- restore custom calls in non-stream JSON and Responses SSE
- lift Responses Lite `additional_tools` into the upstream callable tool list
- proxy `tool_search` through a reversible function tool
- restore `tool_search_call` in JSON and SSE responses
- inject complete dynamic definitions from `tool_search_output.tools`
- normalize `inputSchema` / `input_schema` to Grok `parameters`
- strip `defer_loading`, `deferLoading`, and other client-only tool metadata
- deduplicate top-level and dynamically injected tools
- keep all alias and stream state request-local
- add apply_patch batching guidance and a 128 KiB streamed tool-input hard limit
- include `grok-4.6` in the pre-catalog fallback model set

## Root cause

Simple Grok proxy tests used ordinary prompts and did not include the full Codex tool inventory. Real Codex requests contain custom tools, namespace declarations, Responses Lite carriers, tool-search history, and strict historical items. Grok's native Responses deserializer rejects unsupported tagged variants before model generation.

The compatibility boundary lowers only Codex-specific extensions. Native Grok hosted tools and the upstream Grok platform remain intact.

## Compatibility matrix

Validated:

- function/shell calls
- top-level custom tools
- namespaced function and custom tools
- function/custom/tool-search name collisions
- custom and tool-search choices
- custom call/output history
- tool-search call/output history
- Responses Lite additional_tools
- tool_search to dynamic additional-tools injection
- non-stream response restoration
- SSE output-item and completion restoration
- multi-call continuation
- JSON escaping
- request-local concurrent mappings
- medium custom inputs
- oversized streamed tool-call protection
- existing namespace and web-search behavior

## Automated validation

Passed:

- `go test ./proxy -count=1`
- focused Grok custom, namespace, tool-search, dynamic-injection, history, JSON, SSE, collision, and concurrency tests
- `go vet ./proxy ./auth`

The clean worktree root package requires generated `frontend/dist/*` for its `go:embed`; all individual packages in the broader test run passed. Focused `-race` was unavailable because the bundled Windows Go environment has CGO disabled.

## Live Codex / Grok 4.6 validation

Tested through a real Codex desktop task routed to `grok-4.6` with repeated `/v1/responses` HTTP 200 results:

- custom `apply_patch` create and update
- namespace tools
- multi-tool continuation
- function/custom output history replay
- JSON escaping
- 9.4 KiB custom input
- tool_search discovery
- dynamic injection of a tool not present before search
- real call to newly injected `mcp__codex_apps__github___get_repo`
- public repository metadata returned successfully

No 422, `unknown variant`, missing continuation output, or dynamic-tool-not-injected failure remained.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for custom tools and tool-search tools in Grok requests and responses.
  * Improved handling of tool namespaces, aliases, name collisions, and dynamically loaded tools.
  * Preserved tool calls and arguments during history replay and streaming responses.
  * Added safeguards for oversized tool inputs, including clear failure responses.

* **Bug Fixes**
  * Improved schema normalization, numeric value preservation, and streamed function-argument handling.
  * Prevented duplicate tool definitions and ensured mappings remain isolated between requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->