### PR TITLE
fix(compaction): preserve opaque affinity and normalize portable summaries

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,6 +52,9 @@ CODEX_PORT=8080
 # Codex 会话黏性 TTL，支持 Go duration（如 1h、90m）或秒数
 # CODEX_SESSION_AFFINITY_TTL=1h
 
+# 加密压缩状态的来源亲和 TTL；仅缓存 SHA-256 摘要与来源元数据
+# CODEX_COMPACTION_AFFINITY_TTL=168h
+
 # 脱敏输出 Codex 指纹策略诊断日志
 # CODEX_FINGERPRINT_DEBUG=false
 

--- a/.env.sqlite.example
+++ b/.env.sqlite.example
@@ -56,6 +56,9 @@ DATABASE_PATH=/data/codex2api.db
 # Codex 会话黏性 TTL，支持 Go duration（如 1h、90m）或秒数
 # CODEX_SESSION_AFFINITY_TTL=1h
 
+# 加密压缩状态的来源亲和 TTL；仅缓存 SHA-256 摘要与来源元数据
+# CODEX_COMPACTION_AFFINITY_TTL=168h
+
 # 脱敏输出 Codex 指纹策略诊断日志
 # CODEX_FINGERPRINT_DEBUG=false
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- **Encrypted compaction state stays with the upstream that created it.** Responses HTTP, compact, and WebSocket paths record a SHA-256 digest plus the producer account and compatibility domain, prefer that producer on reuse, and permit failover only inside the same native or relay domain. Unknown pre-deployment state keeps legacy scheduling; conflicting known sources return 400, while a known source with no compatible account returns an explicit 503. `CODEX_COMPACTION_AFFINITY_TTL` controls the rolling seven-day default without storing opaque encrypted content.
+
 ## v2.8.0 - 2026-08-16
 
 ### Features

--- a/auth/store.go
+++ b/auth/store.go
@@ -6112,6 +6112,14 @@ func (s *Store) takeByIDExcluding(id int64, apiKeyID int64, exclude map[int64]bo
 	return s.takeByIDMode(id, apiKeyID, exclude, filter, false)
 }
 
+// TakePreferredAccountWithFilter attempts to acquire one specific account
+// while applying the same availability, API-key, egress, filter, cooldown, and
+// concurrency gates as normal scheduling. It intentionally bypasses session
+// affinity policy so callers can preserve opaque upstream-owned state.
+func (s *Store) TakePreferredAccountWithFilter(id int64, apiKeyID int64, exclude map[int64]bool, filter AccountFilter) *Account {
+	return s.takeByIDExcluding(id, apiKeyID, exclude, filter)
+}
+
 func (s *Store) takeByIDForContinuation(id int64, apiKeyID int64, exclude map[int64]bool, filter AccountFilter) *Account {
 	return s.takeByIDMode(id, apiKeyID, exclude, filter, true)
 }

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -60,6 +60,7 @@ Codex2API 采用三层配置架构：
 | `CODEX_TRANSPORT_MODE` | 否 | `standard` | Codex HTTP transport：默认标准 Go TLS；`utls_chrome` 可回滚旧 Chrome uTLS 行为 |
 | `CODEX_WS_SEND_USER_AGENT` | 否 | `true` | WS 握手是否发送 Codex `User-Agent`/`Version`；设为 `false` 可关闭 |
 | `CODEX_SESSION_AFFINITY_TTL` | 否 | `1h` | Codex 会话到账号/代理的黏性 TTL，支持 `1h`、`90m` 或秒数 |
+| `CODEX_COMPACTION_AFFINITY_TTL` | 否 | `168h` | 加密压缩状态的来源亲和 TTL。缓存仅保存密文的 SHA-256 摘要、来源账号和兼容域；已知状态不会跨 Codex 官方、不同 Responses 中转或 Grok 上游流转 |
 | `CODEX_FINGERPRINT_DEBUG` | 否 | `false` | 输出脱敏指纹策略诊断日志，不记录 token |
 
 > `CODEX_UPSTREAM_TRANSPORT` 只控制 HTTP 入站请求转发到 Codex 上游时使用 `http` 还是 `ws`。客户端侧 WebSocket 入口独立可用：使用 `GET ws://<host>/v1/responses` 建连，首帧发送 `response.create` JSON，服务端会通过 Codex 上游 WS 返回 Responses 事件帧。

