### PR TITLE
fix(grok): isolate capability probes from user traffic

### DIFF
--- a/admin/account_live.go
+++ b/admin/account_live.go
@@ -1,0 +1,36 @@
+package admin
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+type accountLiveItem struct {
+	ActiveRequests int64 `json:"active_requests"`
+}
+
+// GetAccountLiveState returns request-local runtime counters for the visible
+// account page. It intentionally reads only in-memory atomics, so frequent UI
+// polling does not touch the database or rebuild the paged account snapshot.
+func (h *Handler) GetAccountLiveState(c *gin.Context) {
+	ids, err := parseAccountListIDs(c.Query("ids"))
+	if err != nil {
+		writeError(c, http.StatusBadRequest, "ids 参数无效")
+		return
+	}
+	if len(ids) > accountListPageMax {
+		writeError(c, http.StatusBadRequest, "ids 最多允许 500 个")
+		return
+	}
+
+	live := make(map[int64]accountLiveItem, len(ids))
+	for _, id := range ids {
+		account := h.store.FindByID(id)
+		if account == nil {
+			continue
+		}
+		live[id] = accountLiveItem{ActiveRequests: account.GetActiveRequests()}
+	}
+	c.JSON(http.StatusOK, gin.H{"accounts": live})
+}

--- a/admin/account_live_test.go
+++ b/admin/account_live_test.go
@@ -1,0 +1,42 @@
+package admin
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/codex2api/auth"
+	"github.com/gin-gonic/gin"
+)
+
+func TestGetAccountLiveStateReturnsVisibleInflightCounts(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	store := auth.NewStore(nil, nil, nil)
+	account := &auth.Account{DBID: 42, AccessToken: "token"}
+	atomic.StoreInt64(&account.ActiveRequests, 3)
+	store.AddAccount(account)
+	handler := &Handler{store: store}
+
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Request = httptest.NewRequest(http.MethodGet, "/api/admin/accounts/live?ids=42,99", nil)
+	handler.GetAccountLiveState(ctx)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", recorder.Code, recorder.Body.String())
+	}
+	var response struct {
+		Accounts map[string]accountLiveItem `json:"accounts"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatal(err)
+	}
+	if got := response.Accounts["42"].ActiveRequests; got != 3 {
+		t.Fatalf("active_requests = %d, want 3", got)
+	}
+	if _, exists := response.Accounts["99"]; exists {
+		t.Fatal("missing account unexpectedly returned")
+	}
+}

--- a/admin/grok_probe_test.go
+++ b/admin/grok_probe_test.go
@@ -53,6 +53,30 @@ func TestGrokPersistedStateNeedsRefresh(t *testing.T) {
 	}
 }
 
+func TestGrokCapabilityFailureTTLPreventsRecurringAutomaticProbe(t *testing.T) {
+	now := time.Now()
+	account := &auth.Account{UpstreamType: auth.UpstreamGrok, APIKey: "xai-test", CredentialGeneration: 1}
+	origin := normalizeGrokProbeOrigin(auth.GrokDefaultAPIBaseURL)
+	state := &database.GrokAccountState{
+		CredentialGeneration: 1,
+		Catalogs: []database.GrokModelCatalog{{Snapshot: database.GrokModelCatalogSnapshot{
+			Origin: origin, CredentialGeneration: 1, Status: "ok", ExpiresAt: now.Add(time.Hour),
+		}, Items: []database.GrokModelCatalogItem{{ModelID: "grok-test", CredentialGeneration: 1}}}},
+	}
+	for _, protocol := range []proxy.GrokProtocol{proxy.GrokProtocolResponses, proxy.GrokProtocolChatCompletions, proxy.GrokProtocolMessages} {
+		state.Capabilities = append(state.Capabilities, database.GrokModelCapability{
+			ModelID: "grok-test", Origin: origin, Protocol: string(protocol), CredentialGeneration: 1,
+			Status: "unsupported", ObservedAt: now, ExpiresAt: now.Add(grokCapabilityFailureTTL),
+		})
+	}
+	if grokGenerationNeedsCapabilityProbe(account, state, 1, now.Add(10*time.Minute)) {
+		t.Fatal("negative capability observations should suppress automatic reprobe for 24 hours")
+	}
+	if !grokGenerationNeedsCapabilityProbe(account, state, 1, now.Add(25*time.Hour)) {
+		t.Fatal("expired capability observations should become probe candidates")
+	}
+}
+
 func TestRefreshStaleGrokControlPlaneSelectsOnlyExpiredBillingWhenProbeDisabled(t *testing.T) {
 	var callsMu sync.Mutex
 	calls := map[string]int{}

--- a/admin/grok_state.go
+++ b/admin/grok_state.go
@@ -23,11 +23,15 @@ import (
 )
 
 const (
-	grokFactFreshness          = 5 * time.Minute
-	grokUserUpgradeFreshness   = 60 * time.Second
-	grokBillingHotFreshness    = 30 * time.Second
-	grokCapabilityOKTTL        = 24 * time.Hour
-	grokCapabilityFailureTTL   = 5 * time.Minute
+	grokFactFreshness        = 5 * time.Minute
+	grokUserUpgradeFreshness = 60 * time.Second
+	grokBillingHotFreshness  = 30 * time.Second
+	grokCapabilityOKTTL      = 24 * time.Hour
+	// Automatic capability rebuilds are maintenance, not health checks. Cache
+	// negative/rate-limited observations for a day so the 30-second freshness
+	// scanner cannot turn an unsupported protocol into recurring generation
+	// traffic. Operators can still bypass this TTL with the explicit force probe.
+	grokCapabilityFailureTTL   = 24 * time.Hour
 	grokCapabilityProbeTimeout = 45 * time.Second
 )
 
@@ -969,9 +973,6 @@ func (h *Handler) runGrokCapabilityProbe(ctx context.Context, id int64, force bo
 			ttl := grokCapabilityFailureTTL
 			if observation.status == "ok" {
 				ttl = grokCapabilityOKTTL
-			}
-			if observation.status == "rate_limited" || observation.status == "version_required" {
-				ttl = time.Minute
 			}
 			capability := database.GrokModelCapability{
 				AccountID: id, ModelID: target.model, Origin: target.origin, Protocol: string(protocol),

--- a/admin/handler.go
+++ b/admin/handler.go
@@ -620,6 +620,7 @@ func (h *Handler) RegisterRoutes(r *gin.Engine) {
 	api.GET("/accounts", h.ListAccounts)
 	api.GET("/accounts/analysis", h.GetAccountAnalysis)
 	api.GET("/accounts/page-stats", h.GetAccountPageStats)
+	api.GET("/accounts/live", h.GetAccountLiveState)
 	api.GET("/accounts/:id", h.GetAccount)
 	api.POST("/accounts", h.AddAccount)
 	api.POST("/accounts/at", h.AddATAccount)

--- a/database/account_page_stats.go
+++ b/database/account_page_stats.go
@@ -35,8 +35,8 @@ func (db *DB) GetAccountRequestCountsByIDs(ctx context.Context, ids []int64) (ma
 			COALESCE(SUM(CASE WHEN status_code >= 400 AND %s THEN 1 ELSE 0 END), 0),
 			COALESCE(SUM(CASE WHEN status_code = 429 THEN 1 ELSE 0 END), 0)
 		FROM usage_logs
-		WHERE created_at >= $1 AND account_id IN (%s)
-		GROUP BY account_id`, retryFalse, retryFalse, retryTrue, strings.Join(placeholders, ","))
+		WHERE created_at >= $1 AND %s AND account_id IN (%s)
+		GROUP BY account_id`, retryFalse, retryFalse, retryTrue, db.endUserUsageLogPredicate(), strings.Join(placeholders, ","))
 	rows, err := db.conn.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, err
@@ -77,8 +77,8 @@ func (db *DB) GetAccountUsageWindowsByIDs(ctx context.Context, ids []int64, shor
 		COALESCE(SUM(CASE WHEN created_at >= $1 THEN user_billed ELSE 0 END), 0),
 		COUNT(*), COALESCE(SUM(total_tokens), 0), COALESCE(SUM(account_billed), 0), COALESCE(SUM(user_billed), 0)
 		FROM usage_logs
-		WHERE created_at >= $2 AND status_code <> 499 AND %s AND %s AND account_id IN (%s)
-		GROUP BY account_id`, db.nonRetryUsageLogPredicate(), db.currentAccountUsageGenerationPredicate(), strings.Join(placeholders, ","))
+		WHERE created_at >= $2 AND status_code <> 499 AND %s AND %s AND %s AND account_id IN (%s)
+		GROUP BY account_id`, db.nonRetryUsageLogPredicate(), db.currentAccountUsageGenerationPredicate(), db.endUserUsageLogPredicate(), strings.Join(placeholders, ","))
 	rows, err := db.conn.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, nil, err

--- a/database/postgres.go
+++ b/database/postgres.go
@@ -638,9 +638,22 @@ func (db *DB) ensureUsageStatsRollup(ctx context.Context) error {
 	)`); err != nil {
 		return err
 	}
