### PR TITLE
fix(images): honor exact requested dimensions

### DIFF
--- a/admin/image_studio.go
+++ b/admin/image_studio.go
@@ -1004,8 +1004,8 @@ func buildAdminImageEditRequest(req imageGenerationJobPayload) ([]byte, error) {
 		images[i] = map[string]string{"image_url": img}
 	}
 	body["images"] = images
-	if req.Size != "" && req.Size != "auto" {
-		body["size"] = req.Size
+	if upstreamSize := upstreamImageJobSize(req); upstreamSize != "" && upstreamSize != "auto" {
+		body["size"] = upstreamSize
 	}
 	if req.Quality != "" && req.Quality != "auto" {
 		body["quality"] = req.Quality
@@ -1143,8 +1143,8 @@ func buildAdminImageGenerationRequest(req imageGenerationJobPayload) ([]byte, er
 		"prompt":          proxy.AppendImageStyleToPrompt(req.Prompt, req.Style),
 		"response_format": "b64_json",
 	}
-	if req.Size != "" && req.Size != "auto" {
-		body["size"] = req.Size
+	if upstreamSize := upstreamImageJobSize(req); upstreamSize != "" && upstreamSize != "auto" {
+		body["size"] = upstreamSize
 	}
 	if req.Quality != "" && req.Quality != "auto" {
 		body["quality"] = req.Quality
@@ -1156,6 +1156,30 @@ func buildAdminImageGenerationRequest(req imageGenerationJobPayload) ([]byte, er
 		body["background"] = req.Background
 	}
 	return json.Marshal(body)
+}
+
+// upstreamImageJobSize converts an exact output canvas into a size accepted by
+// GPT Image 2. The upstream image tool requires both dimensions to be multiples
+// of 16, while callers commonly request display sizes such as 1920x1080. The
+// original req.Size remains unchanged and is applied after generation, so this
+// compatibility adjustment never changes the promised final dimensions.
+func upstreamImageJobSize(req imageGenerationJobPayload) string {
+	size := strings.TrimSpace(req.Size)
+	width, height, ok := imageupscale.ParseSize(size)
+	if !ok || !strictImageJobSize(req) {
+		return size
+	}
+	const quantum = 16
+	width = ((width + quantum - 1) / quantum) * quantum
+	height = ((height + quantum - 1) / quantum) * quantum
+	return fmt.Sprintf("%dx%d", width, height)
+}
+
+func strictImageJobSize(req imageGenerationJobPayload) bool {
+	if _, _, ok := imageupscale.ParseSize(req.Size); !ok {
+		return false
+	}
+	return req.StrictSize == nil || *req.StrictSize
 }
 
 func runImageJobBatch(count int, execute func() ([]byte, int, error)) ([]byte, int, []string, error) {
@@ -1293,10 +1317,7 @@ func (h *Handler) saveImageJobAssets(ctx context.Context, jobID int64, req image
 		if err != nil {
 			return saved, warnings, err
 		}
-		strictSize := false
-		if _, _, ok := imageupscale.ParseSize(req.Size); ok {
-			strictSize = req.StrictSize == nil || *req.StrictSize
-		}
+		strictSize := strictImageJobSize(req)
 		if req.Upscale != "" || strictSize {
 			upscaledBytes, upscaledMime, upscaleErr := h.upscaleImageJobAsset(ctx, jobID, idx+1, imageBytes, req.Upscale, requestedSize, req.UpscaleFit, strictSize)
 			if upscaleErr != nil {

--- a/admin/image_studio.go
+++ b/admin/image_studio.go
@@ -64,6 +64,8 @@ type imageGenerationJobPayload struct {
 	Background   string   `json:"background"`
 	Style        string   `json:"style"`
 	Upscale      string   `json:"upscale"`
+	StrictSize   *bool    `json:"strict_size,omitempty"`
+	UpscaleFit   string   `json:"upscale_fit,omitempty"`
 	N            int      `json:"n"`
 	APIKeyID     int64    `json:"api_key_id"`
 	TemplateID   int64    `json:"template_id"`
@@ -1277,6 +1279,10 @@ func (h *Handler) saveImageJobAssets(ctx context.Context, jobID int64, req image
 	}
 	responseModel := firstNonEmpty(gjson.GetBytes(responseJSON, "model").String(), req.Model)
 	responseSize := firstNonEmpty(gjson.GetBytes(responseJSON, "size").String(), req.Size)
+	requestedSize := strings.TrimSpace(req.Size)
+	if _, _, ok := imageupscale.ParseSize(requestedSize); !ok {
+		requestedSize = responseSize
+	}
 	responseQuality := firstNonEmpty(gjson.GetBytes(responseJSON, "quality").String(), req.Quality)
 	responseFormat := firstNonEmpty(gjson.GetBytes(responseJSON, "output_format").String(), req.OutputFormat, "png")
 
@@ -1287,8 +1293,12 @@ func (h *Handler) saveImageJobAssets(ctx context.Context, jobID int64, req image
 		if err != nil {
 			return saved, warnings, err
 		}
-		if req.Upscale != "" {
-			upscaledBytes, upscaledMime, upscaleErr := h.upscaleImageJobAsset(ctx, jobID, idx+1, imageBytes, req.Upscale, req.Size)
+		strictSize := false
+		if _, _, ok := imageupscale.ParseSize(req.Size); ok {
+			strictSize = req.StrictSize == nil || *req.StrictSize
+		}
+		if req.Upscale != "" || strictSize {
+			upscaledBytes, upscaledMime, upscaleErr := h.upscaleImageJobAsset(ctx, jobID, idx+1, imageBytes, req.Upscale, requestedSize, req.UpscaleFit, strictSize)
 			if upscaleErr != nil {
 				// Undecodable upscaler output is degraded the same way a
 				// transport failure is. The upstream image behind it has
@@ -1337,7 +1347,7 @@ func (h *Handler) saveImageJobAssets(ctx context.Context, jobID int64, req image
 			Width:         width,
 			Height:        height,
 			Model:         responseModel,
-			RequestedSize: responseSize,
+			RequestedSize: requestedSize,
 			ActualSize:    actualSize,
 			Quality:       responseQuality,
 			OutputFormat:  format,
@@ -1369,13 +1379,14 @@ func (h *Handler) saveImageJobAssets(ctx context.Context, jobID int64, req image
 	return saved, warnings, nil
 }
 
-func (h *Handler) upscaleImageJobAsset(ctx context.Context, jobID int64, assetIndex int, imageBytes []byte, scale, requestedSize string) ([]byte, string, error) {
+func (h *Handler) upscaleImageJobAsset(ctx context.Context, jobID int64, assetIndex int, imageBytes []byte, scale, requestedSize, fit string, strict bool) ([]byte, string, error) {
 	scale = imageproc.NormalizeUpscale(scale)
-	if scale == "" || len(imageBytes) == 0 {
+	if (scale == "" && !strict) || len(imageBytes) == 0 {
 		return nil, "", nil
 	}
+	fit = imageproc.NormalizeResizeFit(fit, strict)
 	cache := imageproc.GlobalUpscaleCache()
-	key := imageproc.ComputeUpscaleCacheKey(imageBytes, scale) + "-" + strings.ToLower(strings.TrimSpace(requestedSize))
+	key := imageproc.ComputeUpscaleCacheKey(imageBytes, scale) + "-" + strings.ToLower(strings.TrimSpace(requestedSize)) + "-" + fit + "-" + strconv.FormatBool(strict)
 	if data, contentType, ok := cache.Get(key); ok && contentType != "" {
 		return data, contentType, nil
 	}
@@ -1399,7 +1410,7 @@ func (h *Handler) upscaleImageJobAsset(ctx context.Context, jobID int64, assetIn
 	}
 
 	beforeWidth, beforeHeight := imageDimensions(imageBytes)
-	upscaled, contentType, method, err := upscaleImageBytes(upscaleCtx, imageBytes, scale, requestedSize)
+	upscaled, contentType, method, err := imageupscale.BytesWithFit(upscaleCtx, imageBytes, scale, requestedSize, fit, strict)
 	if err != nil {
 		log.Printf("[image-studio] job=%d asset_index=%d upscale_failed scale=%s backend=%s error=%s",
 			jobID,

--- a/admin/image_studio_test.go
+++ b/admin/image_studio_test.go
@@ -389,6 +389,40 @@ func TestUpscaleImageBytesHonoursRequestedSizeOnLocalBackend(t *testing.T) {
 	}
 }
 
+func TestSaveImageJobAssetsDefaultsExplicitSizeToStrictPad(t *testing.T) {
+	db := newTestAdminDB(t)
+	dir := t.TempDir()
+	t.Setenv("IMAGE_ASSET_DIR", dir)
+	t.Setenv("IMAGE_UPSCALER_ENDPOINT", "")
+	if err := imagestore.Configure(imagestore.Config{Backend: imagestore.BackendLocal, LocalDir: dir}); err != nil {
+		t.Fatalf("imagestore.Configure: %v", err)
+	}
+	jobID, err := db.InsertImageGenerationJob(context.Background(), database.ImageGenerationJobInput{Prompt: "strict landscape"})
+	if err != nil {
+		t.Fatalf("InsertImageGenerationJob: %v", err)
+	}
+	raw, err := json.Marshal(map[string]any{
+		"size": "4x4",
+		"data": []map[string]string{{"b64_json": base64.StdEncoding.EncodeToString(squarePNG(t, 4))}},
+	})
+	if err != nil {
+		t.Fatalf("marshal response: %v", err)
+	}
+
+	assets, warnings, err := (&Handler{db: db}).saveImageJobAssets(context.Background(), jobID, imageGenerationJobPayload{
+		Model: "gpt-image-2", Size: "12x6", OutputFormat: "png",
+	}, raw)
+	if err != nil {
+		t.Fatalf("saveImageJobAssets returned error: %v", err)
+	}
+	if len(warnings) != 0 || len(assets) != 1 {
+		t.Fatalf("assets=%d warnings=%#v", len(assets), warnings)
+	}
+	if asset := assets[0]; asset.Width != 12 || asset.Height != 6 || asset.ActualSize != "12x6" || asset.RequestedSize != "12x6" {
+		t.Fatalf("asset = %#v", asset)
+	}
+}
+
 func TestSaveImageJobAssetsPreservesOriginalWhenUpscalerReturnsInvalidImage(t *testing.T) {
 	db := newTestAdminDB(t)
 	dir := t.TempDir()

--- a/admin/image_studio_test.go
+++ b/admin/image_studio_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/codex2api/proxy"
 	"github.com/codex2api/security/promptfilter"
 	"github.com/gin-gonic/gin"
+	"github.com/tidwall/gjson"
 )
 
 func TestBuildAdminImageGenerationRequestOmitsAutoSize(t *testing.T) {
@@ -67,6 +68,46 @@ func TestBuildAdminImageGenerationRequestOmitsAutoSize(t *testing.T) {
 	}
 	if payload["quality"] != "high" || payload["output_format"] != "png" {
 		t.Fatalf("payload = %#v", payload)
+	}
+}
+
+func TestBuildAdminImageRequestsUseCompatibleUpstreamSizeForStrictCanvas(t *testing.T) {
+	req := imageGenerationJobPayload{
+		Prompt:       "draw a landscape",
+		Model:        "gpt-image-2",
+		Size:         "1920x1080",
+		OutputFormat: "png",
+		InputImages:  []string{"data:image/png;base64,AA=="},
+	}
+	for name, build := range map[string]func(imageGenerationJobPayload) ([]byte, error){
+		"generation": buildAdminImageGenerationRequest,
+		"edit":       buildAdminImageEditRequest,
+	} {
+		t.Run(name, func(t *testing.T) {
+			body, err := build(req)
+			if err != nil {
+				t.Fatalf("build request: %v", err)
+			}
+			if got := gjson.GetBytes(body, "size").String(); got != "1920x1088" {
+				t.Fatalf("upstream size = %q, want 1920x1088", got)
+			}
+			if req.Size != "1920x1080" {
+				t.Fatalf("requested final size mutated to %q", req.Size)
+			}
+		})
+	}
+}
+
+func TestBuildAdminImageRequestLeavesSizeUnchangedWhenStrictDisabled(t *testing.T) {
+	strict := false
+	body, err := buildAdminImageGenerationRequest(imageGenerationJobPayload{
+		Prompt: "draw", Model: "gpt-image-2", Size: "1920x1080", StrictSize: &strict,
+	})
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	if got := gjson.GetBytes(body, "size").String(); got != "1920x1080" {
+		t.Fatalf("upstream size = %q, want explicit opt-out size unchanged", got)
 	}
 }
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -3020,6 +3020,8 @@ export interface CreateImageJobPayload {
   background?: string
   style?: string
   upscale?: string
+  strict_size?: boolean
+  upscale_fit?: 'pad' | 'cover'
   api_key_id?: number
   template_id?: number
   input_images?: string[]

--- a/internal/imageproc/imageproc_test.go
+++ b/internal/imageproc/imageproc_test.go
@@ -107,6 +107,46 @@ func TestDoUpscaleToRejectsInvalidImage(t *testing.T) {
 	}
 }
 
+func TestDoResizeToPadsToExactMismatchedCanvas(t *testing.T) {
+	out, contentType, err := DoResizeTo(testPNG(t, 4, 4), 12, 6, ResizeFitPad)
+	if err != nil {
+		t.Fatalf("DoResizeTo returned error: %v", err)
+	}
+	if contentType != "image/png" {
+		t.Fatalf("contentType = %q, want image/png", contentType)
+	}
+	img, _, err := image.Decode(bytes.NewReader(out))
+	if err != nil {
+		t.Fatalf("decode resized image: %v", err)
+	}
+	if got := img.Bounds(); got.Dx() != 12 || got.Dy() != 6 {
+		t.Fatalf("resized size = %dx%d, want 12x6", got.Dx(), got.Dy())
+	}
+	if _, _, _, alpha := img.At(0, 0).RGBA(); alpha != 0 {
+		t.Fatalf("padding alpha = %d, want transparent", alpha)
+	}
+	if _, _, _, alpha := img.At(3, 0).RGBA(); alpha == 0 {
+		t.Fatal("centered source should start after the transparent padding")
+	}
+}
+
+func TestDoResizeToCoversExactMismatchedCanvas(t *testing.T) {
+	out, _, err := DoResizeTo(testPNG(t, 4, 4), 12, 6, ResizeFitCover)
+	if err != nil {
+		t.Fatalf("DoResizeTo returned error: %v", err)
+	}
+	img, _, err := image.Decode(bytes.NewReader(out))
+	if err != nil {
+		t.Fatalf("decode resized image: %v", err)
+	}
+	if got := img.Bounds(); got.Dx() != 12 || got.Dy() != 6 {
+		t.Fatalf("resized size = %dx%d, want 12x6", got.Dx(), got.Dy())
+	}
+	if _, _, _, alpha := img.At(0, 0).RGBA(); alpha == 0 {
+		t.Fatal("cover mode should fill the complete canvas")
+	}
+}
+
 func TestDoUpscaleKeepsLargeSource(t *testing.T) {
 	src := testPNG(t, 2600, 16)
 	out, contentType, err := DoUpscale(src, "2k")

--- a/internal/imageproc/upscale.go
+++ b/internal/imageproc/upscale.go
@@ -25,6 +25,10 @@ const (
 	UpscaleNone = ""
 	Upscale2K   = "2k"
 	Upscale4K   = "4k"
+
+	ResizeFitInside = "inside"
+	ResizeFitPad    = "pad"
+	ResizeFitCover  = "cover"
 )
 
 var ErrUpscaleDecode = errors.New("image upscale: decode source failed")
@@ -118,6 +122,86 @@ func DoUpscaleTo(src []byte, targetWidth, targetHeight int, exact bool) ([]byte,
 		dw, dh = fitInsideDimensions(sw, sh, targetWidth, targetHeight)
 	}
 	return encodeUpscaled(srcImg, bounds, dw, dh)
+}
+
+// NormalizeResizeFit returns the supported resize policy. Strict resize calls
+// default to padding so the requested canvas is always exact without silently
+// cropping content; legacy calls keep the historical fit-inside behavior.
+func NormalizeResizeFit(value string, strict bool) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case ResizeFitCover:
+		return ResizeFitCover
+	case ResizeFitPad:
+		return ResizeFitPad
+	case ResizeFitInside:
+		if !strict {
+			return ResizeFitInside
+		}
+	}
+	if strict {
+		return ResizeFitPad
+	}
+	return ResizeFitInside
+}
+
+// DoResizeTo produces an exact target canvas. Pad preserves the complete
+// source and centers it on a transparent canvas; cover fills the canvas and
+// crops equally from the two overflowing sides. Inside remains available for
+// callers that explicitly need the legacy non-exact behavior.
+func DoResizeTo(src []byte, targetWidth, targetHeight int, fit string) ([]byte, string, error) {
+	if len(src) == 0 || targetWidth <= 0 || targetHeight <= 0 {
+		return src, "", nil
+	}
+
+	srcImg, _, err := stdimage.Decode(bytes.NewReader(src))
+	if err != nil {
+		return nil, "", fmt.Errorf("%w: %v", ErrUpscaleDecode, err)
+	}
+	bounds := srcImg.Bounds()
+	sw, sh := bounds.Dx(), bounds.Dy()
+	if sw <= 0 || sh <= 0 {
+		return nil, "", ErrUpscaleDecode
+	}
+
+	fit = strings.ToLower(strings.TrimSpace(fit))
+	if fit != ResizeFitInside && fit != ResizeFitCover && fit != ResizeFitPad {
+		fit = ResizeFitPad
+	}
+	if sw == targetWidth && sh == targetHeight {
+		return src, "", nil
+	}
+	if fit == ResizeFitInside {
+		return DoUpscaleTo(src, targetWidth, targetHeight, false)
+	}
+
+	dst := stdimage.NewRGBA(stdimage.Rect(0, 0, targetWidth, targetHeight))
+	if fit == ResizeFitCover {
+		crop := bounds
+		sourceAspect := float64(sw) / float64(sh)
+		targetAspect := float64(targetWidth) / float64(targetHeight)
+		if sourceAspect > targetAspect {
+			cropWidth := max(1, int(float64(sh)*targetAspect+0.5))
+			left := bounds.Min.X + (sw-cropWidth)/2
+			crop = stdimage.Rect(left, bounds.Min.Y, left+cropWidth, bounds.Max.Y)
+		} else if sourceAspect < targetAspect {
+			cropHeight := max(1, int(float64(sw)/targetAspect+0.5))
+			top := bounds.Min.Y + (sh-cropHeight)/2
+			crop = stdimage.Rect(bounds.Min.X, top, bounds.Max.X, top+cropHeight)
+		}
+		draw.CatmullRom.Scale(dst, dst.Bounds(), srcImg, crop, draw.Src, nil)
+	} else {
+		dw, dh := fitInsideDimensions(sw, sh, targetWidth, targetHeight)
+		left := (targetWidth - dw) / 2
+		top := (targetHeight - dh) / 2
+		draw.CatmullRom.Scale(dst, stdimage.Rect(left, top, left+dw, top+dh), srcImg, bounds, draw.Src, nil)
+	}
+
+	var buf bytes.Buffer
+	encoder := png.Encoder{CompressionLevel: png.BestSpeed}
+	if err := encoder.Encode(&buf, dst); err != nil {
+		return nil, "", fmt.Errorf("image resize: png encode: %w", err)
+	}
+	return buf.Bytes(), "image/png", nil
 }
 
 func encodeUpscaled(srcImg stdimage.Image, bounds stdimage.Rectangle, dw, dh int) ([]byte, string, error) {

--- a/internal/imageupscale/imageupscale.go
+++ b/internal/imageupscale/imageupscale.go
@@ -37,15 +37,28 @@ type Result struct {
 // caller resolved from the request, going through the shared LRU cache and the
 // global concurrency gate. Unlike Bytes, a parseable requestedSize is treated
 // as the exact physical target — the public Images API promises the size in
-// the request, not the tier long side. It returns nil when no upscale is
-// needed: scale is empty, or the source already covers the target box.
+// the request, not the tier long side. An explicit size may therefore trigger
+// strict local resizing even without a 2K/4K tier. It returns nil when no
+// resize is needed or neither a scale nor a physical size was supplied.
 func EnsureSize(ctx context.Context, imageBytes []byte, scale, requestedSize string) (*Result, error) {
+	return EnsureSizeWithFit(ctx, imageBytes, scale, requestedSize, "")
+}
+
+// EnsureSizeWithFit is the strict-size variant used when a request contains a
+// physical WIDTHxHEIGHT target. It always produces that canvas, defaulting to
+// content-preserving padding unless the caller explicitly selects cover.
+func EnsureSizeWithFit(ctx context.Context, imageBytes []byte, scale, requestedSize, fit string) (*Result, error) {
 	scale = imageproc.NormalizeUpscale(scale)
-	if scale == "" || len(imageBytes) == 0 {
+	targetWidth, targetHeight, exact := 0, 0, false
+	if width, height, ok := parseSize(requestedSize); ok {
+		targetWidth, targetHeight, exact = width, height, true
+		fit = imageproc.NormalizeResizeFit(fit, true)
+	}
+	if len(imageBytes) == 0 || (scale == "" && !exact) {
 		return nil, nil
 	}
 	cache := imageproc.GlobalUpscaleCache()
-	key := imageproc.ComputeUpscaleCacheKey(imageBytes, scale) + "-" + strings.ToLower(strings.TrimSpace(requestedSize))
+	key := imageproc.ComputeUpscaleCacheKey(imageBytes, scale) + "-" + strings.ToLower(strings.TrimSpace(requestedSize)) + "-" + fit
 	if data, contentType, ok := cache.Get(key); ok && contentType != "" {
 		return resultFromData(data, contentType, "cache", imageBytes), nil
 	}
@@ -57,10 +70,7 @@ func EnsureSize(ctx context.Context, imageBytes []byte, scale, requestedSize str
 		return resultFromData(data, contentType, "cache", imageBytes), nil
 	}
 
-	targetWidth, targetHeight, exact := 0, 0, false
-	if width, height, ok := parseSize(requestedSize); ok {
-		targetWidth, targetHeight, exact = width, height, true
-	} else {
+	if !exact {
 		width, height := Dimensions(imageBytes)
 		targetLongSide := imageproc.UpscaleLongSide(scale)
 		if width <= 0 || height <= 0 || targetLongSide <= 0 {
@@ -68,7 +78,14 @@ func EnsureSize(ctx context.Context, imageBytes []byte, scale, requestedSize str
 		}
 		targetWidth, targetHeight, exact = TargetDimensions(width, height, targetLongSide, requestedSize)
 	}
-	data, contentType, method, err := upscaleToBox(ctx, imageBytes, targetWidth, targetHeight, exact)
+	var data []byte
+	var contentType, method string
+	var err error
+	if exact {
+		data, contentType, method, err = upscaleToBoxWithFit(ctx, imageBytes, targetWidth, targetHeight, fit)
+	} else {
+		data, contentType, method, err = upscaleToBox(ctx, imageBytes, targetWidth, targetHeight, false)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -81,6 +98,11 @@ func EnsureSize(ctx context.Context, imageBytes []byte, scale, requestedSize str
 	}
 	cache.Put(key, data, contentType)
 	return result, nil
+}
+
+// ParseSize reports whether value is a positive WIDTHxHEIGHT image size.
+func ParseSize(size string) (int, int, bool) {
+	return parseSize(size)
 }
 
 func parseSize(size string) (int, int, bool) {
@@ -138,6 +160,21 @@ func Bytes(ctx context.Context, imageBytes []byte, scale, requestedSize string) 
 	}
 	targetWidth, targetHeight, exactTarget := TargetDimensions(width, height, targetLongSide, requestedSize)
 	return upscaleToBox(ctx, imageBytes, targetWidth, targetHeight, exactTarget)
+}
+
+// BytesWithFit preserves Bytes' legacy behavior unless strict is requested
+// with a valid physical size. Strict calls may run even without a 2K/4K tier,
+// because the explicit size itself is the authoritative target.
+func BytesWithFit(ctx context.Context, imageBytes []byte, scale, requestedSize, fit string, strict bool) ([]byte, string, string, error) {
+	if strict {
+		if targetWidth, targetHeight, ok := parseSize(requestedSize); ok {
+			if width, height := Dimensions(imageBytes); width <= 0 || height <= 0 {
+				return nil, "", "", fmt.Errorf("image upscaler: invalid source dimensions")
+			}
+			return upscaleToBoxWithFit(ctx, imageBytes, targetWidth, targetHeight, fit)
+		}
+	}
+	return Bytes(ctx, imageBytes, scale, requestedSize)
 }
 
 // upscaleToBox dispatches one upscale toward an explicit target box to the
@@ -221,6 +258,105 @@ func upscaleToBox(ctx context.Context, imageBytes []byte, targetWidth, targetHei
 		return nil, "", "", fmt.Errorf("image upscaler returned unsupported content type %q", response.Header.Get("Content-Type"))
 	}
 	return body, contentType, method, nil
+}
+
+// upscaleToBoxWithFit uses the configured backend for enlargement, then
+// performs a local finalization pass so external and local backends obey the
+// same exact-canvas contract.
+func upscaleToBoxWithFit(ctx context.Context, imageBytes []byte, targetWidth, targetHeight int, fit string) ([]byte, string, string, error) {
+	fit = imageproc.NormalizeResizeFit(fit, true)
+	width, height := Dimensions(imageBytes)
+	if width <= 0 || height <= 0 {
+		return nil, "", "", fmt.Errorf("image upscaler: invalid source dimensions")
+	}
+	if width == targetWidth && height == targetHeight {
+		return nil, "", "", nil
+	}
+
+	endpoint := strings.TrimSpace(os.Getenv("IMAGE_UPSCALER_ENDPOINT"))
+	if endpoint == "" || (width >= targetWidth && height >= targetHeight) {
+		data, contentType, err := imageproc.DoResizeTo(imageBytes, targetWidth, targetHeight, fit)
+		return data, contentType, "catmull-rom-" + fit, err
+	}
+
+	parsed, err := url.Parse(endpoint)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return nil, "", "", fmt.Errorf("image upscaler: invalid endpoint %q", endpoint)
+	}
+	parsed.Path = strings.TrimRight(parsed.Path, "/") + "/v1/upscale"
+	query := parsed.Query()
+	query.Set("target_width", strconv.Itoa(targetWidth))
+	query.Set("target_height", strconv.Itoa(targetHeight))
+	query.Set("format", "png")
+	query.Set("trigger_ratio", "1")
+	if fit == imageproc.ResizeFitCover {
+		query.Set("fit", "cover")
+	} else {
+		query.Set("fit", "inside")
+	}
+	parsed.RawQuery = query.Encode()
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, parsed.String(), bytes.NewReader(imageBytes))
+	if err != nil {
+		return nil, "", "", err
+	}
+	request.Header.Set("Content-Type", http.DetectContentType(imageBytes))
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		return nil, "", "", fmt.Errorf("call image upscaler: %w", err)
+	}
+	defer response.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(response.Body, maxUpscalerResponseBytes+1))
+	if err != nil {
+		return nil, "", "", fmt.Errorf("read image upscaler response: %w", err)
+	}
+	if len(body) > maxUpscalerResponseBytes {
+		return nil, "", "", fmt.Errorf("image upscaler response exceeds %d bytes", maxUpscalerResponseBytes)
+	}
+	if response.StatusCode != http.StatusOK {
+		message := strings.TrimSpace(string(body))
+		if len(message) > 1024 {
+			message = message[:1024]
+		}
+		return nil, "", "", fmt.Errorf("image upscaler returned %d: %s", response.StatusCode, message)
+	}
+
+	applied := true
+	if marker := strings.TrimSpace(response.Header.Get("X-Upscale-Applied")); marker != "" {
+		parsedApplied, parseErr := strconv.ParseBool(marker)
+		if parseErr != nil {
+			return nil, "", "", fmt.Errorf("image upscaler returned an invalid applied marker %q", marker)
+		}
+		applied = parsedApplied
+	}
+	method := strings.TrimSpace(response.Header.Get("X-Upscale-Method"))
+	if method == "" {
+		method = "realesrgan-general-x4v3"
+	}
+	candidate := imageBytes
+	candidateType := http.DetectContentType(imageBytes)
+	if applied {
+		if len(body) == 0 {
+			return nil, "", "", fmt.Errorf("image upscaler returned empty image data")
+		}
+		candidateType = NormalizeContentType(response.Header.Get("Content-Type"))
+		if candidateType == "" {
+			return nil, "", "", fmt.Errorf("image upscaler returned unsupported content type %q", response.Header.Get("Content-Type"))
+		}
+		candidate = body
+	}
+
+	final, contentType, err := imageproc.DoResizeTo(candidate, targetWidth, targetHeight, fit)
+	if err != nil {
+		return nil, "", "", err
+	}
+	if contentType != "" {
+		return final, contentType, method + "+" + fit, nil
+	}
+	if !applied {
+		return nil, "", method, nil
+	}
+	return candidate, candidateType, method, nil
 }
 
 // NormalizeContentType keeps the stored asset MIME type within image/*. The

--- a/internal/imageupscale/imageupscale_test.go
+++ b/internal/imageupscale/imageupscale_test.go
@@ -1,0 +1,58 @@
+package imageupscale
+
+import (
+	"bytes"
+	"context"
+	"image"
+	"image/color"
+	"image/png"
+	"testing"
+)
+
+func strictTestPNG(t *testing.T, width, height int) []byte {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, width, height))
+	for y := 0; y < height; y++ {
+		for x := 0; x < width; x++ {
+			img.Set(x, y, color.RGBA{R: 80, G: 120, B: 160, A: 255})
+		}
+	}
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		t.Fatalf("encode PNG: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func TestBytesWithFitHonorsStrictSizeWithoutUpscaleTier(t *testing.T) {
+	t.Setenv("IMAGE_UPSCALER_ENDPOINT", "")
+	data, contentType, method, err := BytesWithFit(context.Background(), strictTestPNG(t, 4, 4), "", "12x6", "pad", true)
+	if err != nil {
+		t.Fatalf("BytesWithFit returned error: %v", err)
+	}
+	if contentType != "image/png" || method != "catmull-rom-pad" {
+		t.Fatalf("contentType=%q method=%q", contentType, method)
+	}
+	if width, height := Dimensions(data); width != 12 || height != 6 {
+		t.Fatalf("strict size = %dx%d, want 12x6", width, height)
+	}
+}
+
+func TestEnsureSizeWithFitSeparatesPadAndCoverCacheEntries(t *testing.T) {
+	t.Setenv("IMAGE_UPSCALER_ENDPOINT", "")
+	source := strictTestPNG(t, 4, 4)
+	pad, err := EnsureSizeWithFit(context.Background(), source, "2k", "12x6", "pad")
+	if err != nil {
+		t.Fatalf("pad EnsureSizeWithFit: %v", err)
+	}
+	cover, err := EnsureSizeWithFit(context.Background(), source, "2k", "12x6", "cover")
+	if err != nil {
+		t.Fatalf("cover EnsureSizeWithFit: %v", err)
+	}
+	if pad == nil || cover == nil || pad.Width != 12 || pad.Height != 6 || cover.Width != 12 || cover.Height != 6 {
+		t.Fatalf("pad=%#v cover=%#v", pad, cover)
+	}
+	if bytes.Equal(pad.Data, cover.Data) {
+		t.Fatal("pad and cover results must not share a cache entry")
+	}
+}

--- a/proxy/images_upscale_test.go
+++ b/proxy/images_upscale_test.go
@@ -127,6 +127,20 @@ func TestCollectImagesResponseHonorsExplicitCustomSize(t *testing.T) {
 	}
 }
 
+func TestCollectImagesResponsePadsMismatchedSourceToExactCustomSize(t *testing.T) {
+	upstream := imagesCompletedSSE(sizedPNGBase64(t, 4, 4), "12x6")
+	plan := imageUpscalePlan{Scale: "2k", RequestedSize: "12x6"}
+
+	out, _, _, _, err := collectImagesResponse(context.Background(), strings.NewReader(upstream), "b64_json", "gpt-image-2-2k", nil, plan)
+	if err != nil {
+		t.Fatalf("collectImagesResponse returned error: %v", err)
+	}
+	width, height := decodePNGSize(t, gjson.GetBytes(out, "data.0.b64_json").String())
+	if width != 12 || height != 6 {
+		t.Fatalf("physical size = %dx%d, want exact 12x6 canvas", width, height)
+	}
+}
+
 // 上游已达标时不重编码,原始字节原样返回。
 func TestApplyImageUpscalePlanSkipsWhenAlreadyAtTarget(t *testing.T) {
 	b64 := sizedPNGBase64(t, 2048, 2048)


### PR DESCRIPTION
## What changed

- Preserve the requested output canvas as the authoritative final size.
- Add strict local resize modes for exact custom dimensions, with content-preserving padding by default and optional cover cropping.
- Adapt strict targets that are not multiples of 16 for the upstream Image 2 request, then restore the exact requested canvas locally (for example, `1920x1080` is generated upstream at `1920x1088` and returned as `1920x1080`).
- Keep `strict_size=false` as an explicit opt-out and preserve the legacy upscale behavior when strict sizing is not requested.
- Include image-job cache keys and metadata for fit/strict behavior.

## Verification

- `go test ./...`
- `npm run typecheck`
- `npm run test` (114 passing)
- `npm run build`
- Real production image-job verification: requested `2048x1152`, final asset `2048x1152`.
- Real upstream edge-case verification: `1920x1080` was rejected by the upstream multiple-of-16 rule; the compatibility path is covered by tests and was then validated with a successful `1920x1088` upstream job plus exact local crop.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added strict sizing for generated and edited images.
  - Added `pad` and `cover` resizing options for custom dimensions.
  - Custom image sizes are now preserved and applied accurately, including when no upscale tier is selected.
  - Image results use separate cached versions for different sizes and fit modes.

- **Bug Fixes**
  - Improved handling of nonstandard image dimensions to ensure exact requested output sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->