### PR TITLE
fix(responses): identify Codex model discovery requests

### DIFF
--- a/admin/handler.go
+++ b/admin/handler.go
@@ -3167,10 +3167,11 @@ type addOpenAIResponsesAccountReq struct {
 }
 
 type fetchOpenAIResponsesModelsReq struct {
-	AccountID int64  `json:"account_id"`
-	BaseURL   string `json:"base_url"`
-	APIKey    string `json:"api_key"`
-	ProxyURL  string `json:"proxy_url"`
+	AccountID     int64             `json:"account_id"`
+	BaseURL       string            `json:"base_url"`
+	APIKey        string            `json:"api_key"`
+	ProxyURL      string            `json:"proxy_url"`
+	CustomHeaders map[string]string `json:"custom_headers"`
 }
 
 func (h *Handler) AddOpenAIResponsesAccount(c *gin.Context) {
@@ -3324,6 +3325,9 @@ func (h *Handler) FetchOpenAIResponsesModels(c *gin.Context) {
 		if strings.TrimSpace(req.ProxyURL) == "" {
 			req.ProxyURL = row.ProxyURL
 		}
+		if len(req.CustomHeaders) == 0 {
+			req.CustomHeaders = row.GetCredentialStringMap("custom_headers")
+		}
 	}
 	baseURL, err := auth.NormalizeOpenAIResponsesBaseURL(req.BaseURL)
 	if err != nil {
@@ -3338,10 +3342,15 @@ func (h *Handler) FetchOpenAIResponsesModels(c *gin.Context) {
 		writeError(c, http.StatusBadRequest, "代理URL无效")
 		return
 	}
+	customHeaders, err := normalizeCustomHeaders(req.CustomHeaders)
+	if err != nil {
+		writeError(c, http.StatusBadRequest, err.Error())
+		return
+	}
 
 	ctx, cancel := context.WithTimeout(c.Request.Context(), 20*time.Second)
 	defer cancel()
-	models, err := fetchOpenAIResponsesModelIDs(ctx, baseURL, req.APIKey, req.ProxyURL)
+	models, err := fetchOpenAIResponsesModelIDs(ctx, baseURL, req.APIKey, req.ProxyURL, customHeaders)
 	if err != nil {
 		writeError(c, http.StatusBadGateway, err.Error())
 		return
@@ -3474,7 +3483,7 @@ func (h *Handler) UpdateOpenAIResponsesAccount(c *gin.Context) {
 	writeMessage(c, http.StatusOK, "OpenAI Responses API 账号设置已更新")
 }
 
-func fetchOpenAIResponsesModelIDs(ctx context.Context, baseURL, apiKey, proxyURL string) ([]string, error) {
+func fetchOpenAIResponsesModelIDs(ctx context.Context, baseURL, apiKey, proxyURL string, customHeaders map[string]string) ([]string, error) {
 	endpoint := auth.OpenAIResponsesEndpoint(baseURL, "/v1/models")
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	baseDialer := &net.Dialer{Timeout: 10 * time.Second, KeepAlive: 30 * time.Second}
@@ -3492,6 +3501,14 @@ func fetchOpenAIResponsesModelIDs(ctx context.Context, baseURL, apiKey, proxyURL
 	}
 	req.Header.Set("Authorization", "Bearer "+apiKey)
 	req.Header.Set("Accept", "application/json")
+	proxy.ApplyCodexModelDiscoveryHeaders(req.Header, baseURL+"|"+apiKey)
+	for name, value := range customHeaders {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		req.Header.Set(name, value)
+	}
 
 	resp, err := client.Do(req)
 	if err != nil {

--- a/admin/openai_responses_test.go
+++ b/admin/openai_responses_test.go
@@ -20,18 +20,54 @@ func TestFetchOpenAIResponsesModelIDsSupportsV1BaseURL(t *testing.T) {
 		if got := r.Header.Get("Authorization"); got != "Bearer sk-test" {
 			t.Fatalf("Authorization = %q, want Bearer sk-test", got)
 		}
+		if got := r.Header.Get("User-Agent"); !strings.HasPrefix(got, "codex-tui/") {
+			t.Fatalf("User-Agent = %q, want codex-tui prefix", got)
+		}
+		if got := r.Header.Get("Originator"); got != "codex-tui" {
+			t.Fatalf("Originator = %q, want codex-tui", got)
+		}
+		if got := r.Header.Get("Version"); got == "" {
+			t.Fatal("Version must be set")
+		}
+		if got := r.Header.Get("X-Codex-Installation-Id"); got == "" {
+			t.Fatal("X-Codex-Installation-Id must be set")
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"data":[{"id":"gpt-4.1"},{"id":"gpt-4.1"},{"id":"gpt-4.1-mini"}]}`))
 	}))
 	defer server.Close()
 
-	models, err := fetchOpenAIResponsesModelIDs(context.Background(), server.URL+"/v1", "sk-test", "")
+	models, err := fetchOpenAIResponsesModelIDs(context.Background(), server.URL+"/v1", "sk-test", "", nil)
 	if err != nil {
 		t.Fatalf("fetchOpenAIResponsesModelIDs returned error: %v", err)
 	}
 	want := []string{"gpt-4.1", "gpt-4.1-mini"}
 	if !reflect.DeepEqual(models, want) {
 		t.Fatalf("models = %#v, want %#v", models, want)
+	}
+}
+
+func TestFetchOpenAIResponsesModelIDsAppliesCustomHeadersLast(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("User-Agent"); got != "codex-tui/custom" {
+			t.Fatalf("User-Agent = %q, want custom override", got)
+		}
+		if got := r.Header.Get("X-Codex-Installation-Id"); got != "custom-installation" {
+			t.Fatalf("installation ID = %q, want custom override", got)
+		}
+		_, _ = w.Write([]byte(`{"data":[{"id":"gpt-5.6"}]}`))
+	}))
+	defer server.Close()
+
+	models, err := fetchOpenAIResponsesModelIDs(context.Background(), server.URL, "sk-test", "", map[string]string{
+		"User-Agent":              "codex-tui/custom",
+		"X-Codex-Installation-Id": "custom-installation",
+	})
+	if err != nil {
+		t.Fatalf("fetchOpenAIResponsesModelIDs returned error: %v", err)
+	}
+	if !reflect.DeepEqual(models, []string{"gpt-5.6"}) {
+		t.Fatalf("models = %#v", models)
 	}
 }
 

--- a/proxy/useragent.go
+++ b/proxy/useragent.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"hash/fnv"
+	"net/http"
 	"strings"
 	"unicode"
 )
@@ -123,6 +124,25 @@ func effectiveLatestCodexCLIVersion() string {
 
 func MinimalCodexCLIUserAgentForHeaders() string {
 	return replaceCodexUserAgentVersion(defaultCodexCLIUserAgent, effectiveLatestCodexCLIVersion())
+}
+
+// ApplyCodexModelDiscoveryHeaders applies the identity headers used by Codex
+// when it discovers models. Some Responses gateways apply their official
+// client policy to GET /v1/models before any request body exists, so the
+// installation ID cannot rely on client_metadata from /v1/responses.
+func ApplyCodexModelDiscoveryHeaders(headers http.Header, seed string) {
+	if headers == nil {
+		return
+	}
+	version := effectiveLatestCodexCLIVersion()
+	headers.Set("User-Agent", replaceCodexUserAgentVersion(defaultCodexCLIUserAgent, version))
+	headers.Set("Version", version)
+	headers.Set("Originator", Originator)
+	seed = strings.TrimSpace(seed)
+	if seed == "" {
+		seed = "default"
+	}
+	headers.Set(codexInstallationIDHeader, deriveStableCodexUUID("codex2api:model-discovery-installation:v1:"+seed))
 }
 
 func DefaultCodexUserAgentConfigJSON() string {


### PR DESCRIPTION
## Summary

- apply official Codex client identity headers to outbound OpenAI Responses `GET /v1/models` discovery requests
- send a correctly formed Codex User-Agent, `Version`, `Originator`, and a stable `X-Codex-Installation-Id`
- reuse saved custom headers when refreshing models for an existing account and apply them last so explicit overrides still win
- add regression coverage for the generated identity and custom-header precedence

## Root cause

The existing Codex client mimic and installation-ID logic covered the normal Responses execution path, but model discovery used a separate bare HTTP request. That request only set `Authorization` and `Accept`, allowing the Go default User-Agent to reach official-client-gated endpoints.

This complements the earlier Codex installation identifier work. It does not add another setting or credential field; it extends the existing identity behavior to the request path that previously bypassed it.

## Compatibility evidence

A probe against an official-client-gated Responses endpoint returned `unauthorized client detected` for the previous bare model request. Adding the Codex User-Agent changed the response to the normal invalid-token error, confirming that client recognition happened before token validation.

## Verification

- `go test ./...`
- `npm test`
- `npm run typecheck`
- `npm run build`
- `git diff --check`
