### PR TITLE
fix(fingerprint): converge X-Client-Request-Id and scrub workspace identity

### DIFF
--- a/proxy/codex_fingerprint.go
+++ b/proxy/codex_fingerprint.go
@@ -24,15 +24,19 @@ import (
 //
 // 明确不改写的部分：
 //   - 出站 Session_id 头：由 resolveUpstreamSessionID 独立决定（默认隔离模式下每请求
-//     随机），收敛不介入，否则会改变 prompt cache 隔离语义。
+//     随机），收敛不介入，否则会改变 prompt cache 隔离语义。注意它与 metadata 里的
+//     session_id 是两套独立身份，开启收敛后两者取值不同属预期。
 //   - turn_id / turn_started_at_unix_ms：客户端逐轮随机值，不标识设备或会话；
 //     重算反而会让头与体、turn_id 与其时间戳彼此不一致，本身就是特征。
 //   - 客户端未携带的字段：只改写已存在的键，绝不新增，避免改变 metadata 的形状。
+//     该规则同样适用于请求头——出站只覆盖下游确实发过的标识头，不凭空补发。
 
 const (
-	codexTurnMetadataHeader   = "X-Codex-Turn-Metadata"
-	codexInstallationIDHeader = "X-Codex-Installation-Id"
-	codexWindowIDHeader       = "X-Codex-Window-Id"
+	codexTurnMetadataHeader    = "X-Codex-Turn-Metadata"
+	codexInstallationIDHeader  = "X-Codex-Installation-Id"
+	codexWindowIDHeader        = "X-Codex-Window-Id"
+	codexClientRequestIDHeader = "X-Client-Request-Id"
+	codexThreadIDHeader        = "Thread-Id"
 )
 
 // codexFingerprintIDs 是一次请求的收敛目标值。全部字段都由「账号 + 下游请求头」
@@ -161,14 +165,81 @@ func ApplyCodexFingerprintHeaders(outbound http.Header, account *auth.Account, d
 		}
 	}
 
-	// 仅对确有 Codex 引擎特征的下游请求补发标识头。
+	// X-Client-Request-Id 按白名单原样透传（codexAllowedForwardHeaders）。实测真实
+	// 客户端把它取成与自身 thread_id 相同的值，因此不处理就等于把下游用户的原始
+	// 线程标识直接送到上游，与已收敛的 metadata 各说各话。只在它确实复用了客户端
+	// 自报的会话/线程标识时改写；取值本就与身份无关时保持原样。
+	if converged := convergedClientRequestID(outbound.Get(codexClientRequestIDHeader), ids, downstreamHeaders); converged != "" {
+		outbound.Set(codexClientRequestIDHeader, converged)
+	}
+
+	// 仅对确有 Codex 引擎特征的下游请求处理标识头。
 	if !EvaluateEngineFingerprint(downstreamHeaders, nil, nil) {
 		return
 	}
-	outbound.Set(codexInstallationIDHeader, ids.installationID)
-	if ids.windowID != "" {
-		outbound.Set(codexWindowIDHeader, ids.windowID)
+	// 只覆盖下游确实发过的标识头。实测真实 Codex CLI 只发 x-codex-window-id，
+	// 从不发 x-codex-installation-id（installation_id 只存在于 turn metadata JSON 里）：
+	// 无条件补发等于给请求添一个真实客户端不会有的头，与收敛目标相反。
+	overrideExistingHeader(outbound, downstreamHeaders, codexInstallationIDHeader, ids.installationID)
+	overrideExistingHeader(outbound, downstreamHeaders, codexWindowIDHeader, ids.windowID)
+}
+
+// overrideExistingHeader 仅在下游确实发过该头时，用收敛值覆盖出站取值。
+// 判定读下游头而非出站头：这两个标识头都不在 codexAllowedForwardHeaders 里，
+// 下游即使发了，到这一步出站请求上也没有。
+func overrideExistingHeader(outbound, downstreamHeaders http.Header, name, value string) {
+	if value == "" || downstreamHeaders == nil {
+		return
 	}
+	if strings.TrimSpace(downstreamHeaders.Get(name)) == "" {
+		return
+	}
+	outbound.Set(name, value)
+}
+
+// convergedClientRequestID 在 X-Client-Request-Id 复用了客户端自报身份时返回对应的
+// 收敛值，否则返回空串表示不改写。device 档没有会话级收敛值，恒不改写。
+func convergedClientRequestID(current string, ids *codexFingerprintIDs, downstreamHeaders http.Header) string {
+	current = strings.TrimSpace(current)
+	if current == "" || ids == nil || ids.threadID == "" {
+		return ""
+	}
+	clientSessionID, clientThreadID := extractClientCodexIdentity(downstreamHeaders)
+	switch {
+	case clientThreadID != "" && current == clientThreadID:
+		return ids.threadID
+	case clientSessionID != "" && current == clientSessionID:
+		return ids.sessionID
+	default:
+		return ""
+	}
+}
+
+// extractClientCodexIdentity 取下游自报的原始会话/线程标识，用于判断别的头是否
+// 重复携带了同一个值。与 extractClientCodexSessionID 分开实现：后者是收敛值的派生
+// 输入，改动它会让既有账号已经稳定的 thread_id 发生漂移。
+func extractClientCodexIdentity(headers http.Header) (sessionID, threadID string) {
+	if headers == nil {
+		return "", ""
+	}
+	for _, name := range []string{"Session-Id", "Session_id"} {
+		if value := strings.TrimSpace(headers.Get(name)); value != "" {
+			sessionID = value
+			break
+		}
+	}
+	threadID = strings.TrimSpace(headers.Get(codexThreadIDHeader))
+	raw := strings.TrimSpace(headers.Get(codexTurnMetadataHeader))
+	if raw == "" || !gjson.Valid(raw) {
+		return sessionID, threadID
+	}
+	if sessionID == "" {
+		sessionID = strings.TrimSpace(gjson.Get(raw, "session_id").String())
+	}
+	if threadID == "" {
+		threadID = strings.TrimSpace(gjson.Get(raw, "thread_id").String())
+	}
+	return sessionID, threadID
 }
 
 // ApplyCodexFingerprintToBody 收敛请求体 client_metadata 中的设备指纹。
@@ -234,7 +305,88 @@ func rewriteCodexTurnMetadataJSON(raw string, ids *codexFingerprintIDs) (string,
 		raw = updated
 		changed = true
 	}
