### PR TITLE
perf(admin): optimize risk profile aggregation

### DIFF
--- a/admin/handler.go
+++ b/admin/handler.go
@@ -927,7 +927,9 @@ func (h *Handler) hasConfiguredAdminSecret(ctx context.Context) bool {
 
 // GetStats 获取仪表盘统计
 func (h *Handler) GetStats(c *gin.Context) {
-	ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)
+	// Large installations may need more than five seconds to aggregate the
+	// dashboard inputs. Keep the request bounded without failing normal loads.
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 15*time.Second)
 	defer cancel()
 
 	accounts, err := h.db.ListActive(ctx)

--- a/admin/prompt_risk_profile.go
+++ b/admin/prompt_risk_profile.go
@@ -16,6 +16,8 @@ import (
 
 const promptRiskHistoryGuardrail = "画像只统计本地 warn/block 与上游 CY；影子审计和普通命中不再抬高风险。画像不会单独封禁当前请求，只控制可自动失效的模型复核豁免；达到阈值或再次出现 CY 时立即恢复同步审核。"
 
+const promptRiskProfileListTimeout = 20 * time.Second
+
 type promptRiskProfilesResponse struct {
 	Profiles       []*database.PromptRiskProfile `json:"profiles"`
 	Total          int                           `json:"total"`
@@ -69,7 +71,9 @@ func (h *Handler) ListPromptRiskProfiles(c *gin.Context) {
 	if minScore > 100 {
 		minScore = 100
 	}
-	ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)
+	// 生产画像列表需要聚合近 30 天事件。高流量实例可能包含数十万条记录，
+	// 5 秒会在 SQLite 正常计算完成前主动取消，表现为稳定的 500。
+	ctx, cancel := context.WithTimeout(c.Request.Context(), promptRiskProfileListTimeout)
 	defer cancel()
 	profiles, total, err := h.db.ListPromptRiskProfiles(ctx, database.PromptRiskProfileQuery{
 		Page: page, PageSize: pageSize, SubjectType: c.Query("subject_type"), Platform: c.Query("platform"),

--- a/admin/prompt_risk_profile_test.go
+++ b/admin/prompt_risk_profile_test.go
@@ -12,6 +12,12 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+func TestPromptRiskProfileListTimeoutAllowsProductionAggregation(t *testing.T) {
+	if promptRiskProfileListTimeout < 10*time.Second {
+		t.Fatalf("prompt risk profile list timeout = %s, want at least 10s for production aggregation", promptRiskProfileListTimeout)
+	}
+}
+
 func TestPromptRiskProfileListAndDetailAPI(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	db, err := database.New("sqlite", filepath.Join(t.TempDir(), "admin-risk-profile.db"))

--- a/database/prompt_risk_profile.go
+++ b/database/prompt_risk_profile.go
@@ -310,6 +310,8 @@ func (db *DB) ensurePromptRiskEventsTable(ctx context.Context) error {
 		`CREATE INDEX IF NOT EXISTS idx_prompt_risk_events_incident ON prompt_risk_events(incident_id)`,
 		`CREATE INDEX IF NOT EXISTS idx_prompt_risk_events_api_key ON prompt_risk_events(api_key_id, created_at)`,
 		`CREATE INDEX IF NOT EXISTS idx_prompt_risk_events_account ON prompt_risk_events(account_id, created_at)`,
+		`CREATE INDEX IF NOT EXISTS idx_prompt_risk_events_request_match ON prompt_risk_events(request_correlation_id, subject_type, subject_key, event_kind) WHERE request_correlation_id<>''`,
+		`CREATE INDEX IF NOT EXISTS idx_prompt_risk_events_fingerprint_match ON prompt_risk_events(prompt_fingerprint, subject_type, subject_key, created_at, event_kind) WHERE request_correlation_id='' AND prompt_fingerprint<>''`,
 		`CREATE INDEX IF NOT EXISTS idx_prompt_risk_sources_processed ON prompt_risk_event_sources(processed_at)`,
 		`CREATE INDEX IF NOT EXISTS idx_prompt_risk_identities_external ON prompt_risk_identities(platform, external_user_id)`,
 		`CREATE INDEX IF NOT EXISTS idx_prompt_risk_identities_updated ON prompt_risk_identities(updated_at)`,
@@ -656,29 +658,49 @@ func reconcilePromptRiskReviewForSubject(ctx context.Context, exec promptRiskEve
 	if requestID == "" && fingerprint == "" {
 		return nil
 	}
-	windowStart := signal.CreatedAt.Add(-10 * time.Minute)
-	windowEnd := signal.CreatedAt.Add(10 * time.Minute)
-	match := `(request_correlation_id<>'' AND $1<>'' AND request_correlation_id=$1) OR
-		(request_correlation_id='' AND $1='' AND prompt_fingerprint<>'' AND $2<>'' AND prompt_fingerprint=$2 AND created_at >= $3 AND created_at <= $4)`
 	if signal.EventKind == promptRiskEventReviewCleared {
+		if requestID != "" {
+			_, err := exec.ExecContext(ctx, `UPDATE prompt_risk_events SET
+				event_kind=$1, request_risk_score=0, evidence_confidence=95
+				WHERE subject_type=$2 AND subject_key=$3 AND event_kind IN ($4,$5)
+				AND request_correlation_id<>'' AND request_correlation_id=$6`, promptRiskEventLocalBlockCleared, subject.Type, subject.Key,
+				promptRiskEventLocalBlock, promptRiskEventLocalBlockUnverified, requestID)
+			return err
+		}
+		windowStart := signal.CreatedAt.Add(-10 * time.Minute)
+		windowEnd := signal.CreatedAt.Add(10 * time.Minute)
 		_, err := exec.ExecContext(ctx, `UPDATE prompt_risk_events SET
-			event_kind=$5, request_risk_score=0, evidence_confidence=95
-			WHERE subject_type=$6 AND subject_key=$7 AND event_kind IN ($8,$9) AND (`+match+`)`,
-			requestID, fingerprint, windowStart, windowEnd, promptRiskEventLocalBlockCleared, subject.Type, subject.Key,
-			promptRiskEventLocalBlock, promptRiskEventLocalBlockUnverified)
+			event_kind=$1, request_risk_score=0, evidence_confidence=95
+			WHERE subject_type=$2 AND subject_key=$3 AND event_kind IN ($4,$5)
+			AND request_correlation_id='' AND prompt_fingerprint<>'' AND prompt_fingerprint=$6
+			AND created_at >= $7 AND created_at <= $8`, promptRiskEventLocalBlockCleared, subject.Type, subject.Key,
+			promptRiskEventLocalBlock, promptRiskEventLocalBlockUnverified, fingerprint, windowStart, windowEnd)
 		return err
 	}
+	if requestID != "" {
+		_, err := exec.ExecContext(ctx, `UPDATE prompt_risk_events SET
+			event_kind=$1, request_risk_score=0, evidence_confidence=95
+			WHERE source_type=$2 AND source_id=$3 AND subject_type=$4 AND subject_key=$5
+			AND event_kind=$6 AND EXISTS (
+				SELECT 1 FROM prompt_risk_events cleared
+				WHERE cleared.subject_type=$4 AND cleared.subject_key=$5 AND cleared.event_kind=$7
+				AND cleared.request_correlation_id<>'' AND cleared.request_correlation_id=$8
+			)`, promptRiskEventLocalBlockCleared, signal.SourceType, signal.SourceID, subject.Type, subject.Key,
+			promptRiskEventLocalBlockUnverified, promptRiskEventReviewCleared, requestID)
+		return err
+	}
+	windowStart := signal.CreatedAt.Add(-10 * time.Minute)
+	windowEnd := signal.CreatedAt.Add(10 * time.Minute)
 	_, err := exec.ExecContext(ctx, `UPDATE prompt_risk_events SET
-		event_kind=$5, request_risk_score=0, evidence_confidence=95
-		WHERE source_type=$6 AND source_id=$7 AND subject_type=$8 AND subject_key=$9
-		AND event_kind=$10 AND EXISTS (
+		event_kind=$1, request_risk_score=0, evidence_confidence=95
+		WHERE source_type=$2 AND source_id=$3 AND subject_type=$4 AND subject_key=$5
+		AND event_kind=$6 AND EXISTS (
 			SELECT 1 FROM prompt_risk_events cleared
-			WHERE cleared.subject_type=$8 AND cleared.subject_key=$9 AND cleared.event_kind=$11 AND (
-				(cleared.request_correlation_id<>'' AND $1<>'' AND cleared.request_correlation_id=$1) OR
-				(cleared.request_correlation_id='' AND $1='' AND cleared.prompt_fingerprint<>'' AND $2<>'' AND cleared.prompt_fingerprint=$2 AND cleared.created_at >= $3 AND cleared.created_at <= $4)
-			)
-		)`, requestID, fingerprint, windowStart, windowEnd, promptRiskEventLocalBlockCleared,
-		signal.SourceType, signal.SourceID, subject.Type, subject.Key, promptRiskEventLocalBlockUnverified, promptRiskEventReviewCleared)
+			WHERE cleared.subject_type=$4 AND cleared.subject_key=$5 AND cleared.event_kind=$7
+			AND cleared.request_correlation_id='' AND cleared.prompt_fingerprint<>'' AND cleared.prompt_fingerprint=$8
+			AND cleared.created_at >= $9 AND cleared.created_at <= $10
+		)`, promptRiskEventLocalBlockCleared, signal.SourceType, signal.SourceID, subject.Type, subject.Key,
+		promptRiskEventLocalBlockUnverified, promptRiskEventReviewCleared, fingerprint, windowStart, windowEnd)
 	return err
 }
 

--- a/database/prompt_risk_profile_test.go
+++ b/database/prompt_risk_profile_test.go
@@ -611,7 +611,7 @@ func TestPromptRiskSQLiteSchemaAndIndexes(t *testing.T) {
 		}
 		indexes[name] = true
 	}
-	for _, name := range []string{"idx_prompt_risk_events_subject", "idx_prompt_risk_events_created", "idx_prompt_risk_events_kind", "idx_prompt_risk_events_incident", "idx_prompt_risk_events_api_key", "idx_prompt_risk_events_account"} {
+	for _, name := range []string{"idx_prompt_risk_events_subject", "idx_prompt_risk_events_created", "idx_prompt_risk_events_kind", "idx_prompt_risk_events_incident", "idx_prompt_risk_events_api_key", "idx_prompt_risk_events_account", "idx_prompt_risk_events_request_match", "idx_prompt_risk_events_fingerprint_match"} {
 		if !indexes[name] {
 			t.Fatalf("prompt_risk_events missing index %q", name)
 		}
@@ -645,9 +645,53 @@ func TestPromptRiskPostgresMigrationDDL(t *testing.T) {
 		"ALTER TABLE prompt_filter_logs ADD COLUMN IF NOT EXISTS session_hash",
 		"idx_prompt_risk_events_subject",
 		"idx_prompt_risk_events_incident",
+		"idx_prompt_risk_events_request_match",
+		"idx_prompt_risk_events_fingerprint_match",
 	} {
 		if !strings.Contains(joined, fragment) {
 			t.Fatalf("postgres risk migration missing %q: %s", fragment, joined)
 		}
 	}
+}
+
+func TestPromptRiskReviewReconciliationUsesTargetedIndexes(t *testing.T) {
+	db, err := New("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("New sqlite: %v", err)
+	}
+	defer db.Close()
+	ctx := context.Background()
+
+	assertPlanUses := func(query string, args []interface{}, indexName string) {
+		t.Helper()
+		rows, err := db.conn.QueryContext(ctx, "EXPLAIN QUERY PLAN "+query, args...)
+		if err != nil {
+			t.Fatalf("explain query plan: %v", err)
+		}
+		defer rows.Close()
+		var plan strings.Builder
+		for rows.Next() {
+			var id, parent, unused int
+			var detail string
+			if err := rows.Scan(&id, &parent, &unused, &detail); err != nil {
+				t.Fatalf("scan query plan: %v", err)
+			}
+			plan.WriteString(detail)
+			plan.WriteByte('\n')
+		}
+		if !strings.Contains(plan.String(), indexName) {
+			t.Fatalf("query plan does not use %s:\n%s", indexName, plan.String())
+		}
+	}
+
+	assertPlanUses(`SELECT id FROM prompt_risk_events
+		WHERE request_correlation_id<>'' AND request_correlation_id=$1
+		AND subject_type=$2 AND subject_key=$3 AND event_kind=$4`,
+		[]interface{}{"request-1", PromptRiskSubjectAPIKey, "key-1", promptRiskEventReviewCleared},
+		"idx_prompt_risk_events_request_match")
+	assertPlanUses(`SELECT id FROM prompt_risk_events
+		WHERE request_correlation_id='' AND prompt_fingerprint<>'' AND prompt_fingerprint=$1
+		AND subject_type=$2 AND subject_key=$3 AND created_at >= $4 AND created_at <= $5 AND event_kind=$6`,
+		[]interface{}{"fingerprint-1", PromptRiskSubjectAPIKey, "key-1", time.Now().Add(-time.Minute), time.Now(), promptRiskEventReviewCleared},
+		"idx_prompt_risk_events_fingerprint_match")
 }


### PR DESCRIPTION
## Summary
- extend dashboard stats and risk-profile aggregation timeouts to tolerate production-sized datasets
- add targeted partial indexes for request-correlation and fingerprint reconciliation
- split reconciliation queries so SQLite can use the targeted indexes
- add schema, migration, query-plan, and timeout regression tests

## Validation
- frontend: 120 tests passed, typecheck passed, production build passed
- `go test ./...`
- `go test -race ./database ./admin -run 'TestPromptRisk(ReviewReconciliationUsesTargetedIndexes|SQLiteSchemaAndIndexes|PostgresMigrationDDL)|TestPromptRiskProfileListTimeout|TestPromptRiskProfileListAndDetailAPI' -count=1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Increased dashboard statistics processing time to support larger and more complex aggregations.
  - Extended prompt risk profile loading time to reduce premature cancellations during production workloads.
  - Improved risk-event review reconciliation for more reliable matching by request and prompt details.

- **Performance**
  - Optimized risk-event lookups, helping review and verification updates complete more efficiently across supported databases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->