-	var initialized int
-	err := db.conn.QueryRowContext(ctx, `SELECT initialized FROM usage_stats_rollup_state WHERE id=1`).Scan(&initialized)
-	if err == nil && initialized == 1 {
+	if db.isSQLite() {
+		columns, err := db.sqliteTableColumns(ctx, "usage_stats_rollup_state")
+		if err != nil {
+			return err
+		}
+		if _, ok := columns["aggregation_version"]; !ok {
+			if _, err := db.conn.ExecContext(ctx, `ALTER TABLE usage_stats_rollup_state ADD COLUMN aggregation_version INTEGER NOT NULL DEFAULT 1`); err != nil {
+				return err
+			}
+		}
+	} else if _, err := db.conn.ExecContext(ctx, `ALTER TABLE usage_stats_rollup_state ADD COLUMN IF NOT EXISTS aggregation_version INTEGER NOT NULL DEFAULT 1`); err != nil {
+		return err
+	}
+	var initialized, aggregationVersion int
+	err := db.conn.QueryRowContext(ctx, `SELECT initialized, aggregation_version FROM usage_stats_rollup_state WHERE id=1`).Scan(&initialized, &aggregationVersion)
+	if err == nil && initialized == 1 && aggregationVersion >= 2 {
 		return nil
 	}
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
@@ -668,7 +681,8 @@ func (db *DB) rebuildUsageStatsRollup(ctx context.Context) error {
 		b.first_token_ms_sum + COALESCE(SUM(CASE WHEN u.first_token_ms > 0 THEN u.first_token_ms ELSE 0 END), 0),
 		b.first_token_samples + COALESCE(SUM(CASE WHEN u.first_token_ms > 0 THEN 1 ELSE 0 END), 0),
 		b.account_billed + COALESCE(SUM(u.account_billed), 0), b.user_billed + COALESCE(SUM(u.user_billed), 0)
-	FROM usage_stats_baseline b LEFT JOIN usage_logs u ON u.status_code <> 499 WHERE b.id=1
+	FROM usage_stats_baseline b LEFT JOIN usage_logs u ON u.status_code <> 499
+		AND TRIM(COALESCE(u.internal_reason, '')) = '' WHERE b.id=1
 	GROUP BY b.total_requests, b.total_tokens, b.prompt_tokens, b.completion_tokens, b.cached_tokens,
 		b.cache_hit_requests, b.first_token_ms_sum, b.first_token_samples, b.account_billed, b.user_billed`); err != nil {
 		return err
@@ -682,12 +696,14 @@ func (db *DB) rebuildUsageStatsRollup(ctx context.Context) error {
 		COALESCE(SUM(CASE WHEN first_token_ms > 0 THEN first_token_ms ELSE 0 END), 0),
 		COALESCE(SUM(CASE WHEN first_token_ms > 0 THEN 1 ELSE 0 END), 0),
 		COALESCE(SUM(account_billed), 0), COALESCE(SUM(user_billed), 0)
-	FROM usage_logs WHERE status_code <> 499 AND TRIM(COALESCE(channel, '')) <> '' GROUP BY TRIM(COALESCE(channel, ''))`); err != nil {
+	FROM usage_logs WHERE status_code <> 499 AND TRIM(COALESCE(internal_reason, '')) = ''
+		AND TRIM(COALESCE(channel, '')) <> '' GROUP BY TRIM(COALESCE(channel, ''))`); err != nil {
 		return err
 	}
-	if _, err := tx.ExecContext(ctx, `INSERT INTO usage_stats_rollup_state (id, initialized, last_log_id, updated_at)
-		VALUES (1, 1, COALESCE((SELECT MAX(id) FROM usage_logs), 0), CURRENT_TIMESTAMP)
-		ON CONFLICT(id) DO UPDATE SET initialized=1, last_log_id=excluded.last_log_id, updated_at=CURRENT_TIMESTAMP`); err != nil {
+	if _, err := tx.ExecContext(ctx, `INSERT INTO usage_stats_rollup_state (id, initialized, last_log_id, aggregation_version, updated_at)
+		VALUES (1, 1, COALESCE((SELECT MAX(id) FROM usage_logs), 0), 2, CURRENT_TIMESTAMP)
+		ON CONFLICT(id) DO UPDATE SET initialized=1, last_log_id=excluded.last_log_id,
+			aggregation_version=excluded.aggregation_version, updated_at=CURRENT_TIMESTAMP`); err != nil {
 		return err
 	}
 	return tx.Commit()
@@ -751,7 +767,7 @@ func applyUsageStatsRollupWithExec(ctx context.Context, execer sqlExecer, batch 
 		item.TotalUserBilled += entry.UserBilled
 	}
 	for _, entry := range batch {
-		if !entry.StoreUsageLog || entry.StatusCode == 499 {
+		if !entry.StoreUsageLog || entry.StatusCode == 499 || strings.TrimSpace(entry.InternalReason) != "" {
 			continue
 		}
 		add("", entry)
@@ -4231,6 +4247,7 @@ func (db *DB) getUsageStats(ctx context.Context, rangeStart, rangeEnd time.Time,
 	FROM usage_logs
 	WHERE created_at >= $1` + endClause + `
 	  AND status_code <> 499
+	  AND TRIM(COALESCE(internal_reason, '')) = ''
 	`
 
 	var todayErrors int64
@@ -4304,6 +4321,7 @@ func (db *DB) CountTodayRequestsByChannel(ctx context.Context) (map[string]int64
 		SELECT COALESCE(channel, ''), COUNT(*)
 		FROM usage_logs
 		WHERE created_at >= $1 AND status_code <> 499
+		  AND TRIM(COALESCE(internal_reason, '')) = ''
 		GROUP BY 1`, db.timeArg(todayStart))
 	if err != nil {
 		return nil, err
@@ -4358,6 +4376,7 @@ func (db *DB) getUsageModelStats(ctx context.Context, limit int, rangeStart, ran
 			COALESCE(SUM(CASE WHEN status_code >= 400 THEN 1 ELSE 0 END), 0) AS error_count
 		FROM usage_logs
 		WHERE `+timeWhere+` AND status_code <> 499
+		  AND TRIM(COALESCE(internal_reason, '')) = ''
 		GROUP BY 1
 		ORDER BY user_billed DESC, requests DESC, model_name ASC
 		LIMIT `+limitPlaceholder+`
@@ -4414,6 +4433,7 @@ func (db *DB) populateUsageBreakdownStats(ctx context.Context, stats *UsageStats
 			COALESCE(SUM(CASE WHEN status_code >= 400 THEN 1 ELSE 0 END), 0) AS error_requests
 		FROM usage_logs
 		WHERE `+timeWhere+` AND status_code <> 499
+		  AND TRIM(COALESCE(internal_reason, '')) = ''
 	`, args...).Scan(
 		&stats.FeatureStats.StreamRequests,
 		&stats.FeatureStats.SyncRequests,
@@ -4456,6 +4476,7 @@ func (db *DB) getUsageEndpointStats(ctx context.Context, limit int, rangeStart, 
 			COALESCE(SUM(user_billed), 0) AS user_billed
 		FROM usage_logs
 		WHERE `+timeWhere+` AND status_code <> 499
+		  AND TRIM(COALESCE(internal_reason, '')) = ''
 		GROUP BY 1
 		ORDER BY requests DESC, endpoint_name ASC
 		LIMIT `+limitPlaceholder+`
@@ -4499,6 +4520,7 @@ func (db *DB) getUsageAPIKeyStats(ctx context.Context, limit int, rangeStart, ra
 			COALESCE(SUM(user_billed), 0) AS user_billed
 		FROM usage_logs
 		WHERE `+timeWhere+` AND status_code <> 499
+		  AND TRIM(COALESCE(internal_reason, '')) = ''
 		GROUP BY 1, 2
 		ORDER BY requests DESC, api_key_label ASC
 		LIMIT `+limitPlaceholder+`
@@ -4540,6 +4562,7 @@ func (db *DB) GetTrafficSnapshot(ctx context.Context) (*TrafficSnapshot, error) 
 			COALESCE(SUM(total_tokens), 0)::float8 AS token_count
 		FROM usage_logs
 		WHERE created_at >= NOW() - INTERVAL '5 minutes'
+		  AND TRIM(COALESCE(internal_reason, '')) = ''
 		GROUP BY 1
 	),
 	current_window AS (
@@ -4753,7 +4776,8 @@ func (db *DB) GetChartAggregation(ctx context.Context, start, end time.Time, buc
 			duration_ms, input_tokens, output_tokens, reasoning_tokens, cached_tokens, status_code
 		FROM usage_logs
 		WHERE created_at >= $1 AND created_at < $2
-		  AND status_code <> 499` + channelClause + `
+		  AND status_code <> 499
+		  AND TRIM(COALESCE(internal_reason, '')) = ''` + channelClause + `
 	)
 	SELECT
 		CASE WHEN GROUPING(bucket) = 0 THEN 'timeline' ELSE 'model' END AS row_kind,
@@ -4858,7 +4882,8 @@ func (db *DB) GetAccountUsageStats(ctx context.Context, accountID int64, days in
 		COALESCE(first_token_ms, 0), status_code, COALESCE(is_retry_attempt, false),
 		COALESCE(attempt_index, 0), COALESCE(stream, false), COALESCE(compact, false)
 	FROM usage_logs
-	WHERE account_id = $1 AND `+timeWhere+` AND status_code <> 499`, queryArgs...)
+	WHERE account_id = $1 AND `+timeWhere+` AND status_code <> 499
+	  AND TRIM(COALESCE(internal_reason, '')) = ''`, queryArgs...)
 	if err != nil {
 		return nil, err
 	}
@@ -5507,6 +5532,13 @@ func (db *DB) nonRetryUsageLogPredicate() string {
 	return "COALESCE(is_retry_attempt, false) = false"
 }
 
+// endUserUsageLogPredicate excludes maintenance/probe traffic from account
+// request, token, and billing aggregates. Internal rows remain queryable in the
+// raw usage log for diagnostics.
+func (db *DB) endUserUsageLogPredicate() string {
+	return "TRIM(COALESCE(internal_reason, '')) = ''"
+}
+
 // currentAccountUsageGenerationPredicate keeps generation-scoped internal
 // traffic (currently Grok capability probes) attached to the credential
 // identity that issued it. Legacy and ordinary request rows use generation 0
@@ -5533,9 +5565,9 @@ func (db *DB) GetAccountRequestCounts(ctx context.Context) (map[int64]*AccountRe
 		COALESCE(SUM(CASE WHEN status_code >= 400 AND %s THEN 1 ELSE 0 END), 0) AS retry_error_count,
 		COALESCE(SUM(CASE WHEN status_code = 429 THEN 1 ELSE 0 END), 0) AS rate_limit_attempt_count
 	FROM usage_logs
-	WHERE created_at >= $1
+	WHERE created_at >= $1 AND %s
 	GROUP BY account_id
-	`, retryFalse, retryFalse, retryTrue)
+	`, retryFalse, retryFalse, retryTrue, db.endUserUsageLogPredicate())
 	rows, err := db.conn.QueryContext(ctx, query, db.timeArg(since))
 	if err != nil {
 		return nil, err
@@ -5562,9 +5594,9 @@ func (db *DB) GetAccountTimeRangeUsage(ctx context.Context, since time.Time) (ma
 		COALESCE(SUM(account_billed), 0) AS account_billed,
 		COALESCE(SUM(user_billed), 0) AS user_billed
 	FROM usage_logs
-	WHERE created_at >= $1 AND status_code <> 499 AND %s AND %s
+	WHERE created_at >= $1 AND status_code <> 499 AND %s AND %s AND %s
 	GROUP BY account_id
-	`, db.nonRetryUsageLogPredicate(), db.currentAccountUsageGenerationPredicate())
+	`, db.nonRetryUsageLogPredicate(), db.currentAccountUsageGenerationPredicate(), db.endUserUsageLogPredicate())
 	rows, err := db.conn.QueryContext(ctx, query, db.timeArg(since))
 	if err != nil {
 		return nil, err
@@ -5595,8 +5627,8 @@ func (db *DB) GetAccountUsageWindows(ctx context.Context, shortSince, longSince 
 		COALESCE(SUM(CASE WHEN created_at >= $1 THEN user_billed ELSE 0 END), 0),
 		COUNT(*), COALESCE(SUM(total_tokens), 0), COALESCE(SUM(account_billed), 0), COALESCE(SUM(user_billed), 0)
 	FROM usage_logs
-	WHERE created_at >= $2 AND status_code <> 499 AND %s AND %s
-	GROUP BY account_id`, db.nonRetryUsageLogPredicate(), db.currentAccountUsageGenerationPredicate())
+	WHERE created_at >= $2 AND status_code <> 499 AND %s AND %s AND %s
+	GROUP BY account_id`, db.nonRetryUsageLogPredicate(), db.currentAccountUsageGenerationPredicate(), db.endUserUsageLogPredicate())
 	rows, err := db.conn.QueryContext(ctx, query, db.timeArg(shortSince), db.timeArg(longSince))
 	if err != nil {
 		return nil, nil, err
@@ -5625,7 +5657,8 @@ func (db *DB) GetAccountUsageWindows(ctx context.Context, shortSince, longSince 
 func (db *DB) GetAccountBilledSince(ctx context.Context, accountID int64, since time.Time) (float64, error) {
 	var billed float64
 	err := db.conn.QueryRowContext(ctx,
-		`SELECT COALESCE(SUM(account_billed), 0) FROM usage_logs WHERE account_id = $1 AND created_at >= $2 AND status_code <> 499`,
+		`SELECT COALESCE(SUM(account_billed), 0) FROM usage_logs WHERE account_id = $1 AND created_at >= $2
+		 AND status_code <> 499 AND TRIM(COALESCE(internal_reason, '')) = ''`,
 		accountID, db.timeArg(since)).Scan(&billed)
 	return billed, err
 }
@@ -5691,6 +5724,7 @@ func (db *DB) getAccountsBilledSinceChunk(ctx context.Context, ids []int64, wind
 		ON usage_logs.account_id = billing_windows.account_id
 		AND usage_logs.created_at >= billing_windows.since_at
 		AND usage_logs.status_code <> 499
+		AND TRIM(COALESCE(usage_logs.internal_reason, '')) = ''
 	GROUP BY billing_windows.account_id
 	`, strings.Join(values, ","))
 

--- a/database/sqlite.go
+++ b/database/sqlite.go
@@ -747,6 +747,7 @@ func (db *DB) getTrafficSnapshotSQLite(ctx context.Context) (*TrafficSnapshot, e
 		SELECT created_at, total_tokens
 		FROM usage_logs
 		WHERE created_at >= $1
+		  AND TRIM(COALESCE(internal_reason, '')) = ''
 	`, db.timeArg(time.Now().Add(-5*time.Minute)))
 	if err != nil {
 		return nil, err
@@ -817,6 +818,7 @@ func (db *DB) getChartAggregationSQLite(ctx context.Context, start, end time.Tim
 		FROM usage_logs
 		WHERE created_at >= $1 AND created_at < $2
 		  AND status_code <> 499
+		  AND TRIM(COALESCE(internal_reason, '')) = ''
 	`
 	args := []interface{}{startArg, endArg, bucketMinutes}
 	if channel != "" {
@@ -849,7 +851,8 @@ func (db *DB) getChartAggregationSQLite(ctx context.Context, start, end time.Tim
 	}
 
 	modelQuery := `SELECT COALESCE(NULLIF(effective_model, ''), NULLIF(model, ''), 'unknown'), COUNT(*)
-		FROM usage_logs WHERE created_at >= $1 AND created_at < $2 AND status_code <> 499`
+		FROM usage_logs WHERE created_at >= $1 AND created_at < $2 AND status_code <> 499
+		  AND TRIM(COALESCE(internal_reason, '')) = ''`
 	modelArgs := []interface{}{startArg, endArg}
 	if channel != "" {
 		modelQuery += " AND channel = $3"
@@ -971,7 +974,8 @@ func (db *DB) getUsageStatsSQLite(ctx context.Context, rangeStart, rangeEnd time
 		COALESCE(SUM(CASE WHEN status_code >= 400 THEN 1 ELSE 0 END), 0),
 		COALESCE(SUM(CASE WHEN created_at >= $2 THEN 1 ELSE 0 END), 0),
 		COALESCE(SUM(CASE WHEN created_at >= $2 THEN total_tokens ELSE 0 END), 0)
-	FROM usage_logs WHERE created_at >= $1 AND status_code <> 499`
+	FROM usage_logs WHERE created_at >= $1 AND status_code <> 499
+	  AND TRIM(COALESCE(internal_reason, '')) = ''`
 	args := []interface{}{db.timeArg(rangeStart), db.timeArg(minuteAgo)}
 	if !rangeEnd.IsZero() {
 		query += fmt.Sprintf(" AND created_at < $%d", len(args)+1)

--- a/database/sqlite_test.go
+++ b/database/sqlite_test.go
@@ -3284,11 +3284,15 @@ func TestAccountUsageAggregatesExcludeTransportRetries(t *testing.T) {
 
 	ctx := context.Background()
 	now := time.Now().UTC().Truncate(time.Second)
-	insertUsage := func(accountID int64, createdAt time.Time, tokens int, billed float64, retry any, statusCode int) {
+	insertUsage := func(accountID int64, createdAt time.Time, tokens int, billed float64, retry any, statusCode int, internalReason ...string) {
 		t.Helper()
+		reason := ""
+		if len(internalReason) > 0 {
+			reason = internalReason[0]
+		}
 		if _, err := db.conn.ExecContext(ctx, `INSERT INTO usage_logs
-			(account_id, status_code, total_tokens, account_billed, user_billed, is_retry_attempt, created_at)
-			VALUES ($1, $2, $3, $4, $4, $5, $6)`, accountID, statusCode, tokens, billed, retry, sqliteTimeParam(createdAt)); err != nil {
+			(account_id, status_code, total_tokens, account_billed, user_billed, is_retry_attempt, internal_reason, created_at)
+			VALUES ($1, $2, $3, $4, $4, $5, $6, $7)`, accountID, statusCode, tokens, billed, retry, reason, sqliteTimeParam(createdAt)); err != nil {
 			t.Fatalf("insert usage log: %v", err)
 		}
 	}
@@ -3301,6 +3305,16 @@ func TestAccountUsageAggregatesExcludeTransportRetries(t *testing.T) {
 	// Client-cancelled rows remain excluded independently of retry classification.
 	insertUsage(1, now.Add(-20*time.Minute), 700, 7, 0, 499)
 	insertUsage(2, now.Add(-time.Hour), 400, 4, 1, 429)
+	// Capability probes remain in raw logs but must not inflate user-facing
+	// request, token, or billing totals.
+	insertUsage(1, now.Add(-10*time.Minute), 500, 5, 0, 200, "grok_capability_probe")
+	var rawProbeCount int
+	if err := db.conn.QueryRowContext(ctx, `SELECT COUNT(*) FROM usage_logs WHERE internal_reason = 'grok_capability_probe'`).Scan(&rawProbeCount); err != nil {
+		t.Fatalf("query raw capability probe: %v", err)
+	}
+	if rawProbeCount != 1 {
+		t.Fatalf("raw capability probe count = %d, want 1", rawProbeCount)
+	}
 
 	assertUsage := func(label string, got *AccountTimeRangeUsage, requests, tokens int64, billed float64) {
 		t.Helper()
@@ -3339,6 +3353,64 @@ func TestAccountUsageAggregatesExcludeTransportRetries(t *testing.T) {
 	assertUsage("scoped long account 1", longByID[1], 2, 300, 3)
 	if _, ok := longByID[2]; ok {
 		t.Fatalf("scoped account 2 should be absent when it has only retry rows: %+v", longByID[2])
+	}
+	requestCounts, err := db.GetAccountRequestCounts(ctx)
+	if err != nil {
+		t.Fatalf("GetAccountRequestCounts: %v", err)
+	}
+	if got := requestCounts[1]; got == nil || got.SuccessCount != 2 || got.ErrorCount != 1 || got.RetryErrorCount != 1 {
+		t.Fatalf("global request counts account 1 = %+v, want success=2 error=1 retry_error=1", got)
+	}
+	requestCountsByID, err := db.GetAccountRequestCountsByIDs(ctx, []int64{1, 2})
+	if err != nil {
+		t.Fatalf("GetAccountRequestCountsByIDs: %v", err)
+	}
+	if got := requestCountsByID[1]; got == nil || got.SuccessCount != 2 || got.ErrorCount != 1 || got.RetryErrorCount != 1 {
+		t.Fatalf("scoped request counts account 1 = %+v, want success=2 error=1 retry_error=1", got)
+	}
+	billed, err := db.GetAccountBilledSince(ctx, 1, now.Add(-3*time.Hour))
+	if err != nil || billed != 12 {
+		t.Fatalf("GetAccountBilledSince = %.2f, err=%v, want 12", billed, err)
+	}
+	billedByID, err := db.GetAccountsBilledSince(ctx, map[int64]time.Time{1: now.Add(-3 * time.Hour)})
+	if err != nil || billedByID[1] != 12 {
+		t.Fatalf("GetAccountsBilledSince = %#v, err=%v, want account 1 billed 12", billedByID, err)
+	}
+}
+
+func TestUsageStatsExcludeInternalCapabilityProbe(t *testing.T) {
+	db := newGrokStateTestDB(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Second)
+	for _, fixture := range []struct {
+		reason string
+		tokens int
+	}{
+		{tokens: 100},
+		{reason: "grok_capability_probe", tokens: 900},
+	} {
+		if _, err := db.conn.ExecContext(ctx, `INSERT INTO usage_logs
+			(account_id, channel, model, status_code, total_tokens, input_tokens, internal_reason, created_at)
+			VALUES (1, 'grok', 'grok-test', 200, $1, $1, $2, $3)`, fixture.tokens, fixture.reason, sqliteTimeParam(now)); err != nil {
+			t.Fatalf("insert usage fixture: %v", err)
+		}
+	}
+	if err := db.rebuildUsageStatsRollup(ctx); err != nil {
+		t.Fatalf("rebuildUsageStatsRollup: %v", err)
+	}
+	stats, err := db.GetUsageStats(ctx, now.Add(-time.Hour), now.Add(time.Hour), "grok")
+	if err != nil {
+		t.Fatalf("GetUsageStats: %v", err)
+	}
+	if stats.TodayRequests != 1 || stats.TodayTokens != 100 || stats.TotalRequests != 1 || stats.TotalTokens != 100 {
+		t.Fatalf("usage stats = today %d/%d total %d/%d, want 1/100", stats.TodayRequests, stats.TodayTokens, stats.TotalRequests, stats.TotalTokens)
+	}
+	chart, err := db.GetChartAggregation(ctx, now.Add(-time.Hour), now.Add(time.Hour), 5, "grok")
+	if err != nil {
+		t.Fatalf("GetChartAggregation: %v", err)
+	}
+	if len(chart.Timeline) != 1 || chart.Timeline[0].Requests != 1 || chart.Timeline[0].InputTokens != 100 {
+		t.Fatalf("chart timeline = %+v, want one end-user request", chart.Timeline)
 	}
 }
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -36,6 +36,7 @@ import type {
   AccountsPageParams,
   AccountsPageResponse,
   AccountPageStatsResponse,
+  AccountLiveStateResponse,
   ChartAggregation,
   CreateAccountResponse,
   CreateAPIKeyResponse,
@@ -568,6 +569,10 @@ export const api = {
   getAccountPageStats: (ids: number[], signal?: AbortSignal) => {
     const query = new URLSearchParams({ ids: ids.join(',') })
     return request<AccountPageStatsResponse>(`/accounts/page-stats?${query}`, { signal })
+  },
+  getAccountLiveState: (ids: number[], signal?: AbortSignal) => {
+    const query = new URLSearchParams({ ids: ids.join(',') })
+    return request<AccountLiveStateResponse>(`/accounts/live?${query}`, { signal })
   },
   addAccount: (data: AddAccountRequest) =>
     request<CreateAccountResponse>('/accounts', { method: 'POST', body: JSON.stringify(data) }),

--- a/frontend/src/hooks/useAccountLiveState.ts
+++ b/frontend/src/hooks/useAccountLiveState.ts
@@ -1,0 +1,45 @@
+import { useEffect, useMemo } from 'react'
+import { api } from '../api'
+import type { AccountLiveStateResponse } from '../types'
+
+export function useAccountLiveState(
+  ids: number[],
+  apply: (response: AccountLiveStateResponse) => void,
+  enabled = true,
+) {
+  const idsKey = useMemo(() => ids.join(','), [ids])
+
+  useEffect(() => {
+    if (!enabled || !idsKey) return undefined
+    let stopped = false
+    let timer: number | undefined
+    let controller: AbortController | undefined
+
+    const poll = async () => {
+      if (stopped) return
+      if (document.hidden) {
+        timer = window.setTimeout(poll, 1000)
+        return
+      }
+      controller?.abort()
+      controller = new AbortController()
+      try {
+        const response = await api.getAccountLiveState(
+          idsKey.split(',').map(Number),
+          controller.signal,
+        )
+        if (!stopped && !controller.signal.aborted) apply(response)
+      } catch {
+        // The next tick retries; live counters must never disrupt the page.
+      }
+      if (!stopped) timer = window.setTimeout(poll, 1000)
+    }
+
+    void poll()
+    return () => {
+      stopped = true
+      controller?.abort()
+      if (timer !== undefined) window.clearTimeout(timer)
+    }
+  }, [apply, enabled, idsKey])
+}

--- a/frontend/src/pages/Accounts.tsx
+++ b/frontend/src/pages/Accounts.tsx
@@ -11,6 +11,7 @@ import ModelLogo from "../components/ModelLogo";
 import OperationResultsModal from "../components/OperationResultsModal";
 import { cn } from "@/lib/utils";
 import GrokAccounts from "./GrokAccounts";
+import { useAccountLiveState } from "../hooks/useAccountLiveState";
 import PageHeader from "../components/PageHeader";
 import { CompactStat } from "../components/CompactStat";
 import Pagination from "../components/Pagination";
@@ -45,6 +46,7 @@ import type {
   AccountEmailDomainFacet,
   AccountOperationSelector,
   AccountPageStatsItem,
+  AccountLiveStateResponse,
 } from "../types";
 import { getErrorMessage } from "../utils/error";
 import { formatRelativeTime, formatBeijingTime } from "../utils/time";
@@ -1165,7 +1167,7 @@ const AccountTableRow = memo(function AccountTableRow({
                                     <AccountStatusCountdown account={account} />
                                     {(account.active_requests ?? 0) > 0 && (
                                       <span
-                                        className="inline-flex items-center gap-1 rounded-md bg-blue-500/10 px-1.5 py-0.5 text-[11px] font-medium tabular-nums text-blue-600 dark:text-blue-400"
+                                        className="inline-flex items-center gap-1 rounded-md bg-blue-50 px-1.5 py-0.5 text-[11px] font-medium tabular-nums text-blue-600 ring-1 ring-inset ring-blue-500/20 dark:bg-blue-950 dark:text-blue-400 dark:ring-blue-400/20"
                                         title={t("accounts.activeRequestsTooltip", {
                                           count: account.active_requests ?? 0,
                                         })}
@@ -2430,6 +2432,20 @@ export default function Accounts() {
     }));
     return account;
   }, [setData]);
+  const visibleAccountIDs = useMemo(
+    () => data.accounts.map((account) => account.id),
+    [data.accounts],
+  );
+  const applyAccountLiveState = useCallback((response: AccountLiveStateResponse) => {
+    setData((current) => ({
+      ...current,
+      accounts: current.accounts.map((account) => ({
+        ...account,
+        active_requests: response.accounts[String(account.id)]?.active_requests ?? 0,
+      })),
+    }));
+  }, [setData]);
+  useAccountLiveState(visibleAccountIDs, applyAccountLiveState, providerView === "codex");
   const loadAccountDetail = useCallback(
     (account: AccountRow) =>
       account.detail_loaded ? Promise.resolve(account) : api.getAccount(account.id),
@@ -12763,11 +12779,27 @@ function AccountMobileCard({
                 </div>
               </div>
               <div className="shrink-0">
-                <StatusBadge
-                  status={account.status}
-                  detail={getAccountRateLimitWindow(account) ?? undefined}
-                  errorMessage={account.error_message}
-                />
+                <div className="flex flex-wrap items-center justify-end gap-1.5">
+                  <StatusBadge
+                    status={account.status}
+                    detail={getAccountRateLimitWindow(account) ?? undefined}
+                    errorMessage={account.error_message}
+                  />
+                  {(account.active_requests ?? 0) > 0 && (
+                    <span
+                      className="inline-flex items-center gap-1 rounded-md bg-blue-50 px-1.5 py-0.5 text-[11px] font-medium tabular-nums text-blue-600 ring-1 ring-inset ring-blue-500/20 dark:bg-blue-950 dark:text-blue-400 dark:ring-blue-400/20"
+                      title={t("accounts.activeRequestsTooltip", {
+                        count: account.active_requests ?? 0,
+                      })}
+                    >
+                      <span
+                        className="size-1.5 animate-pulse rounded-full bg-blue-500 dark:bg-blue-400"
+                        aria-hidden
+                      />
+                      {account.active_requests}
+                    </span>
+                  )}
+                </div>
               </div>
             </div>
 
@@ -13109,6 +13141,22 @@ function AccountMobileCard({
           >
             <AccountHealthBar buckets={healthBuckets} />
           </div>
+          {(account.active_requests ?? 0) > 0 && (
+            <div className="mt-1">
+              <span
+                className="inline-flex items-center gap-1 rounded-md bg-blue-50 px-1.5 py-0.5 text-[11px] font-medium tabular-nums text-blue-600 ring-1 ring-inset ring-blue-500/20 dark:bg-blue-950 dark:text-blue-400 dark:ring-blue-400/20"
+                title={t("accounts.activeRequestsTooltip", {
+                  count: account.active_requests ?? 0,
+                })}
+              >
+                <span
+                  className="size-1.5 animate-pulse rounded-full bg-blue-500 dark:bg-blue-400"
+                  aria-hidden
+                />
+                {account.active_requests}
+              </span>
+            </div>
+          )}
         </div>
       </div>
 

--- a/frontend/src/pages/GrokAccounts.tsx
+++ b/frontend/src/pages/GrokAccounts.tsx
@@ -45,6 +45,7 @@ import type {
   GrokAccountState,
   GrokModelCatalogItem,
   GrokProtocol,
+  AccountLiveStateResponse,
 } from "../types";
 import AccountDetailSheet from "../components/AccountDetailSheet";
 import AccountGroupFilterSelect, {
@@ -66,6 +67,7 @@ import { CompactStat } from "../components/CompactStat";
 import Pagination from "../components/Pagination";
 import StateShell from "../components/StateShell";
 import StatusBadge from "../components/StatusBadge";
+import { useAccountLiveState } from "../hooks/useAccountLiveState";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Select } from "@/components/ui/select";
@@ -633,6 +635,17 @@ function GrokAccounts({
     setDetailAccountData((current) => current?.id === id ? account : current);
     return account;
   }, []);
+  const visibleAccountIDs = useMemo(
+    () => accounts.map((account) => account.id),
+    [accounts],
+  );
+  const applyAccountLiveState = useCallback((response: AccountLiveStateResponse) => {
+    setAccounts((current) => current.map((account) => ({
+      ...account,
+      active_requests: response.accounts[String(account.id)]?.active_requests ?? 0,
+    })));
+  }, []);
+  useAccountLiveState(visibleAccountIDs, applyAccountLiveState);
   const loadAccountDetail = useCallback(
     (account: AccountRow) =>
       account.detail_loaded ? Promise.resolve(account) : api.getAccount(account.id),
@@ -3582,6 +3595,15 @@ function GrokAccountCard({
                 status={disabled ? "paused" : (account.status ?? "unknown")}
                 errorMessage={account.error_message}
               />
+              {(account.active_requests ?? 0) > 0 && (
+                <span
+                  className="inline-flex items-center gap-1 rounded-md bg-blue-50 px-1.5 py-0.5 text-[11px] font-medium tabular-nums text-blue-600 ring-1 ring-inset ring-blue-500/20 dark:bg-blue-950 dark:text-blue-400 dark:ring-blue-400/20"
+                  title={t("accounts.activeRequestsTooltip", { count: account.active_requests ?? 0 })}
+                >
+                  <span className="size-1.5 animate-pulse rounded-full bg-blue-500 dark:bg-blue-400" aria-hidden />
+                  {account.active_requests}
+                </span>
+              )}
             </div>
             <h3
               className="mt-1.5 break-all text-[15px] font-semibold leading-snug tracking-tight text-foreground transition-colors hover:text-primary sm:text-base"
@@ -3953,6 +3975,15 @@ function GrokAccountTableRow({
             status={disabled ? "paused" : (account.status ?? "unknown")}
             errorMessage={account.error_message}
           />
+          {(account.active_requests ?? 0) > 0 && (
+            <span
+              className="inline-flex items-center gap-1 rounded-md bg-blue-50 px-1.5 py-0.5 text-[11px] font-medium tabular-nums text-blue-600 ring-1 ring-inset ring-blue-500/20 dark:bg-blue-950 dark:text-blue-400 dark:ring-blue-400/20"
+              title={t("accounts.activeRequestsTooltip", { count: account.active_requests ?? 0 })}
+            >
+              <span className="size-1.5 animate-pulse rounded-full bg-blue-500 dark:bg-blue-400" aria-hidden />
+              {account.active_requests}
+            </span>
+          )}
           <AccountHealthBar buckets={healthBuckets} />
         </div>
       </TableCell>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -276,6 +276,10 @@ export interface AccountPageStatsResponse {
   stats: Record<string, AccountPageStatsItem>
 }
 
+export interface AccountLiveStateResponse {
+  accounts: Record<string, { active_requests: number }>
+}
+
 export interface AccountsPageParams {
   channel?: 'codex' | 'grok'
   page: number


### PR DESCRIPTION
## What changed

- keep Grok capability probes in raw usage logs for diagnostics while excluding internal traffic from user-facing request, token, billing, dashboard, chart, API-key, and account aggregates
- version and rebuild existing usage rollups so historical capability probes no longer remain in cumulative totals
- cache failed, rate-limited, and version-required capability observations for 24 hours; explicit forced probes still bypass the cache
- expose lightweight in-memory active-request counters and poll them on the Codex and Grok account pages

## Why

The 30-second Grok freshness worker periodically rebuilds missing capabilities with minimal generation requests. Those rows are tagged with `internal_reason=grok_capability_probe`, but existing aggregates treated them as normal end-user traffic. This inflated account request/token figures and made accounts appear continuously active. Short negative capability TTLs also caused unsupported or rate-limited protocols to be retried every few minutes.

## Impact

Raw probe evidence remains available for debugging. User-facing statistics now represent actual client traffic, and unsupported capability probes no longer recur throughout the day. The new live badge reflects only current in-flight requests from in-memory counters.

## Validation

- `go test ./database ./admin -count=1`
- `go vet ./database ./admin`
- `pnpm --dir frontend typecheck`
- `pnpm --dir frontend build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live active-request indicators to account tables and cards.
  * Account activity updates automatically without reloading account lists.
  * Added an authenticated admin view for retrieving live account activity.

* **Bug Fixes**
  * Usage, billing, traffic, and chart metrics now exclude internally generated requests while preserving raw logs.
  * Existing usage summaries are refreshed to apply the updated aggregation rules.

* **Improvements**
  * Capability probe results are cached for up to 24 hours, reducing repeated probes during temporary failures or unsupported responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->