### PR TITLE
fix(proxy): retry unknown provider model routes

### DIFF
--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -5883,6 +5883,9 @@ func isCodexModelUnsupportedError(body []byte) bool {
 		if strings.Contains(lower, "model is not supported when using codex") {
 			return true
 		}
+		if strings.Contains(lower, "unknown provider for model") {
+			return true
+		}
 	}
 	return false
 }

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -3164,6 +3164,10 @@ func TestIsCodexModelUnsupportedError(t *testing.T) {
 	if !isCodexModelUnsupportedError(unsupported) {
 		t.Fatal("应识别模型不支持错误")
 	}
+	unknownProvider := []byte(`{"error":{"type":"upstream_error","message":"unknown provider for model gpt-5.6-sol"}}`)
+	if !isCodexModelUnsupportedError(unknownProvider) {
+		t.Fatal("应识别中转上游缺少模型提供商错误")
+	}
 	if isCodexModelUnsupportedError([]byte(`{"error":{"message":"Invalid value for 'temperature'","type":"invalid_request_error"}}`)) {
 		t.Fatal("普通 invalid_request 不应命中")
 	}
@@ -3176,6 +3180,10 @@ func TestIsCodexModelUnsupportedError(t *testing.T) {
 		t.Fatal("模型不支持的 400 应可换号重试")
 	}
 	general, rate = 0, 0
+	if !shouldRetryHTTPStatus(http.StatusBadRequest, unknownProvider, &general, &rate, 2, 1) {
+		t.Fatal("中转上游缺少模型提供商的 400 应可换号重试")
+	}
+	general, rate = 0, 0
 	if shouldRetryHTTPStatus(http.StatusBadRequest, []byte(`{"error":{"message":"bad request"}}`), &general, &rate, 2, 1) {
 		t.Fatal("普通 400 不应重试")
 	}
@@ -3185,6 +3193,10 @@ func TestResponseFailedModelUnsupportedRetryable(t *testing.T) {
 	payload := []byte(`{"type":"response.failed","response":{"error":{"code":"invalid_request_error","message":"The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account."}}}`)
 	if !responseFailedRetryable(payload) {
 		t.Fatal("模型不支持的 response.failed 应视为可换号重试")
+	}
+	unknownProvider := []byte(`{"type":"response.failed","response":{"status_code":400,"error":{"type":"upstream_error","message":"unknown provider for model gpt-5.6-sol"}}}`)
+	if !responseFailedRetryable(unknownProvider) {
+		t.Fatal("中转上游缺少模型提供商的 response.failed 应视为可换号重试")
 	}
 	plain := []byte(`{"type":"response.failed","response":{"error":{"code":"invalid_request_error","message":"Invalid value for 'temperature'"}}}`)
 	if responseFailedRetryable(plain) {


### PR DESCRIPTION
## Summary

- Treat `unknown provider for model` as an account/model compatibility failure.
- Reuse the existing model cooldown and account-rotation retry path for HTTP and `response.failed` responses.
- Keep ordinary 400 errors and model selection behavior unchanged.

## Root cause

The gateway returned a 400 `upstream_error` when its selected upstream route did not provide `gpt-5.6-sol`. The existing detector only recognized the official Codex wording, so this gateway-specific error was passed through instead of rotating to another compatible account.

## Validation

- `go test ./proxy -run 'Test(IsCodexModelUnsupportedError|ResponseFailedModelUnsupportedRetryable)$' -count=1 -v`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of “unknown provider for model” errors.
  * These errors are now treated as retryable unsupported-model failures for both standard and streaming responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->