--- a/proxy/compaction_provenance.go
+++ b/proxy/compaction_provenance.go
@@ -91,9 +91,12 @@ func accountCompactionDomain(account *auth.Account) string {
 		return ""
 	}
 	if account.IsGrokAPI() {
-		baseURL, _ := account.GrokCredentials()
-		if canonical := canonicalCompactionBaseURL(baseURL); canonical != "" {
-			return "grok:" + canonical
+		// Grok resolves the actual upstream route from the model catalog at
+		// request time. The configured base URL is therefore not a safe
+		// compatibility boundary for opaque compaction state. Keep Grok state
+		// account-local until the resolved route is available at record time.
+		if account.ID() > 0 {
+			return fmt.Sprintf("grok:account:%d", account.ID())
 		}
 		return ""
 	}
@@ -147,7 +150,7 @@ func requestCompactionEncryptedContents(body []byte) []string {
 	}
 	contents := make([]string, 0, 1)
 	inspect := func(item gjson.Result) {
-		if !gjsonResultIsCompactionHistory(item) {
+		if !gjsonResultHasEncryptedCompaction(item) {
 			return
 		}
 		if encrypted := strings.TrimSpace(item.Get("encrypted_content").String()); encrypted != "" {

--- a/proxy/compaction_provenance.go
+++ b/proxy/compaction_provenance.go
@@ -1,18 +1,23 @@
 package proxy
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
+	"net/http"
 	"net/url"
 	"os"
 	"strings"
 	"time"
 
+	"github.com/codex2api/api"
 	"github.com/codex2api/auth"
+	"github.com/gin-gonic/gin"
 	"github.com/tidwall/gjson"
 )
 
@@ -22,6 +27,7 @@ const (
 	nativeCodexCompactionDomain        = "codex:openai"
 	defaultCompactionProvenanceTTL     = 7 * 24 * time.Hour
 	compactionProvenanceRecordVersion  = 1
+	compactionProvenanceCacheTimeout   = 500 * time.Millisecond
 )
 
 var errConflictingCompactionProvenance = errors.New("conflicting compaction provenance domains")
@@ -114,6 +120,11 @@ func (h *Handler) recordCompactionProvenance(ctx context.Context, account *auth.
 	if encryptedContent == "" || domain == "" || account.ID() <= 0 {
 		return nil
 	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	cacheCtx, cancel := context.WithTimeout(ctx, compactionProvenanceCacheTimeout)
+	defer cancel()
 	now := time.Now().UTC()
 	record := compactionProvenanceRecord{
 		Version:             compactionProvenanceRecordVersion,
@@ -126,7 +137,7 @@ func (h *Handler) recordCompactionProvenance(ctx context.Context, account *auth.
 	if err != nil {
 		return err
 	}
-	return h.cache.SetRuntime(ctx, compactionProvenanceCacheNamespace, compactionContentDigest(encryptedContent), raw, compactionProvenanceTTL())
+	return h.cache.SetRuntime(cacheCtx, compactionProvenanceCacheNamespace, compactionContentDigest(encryptedContent), raw, compactionProvenanceTTL())
 }
 
 func requestCompactionEncryptedContents(body []byte) []string {
@@ -154,6 +165,59 @@ func requestCompactionEncryptedContents(body []byte) []string {
 	return contents
 }
 
+func gjsonResultHasEncryptedCompaction(result gjson.Result) bool {
+	if !result.IsObject() {
+		return false
+	}
+	itemType := strings.TrimSpace(result.Get("type").String())
+	return strings.EqualFold(itemType, "compaction") ||
+		strings.EqualFold(itemType, "context_compaction") ||
+		strings.EqualFold(itemType, "compaction_summary")
+}
+
+func compactionEncryptedContentsFromPayload(payload []byte) []string {
+	if len(payload) == 0 || !bytes.Contains(payload, []byte(`"encrypted_content"`)) || !gjson.ValidBytes(payload) {
+		return nil
+	}
+	root := gjson.ParseBytes(payload)
+	contents := make([]string, 0, 1)
+	seen := make(map[string]struct{})
+	inspect := func(item gjson.Result) {
+		if !gjsonResultHasEncryptedCompaction(item) {
+			return
+		}
+		encrypted := strings.TrimSpace(item.Get("encrypted_content").String())
+		if encrypted == "" {
+			return
+		}
+		if _, ok := seen[encrypted]; ok {
+			return
+		}
+		seen[encrypted] = struct{}{}
+		contents = append(contents, encrypted)
+	}
+	inspect(root)
+	inspect(root.Get("item"))
+	for _, path := range []string{"output", "response.output"} {
+		items := root.Get(path)
+		if items.IsArray() {
+			items.ForEach(func(_, item gjson.Result) bool {
+				inspect(item)
+				return true
+			})
+		}
+	}
+	return contents
+}
+
+func (h *Handler) recordCompactionProvenanceFromPayload(ctx context.Context, account *auth.Account, payload []byte) {
+	for _, encryptedContent := range compactionEncryptedContentsFromPayload(payload) {
+		if err := h.recordCompactionProvenance(ctx, account, encryptedContent); err != nil {
+			log.Printf("record compaction provenance failed: account=%d err=%v", account.ID(), err)
+		}
+	}
+}
+
 func (h *Handler) resolveCompactionAffinity(ctx context.Context, body []byte) (compactionAffinityResolution, error) {
 	if h == nil || h.cache == nil {
 		return compactionAffinityResolution{}, nil
@@ -162,11 +226,16 @@ func (h *Handler) resolveCompactionAffinity(ctx context.Context, body []byte) (c
 	if len(contents) == 0 {
 		return compactionAffinityResolution{}, nil
 	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	cacheCtx, cancel := context.WithTimeout(ctx, compactionProvenanceCacheTimeout)
+	defer cancel()
 
 	var resolution compactionAffinityResolution
 	for _, encryptedContent := range contents {
 		digest := compactionContentDigest(encryptedContent)
-		raw, ok, err := h.cache.GetRuntime(ctx, compactionProvenanceCacheNamespace, digest)
+		raw, ok, err := h.cache.GetRuntime(cacheCtx, compactionProvenanceCacheNamespace, digest)
 		if err != nil {
 			return compactionAffinityResolution{}, fmt.Errorf("read compaction provenance: %w", err)
 		}
@@ -175,7 +244,7 @@ func (h *Handler) resolveCompactionAffinity(ctx context.Context, body []byte) (c
 		}
 		record, err := decodeCompactionProvenanceRecord(raw)
 		if err != nil {
-			_ = h.cache.DeleteRuntime(ctx, compactionProvenanceCacheNamespace, digest)
+			_ = h.cache.DeleteRuntime(cacheCtx, compactionProvenanceCacheNamespace, digest)
 			continue
 		}
 		if resolution.Known && resolution.CompatibilityDomain != record.CompatibilityDomain {
@@ -192,10 +261,34 @@ func (h *Handler) resolveCompactionAffinity(ctx context.Context, body []byte) (c
 		record.LastSeenAt = time.Now().UTC()
 		refreshed, marshalErr := json.Marshal(record)
 		if marshalErr == nil {
-			_ = h.cache.SetRuntime(ctx, compactionProvenanceCacheNamespace, digest, refreshed, compactionProvenanceTTL())
+			_ = h.cache.SetRuntime(cacheCtx, compactionProvenanceCacheNamespace, digest, refreshed, compactionProvenanceTTL())
 		}
 	}
 	return resolution, nil
+}
+
+func compactionProvenanceConflictAPIError() *api.APIError {
+	return api.NewAPIError(api.ErrorCode("compaction_provenance_conflict"), "Compaction state contains conflicting upstream provenance", api.ErrorTypeInvalidRequest)
+}
+
+func compactionProvenanceUnavailableAPIError() *api.APIError {
+	return api.NewAPIError(api.ErrorCode("compaction_provenance_unavailable"), "Compaction provenance is temporarily unavailable", api.ErrorTypeServer)
+}
+
+func compactionUpstreamUnavailableAPIError() *api.APIError {
+	return api.NewAPIError(api.ErrorCode("compaction_upstream_unavailable"), "No account is available for the upstream that created this compaction state", api.ErrorTypeServer)
+}
+
+func sendCompactionProvenanceConflict(c *gin.Context) {
+	api.SendErrorWithStatus(c, compactionProvenanceConflictAPIError(), http.StatusBadRequest)
+}
+
+func sendCompactionProvenanceUnavailable(c *gin.Context) {
+	api.SendErrorWithStatus(c, compactionProvenanceUnavailableAPIError(), http.StatusServiceUnavailable)
+}
+
+func sendCompactionUpstreamUnavailable(c *gin.Context) {
+	api.SendErrorWithStatus(c, compactionUpstreamUnavailableAPIError(), http.StatusServiceUnavailable)
 }
 
 func compactionDomainFilter(domain string, next auth.AccountFilter) auth.AccountFilter {

--- a/proxy/compaction_provenance.go
+++ b/proxy/compaction_provenance.go
@@ -1,0 +1,209 @@
+package proxy
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/codex2api/auth"
+	"github.com/tidwall/gjson"
+)
+
+const (
+	compactionProvenanceCacheNamespace = "compaction-provenance"
+	compactionAffinityTTLEnv           = "CODEX_COMPACTION_AFFINITY_TTL"
+	nativeCodexCompactionDomain        = "codex:openai"
+	defaultCompactionProvenanceTTL     = 7 * 24 * time.Hour
+	compactionProvenanceRecordVersion  = 1
+)
+
+var errConflictingCompactionProvenance = errors.New("conflicting compaction provenance domains")
+
+type compactionProvenanceRecord struct {
+	Version             int       `json:"version"`
+	AccountID           int64     `json:"account_id"`
+	CompatibilityDomain string    `json:"compatibility_domain"`
+	CreatedAt           time.Time `json:"created_at"`
+	LastSeenAt          time.Time `json:"last_seen_at"`
+}
+
+type compactionAffinityResolution struct {
+	Known               bool
+	CompatibilityDomain string
+	PreferredAccountID  int64
+}
+
+func compactionContentDigest(encryptedContent string) string {
+	sum := sha256.Sum256([]byte(encryptedContent))
+	return hex.EncodeToString(sum[:])
+}
+
+func compactionProvenanceTTL() time.Duration {
+	raw := strings.TrimSpace(os.Getenv(compactionAffinityTTLEnv))
+	if raw == "" {
+		return defaultCompactionProvenanceTTL
+	}
+	ttl, err := time.ParseDuration(raw)
+	if err != nil || ttl <= 0 {
+		return defaultCompactionProvenanceTTL
+	}
+	return ttl
+}
+
+func canonicalCompactionBaseURL(raw string) string {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return ""
+	}
+	parsed.Scheme = strings.ToLower(parsed.Scheme)
+	parsed.Host = strings.ToLower(parsed.Host)
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	parsed.Path = strings.TrimRight(parsed.Path, "/")
+	return parsed.String()
+}
+
+func accountCompactionDomain(account *auth.Account) string {
+	if account == nil {
+		return ""
+	}
+	if account.IsOpenAIResponsesAPI() {
+		baseURL, _ := account.OpenAIResponsesCredentials()
+		if normalized, err := auth.NormalizeOpenAIResponsesBaseURL(baseURL); err == nil {
+			baseURL = normalized
+		}
+		if canonical := canonicalCompactionBaseURL(baseURL); canonical != "" {
+			return "responses:" + canonical
+		}
+		return ""
+	}
+	if account.IsGrokAPI() {
+		baseURL, _ := account.GrokCredentials()
+		if canonical := canonicalCompactionBaseURL(baseURL); canonical != "" {
+			return "grok:" + canonical
+		}
+		return ""
+	}
+	return nativeCodexCompactionDomain
+}
+
+func decodeCompactionProvenanceRecord(raw json.RawMessage) (compactionProvenanceRecord, error) {
+	var record compactionProvenanceRecord
+	if err := json.Unmarshal(raw, &record); err != nil {
+		return compactionProvenanceRecord{}, err
+	}
+	if record.Version != compactionProvenanceRecordVersion || record.AccountID <= 0 || strings.TrimSpace(record.CompatibilityDomain) == "" {
+		return compactionProvenanceRecord{}, errors.New("invalid compaction provenance record")
+	}
+	return record, nil
+}
+
+func (h *Handler) recordCompactionProvenance(ctx context.Context, account *auth.Account, encryptedContent string) error {
+	if h == nil || h.cache == nil || account == nil {
+		return nil
+	}
+	encryptedContent = strings.TrimSpace(encryptedContent)
+	domain := accountCompactionDomain(account)
+	if encryptedContent == "" || domain == "" || account.ID() <= 0 {
+		return nil
+	}
+	now := time.Now().UTC()
+	record := compactionProvenanceRecord{
+		Version:             compactionProvenanceRecordVersion,
+		AccountID:           account.ID(),
+		CompatibilityDomain: domain,
+		CreatedAt:           now,
+		LastSeenAt:          now,
+	}
+	raw, err := json.Marshal(record)
+	if err != nil {
+		return err
+	}
+	return h.cache.SetRuntime(ctx, compactionProvenanceCacheNamespace, compactionContentDigest(encryptedContent), raw, compactionProvenanceTTL())
+}
+
+func requestCompactionEncryptedContents(body []byte) []string {
+	input := gjson.GetBytes(body, "input")
+	if !input.Exists() {
+		return nil
+	}
+	contents := make([]string, 0, 1)
+	inspect := func(item gjson.Result) {
+		if !gjsonResultIsCompactionHistory(item) {
+			return
+		}
+		if encrypted := strings.TrimSpace(item.Get("encrypted_content").String()); encrypted != "" {
+			contents = append(contents, encrypted)
+		}
+	}
+	if input.IsArray() {
+		input.ForEach(func(_, item gjson.Result) bool {
+			inspect(item)
+			return true
+		})
+	} else {
+		inspect(input)
+	}
+	return contents
+}
+
+func (h *Handler) resolveCompactionAffinity(ctx context.Context, body []byte) (compactionAffinityResolution, error) {
+	if h == nil || h.cache == nil {
+		return compactionAffinityResolution{}, nil
+	}
+	contents := requestCompactionEncryptedContents(body)
+	if len(contents) == 0 {
+		return compactionAffinityResolution{}, nil
+	}
+
+	var resolution compactionAffinityResolution
+	for _, encryptedContent := range contents {
+		digest := compactionContentDigest(encryptedContent)
+		raw, ok, err := h.cache.GetRuntime(ctx, compactionProvenanceCacheNamespace, digest)
+		if err != nil {
+			return compactionAffinityResolution{}, fmt.Errorf("read compaction provenance: %w", err)
+		}
+		if !ok {
+			continue
+		}
+		record, err := decodeCompactionProvenanceRecord(raw)
+		if err != nil {
+			_ = h.cache.DeleteRuntime(ctx, compactionProvenanceCacheNamespace, digest)
+			continue
+		}
+		if resolution.Known && resolution.CompatibilityDomain != record.CompatibilityDomain {
+			return compactionAffinityResolution{}, errConflictingCompactionProvenance
+		}
+		if !resolution.Known {
+			resolution = compactionAffinityResolution{
+				Known:               true,
+				CompatibilityDomain: record.CompatibilityDomain,
+				PreferredAccountID:  record.AccountID,
+			}
+		}
+
+		record.LastSeenAt = time.Now().UTC()
+		refreshed, marshalErr := json.Marshal(record)
+		if marshalErr == nil {
+			_ = h.cache.SetRuntime(ctx, compactionProvenanceCacheNamespace, digest, refreshed, compactionProvenanceTTL())
+		}
+	}
+	return resolution, nil
+}
+
+func compactionDomainFilter(domain string, next auth.AccountFilter) auth.AccountFilter {
+	domain = strings.TrimSpace(domain)
+	return func(account *auth.Account) bool {
+		if account == nil || accountCompactionDomain(account) != domain {
+			return false
+		}
+		return next == nil || next(account)
+	}
+}

--- a/proxy/compaction_provenance_test.go
+++ b/proxy/compaction_provenance_test.go
@@ -1,0 +1,152 @@
+package proxy
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/codex2api/auth"
+	"github.com/codex2api/cache"
+)
+
+func TestCompactionProvenanceTTL(t *testing.T) {
+	t.Setenv(compactionAffinityTTLEnv, "36h")
+	if got := compactionProvenanceTTL(); got != 36*time.Hour {
+		t.Fatalf("compactionProvenanceTTL() = %v, want 36h", got)
+	}
+
+	t.Setenv(compactionAffinityTTLEnv, "invalid")
+	if got := compactionProvenanceTTL(); got != defaultCompactionProvenanceTTL {
+		t.Fatalf("invalid TTL = %v, want default %v", got, defaultCompactionProvenanceTTL)
+	}
+}
+
+func TestAccountCompactionDomain(t *testing.T) {
+	tests := []struct {
+		name    string
+		account *auth.Account
+		want    string
+	}{
+		{name: "native codex", account: &auth.Account{DBID: 1, AccessToken: "at"}, want: nativeCodexCompactionDomain},
+		{
+			name: "responses relay canonicalizes endpoint",
+			account: &auth.Account{
+				DBID: 2, UpstreamType: auth.UpstreamOpenAIResponses,
+				BaseURL: "HTTPS://Relay.Example.com/v1/?tenant=ignored", APIKey: "key",
+			},
+			want: "responses:https://relay.example.com/v1",
+		},
+		{
+			name: "different relay stays isolated",
+			account: &auth.Account{
+				DBID: 3, UpstreamType: auth.UpstreamOpenAIResponses,
+				BaseURL: "https://other.example.com/v1", APIKey: "key",
+			},
+			want: "responses:https://other.example.com/v1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := accountCompactionDomain(tt.account); got != tt.want {
+				t.Fatalf("accountCompactionDomain() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRecordCompactionProvenanceStoresDigestOnly(t *testing.T) {
+	tokenCache := cache.NewMemory(1)
+	handler := &Handler{cache: tokenCache}
+	account := &auth.Account{
+		DBID: 42, UpstreamType: auth.UpstreamOpenAIResponses,
+		BaseURL: "https://relay.example/v1", APIKey: "key",
+	}
+	const encrypted = "opaque-encrypted-state"
+
+	if err := handler.recordCompactionProvenance(context.Background(), account, encrypted); err != nil {
+		t.Fatalf("recordCompactionProvenance() error = %v", err)
+	}
+	digest := compactionContentDigest(encrypted)
+	raw, ok, err := tokenCache.GetRuntime(context.Background(), compactionProvenanceCacheNamespace, digest)
+	if err != nil || !ok {
+		t.Fatalf("GetRuntime() = ok %v, err %v", ok, err)
+	}
+	if strings.Contains(string(raw), encrypted) {
+		t.Fatalf("cache value leaked encrypted content: %s", raw)
+	}
+
+	record, err := decodeCompactionProvenanceRecord(raw)
+	if err != nil {
+		t.Fatalf("decodeCompactionProvenanceRecord() error = %v", err)
+	}
+	if record.AccountID != 42 || record.CompatibilityDomain != "responses:https://relay.example/v1" {
+		t.Fatalf("unexpected record: %+v", record)
+	}
+}
+
+func TestResolveCompactionAffinity(t *testing.T) {
+	tokenCache := cache.NewMemory(1)
+	handler := &Handler{cache: tokenCache}
+	relay := &auth.Account{
+		DBID: 7, UpstreamType: auth.UpstreamOpenAIResponses,
+		BaseURL: "https://relay.example/v1", APIKey: "key",
+	}
+	if err := handler.recordCompactionProvenance(context.Background(), relay, "known"); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("known source resolves domain and producer", func(t *testing.T) {
+		resolution, err := handler.resolveCompactionAffinity(context.Background(), []byte(`{"input":[{"type":"compaction","encrypted_content":"known"}]}`))
+		if err != nil {
+			t.Fatalf("resolveCompactionAffinity() error = %v", err)
+		}
+		if !resolution.Known || resolution.CompatibilityDomain != "responses:https://relay.example/v1" || resolution.PreferredAccountID != 7 {
+			t.Fatalf("unexpected resolution: %+v", resolution)
+		}
+	})
+
+	t.Run("all unknown preserves legacy scheduling", func(t *testing.T) {
+		resolution, err := handler.resolveCompactionAffinity(context.Background(), []byte(`{"input":[{"type":"compaction","encrypted_content":"external"}]}`))
+		if err != nil {
+			t.Fatalf("resolveCompactionAffinity() error = %v", err)
+		}
+		if resolution.Known {
+			t.Fatalf("unknown source unexpectedly resolved: %+v", resolution)
+		}
+	})
+
+	t.Run("known plus unknown keeps known domain", func(t *testing.T) {
+		resolution, err := handler.resolveCompactionAffinity(context.Background(), []byte(`{"input":[{"type":"compaction","encrypted_content":"external"},{"type":"compaction","encrypted_content":"known"}]}`))
+		if err != nil || !resolution.Known {
+			t.Fatalf("resolution = %+v, err = %v", resolution, err)
+		}
+	})
+
+	t.Run("conflicting known domains are rejected", func(t *testing.T) {
+		other := &auth.Account{DBID: 8, AccessToken: "native"}
+		if err := handler.recordCompactionProvenance(context.Background(), other, "other"); err != nil {
+			t.Fatal(err)
+		}
+		_, err := handler.resolveCompactionAffinity(context.Background(), []byte(`{"input":[{"type":"compaction","encrypted_content":"known"},{"type":"compaction","encrypted_content":"other"}]}`))
+		if err == nil || !strings.Contains(err.Error(), "conflicting") {
+			t.Fatalf("conflict error = %v", err)
+		}
+	})
+}
+
+func TestCompactionDomainFilter(t *testing.T) {
+	wantDomain := "responses:https://relay.example/v1"
+	filter := compactionDomainFilter(wantDomain, func(account *auth.Account) bool { return account.DBID != 99 })
+	matching := &auth.Account{DBID: 1, UpstreamType: auth.UpstreamOpenAIResponses, BaseURL: "https://relay.example/v1", APIKey: "key"}
+	otherRelay := &auth.Account{DBID: 2, UpstreamType: auth.UpstreamOpenAIResponses, BaseURL: "https://other.example/v1", APIKey: "key"}
+	native := &auth.Account{DBID: 3, AccessToken: "at"}
+
+	if !filter(matching) {
+		t.Fatal("matching relay was rejected")
+	}
+	if filter(otherRelay) || filter(native) {
+		t.Fatal("cross-domain account was accepted")
+	}
+}

--- a/proxy/compaction_provenance_test.go
+++ b/proxy/compaction_provenance_test.go
@@ -1,13 +1,22 @@
 package proxy
 
 import (
+	"bytes"
 	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/codex2api/auth"
 	"github.com/codex2api/cache"
+	"github.com/codex2api/config"
+	"github.com/codex2api/database"
+	"github.com/gin-gonic/gin"
+	"github.com/gorilla/websocket"
 )
 
 func TestCompactionProvenanceTTL(t *testing.T) {
@@ -148,5 +157,280 @@ func TestCompactionDomainFilter(t *testing.T) {
 	}
 	if filter(otherRelay) || filter(native) {
 		t.Fatal("cross-domain account was accepted")
+	}
+}
+
+func TestCompactionEncryptedContentsFromPayload(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload string
+		want    string
+	}{
+		{name: "output item done", payload: `{"type":"response.output_item.done","item":{"type":"compaction","encrypted_content":"event-state"}}`, want: "event-state"},
+		{name: "completed response", payload: `{"type":"response.completed","response":{"output":[{"type":"compaction","encrypted_content":"completed-state"}]}}`, want: "completed-state"},
+		{name: "compact json", payload: `{"output":[{"type":"context_compaction","encrypted_content":"json-state"}]}`, want: "json-state"},
+		{name: "direct item", payload: `{"type":"compaction","encrypted_content":"direct-state"}`, want: "direct-state"},
+		{name: "reasoning is excluded", payload: `{"output":[{"type":"reasoning","encrypted_content":"reasoning-state"}]}`, want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := compactionEncryptedContentsFromPayload([]byte(tt.payload))
+			if tt.want == "" {
+				if len(got) != 0 {
+					t.Fatalf("contents = %v, want none", got)
+				}
+				return
+			}
+			if len(got) != 1 || got[0] != tt.want {
+				t.Fatalf("contents = %v, want [%q]", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRecordCompactionProvenanceFromPayload(t *testing.T) {
+	tokenCache := cache.NewMemory(1)
+	handler := &Handler{cache: tokenCache}
+	account := &auth.Account{DBID: 17, AccessToken: "native"}
+	payload := []byte(`{"type":"response.output_item.done","item":{"type":"compaction","encrypted_content":"recorded-output"}}`)
+
+	handler.recordCompactionProvenanceFromPayload(context.Background(), account, payload)
+	_, ok, err := tokenCache.GetRuntime(context.Background(), compactionProvenanceCacheNamespace, compactionContentDigest("recorded-output"))
+	if err != nil || !ok {
+		t.Fatalf("recorded output lookup = ok %v, err %v", ok, err)
+	}
+}
+
+func newCompactionAffinityRelay(t *testing.T, calls *atomic.Int32) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, "data: {\"type\":\"response.output_item.done\",\"item\":{\"type\":\"compaction\",\"encrypted_content\":\"stream-output-state\"}}\n\n")
+		_, _ = io.WriteString(w, "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_affinity\",\"status\":\"completed\",\"output\":[],\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}}\n\n")
+	}))
+}
+
+func newCompactionAffinityStore(accounts ...*auth.Account) *auth.Store {
+	store := auth.NewStore(nil, nil, &database.SystemSettings{
+		MaxConcurrency:      2,
+		MaxRetries:          0,
+		MaxRateLimitRetries: 0,
+	})
+	for _, account := range accounts {
+		store.AddAccount(account)
+	}
+	return store
+}
+
+func runCompactionAffinityResponses(t *testing.T, handler *Handler, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	ginContext, _ := gin.CreateTestContext(recorder)
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	ginContext.Request = req
+	handler.Responses(ginContext)
+	return recorder
+}
+
+func TestResponsesRoutesKnownCompactionToProducerDomain(t *testing.T) {
+	var otherCalls, producerCalls atomic.Int32
+	otherUpstream := newCompactionAffinityRelay(t, &otherCalls)
+	defer otherUpstream.Close()
+	producerUpstream := newCompactionAffinityRelay(t, &producerCalls)
+	defer producerUpstream.Close()
+
+	other := &auth.Account{DBID: 1, UpstreamType: auth.UpstreamOpenAIResponses, BaseURL: otherUpstream.URL, APIKey: "other", Models: []string{"gpt-4.1-direct"}}
+	producer := &auth.Account{DBID: 2, UpstreamType: auth.UpstreamOpenAIResponses, BaseURL: producerUpstream.URL, APIKey: "producer", Models: []string{"gpt-4.1-direct"}}
+	handler := NewHandler(newCompactionAffinityStore(other, producer), nil, nil, nil)
+	handler.SetRuntimeCache(cache.NewMemory(1))
+	if err := handler.recordCompactionProvenance(context.Background(), producer, "known-state"); err != nil {
+		t.Fatal(err)
+	}
+
+	recorder := runCompactionAffinityResponses(t, handler, `{"model":"gpt-4.1-direct","stream":true,"input":[{"type":"compaction","encrypted_content":"known-state"},{"role":"user","content":"continue"}]}`)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	if producerCalls.Load() != 1 || otherCalls.Load() != 0 {
+		t.Fatalf("producer calls = %d, other calls = %d", producerCalls.Load(), otherCalls.Load())
+	}
+	if _, ok, err := handler.cache.GetRuntime(context.Background(), compactionProvenanceCacheNamespace, compactionContentDigest("stream-output-state")); err != nil || !ok {
+		t.Fatalf("stream output provenance = ok %v, err %v", ok, err)
+	}
+}
+
+func TestResponsesKnownCompactionWithoutCompatibleAccountReturnsExplicit503(t *testing.T) {
+	var localCalls atomic.Int32
+	localUpstream := newCompactionAffinityRelay(t, &localCalls)
+	defer localUpstream.Close()
+
+	local := &auth.Account{DBID: 1, UpstreamType: auth.UpstreamOpenAIResponses, BaseURL: localUpstream.URL, APIKey: "local", Models: []string{"gpt-4.1-direct"}}
+	ghost := &auth.Account{DBID: 99, UpstreamType: auth.UpstreamOpenAIResponses, BaseURL: "https://unavailable.example/v1", APIKey: "ghost"}
+	handler := NewHandler(newCompactionAffinityStore(local), nil, nil, nil)
+	handler.SetRuntimeCache(cache.NewMemory(1))
+	if err := handler.recordCompactionProvenance(context.Background(), ghost, "orphaned-state"); err != nil {
+		t.Fatal(err)
+	}
+
+	recorder := runCompactionAffinityResponses(t, handler, `{"model":"gpt-4.1-direct","stream":true,"input":[{"type":"compaction","encrypted_content":"orphaned-state"}]}`)
+	if recorder.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503; body = %s", recorder.Code, recorder.Body.String())
+	}
+	if !strings.Contains(recorder.Body.String(), "compaction_upstream_unavailable") {
+		t.Fatalf("missing explicit compaction error: %s", recorder.Body.String())
+	}
+	if localCalls.Load() != 0 {
+		t.Fatalf("incompatible upstream received %d calls", localCalls.Load())
+	}
+}
+
+func TestResponsesKnownCompactionAllowsSameDomainAccountFailover(t *testing.T) {
+	var calls atomic.Int32
+	upstream := newCompactionAffinityRelay(t, &calls)
+	defer upstream.Close()
+
+	producer := &auth.Account{DBID: 1, UpstreamType: auth.UpstreamOpenAIResponses, BaseURL: upstream.URL, APIKey: "producer", Models: []string{"gpt-4.1-direct"}, Status: auth.StatusError}
+	failover := &auth.Account{DBID: 2, UpstreamType: auth.UpstreamOpenAIResponses, BaseURL: upstream.URL, APIKey: "failover", Models: []string{"gpt-4.1-direct"}}
+	handler := NewHandler(newCompactionAffinityStore(producer, failover), nil, nil, nil)
+	handler.SetRuntimeCache(cache.NewMemory(1))
+	if err := handler.recordCompactionProvenance(context.Background(), producer, "same-domain-state"); err != nil {
+		t.Fatal(err)
+	}
+
+	recorder := runCompactionAffinityResponses(t, handler, `{"model":"gpt-4.1-direct","stream":true,"input":[{"type":"compaction","encrypted_content":"same-domain-state"}]}`)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	if calls.Load() != 1 {
+		t.Fatalf("same-domain failover calls = %d, want 1", calls.Load())
+	}
+}
+
+func TestResponsesRejectsConflictingKnownCompactionDomains(t *testing.T) {
+	var calls atomic.Int32
+	upstream := newCompactionAffinityRelay(t, &calls)
+	defer upstream.Close()
+	local := &auth.Account{DBID: 1, UpstreamType: auth.UpstreamOpenAIResponses, BaseURL: upstream.URL, APIKey: "local", Models: []string{"gpt-4.1-direct"}}
+	handler := NewHandler(newCompactionAffinityStore(local), nil, nil, nil)
+	handler.SetRuntimeCache(cache.NewMemory(1))
+	if err := handler.recordCompactionProvenance(context.Background(), local, "relay-state"); err != nil {
+		t.Fatal(err)
+	}
+	if err := handler.recordCompactionProvenance(context.Background(), &auth.Account{DBID: 2, AccessToken: "native"}, "native-state"); err != nil {
+		t.Fatal(err)
+	}
+
+	recorder := runCompactionAffinityResponses(t, handler, `{"model":"gpt-4.1-direct","stream":true,"input":[{"type":"compaction","encrypted_content":"relay-state"},{"type":"compaction","encrypted_content":"native-state"}]}`)
+	if recorder.Code != http.StatusBadRequest || !strings.Contains(recorder.Body.String(), "compaction_provenance_conflict") {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	if calls.Load() != 0 {
+		t.Fatalf("upstream received %d calls", calls.Load())
+	}
+}
+
+func newCompactionAffinityCompactRelay(t *testing.T, calls *atomic.Int32) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"cmp-affinity","object":"response.compaction","output":[{"type":"compaction","encrypted_content":"next-state"}],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}`)
+	}))
+}
+
+func TestResponsesCompactRoutesKnownCompactionToProducerDomain(t *testing.T) {
+	var otherCalls, producerCalls atomic.Int32
+	otherUpstream := newCompactionAffinityCompactRelay(t, &otherCalls)
+	defer otherUpstream.Close()
+	producerUpstream := newCompactionAffinityCompactRelay(t, &producerCalls)
+	defer producerUpstream.Close()
+
+	other := &auth.Account{DBID: 1, UpstreamType: auth.UpstreamOpenAIResponses, BaseURL: otherUpstream.URL, APIKey: "other", Models: []string{"gpt-4.1-direct"}}
+	producer := &auth.Account{DBID: 2, UpstreamType: auth.UpstreamOpenAIResponses, BaseURL: producerUpstream.URL, APIKey: "producer", Models: []string{"gpt-4.1-direct"}}
+	handler := NewHandler(newCompactionAffinityStore(other, producer), nil, nil, nil)
+	handler.SetRuntimeCache(cache.NewMemory(1))
+	if err := handler.recordCompactionProvenance(context.Background(), producer, "known-compact-state"); err != nil {
+		t.Fatal(err)
+	}
+
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	ginContext, _ := gin.CreateTestContext(recorder)
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses/compact", bytes.NewBufferString(`{"model":"gpt-4.1-direct","input":[{"type":"compaction","encrypted_content":"known-compact-state"}]}`))
+	req.Header.Set("Content-Type", "application/json")
+	ginContext.Request = req
+	handler.ResponsesCompact(ginContext)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	if producerCalls.Load() != 1 || otherCalls.Load() != 0 {
+		t.Fatalf("producer calls = %d, other calls = %d", producerCalls.Load(), otherCalls.Load())
+	}
+	if _, ok, err := handler.cache.GetRuntime(context.Background(), compactionProvenanceCacheNamespace, compactionContentDigest("next-state")); err != nil || !ok {
+		t.Fatalf("compact output provenance = ok %v, err %v; response=%s", ok, err, recorder.Body.String())
+	}
+}
+
+func TestResponsesWebSocketRoutesAndRecordsKnownCompaction(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	previousExec := WebsocketExecuteFunc
+	t.Cleanup(func() { WebsocketExecuteFunc = previousExec })
+
+	selectedAccount := make(chan int64, 1)
+	WebsocketExecuteFunc = func(ctx context.Context, account *auth.Account, requestBody []byte, sessionID string, proxyOverride string, apiKey string, deviceCfg *DeviceProfileConfig, headers http.Header, poolRouteKey string) (*http.Response, error) {
+		selectedAccount <- account.ID()
+		sse := `data: {"type":"response.output_item.done","item":{"type":"compaction","encrypted_content":"ws-output-state"}}` + "\n\n" +
+			`data: {"type":"response.completed","response":{"id":"resp_ws_affinity","status":"completed","output":[],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}}` + "\n\n"
+		return &http.Response{StatusCode: http.StatusOK, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(sse))}, nil
+	}
+
+	first := &auth.Account{DBID: 1, AccessToken: "first", PlanType: "plus", AccountID: "first"}
+	producer := &auth.Account{DBID: 2, AccessToken: "producer", PlanType: "plus", AccountID: "producer"}
+	handler := NewHandler(newCompactionAffinityStore(first, producer), nil, &config.Config{AllowAnonymousV1: true}, nil)
+	handler.SetRuntimeCache(cache.NewMemory(1))
+	if err := handler.recordCompactionProvenance(context.Background(), producer, "ws-known-state"); err != nil {
+		t.Fatal(err)
+	}
+
+	router := gin.New()
+	handler.RegisterRoutes(router)
+	server := httptest.NewServer(router)
+	defer server.Close()
+	conn, response, err := websocket.DefaultDialer.Dial("ws"+strings.TrimPrefix(server.URL, "http")+"/v1/responses", nil)
+	if err != nil {
+		if response != nil {
+			t.Fatalf("dial websocket: %v status=%d", err, response.StatusCode)
+		}
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	if err := conn.WriteMessage(websocket.TextMessage, []byte(`{"model":"gpt-5.4","input":[{"type":"compaction","encrypted_content":"ws-known-state"}]}`)); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case accountID := <-selectedAccount:
+		if accountID != producer.ID() {
+			t.Fatalf("selected account = %d, want producer %d", accountID, producer.ID())
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for upstream websocket request")
+	}
+
+	_ = conn.SetReadDeadline(time.Now().Add(time.Second))
+	for range 2 {
+		if _, _, err := conn.ReadMessage(); err != nil {
+			t.Fatalf("read websocket response: %v", err)
+		}
+	}
+	if _, ok, err := handler.cache.GetRuntime(context.Background(), compactionProvenanceCacheNamespace, compactionContentDigest("ws-output-state")); err != nil || !ok {
+		t.Fatalf("websocket output provenance = ok %v, err %v", ok, err)
 	}
 }

--- a/proxy/compaction_provenance_test.go
+++ b/proxy/compaction_provenance_test.go
@@ -3,10 +3,12 @@ package proxy
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -54,6 +56,14 @@ func TestAccountCompactionDomain(t *testing.T) {
 			},
 			want: "responses:https://other.example.com/v1",
 		},
+		{
+			name: "grok route stays account isolated",
+			account: &auth.Account{
+				DBID: 4, UpstreamType: auth.UpstreamGrok,
+				BaseURL: "https://shared-grok.example/v1", APIKey: "key-a",
+			},
+			want: "grok:account:4",
+		},
 	}
 
 	for _, tt := range tests {
@@ -62,6 +72,14 @@ func TestAccountCompactionDomain(t *testing.T) {
 				t.Fatalf("accountCompactionDomain() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestGrokCompactionDomainsDoNotAssumeConfiguredBaseURLIsResolvedRoute(t *testing.T) {
+	first := &auth.Account{DBID: 4, UpstreamType: auth.UpstreamGrok, BaseURL: "https://shared-grok.example/v1", APIKey: "key-a"}
+	second := &auth.Account{DBID: 5, UpstreamType: auth.UpstreamGrok, BaseURL: "https://shared-grok.example/v1", APIKey: "key-b"}
+	if firstDomain, secondDomain := accountCompactionDomain(first), accountCompactionDomain(second); firstDomain == secondDomain {
+		t.Fatalf("Grok accounts with model-resolved routes shared domain %q", firstDomain)
 	}
 }
 
@@ -133,6 +151,13 @@ func TestResolveCompactionAffinity(t *testing.T) {
 		}
 	})
 
+	t.Run("encrypted compaction summary resolves like output recorder", func(t *testing.T) {
+		resolution, err := handler.resolveCompactionAffinity(context.Background(), []byte(`{"input":[{"type":"compaction_summary","encrypted_content":"known"}]}`))
+		if err != nil || !resolution.Known || resolution.PreferredAccountID != relay.ID() {
+			t.Fatalf("resolution = %+v, err = %v", resolution, err)
+		}
+	})
+
 	t.Run("conflicting known domains are rejected", func(t *testing.T) {
 		other := &auth.Account{DBID: 8, AccessToken: "native"}
 		if err := handler.recordCompactionProvenance(context.Background(), other, "other"); err != nil {
@@ -143,6 +168,39 @@ func TestResolveCompactionAffinity(t *testing.T) {
 			t.Fatalf("conflict error = %v", err)
 		}
 	})
+}
+
+type compactionRuntimeTrackingCache struct {
+	cache.TokenCache
+	mu      sync.Mutex
+	setTTLs []time.Duration
+}
+
+func (c *compactionRuntimeTrackingCache) SetRuntime(ctx context.Context, namespace, key string, value json.RawMessage, ttl time.Duration) error {
+	c.mu.Lock()
+	c.setTTLs = append(c.setTTLs, ttl)
+	c.mu.Unlock()
+	return c.TokenCache.SetRuntime(ctx, namespace, key, value, ttl)
+}
+
+func TestResolveCompactionAffinityRefreshesRollingTTL(t *testing.T) {
+	t.Setenv(compactionAffinityTTLEnv, "36h")
+	tracking := &compactionRuntimeTrackingCache{TokenCache: cache.NewMemory(1)}
+	handler := &Handler{cache: tracking}
+	account := &auth.Account{DBID: 31, AccessToken: "native"}
+	if err := handler.recordCompactionProvenance(context.Background(), account, "rolling-state"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := handler.resolveCompactionAffinity(context.Background(), []byte(`{"input":[{"type":"compaction","encrypted_content":"rolling-state"}]}`)); err != nil {
+		t.Fatal(err)
+	}
+
+	tracking.mu.Lock()
+	ttls := append([]time.Duration(nil), tracking.setTTLs...)
+	tracking.mu.Unlock()
+	if len(ttls) != 2 || ttls[0] != 36*time.Hour || ttls[1] != 36*time.Hour {
+		t.Fatalf("runtime Set TTLs = %v, want initial + refreshed 36h", ttls)
+	}
 }
 
 func TestCompactionDomainFilter(t *testing.T) {
@@ -246,7 +304,10 @@ func TestResponsesRoutesKnownCompactionToProducerDomain(t *testing.T) {
 
 	other := &auth.Account{DBID: 1, UpstreamType: auth.UpstreamOpenAIResponses, BaseURL: otherUpstream.URL, APIKey: "other", Models: []string{"gpt-4.1-direct"}}
 	producer := &auth.Account{DBID: 2, UpstreamType: auth.UpstreamOpenAIResponses, BaseURL: producerUpstream.URL, APIKey: "producer", Models: []string{"gpt-4.1-direct"}}
-	handler := NewHandler(newCompactionAffinityStore(other, producer), nil, nil, nil)
+	other.SetSchedulerPriority(100)
+	store := newCompactionAffinityStore(other, producer)
+	store.SetAffinityMode(auth.AffinityModeOff)
+	handler := NewHandler(store, nil, nil, nil)
 	handler.SetRuntimeCache(cache.NewMemory(1))
 	if err := handler.recordCompactionProvenance(context.Background(), producer, "known-state"); err != nil {
 		t.Fatal(err)
@@ -261,6 +322,72 @@ func TestResponsesRoutesKnownCompactionToProducerDomain(t *testing.T) {
 	}
 	if _, ok, err := handler.cache.GetRuntime(context.Background(), compactionProvenanceCacheNamespace, compactionContentDigest("stream-output-state")); err != nil || !ok {
 		t.Fatalf("stream output provenance = ok %v, err %v", ok, err)
+	}
+}
+
+func TestResponsesPrefersProducerIndependentOfSessionAffinityMode(t *testing.T) {
+	var seenAuthorization string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenAuthorization = r.Header.Get("Authorization")
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_preferred\",\"status\":\"completed\",\"output\":[],\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}}\n\n")
+	}))
+	defer upstream.Close()
+
+	other := &auth.Account{DBID: 1, UpstreamType: auth.UpstreamOpenAIResponses, BaseURL: upstream.URL, APIKey: "other", Models: []string{"gpt-4.1-direct"}}
+	producer := &auth.Account{DBID: 2, UpstreamType: auth.UpstreamOpenAIResponses, BaseURL: upstream.URL, APIKey: "producer", Models: []string{"gpt-4.1-direct"}, HealthTier: auth.HealthTierWarm}
+	other.SetSchedulerPriority(100)
+	store := newCompactionAffinityStore(other, producer)
+	store.SetAffinityMode(auth.AffinityModeOff)
+	handler := NewHandler(store, nil, nil, nil)
+	handler.SetRuntimeCache(cache.NewMemory(1))
+	if err := handler.recordCompactionProvenance(context.Background(), producer, "producer-state"); err != nil {
+		t.Fatal(err)
+	}
+
+	recorder := runCompactionAffinityResponses(t, handler, `{"model":"gpt-4.1-direct","stream":true,"input":[{"type":"compaction","encrypted_content":"producer-state"}]}`)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	if seenAuthorization != "Bearer producer" {
+		t.Fatalf("Authorization = %q, want producer credential", seenAuthorization)
+	}
+}
+
+func TestResponsesNonStreamRoutesAndRecordsKnownCompaction(t *testing.T) {
+	var otherCalls, producerCalls atomic.Int32
+	newJSONRelay := func(calls *atomic.Int32, outputState string) *httptest.Server {
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			calls.Add(1)
+			_, _ = io.Copy(io.Discard, r.Body)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"id":"resp_nonstream","status":"completed","output":[{"type":"compaction","encrypted_content":"`+outputState+`"}],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}`)
+		}))
+	}
+	otherUpstream := newJSONRelay(&otherCalls, "wrong-output")
+	defer otherUpstream.Close()
+	producerUpstream := newJSONRelay(&producerCalls, "nonstream-output-state")
+	defer producerUpstream.Close()
+
+	other := &auth.Account{DBID: 1, UpstreamType: auth.UpstreamOpenAIResponses, BaseURL: otherUpstream.URL, APIKey: "other", Models: []string{"gpt-4.1-direct"}}
+	producer := &auth.Account{DBID: 2, UpstreamType: auth.UpstreamOpenAIResponses, BaseURL: producerUpstream.URL, APIKey: "producer", Models: []string{"gpt-4.1-direct"}, HealthTier: auth.HealthTierWarm}
+	other.SetSchedulerPriority(100)
+	handler := NewHandler(newCompactionAffinityStore(other, producer), nil, nil, nil)
+	handler.SetRuntimeCache(cache.NewMemory(1))
+	if err := handler.recordCompactionProvenance(context.Background(), producer, "nonstream-known-state"); err != nil {
+		t.Fatal(err)
+	}
+
+	recorder := runCompactionAffinityResponses(t, handler, `{"model":"gpt-4.1-direct","stream":false,"input":[{"type":"compaction","encrypted_content":"nonstream-known-state"}]}`)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	if producerCalls.Load() != 1 || otherCalls.Load() != 0 {
+		t.Fatalf("producer calls = %d, other calls = %d", producerCalls.Load(), otherCalls.Load())
+	}
+	if _, ok, err := handler.cache.GetRuntime(context.Background(), compactionProvenanceCacheNamespace, compactionContentDigest("nonstream-output-state")); err != nil || !ok {
+		t.Fatalf("nonstream output provenance = ok %v, err %v", ok, err)
 	}
 }
 

--- a/proxy/compaction_provenance_test.go
+++ b/proxy/compaction_provenance_test.go
@@ -325,6 +325,72 @@ func TestResponsesRoutesKnownCompactionToProducerDomain(t *testing.T) {
 	}
 }
 
+func TestResponsesPortableCompactionReturnsToNormalPoolScheduling(t *testing.T) {
+	var otherCalls, producerCalls atomic.Int32
+	var receivedBody []byte
+	otherUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		otherCalls.Add(1)
+		receivedBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_portable\",\"status\":\"completed\",\"output\":[],\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}}\n\n")
+	}))
+	defer otherUpstream.Close()
+	producerUpstream := newCompactionAffinityRelay(t, &producerCalls)
+	defer producerUpstream.Close()
+
+	other := &auth.Account{DBID: 1, UpstreamType: auth.UpstreamOpenAIResponses, BaseURL: otherUpstream.URL, APIKey: "other", Models: []string{"gpt-4.1-direct"}}
+	producer := &auth.Account{DBID: 2, UpstreamType: auth.UpstreamOpenAIResponses, BaseURL: producerUpstream.URL, APIKey: "producer", Models: []string{"gpt-4.1-direct"}}
+	other.SetSchedulerPriority(100)
+	store := newCompactionAffinityStore(other, producer)
+	store.SetAffinityMode(auth.AffinityModeOff)
+	handler := NewHandler(store, nil, nil, nil)
+	handler.SetRuntimeCache(cache.NewMemory(1))
+	if err := handler.recordCompactionProvenance(context.Background(), producer, portableCompactionFixture); err != nil {
+		t.Fatal(err)
+	}
+
+	recorder := runCompactionAffinityResponses(t, handler, `{"model":"gpt-4.1-direct","stream":true,"input":[{"type":"compaction","encrypted_content":"`+portableCompactionFixture+`"},{"role":"user","content":"continue"}]}`)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	if otherCalls.Load() != 1 || producerCalls.Load() != 0 {
+		t.Fatalf("normal scheduler should select higher-priority account: other calls = %d, producer calls = %d", otherCalls.Load(), producerCalls.Load())
+	}
+	if bytes.Contains(receivedBody, []byte(portableCompactionEnvelopePrefix)) {
+		t.Fatalf("portable envelope reached upstream: %s", receivedBody)
+	}
+	if !bytes.Contains(receivedBody, []byte("portable context")) {
+		t.Fatalf("decoded summary missing upstream: %s", receivedBody)
+	}
+}
+
+func TestResponsesMixedPortableAndOpaqueCompactionRetainsOpaqueAffinity(t *testing.T) {
+	var otherCalls, producerCalls atomic.Int32
+	otherUpstream := newCompactionAffinityRelay(t, &otherCalls)
+	defer otherUpstream.Close()
+	producerUpstream := newCompactionAffinityRelay(t, &producerCalls)
+	defer producerUpstream.Close()
+
+	other := &auth.Account{DBID: 1, UpstreamType: auth.UpstreamOpenAIResponses, BaseURL: otherUpstream.URL, APIKey: "other", Models: []string{"gpt-4.1-direct"}}
+	producer := &auth.Account{DBID: 2, UpstreamType: auth.UpstreamOpenAIResponses, BaseURL: producerUpstream.URL, APIKey: "producer", Models: []string{"gpt-4.1-direct"}}
+	other.SetSchedulerPriority(100)
+	store := newCompactionAffinityStore(other, producer)
+	store.SetAffinityMode(auth.AffinityModeOff)
+	handler := NewHandler(store, nil, nil, nil)
+	handler.SetRuntimeCache(cache.NewMemory(1))
+	if err := handler.recordCompactionProvenance(context.Background(), producer, "known-opaque"); err != nil {
+		t.Fatal(err)
+	}
+
+	recorder := runCompactionAffinityResponses(t, handler, `{"model":"gpt-4.1-direct","stream":true,"input":[{"type":"compaction","encrypted_content":"`+portableCompactionFixture+`"},{"type":"compaction","encrypted_content":"known-opaque"}]}`)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	if producerCalls.Load() != 1 || otherCalls.Load() != 0 {
+		t.Fatalf("remaining opaque state must retain producer affinity: producer calls = %d, other calls = %d", producerCalls.Load(), otherCalls.Load())
+	}
+}
+
 func TestResponsesPrefersProducerIndependentOfSessionAffinityMode(t *testing.T) {
 	var seenAuthorization string
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -505,6 +571,40 @@ func TestResponsesCompactRoutesKnownCompactionToProducerDomain(t *testing.T) {
 	}
 }
 