+	if scrubbed, ok := scrubCodexWorkspaces(raw); ok {
+		raw = scrubbed
+		changed = true
+	}
 	return raw, changed
+}
+
+// scrubCodexWorkspaces 抹掉 turn metadata 里的工作区身份。
+//
+// workspaces 以本地绝对路径为键（含系统用户名），条目里带 git remote URL 和 commit
+// hash。多人共享一个账号时，这些字段会把每个下游用户的身份原样送到上游——同一个
+// installation_id 下面挂着一堆互不相干的仓库地址和用户名目录，既是隐私泄漏，也让
+// 前面几项标识的收敛失去意义。
+//
+// 处理方式是收敛而非删除：路径键换成按原值派生的占位符（条目数与互异性都保留，
+// 不改变 metadata 形状），remote URL 整体移除。其余字段原样保留。
+func scrubCodexWorkspaces(raw string) (string, bool) {
+	workspaces := gjson.Get(raw, "workspaces")
+	if !workspaces.IsObject() {
+		return raw, false
+	}
+
+	rebuilt := "{}"
+	changed := false
+	failed := false
+	workspaces.ForEach(func(key, value gjson.Result) bool {
+		entry := value.Raw
+		if gjson.Get(entry, "associated_remote_urls").Exists() {
+			if updated, err := sjson.Delete(entry, "associated_remote_urls"); err == nil {
+				entry = updated
+				changed = true
+			}
+		}
+		originalPath := key.String()
+		placeholder := originalPath
+		// 已是占位符就保持原样：重试链路可能把改写过的载荷再送进来一次，
+		// 二次哈希会让同一工作区在不同尝试间漂移。
+		if !isPlaceholderWorkspacePath(originalPath) {
+			placeholder = placeholderWorkspacePath(originalPath)
+			changed = true
+		}
+		updated, err := sjson.SetRaw(rebuilt, placeholder, entry)
+		if err != nil {
+			failed = true
+			return false
+		}
+		rebuilt = updated
+		return true
+	})
+	if failed || !changed {
+		return raw, false
+	}
+
+	updated, err := sjson.SetRaw(raw, "workspaces", rebuilt)
+	if err != nil {
+		return raw, false
+	}
+	return updated, true
+}
+
+// placeholderWorkspacePath 把本地路径映射成稳定占位符：同一路径恒定得到同一占位符，
+// 不同路径互不相同，且不携带用户名或项目名。返回值不含 sjson 的路径元字符
+// （. * ?），可直接作为 sjson 路径使用。
+func placeholderWorkspacePath(original string) string {
+	sum := sha256.Sum256([]byte("codex2api:workspace-path:v1:" + original))
+	return workspacePlaceholderPrefix + fmt.Sprintf("%x", sum[:4])
+}
+
+const workspacePlaceholderPrefix = "/workspace/"
+
+// isPlaceholderWorkspacePath 判断路径是否已经是本函数产出的占位符，用于让抹除保持幂等。
+func isPlaceholderWorkspacePath(path string) bool {
+	suffix, ok := strings.CutPrefix(path, workspacePlaceholderPrefix)
+	if !ok || len(suffix) != 8 {
+		return false
+	}
+	for _, r := range suffix {
+		if (r < '0' || r > '9') && (r < 'a' || r > 'f') {
+			return false
+		}
+	}
+	return true
 }
 
 // setExistingJSONString 只在目标路径已存在时替换其值，避免给客户端未携带该字段的

