### PR TITLE
fix(database): serialize SQLite write transactions

### DIFF
--- a/database/account_groups.go
+++ b/database/account_groups.go
@@ -196,48 +196,49 @@ func (db *DB) UpdateAccountGroup(ctx context.Context, id int64, name, descriptio
 
 func (db *DB) DeleteAccountGroup(ctx context.Context, id int64, force ...bool) error {
 	allowMembers := len(force) > 0 && force[0]
-	tx, err := db.conn.BeginTx(ctx, nil)
-	if err != nil {
-		return err
-	}
-	defer tx.Rollback()
-	ph := "$1"
-	if db.isSQLite() {
-		ph = "?"
-	}
-	var count int64
-	memberCountQuery := `
+	err := db.withWriteTx(ctx, func(tx *sql.Tx) error {
+		ph := "$1"
+		if db.isSQLite() {
+			ph = "?"
+		}
+		var count int64
+		memberCountQuery := `
 		SELECT COUNT(*)
 		FROM account_group_members m
 		JOIN accounts a ON a.id = m.account_id
 		WHERE m.group_id = ` + ph + ` AND a.status <> 'deleted' AND COALESCE(a.error_message, '') <> 'deleted'`
-	if err := tx.QueryRowContext(ctx, memberCountQuery, id).Scan(&count); err != nil {
-		return err
-	}
-	if count > 0 && !allowMembers {
-		return ErrAccountGroupNotEmpty
-	}
-	if _, err := tx.ExecContext(ctx, "DELETE FROM account_group_members WHERE group_id = "+ph, id); err != nil {
-		return err
-	}
-	if err := pruneDeletedGroupFromAPIKeyScopes(ctx, tx, db.isSQLite(), id); err != nil {
-		return err
-	}
-	if err := pruneDeletedScopeFromAPIKeyLimits(ctx, tx, db.isSQLite(), APIKeyScopeTypeGroup, id); err != nil {
-		return err
-	}
-	res, err := tx.ExecContext(ctx, "DELETE FROM account_groups WHERE id = "+ph, id)
+		if err := tx.QueryRowContext(ctx, memberCountQuery, id).Scan(&count); err != nil {
+			return err
+		}
+		if count > 0 && !allowMembers {
+			return ErrAccountGroupNotEmpty
+		}
+		if _, err := tx.ExecContext(ctx, "DELETE FROM account_group_members WHERE group_id = "+ph, id); err != nil {
+			return err
+		}
+		if err := pruneDeletedGroupFromAPIKeyScopes(ctx, tx, db.isSQLite(), id); err != nil {
+			return err
+		}
+		if err := pruneDeletedScopeFromAPIKeyLimits(ctx, tx, db.isSQLite(), APIKeyScopeTypeGroup, id); err != nil {
+			return err
+		}
+		res, err := tx.ExecContext(ctx, "DELETE FROM account_groups WHERE id = "+ph, id)
+		if err != nil {
+			return err
+		}
+		affected, err := res.RowsAffected()
+		if err != nil {
+			return err
+		}
+		if affected == 0 {
+			return sql.ErrNoRows
+		}
+		return nil
+	})
 	if err != nil {
 		return err
 	}
-	affected, err := res.RowsAffected()
-	if err != nil {
-		return err
-	}
-	if affected == 0 {
-		return sql.ErrNoRows
-	}
-	return tx.Commit()
+	return nil
 }
 
 func pruneDeletedGroupFromAPIKeyScopes(ctx context.Context, tx *sql.Tx, sqlite bool, groupID int64) error {
@@ -357,34 +358,35 @@ func containsInt64(slice []int64, target int64) bool {
 }
 
 func (db *DB) SetAccountGroups(ctx context.Context, accountID int64, groupIDs []int64) error {
-	tx, err := db.conn.BeginTx(ctx, nil)
+	err := db.withWriteTx(ctx, func(tx *sql.Tx) error {
+		ph := "$1"
+		insertQ := "INSERT INTO account_group_members (account_id, group_id) VALUES ($1, $2)"
+		if db.isSQLite() {
+			ph = "?"
+			insertQ = "INSERT INTO account_group_members (account_id, group_id) VALUES (?, ?)"
+		}
+		if _, err := tx.ExecContext(ctx, "DELETE FROM account_group_members WHERE account_id = "+ph, accountID); err != nil {
+			return err
+		}
+		seen := make(map[int64]struct{}, len(groupIDs))
+		for _, gid := range groupIDs {
+			if gid <= 0 {
+				continue
+			}
+			if _, ok := seen[gid]; ok {
+				continue
+			}
+			seen[gid] = struct{}{}
+			if _, err := tx.ExecContext(ctx, insertQ, accountID, gid); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
 	if err != nil {
 		return err
 	}
-	defer tx.Rollback()
-	ph := "$1"
-	insertQ := "INSERT INTO account_group_members (account_id, group_id) VALUES ($1, $2)"
-	if db.isSQLite() {
-		ph = "?"
-		insertQ = "INSERT INTO account_group_members (account_id, group_id) VALUES (?, ?)"
-	}
-	if _, err := tx.ExecContext(ctx, "DELETE FROM account_group_members WHERE account_id = "+ph, accountID); err != nil {
-		return err
-	}
-	seen := make(map[int64]struct{}, len(groupIDs))
-	for _, gid := range groupIDs {
-		if gid <= 0 {
-			continue
-		}
-		if _, ok := seen[gid]; ok {
-			continue
-		}
-		seen[gid] = struct{}{}
-		if _, err := tx.ExecContext(ctx, insertQ, accountID, gid); err != nil {
-			return err
-		}
-	}
-	return tx.Commit()
+	return nil
 }
 
 // BatchSetAccountGroups 在单个事务里把一批账号的分组归属整体替换成 groupIDs。
@@ -397,15 +399,13 @@ func (db *DB) BatchSetAccountGroups(ctx context.Context, accountIDs []int64, gro
 	if len(accountIDs) == 0 || len(groupIDs) == 0 {
 		return nil
 	}
-	tx, err := db.conn.BeginTx(ctx, nil)
+	err := db.withWriteTx(ctx, func(tx *sql.Tx) error {
+		return db.batchReplaceAccountGroups(ctx, tx, accountIDs, groupIDs)
+	})
 	if err != nil {
 		return err
 	}
-	defer tx.Rollback()
-	if err := db.batchReplaceAccountGroups(ctx, tx, accountIDs, groupIDs); err != nil {
-		return err
-	}
-	return tx.Commit()
+	return nil
 }
 
 func (db *DB) GetAccountGroupIDs(ctx context.Context, accountID int64) ([]int64, error) {

--- a/database/postgres.go
+++ b/database/postgres.go
@@ -4036,7 +4036,9 @@ func (db *DB) flushLogBatch(drain bool) bool {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second) // 增加超时时间
 	defer cancel()
 
-	if err := db.insertUsageLogBatch(ctx, batch); err != nil {
+	if err := db.withSQLiteWriteLock(ctx, func() error {
+		return db.insertUsageLogBatch(ctx, batch)
+	}); err != nil {
 		// 瞬时故障（连接断开、超时、死锁）原样放回缓冲区重试，一条都不能丢。
 		if !isUsageLogDataError(err) {
 			log.Printf("批量写入日志失败，已重新放回缓冲区等待重试: %v", err)
@@ -7149,38 +7151,40 @@ func (db *DB) BatchSetError(ctx context.Context, ids []int64, errorMsg string) e
 
 // SoftDeleteAccount 将账号标记为 deleted，保留数据用于审计和事件追溯。
 func (db *DB) SoftDeleteAccount(ctx context.Context, id int64) error {
-	tx, err := db.conn.BeginTx(ctx, nil)
-	if err != nil {
-		return err
-	}
-	defer tx.Rollback()
+	return db.withSQLiteWriteLock(ctx, func() error {
+		tx, err := db.conn.BeginTx(ctx, nil)
+		if err != nil {
+			return err
+		}
+		defer tx.Rollback()
 
-	query := `
-		UPDATE accounts
-		SET status = 'deleted',
-			error_message = '',
-			cooldown_reason = '',
-			cooldown_until = NULL,
-			deleted_at = CURRENT_TIMESTAMP,
-			updated_at = CURRENT_TIMESTAMP
-		WHERE id = $1 AND status <> 'deleted'
-	`
-	res, err := tx.ExecContext(ctx, query, id)
-	if err != nil {
-		return err
-	}
-	affected, err := res.RowsAffected()
-	if err != nil {
-		return err
-	}
-	if affected == 0 {
-		return sql.ErrNoRows
-	}
-	// Keep the last group membership snapshot on the soft-deleted account.
-	// Usage reports need it to attribute historical requests after an account
-	// moves to the recycle bin. Active-account queries already exclude deleted
-	// accounts, while restoring the account reuses the retained memberships.
-	return tx.Commit()
+		query := `
+			UPDATE accounts
+			SET status = 'deleted',
+				error_message = '',
+				cooldown_reason = '',
+				cooldown_until = NULL,
+				deleted_at = CURRENT_TIMESTAMP,
+				updated_at = CURRENT_TIMESTAMP
+			WHERE id = $1 AND status <> 'deleted'
+		`
+		res, err := tx.ExecContext(ctx, query, id)
+		if err != nil {
+			return err
+		}
+		affected, err := res.RowsAffected()
+		if err != nil {
+			return err
+		}
+		if affected == 0 {
+			return sql.ErrNoRows
+		}
+		// Keep the last group membership snapshot on the soft-deleted account.
+		// Usage reports need it to attribute historical requests after an account
+		// moves to the recycle bin. Active-account queries already exclude deleted
+		// accounts, while restoring the account reuses the retained memberships.
+		return tx.Commit()
+	})
 }
 
 // ListDeleted 获取回收站中的账号（被软删除、尚未彻底清除的账号）。
@@ -7346,37 +7350,39 @@ func (db *DB) PurgeDeletedAccounts(ctx context.Context) (int64, error) {
 
 // BatchSoftDeleteAccounts 批量软删除账号，分批执行避免 SQL 参数过多。
 func (db *DB) BatchSoftDeleteAccounts(ctx context.Context, ids []int64) error {
-	const batchSize = 500
-	for i := 0; i < len(ids); i += batchSize {
-		end := i + batchSize
-		if end > len(ids) {
-			end = len(ids)
-		}
-		batch := ids[i:end]
+	return db.withSQLiteWriteLock(ctx, func() error {
+		const batchSize = 500
+		for i := 0; i < len(ids); i += batchSize {
+			end := i + batchSize
+			if end > len(ids) {
+				end = len(ids)
+			}
+			batch := ids[i:end]
 
-		placeholders := make([]string, len(batch))
-		args := make([]interface{}, 0, len(batch))
-		for j, id := range batch {
-			placeholders[j] = fmt.Sprintf("$%d", j+1)
-			args = append(args, id)
-		}
+			placeholders := make([]string, len(batch))
+			args := make([]interface{}, 0, len(batch))
+			for j, id := range batch {
+				placeholders[j] = fmt.Sprintf("$%d", j+1)
+				args = append(args, id)
+			}
 
-		query := fmt.Sprintf(
-			`UPDATE accounts
-			SET status = 'deleted',
-				error_message = '',
-				cooldown_reason = '',
-				cooldown_until = NULL,
-				deleted_at = CURRENT_TIMESTAMP,
-				updated_at = CURRENT_TIMESTAMP
-			WHERE status <> 'deleted' AND id IN (%s)`,
-			strings.Join(placeholders, ","),
-		)
-		if _, err := db.conn.ExecContext(ctx, query, args...); err != nil {
-			return fmt.Errorf("batch %d-%d failed: %w", i, end, err)
+			query := fmt.Sprintf(
+				`UPDATE accounts
+				SET status = 'deleted',
+					error_message = '',
+					cooldown_reason = '',
+					cooldown_until = NULL,
+					deleted_at = CURRENT_TIMESTAMP,
+					updated_at = CURRENT_TIMESTAMP
+				WHERE status <> 'deleted' AND id IN (%s)`,
+				strings.Join(placeholders, ","),
+			)
+			if _, err := db.conn.ExecContext(ctx, query, args...); err != nil {
+				return fmt.Errorf("batch %d-%d failed: %w", i, end, err)
+			}
 		}
-	}
-	return nil
+		return nil
+	})
 }
 
 // BatchInsertAccountEvents 批量插入账号事件。

--- a/database/sqlite.go
+++ b/database/sqlite.go
@@ -3,6 +3,7 @@ package database
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"net/url"
 	"sort"
@@ -70,6 +71,27 @@ func (db *DB) withSQLiteWriteLock(ctx context.Context, fn func() error) error {
 	case <-ctx.Done():
 		return ctx.Err()
 	}
+}
+
+// withWriteTx serializes top-level SQLite mutations while preserving the
+// normal transaction behavior for PostgreSQL. Callers pass all nested writes
+// through the same transaction to avoid writer-gate re-entry deadlocks.
+func (db *DB) withWriteTx(ctx context.Context, fn func(*sql.Tx) error) error {
+	if db == nil || db.conn == nil {
+		return errors.New("database is not initialized")
+	}
+	run := func() error {
+		tx, err := db.conn.BeginTx(ctx, nil)
+		if err != nil {
+			return err
+		}
+		defer tx.Rollback()
+		if err := fn(tx); err != nil {
+			return err
+		}
+		return tx.Commit()
+	}
+	return db.withSQLiteWriteLock(ctx, run)
 }
 
 func (db *DB) configureSQLite(ctx context.Context) error {

--- a/database/sqlite_test.go
+++ b/database/sqlite_test.go
@@ -1788,6 +1788,54 @@ func TestDeleteAccountGroupDoesNotBroadenScopedAPIKey(t *testing.T) {
 	}
 }
 
+func TestSQLiteAccountGroupMutationsWaitForUnifiedWriteLock(t *testing.T) {
+	db, err := New("sqlite", filepath.Join(t.TempDir(), "codex2api.db"))
+	if err != nil {
+		t.Fatalf("New(sqlite): %v", err)
+	}
+	defer db.Close()
+
+	ctx := context.Background()
+	groupA, err := db.CreateAccountGroup(ctx, "lock-a", "", "", 0, 0, sql.NullInt64{})
+	if err != nil {
+		t.Fatalf("CreateAccountGroup A: %v", err)
+	}
+	groupB, err := db.CreateAccountGroup(ctx, "lock-b", "", "", 0, 0, sql.NullInt64{})
+	if err != nil {
+		t.Fatalf("CreateAccountGroup B: %v", err)
+	}
+	accountID, err := db.InsertAccount(ctx, "lock-account", "refresh-token", "")
+	if err != nil {
+		t.Fatalf("InsertAccount: %v", err)
+	}
+
+	assertBlocked := func(name string, operation func() error) {
+		t.Helper()
+		db.sqliteWriteSem <- struct{}{}
+		done := make(chan error, 1)
+		go func() { done <- operation() }()
+		select {
+		case err := <-done:
+			t.Fatalf("%s bypassed SQLite write lock: %v", name, err)
+		case <-time.After(50 * time.Millisecond):
+		}
+		<-db.sqliteWriteSem
+		if err := <-done; err != nil {
+			t.Fatalf("%s after lock release: %v", name, err)
+		}
+	}
+
+	assertBlocked("SetAccountGroups", func() error {
+		return db.SetAccountGroups(ctx, accountID, []int64{groupA})
+	})
+	assertBlocked("BatchSetAccountGroups", func() error {
+		return db.BatchSetAccountGroups(ctx, []int64{accountID}, []int64{groupB})
+	})
+	assertBlocked("DeleteAccountGroup", func() error {
+		return db.DeleteAccountGroup(ctx, groupA, true)
+	})
+}
+
 func TestUsageLogsPersistEffectiveModel(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "codex2api.db")
 
@@ -2682,6 +2730,59 @@ func TestSoftDeleteAccountMarksDeletedStatus(t *testing.T) {
 	}
 	if !deletedAt.Valid || deletedAt.String == "" {
 		t.Fatal("deleted_at 未写入")
+	}
+}
+
+func TestSQLiteSoftDeleteWaitsForUnifiedWriteLock(t *testing.T) {
+	db, err := New("sqlite", filepath.Join(t.TempDir(), "codex2api.db"))
+	if err != nil {
+		t.Fatalf("New(sqlite) 返回错误: %v", err)
+	}
+	defer db.Close()
+
+	ctx := context.Background()
+	singleID, err := db.InsertAccount(ctx, "queued-single-delete", "rt-single-delete", "")
+	if err != nil {
+		t.Fatalf("InsertAccount(single) 返回错误: %v", err)
+	}
+	batchID, err := db.InsertAccount(ctx, "queued-batch-delete", "rt-batch-delete", "")
+	if err != nil {
+		t.Fatalf("InsertAccount(batch) 返回错误: %v", err)
+	}
+
+	db.sqliteWriteSem <- struct{}{}
+	singleDone := make(chan error, 1)
+	go func() { singleDone <- db.SoftDeleteAccount(ctx, singleID) }()
+	select {
+	case err := <-singleDone:
+		t.Fatalf("SoftDeleteAccount bypassed SQLite write lock: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	<-db.sqliteWriteSem
+	if err := <-singleDone; err != nil {
+		t.Fatalf("SoftDeleteAccount after lock release: %v", err)
+	}
+
+	db.sqliteWriteSem <- struct{}{}
+	batchDone := make(chan error, 1)
+	go func() { batchDone <- db.BatchSoftDeleteAccounts(ctx, []int64{batchID}) }()
+	select {
+	case err := <-batchDone:
+		t.Fatalf("BatchSoftDeleteAccounts bypassed SQLite write lock: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	<-db.sqliteWriteSem
+	if err := <-batchDone; err != nil {
+		t.Fatalf("BatchSoftDeleteAccounts after lock release: %v", err)
+	}
+
+	var deletedCount int
+	if err := db.conn.QueryRowContext(ctx, `SELECT COUNT(*) FROM accounts
+		WHERE id IN ($1,$2) AND status = 'deleted'`, singleID, batchID).Scan(&deletedCount); err != nil {
+		t.Fatalf("query deleted accounts: %v", err)
+	}
+	if deletedCount != 2 {
+		t.Fatalf("deleted count = %d, want 2", deletedCount)
 	}
 }
 

--- a/database/usage_log_flush_test.go
+++ b/database/usage_log_flush_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/lib/pq"
 )
@@ -64,6 +65,44 @@ func TestFlushUsageLogsDrainsBeyondOneBatch(t *testing.T) {
 	}
 	if stats := db.GetUsageLogRuntimeStats(); stats.BufferLength != 0 {
 		t.Fatalf("BufferLength = %d，want 0", stats.BufferLength)
+	}
+}
+
+func TestSQLiteUsageLogFlushWaitsForUnifiedWriteLock(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "codex2api.db")
+	db, err := New("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("New(sqlite) 返回错误: %v", err)
+	}
+	close(db.logStop)
+	db.logWg.Wait()
+	defer db.conn.Close()
+
+	db.SetUsageLogConfig(UsageLogModeFull, 10, maxUsageLogFlushIntervalSeconds)
+	insertUsageLogs(t, db, 1)
+	db.sqliteWriteSem <- struct{}{}
+	flushed := make(chan struct{})
+	go func() {
+		db.FlushUsageLogs()
+		close(flushed)
+	}()
+	select {
+	case <-flushed:
+		t.Fatal("FlushUsageLogs bypassed SQLite write lock")
+	case <-time.After(50 * time.Millisecond):
+	}
+	<-db.sqliteWriteSem
+	select {
+	case <-flushed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("FlushUsageLogs did not resume after SQLite write lock release")
+	}
+	logs, err := db.ListRecentUsageLogs(context.Background(), 10)
+	if err != nil {
+		t.Fatalf("ListRecentUsageLogs 返回错误: %v", err)
+	}
+	if len(logs) != 1 {
+		t.Fatalf("flushed logs = %d, want 1", len(logs))
 	}
 }
 


### PR DESCRIPTION
## Summary
- serialize SQLite account-group mutations and account soft-delete writes through the unified write lock
- serialize usage-log batch flushes to prevent lock starvation and SQLITE_BUSY failures
- add regression coverage for group mutations, soft-delete, and usage-log flush contention

## Validation
- `go test ./database ./admin ./proxy`
- `go test -race ./database -run 'TestSQLite(AccountGroupMutationsWaitForUnifiedWriteLock|SoftDeleteWaitsForUnifiedWriteLock|UsageLogFlushWaitsForUnifiedWriteLock)|TestFlushUsageLogsDrainsBeyondOneBatch' -count=1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of SQLite write operations by coordinating account updates, account-group changes, and usage-log flushing.
  * Prevented conflicting write operations from running simultaneously, reducing the risk of database contention or inconsistent results.

* **Tests**
  * Added coverage confirming write operations wait appropriately and complete successfully once database access is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->