+func TestResponsesCompactPortableCompactionReturnsToNormalPoolScheduling(t *testing.T) {
+	var otherCalls, producerCalls atomic.Int32
+	otherUpstream := newCompactionAffinityCompactRelay(t, &otherCalls)
+	defer otherUpstream.Close()
+	producerUpstream := newCompactionAffinityCompactRelay(t, &producerCalls)
+	defer producerUpstream.Close()
+
+	other := &auth.Account{DBID: 1, UpstreamType: auth.UpstreamOpenAIResponses, BaseURL: otherUpstream.URL, APIKey: "other", Models: []string{"gpt-4.1-direct"}}
+	producer := &auth.Account{DBID: 2, UpstreamType: auth.UpstreamOpenAIResponses, BaseURL: producerUpstream.URL, APIKey: "producer", Models: []string{"gpt-4.1-direct"}}
+	other.SetSchedulerPriority(100)
+	store := newCompactionAffinityStore(other, producer)
+	store.SetAffinityMode(auth.AffinityModeOff)
+	handler := NewHandler(store, nil, nil, nil)
+	handler.SetRuntimeCache(cache.NewMemory(1))
+	if err := handler.recordCompactionProvenance(context.Background(), producer, portableCompactionFixture); err != nil {
+		t.Fatal(err)
+	}
+
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	ginContext, _ := gin.CreateTestContext(recorder)
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses/compact", bytes.NewBufferString(`{"model":"gpt-4.1-direct","input":[{"type":"compaction","encrypted_content":"`+portableCompactionFixture+`"}]}`))
+	req.Header.Set("Content-Type", "application/json")
+	ginContext.Request = req
+	handler.ResponsesCompact(ginContext)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	if otherCalls.Load() != 1 || producerCalls.Load() != 0 {
+		t.Fatalf("compact normal scheduler should select higher-priority account: other calls = %d, producer calls = %d", otherCalls.Load(), producerCalls.Load())
+	}
+}
+
 func TestResponsesWebSocketRoutesAndRecordsKnownCompaction(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	previousExec := WebsocketExecuteFunc
@@ -559,5 +659,61 @@ func TestResponsesWebSocketRoutesAndRecordsKnownCompaction(t *testing.T) {
 	}
 	if _, ok, err := handler.cache.GetRuntime(context.Background(), compactionProvenanceCacheNamespace, compactionContentDigest("ws-output-state")); err != nil || !ok {
 		t.Fatalf("websocket output provenance = ok %v, err %v", ok, err)
+	}
+}
+
+func TestResponsesWebSocketPortableCompactionReturnsToNormalPoolScheduling(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	previousExec := WebsocketExecuteFunc
+	t.Cleanup(func() { WebsocketExecuteFunc = previousExec })
+
+	type selection struct {
+		accountID int64
+		body      []byte
+	}
+	selected := make(chan selection, 1)
+	WebsocketExecuteFunc = func(ctx context.Context, account *auth.Account, requestBody []byte, sessionID string, proxyOverride string, apiKey string, deviceCfg *DeviceProfileConfig, headers http.Header, poolRouteKey string) (*http.Response, error) {
+		selected <- selection{accountID: account.ID(), body: append([]byte(nil), requestBody...)}
+		sse := `data: {"type":"response.completed","response":{"id":"resp_ws_portable","status":"completed","output":[],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}}` + "\n\n"
+		return &http.Response{StatusCode: http.StatusOK, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(sse))}, nil
+	}
+
+	other := &auth.Account{DBID: 1, AccessToken: "other", PlanType: "plus", AccountID: "other"}
+	producer := &auth.Account{DBID: 2, AccessToken: "producer", PlanType: "plus", AccountID: "producer"}
+	other.SetSchedulerPriority(100)
+	store := newCompactionAffinityStore(other, producer)
+	store.SetAffinityMode(auth.AffinityModeOff)
+	handler := NewHandler(store, nil, &config.Config{AllowAnonymousV1: true}, nil)
+	handler.SetRuntimeCache(cache.NewMemory(1))
+	if err := handler.recordCompactionProvenance(context.Background(), producer, portableCompactionFixture); err != nil {
+		t.Fatal(err)
+	}
+
+	router := gin.New()
+	handler.RegisterRoutes(router)
+	server := httptest.NewServer(router)
+	defer server.Close()
+	conn, response, err := websocket.DefaultDialer.Dial("ws"+strings.TrimPrefix(server.URL, "http")+"/v1/responses", nil)
+	if err != nil {
+		if response != nil {
+			t.Fatalf("dial websocket: %v status=%d", err, response.StatusCode)
+		}
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	if err := conn.WriteMessage(websocket.TextMessage, []byte(`{"model":"gpt-5.4","input":[{"type":"compaction","encrypted_content":"`+portableCompactionFixture+`"}]}`)); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case got := <-selected:
+		if got.accountID != other.ID() {
+			t.Fatalf("selected account = %d, want normal higher-priority account %d", got.accountID, other.ID())
+		}
+		if bytes.Contains(got.body, []byte(portableCompactionEnvelopePrefix)) || !bytes.Contains(got.body, []byte("portable context")) {
+			t.Fatalf("portable compaction was not normalized before WebSocket dispatch: %s", got.body)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for upstream websocket request")
 	}
 }