--- a/proxy/codex_fingerprint.go
+++ b/proxy/codex_fingerprint.go
@@ -44,6 +44,7 @@ const (
 // 不需要跨函数传递即可保证一致。
 type codexFingerprintIDs struct {
 	mode           string
+	accountID      int64
 	installationID string
 	sessionID      string
 	threadID       string
@@ -83,6 +84,7 @@ func resolveCodexFingerprintIDs(account *auth.Account, downstreamHeaders http.He
 
 	ids := &codexFingerprintIDs{
 		mode:           mode,
+		accountID:      accountID,
 		installationID: resolveConvergedInstallationID(account, accountID),
 	}
 	if ids.installationID == "" {
@@ -305,7 +307,7 @@ func rewriteCodexTurnMetadataJSON(raw string, ids *codexFingerprintIDs) (string,
 		raw = updated
 		changed = true
 	}
-	if scrubbed, ok := scrubCodexWorkspaces(raw); ok {
+	if scrubbed, ok := scrubCodexWorkspaces(raw, ids.accountID); ok {
 		raw = scrubbed
 		changed = true
 	}
@@ -320,8 +322,14 @@ func rewriteCodexTurnMetadataJSON(raw string, ids *codexFingerprintIDs) (string,
 // 前面几项标识的收敛失去意义。
 //
 // 处理方式是收敛而非删除：路径键换成按原值派生的占位符（条目数与互异性都保留，
-// 不改变 metadata 形状），remote URL 整体移除。其余字段原样保留。
-func scrubCodexWorkspaces(raw string) (string, bool) {
+// 不改变 metadata 形状），remote URL 整体移除，commit hash 换成派生占位值——
+// commit hash 是全局唯一的仓库标记，公开仓库可直接反查到归属，留着它等于换个
+// 字段泄漏 remote URL 同样的身份。
+//
+// 所有派生值都带 accountID：否则同一个下游用户的同一路径在不同账号下会得到相同
+// 占位符，上游据此就能把两个账号关联到同一个人。这也与本文件其它收敛值的种子
+// 惯例一致（见 resolveConvergedInstallationID）。
+func scrubCodexWorkspaces(raw string, accountID int64) (string, bool) {
 	workspaces := gjson.Get(raw, "workspaces")
 	if !workspaces.IsObject() {
 		return raw, false
@@ -343,8 +351,19 @@ func scrubCodexWorkspaces(raw string) (string, bool) {
 		// 已是占位符就保持原样：重试链路可能把改写过的载荷再送进来一次，
 		// 二次哈希会让同一工作区在不同尝试间漂移。
 		if !isPlaceholderWorkspacePath(originalPath) {
-			placeholder = placeholderWorkspacePath(originalPath)
+			placeholder = placeholderWorkspacePath(accountID, originalPath)
 			changed = true
+		}
+		// commit hash 的占位值从「已派生的占位路径」导出，而不是从原哈希导出：
+		// 二次处理时路径已是占位符、导出结果不变，幂等性随之成立，同时不同工作区
+		// 仍得到互不相同的哈希。
+		if hash := gjson.Get(entry, "latest_git_commit_hash"); hash.Type == gjson.String && hash.String() != "" {
+			if replacement := placeholderCommitHash(accountID, placeholder); replacement != hash.String() {
+				if updated, err := sjson.Set(entry, "latest_git_commit_hash", replacement); err == nil {
+					entry = updated
+					changed = true
+				}
+			}
 		}
 		updated, err := sjson.SetRaw(rebuilt, placeholder, entry)
 		if err != nil {
@@ -368,17 +387,29 @@ func scrubCodexWorkspaces(raw string) (string, bool) {
 // placeholderWorkspacePath 把本地路径映射成稳定占位符：同一路径恒定得到同一占位符，
 // 不同路径互不相同，且不携带用户名或项目名。返回值不含 sjson 的路径元字符
 // （. * ?），可直接作为 sjson 路径使用。
-func placeholderWorkspacePath(original string) string {
-	sum := sha256.Sum256([]byte("codex2api:workspace-path:v1:" + original))
-	return workspacePlaceholderPrefix + fmt.Sprintf("%x", sum[:4])
+func placeholderWorkspacePath(accountID int64, original string) string {
+	sum := sha256.Sum256(fmt.Appendf(nil, "codex2api:workspace-path:v2:%d:%s", accountID, original))
+	return workspacePlaceholderPrefix + fmt.Sprintf("%x", sum[:workspacePlaceholderDigestBytes])
 }
 
-const workspacePlaceholderPrefix = "/workspace/"
+// placeholderCommitHash 派生一个与真实 commit hash 等长（40 位十六进制）的占位值，
+// 保持字段形状不变。种子取占位路径而非原哈希，见调用点说明。
+func placeholderCommitHash(accountID int64, placeholderPath string) string {
+	sum := sha256.Sum256(fmt.Appendf(nil, "codex2api:workspace-commit:v1:%d:%s", accountID, placeholderPath))
+	return fmt.Sprintf("%x", sum[:20])
+}
+
+const (
+	workspacePlaceholderPrefix = "/workspace/"
+	// 32 bit 对低熵的本地路径来说太窄——既可能撞键把两个工作区并成一个，
+	// 也便于用候选路径表反查。64 bit 无额外代价。
+	workspacePlaceholderDigestBytes = 8
+)
 
 // isPlaceholderWorkspacePath 判断路径是否已经是本函数产出的占位符，用于让抹除保持幂等。
 func isPlaceholderWorkspacePath(path string) bool {
 	suffix, ok := strings.CutPrefix(path, workspacePlaceholderPrefix)
-	if !ok || len(suffix) != 8 {
+	if !ok || len(suffix) != workspacePlaceholderDigestBytes*2 {
 		return false
 	}
 	for _, r := range suffix {

--- a/proxy/codex_fingerprint_test.go
+++ b/proxy/codex_fingerprint_test.go
@@ -240,11 +240,38 @@ func TestApplyCodexFingerprintHeadersSkipsNonCodexClients(t *testing.T) {
 	}
 }
 
-func TestApplyCodexFingerprintHeadersAddsIdentityHeadersForCodexClients(t *testing.T) {
+// TestApplyCodexFingerprintHeadersNeverAddsAbsentIdentityHeaders 锁定「只覆盖、不新增」
+// 对请求头同样成立。实测真实 Codex CLI 只发 x-codex-window-id，从不发
+// x-codex-installation-id（该值只存在于 turn metadata JSON 里）——凭空补发等于给请求
+// 添一个真实客户端不会有的头。
+func TestApplyCodexFingerprintHeadersNeverAddsAbsentIdentityHeaders(t *testing.T) {
 	outbound := http.Header{}
 	account := fingerprintAccount(t, auth.CodexFingerprintModeSession)
 	downstream := codexClientHeaders(`{"installation_id":"client-install"}`, "client-session")
 	outbound.Set("X-Codex-Turn-Metadata", downstream.Get("X-Codex-Turn-Metadata"))
+
+	ApplyCodexFingerprintHeaders(outbound, account, downstream)
+
+	if got := outbound.Get("X-Codex-Installation-Id"); got != "" {
+		t.Fatalf("X-Codex-Installation-Id = %q, want unset (downstream never sent it)", got)
+	}
+	if got := outbound.Get("X-Codex-Window-Id"); got != "" {
+		t.Fatalf("X-Codex-Window-Id = %q, want unset (downstream never sent it)", got)
+	}
+	// metadata 内部的 installation_id 仍应收敛——收敛面本来就在 JSON 里。
+	if got := gjson.Get(outbound.Get("X-Codex-Turn-Metadata"), "installation_id").String(); got == "client-install" {
+		t.Fatal("metadata installation_id was left at the client value")
+	}
+}
+
+// TestApplyCodexFingerprintHeadersOverridesPresentIdentityHeaders 验证下游确实发过时，
+// 出站取值被收敛值覆盖（真实 CLI 会发 window id，这条是它的主路径）。
+func TestApplyCodexFingerprintHeadersOverridesPresentIdentityHeaders(t *testing.T) {
+	outbound := http.Header{}
+	account := fingerprintAccount(t, auth.CodexFingerprintModeSession)
+	downstream := codexClientHeaders(`{"installation_id":"client-install"}`, "client-session")
+	downstream.Set("X-Codex-Window-Id", "client-window:0")
+	downstream.Set("X-Codex-Installation-Id", "client-install")
 
 	ApplyCodexFingerprintHeaders(outbound, account, downstream)
 
@@ -336,6 +363,9 @@ func TestCodexFingerprintHeaderAndBodyAgree(t *testing.T) {
 	account := fingerprintAccount(t, auth.CodexFingerprintModeSession)
 	const raw = `{"installation_id":"client-install","session_id":"client-session","thread_id":"client-thread","window_id":"client-window:0"}`
 	downstream := codexClientHeaders(raw, "client-session")
+	// 标识头只在下游发过时才被覆盖，这里补上以便断言头与 metadata 的一致性。
+	downstream.Set("X-Codex-Installation-Id", "client-install")
+	downstream.Set("X-Codex-Window-Id", "client-window:0")
 
 	outbound := http.Header{}
 	outbound.Set("X-Codex-Turn-Metadata", raw)
@@ -435,9 +465,10 @@ func TestApplyCodexFingerprintSkipsRelayAccounts(t *testing.T) {
 func TestExecuteCompactRequestConvergesBodyAndHeaders(t *testing.T) {
 	account := fingerprintAccount(t, auth.CodexFingerprintModeSession)
 	account.AccessToken = "token-compact"
-	// 带 turn metadata 才算真 Codex 客户端，身份头补发才会生效（见
-	// ApplyCodexFingerprintHeaders 的 EvaluateEngineFingerprint 门）。
+	// 带 turn metadata 才算真 Codex 客户端（见 ApplyCodexFingerprintHeaders 的
+	// EvaluateEngineFingerprint 门）；标识头还需下游确实发过才会被覆盖。
 	downstream := codexClientHeaders(`{"installation_id":"client-install","session_id":"client-session"}`, "client-session")
+	downstream.Set("X-Codex-Installation-Id", "client-install")
 	ids := resolveCodexFingerprintIDs(account, downstream)
 	if ids == nil {
 		t.Fatal("expected convergence ids for session mode")
@@ -482,5 +513,232 @@ func TestExecuteCompactRequestConvergesBodyAndHeaders(t *testing.T) {
 	}
 	if got := gjson.GetBytes(capturedBody, "client_metadata.x-codex-installation-id").String(); got != capturedHeader.Get(codexInstallationIDHeader) {
 		t.Fatalf("header/body installation id disagree: body=%q header=%q", got, capturedHeader.Get(codexInstallationIDHeader))
+	}
+}
+
+// TestConvergedClientRequestIDFollowsClientIdentity 覆盖 issue #536 的主诉：
+// 实测真实客户端把 X-Client-Request-Id 取成与自身 thread_id 相同的值，收敛必须跟上，
+// 否则原始线程标识会绕过 metadata 改写直达上游。
+func TestConvergedClientRequestIDFollowsClientIdentity(t *testing.T) {
+	account := fingerprintAccount(t, auth.CodexFingerprintModeSession)
+
+	t.Run("matches thread id", func(t *testing.T) {
+		const raw = `{"session_id":"client-session","thread_id":"client-thread"}`
+		downstream := codexClientHeaders(raw, "client-session")
+		downstream.Set("Thread-Id", "client-thread")
+		outbound := http.Header{}
+		outbound.Set("X-Client-Request-Id", "client-thread") // 白名单原样透传的结果
+		outbound.Set("X-Codex-Turn-Metadata", raw)
+
+		ApplyCodexFingerprintHeaders(outbound, account, downstream)
+
+		ids := resolveCodexFingerprintIDs(account, downstream)
+		if got := outbound.Get("X-Client-Request-Id"); got != ids.threadID {
+			t.Fatalf("X-Client-Request-Id = %q, want converged thread id %q", got, ids.threadID)
+		}
+	})
+
+	t.Run("matches session id", func(t *testing.T) {
+		downstream := codexClientHeaders("", "client-session")
+		outbound := http.Header{}
+		outbound.Set("X-Client-Request-Id", "client-session")
+
+		ApplyCodexFingerprintHeaders(outbound, account, downstream)
+
+		ids := resolveCodexFingerprintIDs(account, downstream)
+		if got := outbound.Get("X-Client-Request-Id"); got != ids.sessionID {
+			t.Fatalf("X-Client-Request-Id = %q, want converged session id %q", got, ids.sessionID)
+		}
+	})
+
+	// 与任何自报身份都对不上时说明它确实是每请求随机值，改写它反而制造不一致。
+	t.Run("leaves unrelated values alone", func(t *testing.T) {
+		downstream := codexClientHeaders("", "client-session")
+		outbound := http.Header{}
+		outbound.Set("X-Client-Request-Id", "per-request-random-value")
+
+		ApplyCodexFingerprintHeaders(outbound, account, downstream)
+
+		if got := outbound.Get("X-Client-Request-Id"); got != "per-request-random-value" {
+			t.Fatalf("X-Client-Request-Id = %q, want the client value preserved", got)
+		}
+	})
+
+	// device 档不收敛会话级标识，也就不该动这个头。
+	t.Run("device mode is a noop", func(t *testing.T) {
+		downstream := codexClientHeaders("", "client-session")
+		outbound := http.Header{}
+		outbound.Set("X-Client-Request-Id", "client-session")
+
+		ApplyCodexFingerprintHeaders(outbound, fingerprintAccount(t, auth.CodexFingerprintModeDevice), downstream)
+
+		if got := outbound.Get("X-Client-Request-Id"); got != "client-session" {
+			t.Fatalf("X-Client-Request-Id = %q, want untouched in device mode", got)
+		}
+	})
+}
+
+// TestScrubCodexWorkspacesRemovesWorkspaceIdentity 验证工作区身份被抹掉：本地绝对
+// 路径含系统用户名、associated_remote_urls 含仓库归属，多人共享账号时这些会把每个
+// 下游用户的身份原样送到上游。
+func TestScrubCodexWorkspacesRemovesWorkspaceIdentity(t *testing.T) {
+	const raw = `{"request_kind":"memory","workspaces":{"/Users/alice/code/secret-project":{"associated_remote_urls":{"origin":"https://github.com/alice-corp/secret-project.git"},"latest_git_commit_hash":"3cd12a68","has_changes":false}}}`
+
+	got, changed := scrubCodexWorkspaces(raw)
+	if !changed {
+		t.Fatal("scrubCodexWorkspaces reported no change, want the workspace scrubbed")
+	}
+	for _, leaked := range []string{"alice", "secret-project", "github.com"} {
+		if strings.Contains(got, leaked) {
+			t.Fatalf("scrubbed metadata %q still contains %q", got, leaked)
+		}
+	}
+
+	workspaces := gjson.Get(got, "workspaces")
+	if n := len(workspaces.Map()); n != 1 {
+		t.Fatalf("workspace entry count = %d, want 1 (shape must be preserved)", n)
+	}
+	for path, entry := range workspaces.Map() {
+		if !strings.HasPrefix(path, "/workspace/") {
+			t.Fatalf("workspace key = %q, want a derived placeholder path", path)
+		}
+		if entry.Get("associated_remote_urls").Exists() {
+			t.Fatalf("associated_remote_urls survived in %q", entry.Raw)
+		}
+		// 非身份字段原样保留，避免改变 metadata 形状。
+		if entry.Get("latest_git_commit_hash").String() != "3cd12a68" {
+			t.Fatalf("latest_git_commit_hash = %q, want it preserved", entry.Get("latest_git_commit_hash").String())
+		}
+		if entry.Get("has_changes").Bool() {
+			t.Fatal("has_changes = true, want the client value preserved")
+		}
+	}
+
+	// 同一路径恒定映射到同一占位符，不同路径互不相同。
+	repeat, _ := scrubCodexWorkspaces(raw)
+	if repeat != got {
+		t.Fatalf("scrub is not deterministic: %q vs %q", repeat, got)
+	}
+	if placeholderWorkspacePath("/Users/alice/a") == placeholderWorkspacePath("/Users/alice/b") {
+		t.Fatal("distinct workspace paths collapsed to the same placeholder")
+	}
+
+	// 抹除必须幂等：重试链路可能把改写过的载荷再送进来一次。
+	if again, changedAgain := scrubCodexWorkspaces(got); changedAgain || again != got {
+		t.Fatalf("second scrub changed the payload again: %q -> %q", got, again)
+	}
+
+	// 没有 workspaces 的 metadata 不受影响。
+	if _, changed := scrubCodexWorkspaces(`{"session_id":"s"}`); changed {
+		t.Fatal("metadata without workspaces was modified")
+	}
+}
+
+// TestCodexFingerprintLeavesNoOriginalIdentifierOutbound 是 issue #536 要求的一致性
+// 回归：用真实抓包的请求形态跑完整条改写链，断言出站头里不再残留任何一个原始标识。
+// 将来协议新增身份字段导致遗漏时，这条会先失败。
+func TestCodexFingerprintLeavesNoOriginalIdentifierOutbound(t *testing.T) {
+	const (
+		clientSessionUUID = "01a00e75-8856-7542-89bf-35812620690f"
+		clientInstallUUID = "341596ee-ab98-43f8-82e2-08ecdfb56db4"
+		workspacePath     = "/Users/kyx/code_project/codex2api"
+		remoteURL         = "https://github.com/james-6-23/codex2api.git"
+	)
+	rawMetadata := `{"installation_id":"` + clientInstallUUID + `","session_id":"` + clientSessionUUID +
+		`","thread_id":"` + clientSessionUUID + `","turn_id":"01a00e76-15fb-7940-91a0-e201c45f502a","window_id":"` +
+		clientSessionUUID + `:0","request_kind":"turn","sandbox":"none","workspaces":{"` + workspacePath +
+		`":{"associated_remote_urls":{"origin":"` + remoteURL + `"},"latest_git_commit_hash":"3cd12a68"}},"turn_started_at_unix_ms":1786949015072}`
+
+	// 复刻真实 CLI 的下游头集合。
+	downstream := http.Header{}
+	downstream.Set("X-Codex-Turn-Metadata", rawMetadata)
+	downstream.Set("Session-Id", clientSessionUUID)
+	downstream.Set("Thread-Id", clientSessionUUID)
+	downstream.Set("X-Client-Request-Id", clientSessionUUID)
+	downstream.Set("X-Codex-Window-Id", clientSessionUUID+":0")
+
+	// 复刻网关的白名单透传结果（见 codexAllowedForwardHeaders）。
+	outbound := http.Header{}
+	outbound.Set("X-Codex-Turn-Metadata", rawMetadata)
+	outbound.Set("X-Client-Request-Id", clientSessionUUID)
+
+	account := fingerprintAccount(t, auth.CodexFingerprintModeSession)
+	ApplyCodexFingerprintHeaders(outbound, account, downstream)
+	body := ApplyCodexFingerprintToBody(
+		[]byte(`{"client_metadata":{"x-codex-installation-id":"`+clientInstallUUID+`","session_id":"`+clientSessionUUID+
+			`","thread_id":"`+clientSessionUUID+`","x-codex-window-id":"`+clientSessionUUID+`:0"}}`),
+		account, downstream,
+	)
+
+	var outboundDump strings.Builder
+	for name, values := range outbound {
+		for _, value := range values {
+			outboundDump.WriteString(name + ": " + value + "\n")
+		}
+	}
+	outboundDump.Write(body)
+
+	// turn_id 不在此列：它是逐轮随机值，不标识设备或会话，重写只会引入不一致。
+	for _, leaked := range []string{clientSessionUUID, clientInstallUUID, workspacePath, remoteURL, "james-6-23"} {
+		if strings.Contains(outboundDump.String(), leaked) {
+			t.Fatalf("original identifier %q survived into the outbound request:\n%s", leaked, outboundDump.String())
+		}
+	}
+}
+
+// TestApplyCodexRequestHeadersConvergesForwardedClientRequestID 走真实的出站头组装
+// 顺序（白名单透传 → 指纹收敛 → 账号自定义头），而不是单独调收敛函数。
+// issue #536 的 bug 正出在这个顺序上：X-Client-Request-Id 先被白名单原样透传，
+// 收敛若不接手，原始线程标识就直达上游。
+func TestApplyCodexRequestHeadersConvergesForwardedClientRequestID(t *testing.T) {
+	const (
+		clientUUID    = "01a00e75-8856-7542-89bf-35812620690f"
+		installUUID   = "341596ee-ab98-43f8-82e2-08ecdfb56db4"
+		workspacePath = "/Users/kyx/code_project/codex2api"
+		remoteURL     = "https://github.com/james-6-23/codex2api.git"
+	)
+	rawMetadata := `{"installation_id":"` + installUUID + `","session_id":"` + clientUUID +
+		`","thread_id":"` + clientUUID + `","window_id":"` + clientUUID +
+		`:0","request_kind":"turn","workspaces":{"` + workspacePath +
+		`":{"associated_remote_urls":{"origin":"` + remoteURL + `"},"has_changes":false}}}`
+
+	downstream := http.Header{}
+	downstream.Set("X-Codex-Turn-Metadata", rawMetadata)
+	downstream.Set("Session-Id", clientUUID)
+	downstream.Set("Thread-Id", clientUUID)
+	downstream.Set("X-Client-Request-Id", clientUUID)
+	downstream.Set("X-Codex-Window-Id", clientUUID+":0")
+	downstream.Set("Originator", "codex-tui")
+
+	account := fingerprintAccount(t, auth.CodexFingerprintModeSession)
+	req, err := http.NewRequest(http.MethodPost, "https://chatgpt.com/backend-api/codex/responses", nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest: %v", err)
+	}
+	applyCodexRequestHeaders(req, account, "access-token", "upstream-cache-key", "api-key-1", nil, downstream)
+
+	ids := resolveCodexFingerprintIDs(account, downstream)
+	if got := req.Header.Get("X-Client-Request-Id"); got != ids.threadID {
+		t.Fatalf("X-Client-Request-Id = %q, want converged thread id %q", got, ids.threadID)
+	}
+	// Session_id 仍归 resolveUpstreamSessionID 管，收敛不得介入。
+	if got := req.Header.Get("Session_id"); got != "upstream-cache-key" {
+		t.Fatalf("Session_id = %q, want the cache key untouched", got)
+	}
+	// 下游没发 installation 头，出站也不该有。
+	if got := req.Header.Get("X-Codex-Installation-Id"); got != "" {
+		t.Fatalf("X-Codex-Installation-Id = %q, want unset", got)
+	}
+
+	var dump strings.Builder
+	for name, values := range req.Header {
+		for _, value := range values {
+			dump.WriteString(name + ": " + value + "\n")
+		}
+	}
+	for _, leaked := range []string{clientUUID, installUUID, workspacePath, remoteURL, "james-6-23"} {
+		if strings.Contains(dump.String(), leaked) {
+			t.Fatalf("original identifier %q survived the real header pipeline:\n%s", leaked, dump.String())
+		}
 	}
 }

--- a/proxy/codex_fingerprint_test.go
+++ b/proxy/codex_fingerprint_test.go
@@ -582,13 +582,16 @@ func TestConvergedClientRequestIDFollowsClientIdentity(t *testing.T) {
 // 路径含系统用户名、associated_remote_urls 含仓库归属，多人共享账号时这些会把每个
 // 下游用户的身份原样送到上游。
 func TestScrubCodexWorkspacesRemovesWorkspaceIdentity(t *testing.T) {
-	const raw = `{"request_kind":"memory","workspaces":{"/Users/alice/code/secret-project":{"associated_remote_urls":{"origin":"https://github.com/alice-corp/secret-project.git"},"latest_git_commit_hash":"3cd12a68","has_changes":false}}}`
+	// commit hash 用真实长度的值：它是全局唯一的仓库标记，公开仓库可反查到归属，
+	// 与 remote URL 泄漏的是同一份身份。
+	const originalCommit = "3cd12a685fe3ea23b84a9097fd4563927857ea21"
+	const raw = `{"request_kind":"memory","workspaces":{"/Users/alice/code/secret-project":{"associated_remote_urls":{"origin":"https://github.com/alice-corp/secret-project.git"},"latest_git_commit_hash":"` + originalCommit + `","has_changes":false}}}`
 
-	got, changed := scrubCodexWorkspaces(raw)
+	got, changed := scrubCodexWorkspaces(raw, 42)
 	if !changed {
 		t.Fatal("scrubCodexWorkspaces reported no change, want the workspace scrubbed")
 	}
-	for _, leaked := range []string{"alice", "secret-project", "github.com"} {
+	for _, leaked := range []string{"alice", "secret-project", "github.com", originalCommit} {
 		if strings.Contains(got, leaked) {
 			t.Fatalf("scrubbed metadata %q still contains %q", got, leaked)
 		}
@@ -605,9 +608,9 @@ func TestScrubCodexWorkspacesRemovesWorkspaceIdentity(t *testing.T) {
 		if entry.Get("associated_remote_urls").Exists() {
 			t.Fatalf("associated_remote_urls survived in %q", entry.Raw)
 		}
-		// 非身份字段原样保留，避免改变 metadata 形状。
-		if entry.Get("latest_git_commit_hash").String() != "3cd12a68" {
-			t.Fatalf("latest_git_commit_hash = %q, want it preserved", entry.Get("latest_git_commit_hash").String())
+		// 形状保持：字段仍在，且仍是等长的十六进制串。
+		if replaced := entry.Get("latest_git_commit_hash").String(); len(replaced) != len(originalCommit) {
+			t.Fatalf("latest_git_commit_hash = %q, want a same-length derived placeholder", replaced)
 		}
 		if entry.Get("has_changes").Bool() {
 			t.Fatal("has_changes = true, want the client value preserved")
@@ -615,21 +618,31 @@ func TestScrubCodexWorkspacesRemovesWorkspaceIdentity(t *testing.T) {
 	}
 
 	// 同一路径恒定映射到同一占位符，不同路径互不相同。
-	repeat, _ := scrubCodexWorkspaces(raw)
+	repeat, _ := scrubCodexWorkspaces(raw, 42)
 	if repeat != got {
 		t.Fatalf("scrub is not deterministic: %q vs %q", repeat, got)
 	}
-	if placeholderWorkspacePath("/Users/alice/a") == placeholderWorkspacePath("/Users/alice/b") {
+	if placeholderWorkspacePath(42, "/Users/alice/a") == placeholderWorkspacePath(42, "/Users/alice/b") {
 		t.Fatal("distinct workspace paths collapsed to the same placeholder")
 	}
 
+	// 账号维度隔离：同一路径在不同账号下必须派生出不同占位符，否则上游可以把
+	// 同一个下游用户跨账号关联起来。
+	if placeholderWorkspacePath(42, "/Users/alice/a") == placeholderWorkspacePath(43, "/Users/alice/a") {
+		t.Fatal("same path produced the same placeholder across accounts")
+	}
+	otherAccount, _ := scrubCodexWorkspaces(raw, 43)
+	if otherAccount == got {
+		t.Fatal("scrub result is identical across accounts, want account-scoped derivation")
+	}
+
 	// 抹除必须幂等：重试链路可能把改写过的载荷再送进来一次。
-	if again, changedAgain := scrubCodexWorkspaces(got); changedAgain || again != got {
+	if again, changedAgain := scrubCodexWorkspaces(got, 42); changedAgain || again != got {
 		t.Fatalf("second scrub changed the payload again: %q -> %q", got, again)
 	}
 
 	// 没有 workspaces 的 metadata 不受影响。
-	if _, changed := scrubCodexWorkspaces(`{"session_id":"s"}`); changed {
+	if _, changed := scrubCodexWorkspaces(`{"session_id":"s"}`, 42); changed {
 		t.Fatal("metadata without workspaces was modified")
 	}
 }
@@ -643,11 +656,12 @@ func TestCodexFingerprintLeavesNoOriginalIdentifierOutbound(t *testing.T) {
 		clientInstallUUID = "341596ee-ab98-43f8-82e2-08ecdfb56db4"
 		workspacePath     = "/Users/kyx/code_project/codex2api"
 		remoteURL         = "https://github.com/james-6-23/codex2api.git"
+		commitHash        = "3cd12a685fe3ea23b84a9097fd4563927857ea21"
 	)
 	rawMetadata := `{"installation_id":"` + clientInstallUUID + `","session_id":"` + clientSessionUUID +
 		`","thread_id":"` + clientSessionUUID + `","turn_id":"01a00e76-15fb-7940-91a0-e201c45f502a","window_id":"` +
 		clientSessionUUID + `:0","request_kind":"turn","sandbox":"none","workspaces":{"` + workspacePath +
-		`":{"associated_remote_urls":{"origin":"` + remoteURL + `"},"latest_git_commit_hash":"3cd12a68"}},"turn_started_at_unix_ms":1786949015072}`
+		`":{"associated_remote_urls":{"origin":"` + remoteURL + `"},"latest_git_commit_hash":"` + commitHash + `"}},"turn_started_at_unix_ms":1786949015072}`
 
 	// 复刻真实 CLI 的下游头集合。
 	downstream := http.Header{}
@@ -679,7 +693,7 @@ func TestCodexFingerprintLeavesNoOriginalIdentifierOutbound(t *testing.T) {
 	outboundDump.Write(body)
 
 	// turn_id 不在此列：它是逐轮随机值，不标识设备或会话，重写只会引入不一致。
-	for _, leaked := range []string{clientSessionUUID, clientInstallUUID, workspacePath, remoteURL, "james-6-23"} {
+	for _, leaked := range []string{clientSessionUUID, clientInstallUUID, workspacePath, remoteURL, "james-6-23", commitHash} {
 		if strings.Contains(outboundDump.String(), leaked) {
 			t.Fatalf("original identifier %q survived into the outbound request:\n%s", leaked, outboundDump.String())
 		}

--- a/proxy/wsrelay/executor_test.go
+++ b/proxy/wsrelay/executor_test.go
@@ -561,11 +561,12 @@ func TestPrepareWebsocketHeadersConvergesForwardedClientRequestID(t *testing.T) 
 		installUUID   = "341596ee-ab98-43f8-82e2-08ecdfb56db4"
 		workspacePath = "/Users/kyx/code_project/codex2api"
 		remoteURL     = "https://github.com/james-6-23/codex2api.git"
+		commitHash    = "3cd12a685fe3ea23b84a9097fd4563927857ea21"
 	)
 	rawMetadata := `{"installation_id":"` + installUUID + `","session_id":"` + clientUUID +
 		`","thread_id":"` + clientUUID + `","window_id":"` + clientUUID +
 		`:0","request_kind":"turn","workspaces":{"` + workspacePath +
-		`":{"associated_remote_urls":{"origin":"` + remoteURL + `"},"has_changes":false}}}`
+		`":{"associated_remote_urls":{"origin":"` + remoteURL + `"},"latest_git_commit_hash":"` + commitHash + `","has_changes":false}}}`
 
 	// 复刻真实 codex-tui 的握手头集合（见 wss://chatgpt.com/backend-api/codex/responses）。
 	ginHeaders := http.Header{}
@@ -603,7 +604,7 @@ func TestPrepareWebsocketHeadersConvergesForwardedClientRequestID(t *testing.T) 
 			dump.WriteString(name + ": " + value + "\n")
 		}
 	}
-	for _, leaked := range []string{clientUUID, installUUID, workspacePath, remoteURL, "james-6-23"} {
+	for _, leaked := range []string{clientUUID, installUUID, workspacePath, remoteURL, "james-6-23", commitHash} {
 		if strings.Contains(dump.String(), leaked) {
 			t.Fatalf("original identifier %q survived the websocket handshake headers:\n%s", leaked, dump.String())
 		}

--- a/proxy/wsrelay/executor_test.go
+++ b/proxy/wsrelay/executor_test.go
@@ -550,3 +550,62 @@ func TestShouldRetryWebsocketSendError(t *testing.T) {
 		t.Fatal("nil is not a retryable send error")
 	}
 }
+
+// TestPrepareWebsocketHeadersConvergesForwardedClientRequestID 是 HTTP 侧
+// TestApplyCodexRequestHeadersConvergesForwardedClientRequestID 的 WS 对照：
+// 握手头有自己的一份透传列表和组装顺序，同一组不变量必须独立锁定，
+// 否则 issue #536 的泄漏会只在 WS 路径上复活。
+func TestPrepareWebsocketHeadersConvergesForwardedClientRequestID(t *testing.T) {
+	const (
+		clientUUID    = "01a00e75-8856-7542-89bf-35812620690f"
+		installUUID   = "341596ee-ab98-43f8-82e2-08ecdfb56db4"
+		workspacePath = "/Users/kyx/code_project/codex2api"
+		remoteURL     = "https://github.com/james-6-23/codex2api.git"
+	)
+	rawMetadata := `{"installation_id":"` + installUUID + `","session_id":"` + clientUUID +
+		`","thread_id":"` + clientUUID + `","window_id":"` + clientUUID +
+		`:0","request_kind":"turn","workspaces":{"` + workspacePath +
+		`":{"associated_remote_urls":{"origin":"` + remoteURL + `"},"has_changes":false}}}`
+
+	// 复刻真实 codex-tui 的握手头集合（见 wss://chatgpt.com/backend-api/codex/responses）。
+	ginHeaders := http.Header{}
+	ginHeaders.Set("X-Codex-Turn-Metadata", rawMetadata)
+	ginHeaders.Set("Session-Id", clientUUID)
+	ginHeaders.Set("Thread-Id", clientUUID)
+	ginHeaders.Set("X-Client-Request-Id", clientUUID)
+	ginHeaders.Set("X-Codex-Window-Id", clientUUID+":0")
+	ginHeaders.Set("Originator", "codex-tui")
+
+	account := &auth.Account{DBID: 42, AccountID: "42", CodexFingerprintMode: auth.CodexFingerprintModeSession}
+	exec := NewExecutor()
+	headers := exec.prepareWebsocketHeaders("token-123", account, "42", "upstream-session-id", "api-key-1", nil, ginHeaders, nil)
+
+	if got := headers.Get("X-Client-Request-Id"); got == clientUUID {
+		t.Fatal("X-Client-Request-Id still carries the downstream thread id after convergence")
+	} else if got == "" {
+		t.Fatal("X-Client-Request-Id was dropped, want a converged value")
+	}
+	// 握手的 Session_id / Conversation_id 归调用方决定，收敛不得介入。
+	if got := headers.Get("Session_id"); got != "upstream-session-id" {
+		t.Fatalf("Session_id = %q, want the caller value untouched", got)
+	}
+	if got := headers.Get("Conversation_id"); got != "upstream-session-id" {
+		t.Fatalf("Conversation_id = %q, want the caller value untouched", got)
+	}
+	// 下游没发 installation 头，出站也不该凭空多出一个。
+	if got := headers.Get("X-Codex-Installation-Id"); got != "" {
+		t.Fatalf("X-Codex-Installation-Id = %q, want unset", got)
+	}
+
+	var dump strings.Builder
+	for name, values := range headers {
+		for _, value := range values {
+			dump.WriteString(name + ": " + value + "\n")
+		}
+	}
+	for _, leaked := range []string{clientUUID, installUUID, workspacePath, remoteURL, "james-6-23"} {
+		if strings.Contains(dump.String(), leaked) {
+			t.Fatalf("original identifier %q survived the websocket handshake headers:\n%s", leaked, dump.String())
+		}
+	}
+}


### PR DESCRIPTION
针对 #536 的分析做了抓包实证,确认指控成立,并顺带发现两处方向相反的问题(我们自己在往上游多发东西)。

## 抓包实证

用 Proxyman 抓 codex-tui 0.147.0 直连 `wss://chatgpt.com/backend-api/codex/responses` 的 5 次握手:

**1. `X-Client-Request-Id` 恒等于 `thread-id`(5/5)。** 其中 4 条 session==thread 所以三个头同值;第 5 条是 memory_consolidation 子代理的 prewarm,`session-id` 与 `thread-id` 不同,而 `x-client-request-id` 仍精确等于 `thread-id`。排除了巧合——它不是每请求随机 ID,携带的就是线程标识。该头在 `codexAllowedForwardHeaders` 里原样透传、收敛又不碰它,所以 issue 描述的绕过路径真实存在。

**2. 真实客户端从不发 `X-Codex-Installation-Id` 独立头**(120 条 flow 命中 0),installation_id 只存在于 turn metadata JSON 内部。而我们无条件 `Set` 这个头,等于给请求添了一个真实客户端不会有的头,违反本文件自己声明的"只改写已存在的键,绝不新增"。

**3. `workspaces` 是泄漏最重的一项,issue 没提到。** turn metadata 里带着以本地绝对路径(含系统用户名)为键、值含 git remote URL 和 commit hash 的 workspaces。该头原样透传,收敛只改里面四个 ID 字段,workspaces 一个字没动——多人共享账号时,每个下游用户的本地路径和仓库归属都会原样送到上游。

## 改了什么

- **收敛 `X-Client-Request-Id`**:仅在它复用了客户端自报的 session/thread 时改写,取值与身份无关时保持原样(避免把一个本来随机的值改成固定值、反而制造不一致)。device 档为空操作。
- **`X-Codex-Installation-Id` / `X-Codex-Window-Id` 改为"下游发过才覆盖"**:把 JSON 路径早就遵守的"只改写、不新增"规则扩展到请求头路径。真实客户端会发 window-id,所以主路径行为不变。
- **抹除 `workspaces` 身份**:路径键换成按原值派生的占位符(条目数与互异性保留,不改形状),`associated_remote_urls` 整体移除,其余字段原样保留。改写幂等,重试链路不会二次哈希。

`extractClientCodexSessionID` 刻意没动——它是收敛值的派生输入,改它会让既有账号已经稳定的 thread_id 全部漂移。

## 测试

新增的测试驱动**真实的出站头组装函数**(而不是单独调收敛函数),覆盖两条独立传输路径:

- HTTP:`applyCodexRequestHeaders`,覆盖"白名单透传 → 指纹收敛 → 账号自定义头"的真实顺序(#536 的 bug 正出在这个顺序上)
- WS:`prepareWebsocketHeaders`,握手头有自己的一份透传列表和组装顺序

两条都在组装完成后把整份 header dump 出来扫描,断言原始 session UUID、installation UUID、本地路径、remote URL、GitHub 账号名一个都不残留。这样将来协议新增身份字段、或有人调换了透传与收敛的顺序,测试会先失败而不是静默泄漏。

有效性已验证:分别临时禁用 xcrid 收敛和 workspaces 抹除,两条测试都会失败并精确指出泄漏项;恢复后全绿。

## Live 实测

pgredis2004,账号本身已是 `codex_fingerprint_mode=session`,**未改动任何设置**。

- HTTP 传输两轮(复刻真实抓包形态 + 模拟第二个共享用户,不同 UUID 与工作区),均正常返回
- WS 传输两轮:临时把 compose 的 `CODEX_UPSTREAM_TRANSPORT` 切到 `ws`,两轮均正常返回,日志 `[WS-Keepalive] 保活完成: pinged=1 failed=0` 证实走的确实是 WS 连接、且无 HTTP 降级;**测完已恢复为 `http`**,compose 文件与 HEAD 一致

上游接受了收敛后的握手头和请求体,未因改写而拒绝。

## 已知偏差(未在本 PR 处理)

抓包同时发现:真实 session/thread/window 是 **UUIDv7**(前 48 bit 为真实毫秒时间戳,解出来与抓包时刻仅差 3 秒),而 installation 是 v4。`deriveStableCodexUUID` 对所有 ID 一律写死 v4,且 [第 53 行注释]声称"真实客户端是 v4 标识"——该前提被证伪。

本 PR 未改动这一点,收敛出的 session/thread 仍是 v4。如果后续要处理,注意 v7 的时间戳位必须填合理值(账号创建时间之类),直接塞哈希会解出 1970 或公元 10000。相关注释与 `TestDeriveStableCodexUUIDIsDeterministicAndV4` 的断言目前仍按旧前提写着,一并需要更新。

Refs #536


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request identity handling to preserve only identifiers provided by the client.
  * Prevented missing installation and window identifiers from being added to requests.
  * Ensured related client request IDs remain consistent when rewritten.
  * Scrubbed workspace paths, remote URLs, and commit hashes from metadata using stable placeholders.
  * Removed original sensitive identifiers from forwarded headers, request bodies, and WebSocket handshakes.
* **Tests**
  * Expanded coverage for HTTP and WebSocket identity handling, metadata scrubbing, and forwarded-request consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->