--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -2805,6 +2805,7 @@ func (h *Handler) Responses(c *gin.Context) {
 	} else {
 		rawBody, requestModel, mappedModel, mappingApplied = h.applyConfiguredModelMappingToBody(rawBody, supportedModels)
 	}
+	rawBody, _ = normalizePortableResponsesCompactionHistory(rawBody)
 	setRawRequestBody(c, rawBody)
 
 	// Validate request
@@ -4266,6 +4267,7 @@ func (h *Handler) ResponsesCompact(c *gin.Context) {
 	// 先让全局/渠道映射看到客户端原始模型（包括 -openai-compact 别名）；
 	// 没有命中映射时，再按兼容规则剥离后缀。
 	rawBody, requestModel, mappedModel, mappingApplied := h.applyConfiguredCompactModelMappingToBody(rawBody, supportedModels)
+	rawBody, _ = normalizePortableResponsesCompactionHistory(rawBody)
 	setRawRequestBody(c, rawBody)
 
 	// Validate request

--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -2935,9 +2935,6 @@ func (h *Handler) Responses(c *gin.Context) {
 	}
 	if compactionAffinity.Known {
 		accountFilter = compactionDomainFilter(compactionAffinity.CompatibilityDomain, accountFilter)
-		if preferred := h.store.FindByID(compactionAffinity.PreferredAccountID); preferred != nil && accountFilter(preferred) {
-			h.store.BindSessionAffinity(affinityKey, preferred, preferred.GetProxyURL())
-		}
 	}
 	// scope 并发位在选中账号后才能占，请求退出时统一释放（issue #439 v2）。
 	defer h.ReleaseAPIKeyScopeConcurrency(c)
@@ -2969,7 +2966,12 @@ func (h *Handler) Responses(c *gin.Context) {
 	for attempt := 0; ; attempt++ {
 		account, stickyProxyURL, retainedHTTPFallback := wsHTTPFallback.Take()
 		if !retainedHTTPFallback {
-			if continuationUnavailable && !relayContinuationAttempted {
+			if attempt == 0 && compactionAffinity.Known && !turnContinuationPinned {
+				account = h.store.TakePreferredAccountWithFilter(compactionAffinity.PreferredAccountID, apiKeyID, retryExclusions.ForSelection(), accountFilter)
+			}
+			if account != nil {
+				stickyProxyURL = account.GetProxyURL()
+			} else if continuationUnavailable && !relayContinuationAttempted {
 				account, stickyProxyURL = h.nextAccountForSessionWithFilter(affinityKey, apiKeyID, retryExclusions.ForSelection(), accountFilter)
 			} else if turnContinuationPinned {
 				account, stickyProxyURL = h.nextRetryAccountForContinuation(c.Request.Context(), affinityKey, apiKeyID, retryExclusions, accountFilter)
@@ -4375,9 +4377,6 @@ func (h *Handler) ResponsesCompact(c *gin.Context) {
 	}
 	if compactionAffinity.Known {
 		accountFilter = compactionDomainFilter(compactionAffinity.CompatibilityDomain, accountFilter)
-		if preferred := h.store.FindByID(compactionAffinity.PreferredAccountID); preferred != nil && accountFilter(preferred) {
-			h.store.BindSessionAffinity(affinityKey, preferred, preferred.GetProxyURL())
-		}
 	}
 	// scope 并发位在选中账号后才能占，请求退出时统一释放（issue #439 v2）。
 	defer h.ReleaseAPIKeyScopeConcurrency(c)
@@ -4397,7 +4396,17 @@ func (h *Handler) ResponsesCompact(c *gin.Context) {
 	relayContinuationAttempted := false
 
 	for attempt := 0; ; attempt++ {
-		account, stickyProxyURL := h.nextAccountForSessionWithFilter(affinityKey, apiKeyID, excludeAccounts, accountFilter)
+		var account *auth.Account
+		var stickyProxyURL string
+		if attempt == 0 && compactionAffinity.Known {
+			account = h.store.TakePreferredAccountWithFilter(compactionAffinity.PreferredAccountID, apiKeyID, excludeAccounts, accountFilter)
+			if account != nil {
+				stickyProxyURL = account.GetProxyURL()
+			}
+		}
+		if account == nil {
+			account, stickyProxyURL = h.nextAccountForSessionWithFilter(affinityKey, apiKeyID, excludeAccounts, accountFilter)
+		}
 		if account == nil {
 			if compactionAffinity.Known {
 				sendCompactionUpstreamUnavailable(c)

--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -2924,6 +2924,21 @@ func (h *Handler) Responses(c *gin.Context) {
 	accountFilter = h.applyUpstreamChannelFilter(c, effectiveModel, accountFilter)
 	accountFilter = applyAffinityGroupRouting(c, sessionIdentity, accountFilter)
 	accountFilter = h.applyScopeBudgetFilter(c, accountFilter)
+	compactionAffinity, compactionAffinityErr := h.resolveCompactionAffinity(c.Request.Context(), rawBody)
+	if compactionAffinityErr != nil {
+		if errors.Is(compactionAffinityErr, errConflictingCompactionProvenance) {
+			sendCompactionProvenanceConflict(c)
+		} else {
+			sendCompactionProvenanceUnavailable(c)
+		}
+		return
+	}
+	if compactionAffinity.Known {
+		accountFilter = compactionDomainFilter(compactionAffinity.CompatibilityDomain, accountFilter)
+		if preferred := h.store.FindByID(compactionAffinity.PreferredAccountID); preferred != nil && accountFilter(preferred) {
+			h.store.BindSessionAffinity(affinityKey, preferred, preferred.GetProxyURL())
+		}
+	}
 	// scope 并发位在选中账号后才能占，请求退出时统一释放（issue #439 v2）。
 	defer h.ReleaseAPIKeyScopeConcurrency(c)
 
@@ -2965,6 +2980,10 @@ func (h *Handler) Responses(c *gin.Context) {
 		if account == nil {
 			if lastStatusCode == http.StatusTooManyRequests && len(lastBody) > 0 {
 				h.sendFinalUpstreamError(c, lastStatusCode, lastBody)
+				return
+			}
+			if compactionAffinity.Known {
+				sendCompactionUpstreamUnavailable(c)
 				return
 			}
 			// 候选被 scope 预算剔空时给出真实原因，而不是含糊的「无可用账号」。
@@ -3294,6 +3313,7 @@ func (h *Handler) Responses(c *gin.Context) {
 				var pendingFirstTokenEvents bytes.Buffer
 				readErr = ReadSSEStream(resp.Body, func(data []byte) bool {
 					streamDiag.markUpstreamFrame()
+					h.recordCompactionProvenanceFromPayload(context.Background(), account, data)
 					parsed := gjson.ParseBytes(data)
 					eventType := parsed.Get("type").String()
 					ttftGuard.MarkProgress(eventType)
@@ -3372,6 +3392,7 @@ func (h *Handler) Responses(c *gin.Context) {
 				var respBody []byte
 				respBody, readErr = io.ReadAll(resp.Body)
 				if readErr == nil {
+					h.recordCompactionProvenanceFromPayload(context.Background(), account, respBody)
 					usage = extractUsageFromResult(gjson.GetBytes(respBody, "usage"))
 					actualServiceTier = gjson.GetBytes(respBody, "service_tier").String()
 					imageLogInfo = imageUsageLogInfoFromResponseJSON(respBody)
@@ -3788,6 +3809,7 @@ func (h *Handler) Responses(c *gin.Context) {
 			preflightPassthrough := CurrentRuntimeSettings().CodexPreflightSSEPassthrough
 			forward := func(data []byte) bool {
 				streamDiag.markUpstreamFrame()
+				h.recordCompactionProvenanceFromPayload(context.Background(), account, data)
 				downstreamMu.Lock()
 				defer downstreamMu.Unlock()
 				parsed := gjson.ParseBytes(data)
@@ -3988,6 +4010,7 @@ func (h *Handler) Responses(c *gin.Context) {
 			imageOutputs := make([]json.RawMessage, 0, 1)
 			seenImageOutputs := make(map[string]struct{})
 			readErr = ReadSSEStream(resp.Body, func(data []byte) bool {
+				h.recordCompactionProvenanceFromPayload(context.Background(), account, data)
 				parsed := gjson.ParseBytes(data)
 				eventType := parsed.Get("type").String()
 				if outputItem, ok := extractResponseOutputItemDone(data, seenOutputItems); ok {
@@ -4341,6 +4364,21 @@ func (h *Handler) ResponsesCompact(c *gin.Context) {
 	}
 	accountFilter = applyAffinityGroupRouting(c, sessionIdentity, accountFilter)
 	accountFilter = h.applyScopeBudgetFilter(c, accountFilter)
+	compactionAffinity, compactionAffinityErr := h.resolveCompactionAffinity(c.Request.Context(), rawBody)
+	if compactionAffinityErr != nil {
+		if errors.Is(compactionAffinityErr, errConflictingCompactionProvenance) {
+			sendCompactionProvenanceConflict(c)
+		} else {
+			sendCompactionProvenanceUnavailable(c)
+		}
+		return
+	}
+	if compactionAffinity.Known {
+		accountFilter = compactionDomainFilter(compactionAffinity.CompatibilityDomain, accountFilter)
+		if preferred := h.store.FindByID(compactionAffinity.PreferredAccountID); preferred != nil && accountFilter(preferred) {
+			h.store.BindSessionAffinity(affinityKey, preferred, preferred.GetProxyURL())
+		}
+	}
 	// scope 并发位在选中账号后才能占，请求退出时统一释放（issue #439 v2）。
 	defer h.ReleaseAPIKeyScopeConcurrency(c)
 
@@ -4361,6 +4399,10 @@ func (h *Handler) ResponsesCompact(c *gin.Context) {
 	for attempt := 0; ; attempt++ {
 		account, stickyProxyURL := h.nextAccountForSessionWithFilter(affinityKey, apiKeyID, excludeAccounts, accountFilter)
 		if account == nil {
+			if compactionAffinity.Known {
+				sendCompactionUpstreamUnavailable(c)
+				return
+			}
 			if continuationUnavailable && !relayContinuationAttempted {
 				if msg := scopeBudgetExhaustedMessage(c); msg != "" {
 					SendAPIKeyLimitError(c, http.StatusTooManyRequests, msg)
@@ -4377,6 +4419,10 @@ func (h *Handler) ResponsesCompact(c *gin.Context) {
 				}
 				if msg := scopeBudgetExhaustedMessage(c); msg != "" {
 					SendAPIKeyLimitError(c, http.StatusTooManyRequests, msg)
+					return
+				}
+				if compactionAffinity.Known {
+					sendCompactionUpstreamUnavailable(c)
 					return
 				}
 				c.JSON(http.StatusServiceUnavailable, noAvailableAccountError(effectiveModel))
@@ -4547,6 +4593,7 @@ func (h *Handler) ResponsesCompact(c *gin.Context) {
 				api.SendErrorWithStatus(c, api.NewAPIError(api.ErrCodeUpstreamError, "Failed to read upstream response", api.ErrorTypeUpstream), http.StatusBadGateway)
 				return
 			}
+			h.recordCompactionProvenanceFromPayload(context.Background(), account, respBody)
 
 			h.store.ClearModelCooldown(account, attemptEffectiveModel)
 			h.store.ReportRequestSuccess(account, time.Duration(durationMs)*time.Millisecond)
@@ -4761,6 +4808,7 @@ func (h *Handler) ResponsesCompact(c *gin.Context) {
 			api.SendErrorWithStatus(c, api.NewAPIError(api.ErrCodeUpstreamError, "Failed to read upstream response", api.ErrorTypeUpstream), http.StatusBadGateway)
 			return
 		}
+		h.recordCompactionProvenanceFromPayload(context.Background(), account, respBody)
 
 		// body-signal 兼容模式：SSE 内的 response.failed 终态按上游错误处理，
 		// 语义对齐传统 compact 链路的 HTTP 非 200 分支（含 encrypted_content 剥离重试）。

--- a/proxy/portable_compaction.go
+++ b/proxy/portable_compaction.go
@@ -1,0 +1,124 @@
+package proxy
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/codex2api/security"
+)
+
+const (
+	portableCompactionEnvelopePrefix = "sub2api-emulated-compaction-v1:"
+	portableCompactionSummaryOpen    = "<summary>"
+	portableCompactionSummaryClose   = "</summary>"
+	responsesCompactionSummaryPrefix = "[Conversation summary from earlier turns]\n"
+)
+
+func isResponsesCompactionItemType(itemType string) bool {
+	switch strings.ToLower(strings.TrimSpace(itemType)) {
+	case "compaction", "context_compaction", "compaction_summary":
+		return true
+	default:
+		return false
+	}
+}
+
+func decodePortableCompactionSummary(encryptedContent string) (string, bool) {
+	encoded, ok := strings.CutPrefix(encryptedContent, portableCompactionEnvelopePrefix)
+	if !ok || encoded == "" || len(encoded) > base64.StdEncoding.EncodedLen(security.MaxRequestBodySize) {
+		return "", false
+	}
+	decoded, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil || len(decoded) == 0 || len(decoded) > security.MaxRequestBodySize || !utf8.Valid(decoded) {
+		return "", false
+	}
+
+	wrapped := strings.TrimSpace(string(decoded))
+	if !strings.HasPrefix(wrapped, portableCompactionSummaryOpen) || !strings.HasSuffix(wrapped, portableCompactionSummaryClose) {
+		return "", false
+	}
+	summary := strings.TrimSpace(wrapped[len(portableCompactionSummaryOpen) : len(wrapped)-len(portableCompactionSummaryClose)])
+	if summary == "" {
+		return "", false
+	}
+	return summary, true
+}
+
+func responsesCompactionDeveloperMessage(summary string) map[string]any {
+	return map[string]any{
+		"type": "message",
+		"role": "developer",
+		"content": []any{
+			map[string]any{
+				"type": "input_text",
+				"text": responsesCompactionSummaryPrefix + summary,
+			},
+		},
+	}
+}
+
+func normalizePortableResponsesCompactionItems(body map[string]any) bool {
+	input := body["input"]
+	if inputItem, ok := input.(map[string]any); ok {
+		if !isResponsesCompactionItemType(firstNonEmptyAnyString(inputItem["type"])) {
+			return false
+		}
+		encryptedContent, _ := inputItem["encrypted_content"].(string)
+		summary, portable := decodePortableCompactionSummary(encryptedContent)
+		if !portable {
+			return false
+		}
+		body["input"] = responsesCompactionDeveloperMessage(summary)
+		return true
+	}
+
+	inputItems, ok := input.([]any)
+	if !ok {
+		return false
+	}
+
+	modified := false
+	out := make([]any, 0, len(inputItems))
+	for _, raw := range inputItems {
+		item, ok := raw.(map[string]any)
+		if !ok || !isResponsesCompactionItemType(firstNonEmptyAnyString(item["type"])) {
+			out = append(out, raw)
+			continue
+		}
+		encryptedContent, _ := item["encrypted_content"].(string)
+		summary, portable := decodePortableCompactionSummary(encryptedContent)
+		if !portable {
+			out = append(out, raw)
+			continue
+		}
+		out = append(out, responsesCompactionDeveloperMessage(summary))
+		modified = true
+	}
+
+	if modified {
+		body["input"] = out
+	}
+	return modified
+}
+
+// normalizePortableResponsesCompactionHistory rewrites known reversible
+// emulated compaction envelopes before account affinity is resolved. Opaque
+// encrypted compaction state remains untouched and therefore source-affine.
+func normalizePortableResponsesCompactionHistory(rawBody []byte) ([]byte, bool) {
+	if len(rawBody) == 0 || !bytes.Contains(rawBody, []byte(portableCompactionEnvelopePrefix)) {
+		return rawBody, false
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(rawBody, &body); err != nil || !normalizePortableResponsesCompactionItems(body) {
+		return rawBody, false
+	}
+	normalized, err := json.Marshal(body)
+	if err != nil {
+		return rawBody, false
+	}
+	return normalized, true
+}

--- a/proxy/portable_compaction_test.go
+++ b/proxy/portable_compaction_test.go
@@ -1,0 +1,117 @@
+package proxy
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+const portableCompactionFixture = "sub2api-emulated-compaction-v1:PHN1bW1hcnk+cG9ydGFibGUgY29udGV4dDwvc3VtbWFyeT4="
+
+func TestNormalizeResponsesCompactionItemsDecodesPortableEncryptedSummary(t *testing.T) {
+	body := map[string]any{
+		"input": []any{
+			map[string]any{"type": "message", "role": "user", "content": "before"},
+			map[string]any{"type": "compaction", "encrypted_content": portableCompactionFixture},
+			map[string]any{"type": "message", "role": "user", "content": "after"},
+		},
+	}
+
+	if !normalizeResponsesCompactionItems(body) {
+		t.Fatal("portable compaction should be normalized")
+	}
+
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal normalized body: %v", err)
+	}
+	items := gjson.GetBytes(raw, "input").Array()
+	if len(items) != 3 {
+		t.Fatalf("input length = %d, want 3: %s", len(items), raw)
+	}
+	if got := items[1].Get("type").String(); got != "message" {
+		t.Fatalf("normalized item type = %q, want message: %s", got, items[1].Raw)
+	}
+	if got := items[1].Get("role").String(); got != "developer" {
+		t.Fatalf("normalized item role = %q, want developer: %s", got, items[1].Raw)
+	}
+	text := items[1].Get("content.0.text").String()
+	if !strings.Contains(text, "portable context") {
+		t.Fatalf("normalized summary missing decoded text: %q", text)
+	}
+	if strings.Contains(string(raw), portableCompactionEnvelopePrefix) {
+		t.Fatalf("portable envelope should be removed: %s", raw)
+	}
+}
+
+func TestNormalizePortableResponsesCompactionHistory(t *testing.T) {
+	raw := []byte(`{"model":"gpt-5.6-sol","input":[{"type":"compaction","encrypted_content":"` + portableCompactionFixture + `"},{"type":"message","role":"user","content":"continue"}]}`)
+
+	got, changed := normalizePortableResponsesCompactionHistory(raw)
+	if !changed {
+		t.Fatal("portable compaction request should be rewritten before routing")
+	}
+	if strings.Contains(string(got), portableCompactionEnvelopePrefix) {
+		t.Fatalf("portable envelope should not reach affinity routing: %s", got)
+	}
+	if text := gjson.GetBytes(got, "input.0.content.0.text").String(); !strings.Contains(text, "portable context") {
+		t.Fatalf("decoded summary missing from rewritten body: %s", got)
+	}
+	if gotText := gjson.GetBytes(got, "input.1.content").String(); gotText != "continue" {
+		t.Fatalf("unrelated input changed: got %q; body=%s", gotText, got)
+	}
+}
+
+func TestNormalizePortableResponsesCompactionHistoryLeavesOpaqueOrInvalidContentUntouched(t *testing.T) {
+	tests := []struct {
+		name      string
+		encrypted string
+	}{
+		{name: "opaque upstream state", encrypted: "opaque-blob"},
+		{name: "malformed base64", encrypted: portableCompactionEnvelopePrefix + "%%%"},
+		{name: "invalid utf8", encrypted: portableCompactionEnvelopePrefix + "//4="},
+		{name: "wrong wrapper", encrypted: portableCompactionEnvelopePrefix + "PG5vdC1zdW1tYXJ5PnBvcnRhYmxlIGNvbnRleHQ8L25vdC1zdW1tYXJ5Pg=="},
+		{name: "empty summary", encrypted: portableCompactionEnvelopePrefix + "PHN1bW1hcnk+ICAgPC9zdW1tYXJ5Pg=="},
+		{name: "prefix must be exact", encrypted: " " + portableCompactionFixture},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			raw := []byte(`{"input":[{"type":"compaction","encrypted_content":"` + tc.encrypted + `"}]}`)
+			got, changed := normalizePortableResponsesCompactionHistory(raw)
+			if changed {
+				t.Fatalf("invalid or opaque content should stay affinity-bound: %s", got)
+			}
+			if string(got) != string(raw) {
+				t.Fatalf("body changed unexpectedly:\n got: %s\nwant: %s", got, raw)
+			}
+		})
+	}
+}
+
+func TestNormalizePortableResponsesCompactionHistoryKeepsMixedOpaqueState(t *testing.T) {
+	raw := []byte(`{"input":[{"type":"compaction","encrypted_content":"` + portableCompactionFixture + `"},{"type":"compaction","encrypted_content":"known-opaque"}]}`)
+
+	got, changed := normalizePortableResponsesCompactionHistory(raw)
+	if !changed {
+		t.Fatal("valid portable item in mixed input should be normalized")
+	}
+	contents := requestCompactionEncryptedContents(got)
+	if len(contents) != 1 || contents[0] != "known-opaque" {
+		t.Fatalf("remaining opaque state = %v, want [known-opaque]; body=%s", contents, got)
+	}
+}
+
+func TestNormalizePortableResponsesCompactionHistorySupportsKnownCompactionItemTypes(t *testing.T) {
+	for _, itemType := range []string{"compaction", "context_compaction", "compaction_summary"} {
+		t.Run(itemType, func(t *testing.T) {
+			raw := []byte(`{"input":[{"type":"` + itemType + `","encrypted_content":"` + portableCompactionFixture + `"}]}`)
+			got, changed := normalizePortableResponsesCompactionHistory(raw)
+			if !changed || gjson.GetBytes(got, "input.0.type").String() != "message" {
+				t.Fatalf("known compaction type was not normalized: changed=%v body=%s", changed, got)
+			}
+		})
+	}
+}

--- a/proxy/responses_ws.go
+++ b/proxy/responses_ws.go
@@ -338,6 +338,24 @@ func (h *Handler) forwardResponsesWebSocketTurn(c *gin.Context, conn *websocket.
 	accountFilter = h.withModelCooldownFilter(effectiveModel, accountFilter)
 	accountFilter = applyAffinityGroupRouting(c, sessionIdentity, accountFilter)
 	accountFilter = h.applyScopeBudgetFilter(c, accountFilter)
+	compactionAffinity, compactionAffinityErr := h.resolveCompactionAffinity(c.Request.Context(), rawBody)
+	if compactionAffinityErr != nil {
+		closeCode := websocket.CloseTryAgainLater
+		if errors.Is(compactionAffinityErr, errConflictingCompactionProvenance) {
+			apiErr = compactionProvenanceConflictAPIError()
+			closeCode = websocket.ClosePolicyViolation
+		} else {
+			apiErr = compactionProvenanceUnavailableAPIError()
+		}
+		_ = writeResponsesWSError(conn, apiErr)
+		return newResponsesWSCloseError(closeCode, apiErr.Message, apiErr)
+	}
+	if compactionAffinity.Known {
+		accountFilter = compactionDomainFilter(compactionAffinity.CompatibilityDomain, accountFilter)
+		if preferred := h.store.FindByID(compactionAffinity.PreferredAccountID); preferred != nil && accountFilter(preferred) {
+			h.store.BindSessionAffinity(affinityKey, preferred, preferred.GetProxyURL())
+		}
+	}
 	// scope 并发位在选中账号后才能占，请求退出时统一释放（issue #439 v2）。
 	defer h.ReleaseAPIKeyScopeConcurrency(c)
 
@@ -403,7 +421,9 @@ func (h *Handler) forwardResponsesWebSocketTurn(c *gin.Context, conn *websocket.
 			}
 		}
 		if account == nil {
-			if lastRetryableUpstreamErr != nil {
+			if compactionAffinity.Known {
+				apiErr = compactionUpstreamUnavailableAPIError()
+			} else if lastRetryableUpstreamErr != nil {
 				apiErr = responsesWSClientUpstreamAPIError(lastRetryableUpstreamErr, hideUpstreamErrors)
 			} else if lastStatusCode == http.StatusTooManyRequests && len(lastBody) > 0 {
 				apiErr = responsesWSUpstreamAPIError(lastStatusCode, lastBody)
@@ -763,6 +783,7 @@ func (h *Handler) streamResponsesWSUpstream(
 	}
 
 	readErr = ReadSSEStream(resp.Body, func(data []byte) bool {
+		h.recordCompactionProvenanceFromPayload(context.Background(), account, data)
 		parsed := gjson.ParseBytes(data)
 		eventType := parsed.Get("type").String()
 		clientData := data

--- a/proxy/responses_ws.go
+++ b/proxy/responses_ws.go
@@ -234,6 +234,7 @@ func (h *Handler) forwardResponsesWebSocketTurn(c *gin.Context, conn *websocket.
 
 	supportedModels := h.supportedModelIDs(c.Request.Context())
 	rawBody, requestModel, mappedModel, mappingApplied := h.applyConfiguredModelMappingToBody(rawBody, supportedModels)
+	rawBody, _ = normalizePortableResponsesCompactionHistory(rawBody)
 	c.Set("raw_body", rawBody)
 	if mappedModel != "" {
 		model = mappedModel

--- a/proxy/responses_ws.go
+++ b/proxy/responses_ws.go
@@ -352,9 +352,6 @@ func (h *Handler) forwardResponsesWebSocketTurn(c *gin.Context, conn *websocket.
 	}
 	if compactionAffinity.Known {
 		accountFilter = compactionDomainFilter(compactionAffinity.CompatibilityDomain, accountFilter)
-		if preferred := h.store.FindByID(compactionAffinity.PreferredAccountID); preferred != nil && accountFilter(preferred) {
-			h.store.BindSessionAffinity(affinityKey, preferred, preferred.GetProxyURL())
-		}
 	}
 	// scope 并发位在选中账号后才能占，请求退出时统一释放（issue #439 v2）。
 	defer h.ReleaseAPIKeyScopeConcurrency(c)
@@ -414,7 +411,12 @@ func (h *Handler) forwardResponsesWebSocketTurn(c *gin.Context, conn *websocket.
 					}
 				}
 			}
-			if continuationPinned {
+			if attempt == 0 && compactionAffinity.Known && !continuationPinned {
+				account = h.store.TakePreferredAccountWithFilter(compactionAffinity.PreferredAccountID, apiKeyID, retryExclusions.ForSelection(), accountFilter)
+			}
+			if account != nil {
+				stickyProxyURL = account.GetProxyURL()
+			} else if continuationPinned {
 				account, stickyProxyURL = h.nextRetryAccountForContinuation(c.Request.Context(), affinityKey, apiKeyID, retryExclusions, accountFilter)
 			} else {
 				account, stickyProxyURL = h.nextRetryAccountForSession(c.Request.Context(), affinityKey, apiKeyID, retryExclusions, accountFilter)

--- a/proxy/translator.go
+++ b/proxy/translator.go
@@ -816,9 +816,9 @@ func normalizeResponsesImageOnlyModel(body map[string]any) bool {
 // them to be forwarded as conversation context; the upstream rejects the type
 // with "Invalid input type 'compaction' at index N", so we translate in place.
 //
-// Compact v2 (newer Codex CLI) items are left untouched: compaction items
-// carrying "encrypted_content" originate from the upstream itself and must be
-// forwarded verbatim, or the compacted conversation context is lost.
+// Opaque Compact v2 items are left untouched so they remain source-affine.
+// Known reversible emulated envelopes are decoded into the same developer
+// summary representation as plaintext compaction items.
 func normalizeResponsesCompactionItems(body map[string]any) bool {
 	if len(body) == 0 {
 		return false
@@ -828,8 +828,6 @@ func normalizeResponsesCompactionItems(body map[string]any) bool {
 		return false
 	}
 
-	const summaryPrefix = "[Conversation summary from earlier turns]\n"
-
 	modified := false
 	out := make([]any, 0, len(inputItems))
 	for _, raw := range inputItems {
@@ -838,13 +836,24 @@ func normalizeResponsesCompactionItems(body map[string]any) bool {
 			out = append(out, raw)
 			continue
 		}
-		if firstNonEmptyAnyString(itemMap["type"]) != "compaction" {
+		itemType := firstNonEmptyAnyString(itemMap["type"])
+		if !isResponsesCompactionItemType(itemType) {
 			out = append(out, raw)
 			continue
 		}
 
-		// compact v2: 加密压缩项由上游生成并原生支持，必须原样透传
-		if firstNonEmptyAnyString(itemMap["encrypted_content"]) != "" {
+		if encryptedContent := firstNonEmptyAnyString(itemMap["encrypted_content"]); encryptedContent != "" {
+			rawEncryptedContent, _ := itemMap["encrypted_content"].(string)
+			if summaryText, portable := decodePortableCompactionSummary(rawEncryptedContent); portable {
+				out = append(out, responsesCompactionDeveloperMessage(summaryText))
+				modified = true
+				continue
+			}
+			// Unknown encrypted state must be forwarded verbatim.
+			out = append(out, raw)
+			continue
+		}
+		if itemType != "compaction" {
 			out = append(out, raw)
 			continue
 		}
@@ -858,16 +867,7 @@ func normalizeResponsesCompactionItems(body map[string]any) bool {
 			continue
 		}
 
-		out = append(out, map[string]any{
-			"type": "message",
-			"role": "developer",
-			"content": []any{
-				map[string]any{
-					"type": "input_text",
-					"text": summaryPrefix + summaryText,
-				},
-			},
-		})
+		out = append(out, responsesCompactionDeveloperMessage(summaryText))
 		modified = true
 	}
 


### PR DESCRIPTION
## Summary

- Track opaque compaction `encrypted_content` provenance by SHA-256 digest with a rolling runtime-cache TTL; the encrypted payload itself is never stored.
- Prefer the exact producing account on replay, independent of session-affinity mode, and fail over only inside the same compatibility domain.
- Normalize the known reversible `sub2api-emulated-compaction-v1:` envelope into a developer summary before account selection, so later turns return to normal pool scheduling instead of remaining relay-bound.
- Validate the portable envelope strictly as Base64 UTF-8 with a non-empty `<summary>...</summary>` wrapper; malformed or unknown encrypted state remains opaque and source-affine.
- Cover Responses HTTP streaming and non-streaming, `/responses/compact`, and Responses WebSocket flows, including mixed portable plus opaque input.
- Recognize `compaction`, `context_compaction`, and `compaction_summary`; reject conflicting known provenance and return an explicit unavailable error when no compatible upstream remains.
- Keep Grok provenance account-local because its effective route is resolved per model at request time.

Unknown legacy compaction state keeps the existing scheduler behavior. The provenance TTL defaults to 7 days and can be changed with `CODEX_COMPACTION_AFFINITY_TTL`.

Reference: https://developers.openai.com/api/docs/guides/compaction/

## Tests

- `go test ./... -count=1`
- Focused HTTP, `/responses/compact`, WebSocket, malformed-envelope, and mixed-input routing regressions
- `cd frontend && npm test && npm run typecheck && npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added encrypted compaction-state affinity, helping requests continue through the originating compatible account or domain.
  - Added same-domain failover when the original account is unavailable.
  - Added configurable affinity retention through `CODEX_COMPACTION_AFFINITY_TTL`, defaulting to seven days.
  - Added support for portable encrypted compaction summaries in request history.

- **Bug Fixes**
  - Improved routing consistency across standard, compact, streaming, and WebSocket requests.
  - Added clear handling for conflicting provenance and unavailable compatible accounts.
  - Ensured cached metadata stores only encrypted-state digests and related routing information.
  - Preserved unsupported or invalid compaction content without altering it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->