### PR TITLE
fix(grok): bridge Codex tools across protocol adapters

### DIFF
--- a/proxy/grok_protocol.go
+++ b/proxy/grok_protocol.go
@@ -753,7 +753,7 @@ func (r *chatToResponsesReader) ensureToolOutput(index int) *chatResponseTool {
 }
 
 func (r *chatToResponsesReader) enqueueToolProgress(tool *chatResponseTool) {
-	if tool == nil || tool.id == "" {
+	if tool == nil || tool.id == "" || tool.name == "" {
 		return
 	}
 	if !tool.itemAdded {
@@ -767,6 +767,30 @@ func (r *chatToResponsesReader) enqueueToolProgress(tool *chatResponseTool) {
 	delta := arguments[tool.emittedArgsSize:]
 	tool.emittedArgsSize = len(arguments)
 	r.queue.Write(responseEvent("response.function_call_arguments.delta", map[string]any{"output_index": tool.outputIndex, "item_id": tool.id, "call_id": tool.id, "delta": delta}))
+}
+
+func chatResponseToolItem(tool *chatResponseTool, status string) map[string]any {
+	return map[string]any{
+		"id": tool.id, "type": "function_call", "call_id": tool.id,
+		"name": tool.name, "arguments": tool.arguments.String(), "status": status,
+	}
+}
+
+func (r *chatToResponsesReader) enqueueToolCompletion(tool *chatResponseTool) map[string]any {
+	if tool.id == "" {
+		tool.id = "call_" + uuid.NewString()
+	}
+	if tool.name == "" {
+		return chatResponseToolItem(tool, "incomplete")
+	}
+	r.enqueueToolProgress(tool)
+	item := chatResponseToolItem(tool, "completed")
+	r.queue.Write(responseEvent("response.function_call_arguments.done", map[string]any{
+		"output_index": tool.outputIndex, "item_id": tool.id, "call_id": tool.id,
+		"arguments": tool.arguments.String(),
+	}))
+	r.queue.Write(responseEvent("response.output_item.done", map[string]any{"output_index": tool.outputIndex, "item": item}))
+	return item
 }
 
 func (r *chatToResponsesReader) enqueueCreated() {
@@ -910,10 +934,14 @@ func (r *chatToResponsesReader) emitChatTerminal(status string) {
 			if tool == nil {
 				continue
 			}
+			if status == "completed" {
+				output = append(output, r.enqueueToolCompletion(tool))
+				continue
+			}
 			if tool.id == "" {
 				tool.id = "call_" + uuid.NewString()
 			}
-			output = append(output, map[string]any{"id": tool.id, "type": "function_call", "call_id": tool.id, "name": tool.name, "arguments": tool.arguments.String(), "status": "completed"})
+			output = append(output, chatResponseToolItem(tool, "incomplete"))
 		}
 	}
 	response := map[string]any{"id": r.responseID, "object": "response", "status": status, "model": r.model, "output": output, "usage": usage}
@@ -1015,6 +1043,7 @@ type messagesResponseBlock struct {
 	signature   strings.Builder
 	arguments   strings.Builder
 	outputIndex int
+	itemAdded   bool
 }
 
 func newMessagesToResponsesReader(source io.ReadCloser, model string) io.ReadCloser {
@@ -1032,6 +1061,41 @@ func (r *messagesToResponsesReader) ensureBlock(index int, blockType string) *me
 	r.blocks[index] = block
 	r.output = append(r.output, index)
 	return block
+}
+
+func messagesResponseToolItem(block *messagesResponseBlock, status string) map[string]any {
+	return map[string]any{
+		"id": block.id, "type": "function_call", "call_id": block.id,
+		"name": block.name, "arguments": block.arguments.String(), "status": status,
+	}
+}
+
+func (r *messagesToResponsesReader) enqueueToolAdded(block *messagesResponseBlock) {
+	if block == nil || block.itemAdded || block.id == "" {
+		return
+	}
+	r.queue.Write(responseEvent("response.output_item.added", map[string]any{
+		"output_index": block.outputIndex,
+		"item": map[string]any{
+			"id": block.id, "type": "function_call", "call_id": block.id,
+			"name": block.name, "arguments": "", "status": "in_progress",
+		},
+	}))
+	block.itemAdded = true
+}
+
+func (r *messagesToResponsesReader) enqueueToolCompletion(block *messagesResponseBlock) map[string]any {
+	if block.id == "" {
+		block.id = "call_" + uuid.NewString()
+	}
+	r.enqueueToolAdded(block)
+	item := messagesResponseToolItem(block, "completed")
+	r.queue.Write(responseEvent("response.function_call_arguments.done", map[string]any{
+		"output_index": block.outputIndex, "item_id": block.id, "call_id": block.id,
+		"arguments": block.arguments.String(),
+	}))
+	r.queue.Write(responseEvent("response.output_item.done", map[string]any{"output_index": block.outputIndex, "item": item}))
+	return item
 }
 
 func (r *messagesToResponsesReader) translate(data []byte) {
@@ -1060,8 +1124,7 @@ func (r *messagesToResponsesReader) translate(data []byte) {
 			block.name = event.Get("content_block.name").String()
 		}
 		if blockType == "tool_use" {
-			id := block.id
-			r.queue.Write(responseEvent("response.output_item.added", map[string]any{"output_index": block.outputIndex, "item": map[string]any{"id": id, "type": "function_call", "call_id": id, "name": block.name, "arguments": "", "status": "in_progress"}}))
+			r.enqueueToolAdded(block)
 		}
 	case "content_block_delta":
 		index := int(event.Get("index").Int())
@@ -1140,7 +1203,14 @@ func (r *messagesToResponsesReader) translate(data []byte) {
 					output = append(output, map[string]any{"id": "msg_" + uuid.NewString(), "type": "message", "role": "assistant", "status": "completed", "content": []any{map[string]any{"type": "output_text", "text": block.text.String(), "annotations": []any{}}}})
 				}
 			case "tool_use":
-				output = append(output, map[string]any{"id": block.id, "type": "function_call", "call_id": block.id, "name": block.name, "arguments": block.arguments.String(), "status": "completed"})
+				if status == "completed" {
+					output = append(output, r.enqueueToolCompletion(block))
+					continue
+				}
+				if block.id == "" {
+					block.id = "call_" + uuid.NewString()
+				}
+				output = append(output, messagesResponseToolItem(block, "incomplete"))
 			}
 		}
 		response := map[string]any{"id": r.responseID, "object": "response", "status": status, "model": r.model, "output": output, "usage": usage}
@@ -1302,11 +1372,7 @@ func canonicalGrokResponsesBody(inbound GrokProtocol, inboundBody, responsesBody
 	return body, err
 }
 
-func prepareGrokProtocolBody(protocol, inbound GrokProtocol, inboundBody, responsesBody []byte) ([]byte, error) {
-	canonical, err := canonicalGrokResponsesBody(inbound, inboundBody, responsesBody)
-	if err != nil {
-		return nil, err
-	}
+func convertCanonicalGrokResponsesBody(protocol GrokProtocol, canonical []byte) ([]byte, error) {
 	switch protocol {
 	case GrokProtocolChatCompletions:
 		return convertResponsesToChatRequest(canonical)
@@ -1330,7 +1396,7 @@ func rewriteGrokProtocolModel(body []byte, model string) ([]byte, error) {
 	return sjson.SetBytes(body, "model", model)
 }
 
-func prepareRoutedGrokProtocolBody(route GrokUpstreamRoute, inbound GrokProtocol, inboundBody, responsesBody []byte) ([]byte, error) {
+func prepareRoutedGrokProtocolRequest(route GrokUpstreamRoute, inbound GrokProtocol, inboundBody, responsesBody []byte) (grokPreflightResult, error) {
 	inbound = auth.NormalizeGrokProtocol(string(inbound))
 	// A same-protocol route receives the original downstream object even when
 	// it was selected from catalog apiBackend rather than a fresh capability
@@ -1340,10 +1406,13 @@ func prepareRoutedGrokProtocolBody(route GrokUpstreamRoute, inbound GrokProtocol
 	// ExecuteGrokProtocolRequest.
 	if route.Protocol == inbound && inbound != "" && len(inboundBody) > 0 {
 		body, err := rewriteGrokProtocolModel(inboundBody, route.Model)
-		if err != nil || route.Native {
+		if err != nil {
+			return grokPreflightResult{}, err
+		}
+		if route.Native {
 			// 仅 native 路由按线格式直通返回(forwardGrokNativeResponse),
 			// 可以完整保留 stream=false。
-			return body, err
+			return grokPreflightResult{Body: body, TurnIndex: 1, Model: gjson.GetBytes(body, "model").String()}, nil
 		}
 		// 非 native 的同协议路由不会直通:响应必须经 adaptGrokProtocolResponse
 		// 投影成规范 Responses SSE 再交给下游翻译器,而该投影只处理 SSE。
@@ -1352,7 +1421,7 @@ func prepareRoutedGrokProtocolBody(route GrokUpstreamRoute, inbound GrokProtocol
 		if !grokProtocolBodyStream(body) {
 			forced, forceErr := sjson.SetBytes(body, "stream", true)
 			if forceErr != nil {
-				return nil, forceErr
+				return grokPreflightResult{}, forceErr
 			}
 			if route.Protocol == GrokProtocolChatCompletions {
 				// Chat 的 usage 只随 include_usage 的独立 chunk 下发。
@@ -1362,9 +1431,34 @@ func prepareRoutedGrokProtocolBody(route GrokUpstreamRoute, inbound GrokProtocol
 			}
 			body = forced
 		}
-		return body, nil
+		if route.Protocol == GrokProtocolResponses {
+			return prepareGrokUpstreamBody(body), nil
+		}
+		return grokPreflightResult{Body: clampGrokReasoningEffort(body), TurnIndex: 1, Model: gjson.GetBytes(body, "model").String()}, nil
 	}
-	return prepareGrokProtocolBody(route.Protocol, inbound, inboundBody, responsesBody)
+
+	canonical, err := canonicalGrokResponsesBody(inbound, inboundBody, responsesBody)
+	if err != nil {
+		return grokPreflightResult{}, err
+	}
+	// Codex-only Responses tools and history must be lowered while the request
+	// still has canonical Responses semantics. Converting first rejects those
+	// variants and loses the request-local aliases needed to restore tool calls.
+	preflight := prepareGrokUpstreamBody(canonical)
+	converted, err := convertCanonicalGrokResponsesBody(route.Protocol, preflight.Body)
+	if err != nil {
+		return grokPreflightResult{}, err
+	}
+	if route.Protocol != GrokProtocolResponses {
+		converted = clampGrokReasoningEffort(converted)
+	}
+	preflight.Body = converted
+	return preflight, nil
+}
+
+func prepareRoutedGrokProtocolBody(route GrokUpstreamRoute, inbound GrokProtocol, inboundBody, responsesBody []byte) ([]byte, error) {
+	preflight, err := prepareRoutedGrokProtocolRequest(route, inbound, inboundBody, responsesBody)
+	return preflight.Body, err
 }
 
 func validGrokClientVersion(value string) bool {
@@ -1419,7 +1513,7 @@ func ExecuteGrokProtocolRequest(ctx context.Context, account *auth.Account, inbo
 		model = strings.TrimSpace(gjson.GetBytes(inboundBody, "model").String())
 	}
 	route := ResolveGrokUpstreamRoute(account, model, inbound, time.Now())
-	body, err := prepareRoutedGrokProtocolBody(route, inbound, inboundBody, responsesBody)
+	preflight, err := prepareRoutedGrokProtocolRequest(route, inbound, inboundBody, responsesBody)
 	if err != nil {
 		return nil, ErrBadRequest("Grok protocol conversion failed: " + err.Error())
 	}
@@ -1433,14 +1527,6 @@ func ExecuteGrokProtocolRequest(ctx context.Context, account *auth.Account, inbo
 	account.Mu().RUnlock()
 	if proxyOverride != "" {
 		proxyURL = proxyOverride
-	}
-	preflight := prepareGrokUpstreamBody(body)
-	if route.Protocol != GrokProtocolResponses || (route.Native && route.Protocol == auth.NormalizeGrokProtocol(string(inbound))) {
-		// Responses-specific history preflight cannot be applied after conversion.
-		preflight = grokPreflightResult{Body: body, TurnIndex: 1, Model: model}
-		if !route.Native {
-			preflight.Body = clampGrokReasoningEffort(body)
-		}
 	}
 	logGrokPrefixFingerprint(preflight.Body, preflight.TurnIndex, preflight.Model)
 	send := func(payload []byte, clientVersion string) (*http.Response, error) {
@@ -1515,15 +1601,17 @@ func ExecuteGrokProtocolRequest(ctx context.Context, account *auth.Account, inbo
 	recordGrokUpstreamObservationsAtOrigin(account, resp.Header, route.BaseURL)
 	observeGrokNativeProtocolFailure(account, route, inbound, resp)
 	markGrokNativeRoute(resp, route, inbound)
-	if len(preflight.Aliases) > 0 && resp.Body != nil {
-		streaming := strings.Contains(strings.ToLower(resp.Header.Get("Content-Type")), "event-stream")
-		resp.Body = newGrokNamespaceReverser(resp.Body, streaming, preflight.Aliases)
-	}
 	// Same-protocol native routes retain the provider wire representation. The
 	// concrete handler streams/copies it directly; converted routes continue to
 	// project through canonical Responses SSE for the existing translators.
 	if !isGrokNativeRouteResponse(resp) {
 		adaptGrokProtocolResponse(resp, route.Protocol, model, grokProtocolBodyStream(preflight.Body))
+	}
+	if len(preflight.Aliases) > 0 && resp.Body != nil {
+		streaming := strings.Contains(strings.ToLower(resp.Header.Get("Content-Type")), "event-stream")
+		resp.Body = newGrokNamespaceReverser(resp.Body, streaming, preflight.Aliases)
+		resp.Header.Del("Content-Length")
+		resp.ContentLength = -1
 	}
 	return resp, nil
 }

--- a/proxy/grok_protocol_test.go
+++ b/proxy/grok_protocol_test.go
@@ -3,9 +3,11 @@ package proxy
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -49,6 +51,220 @@ func TestExecuteGrokProtocolRequestUsesCatalogBackend(t *testing.T) {
 	}
 	if !bytes.Contains(data, []byte(`"text":"hi"`)) {
 		t.Fatalf("completed response lost authoritative output: %s", data)
+	}
+}
+
+func TestExecuteGrokProtocolRequestBridgesResponsesToolsThroughChat(t *testing.T) {
+	var captured []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/chat/completions" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		captured, _ = io.ReadAll(r.Body)
+		aliases := make(map[string]string)
+		for _, tool := range gjson.GetBytes(captured, "tools").Array() {
+			if tool.Get("type").String() != "function" || tool.Get("function.name").String() == "" {
+				t.Errorf("non-function Chat tool leaked upstream: %s", tool.Raw)
+				continue
+			}
+			description := tool.Get("function.description").String()
+			switch {
+			case description == "synthetic custom tool":
+				aliases["custom"] = tool.Get("function.name").String()
+			case description == "synthetic namespace function":
+				aliases["namespace"] = tool.Get("function.name").String()
+			case description == "synthetic deferred custom tool":
+				aliases["deferred"] = tool.Get("function.name").String()
+			case strings.HasPrefix(description, "Search and load Codex tools"):
+				aliases["tool_search"] = tool.Get("function.name").String()
+			}
+		}
+		for _, name := range []string{"custom", "namespace", "deferred", "tool_search"} {
+			if aliases[name] == "" {
+				t.Errorf("%s tool was not converted: %s", name, captured)
+			}
+		}
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		writeEvent := func(event any) {
+			encoded, err := json.Marshal(event)
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			_, _ = w.Write([]byte("data: "))
+			_, _ = w.Write(encoded)
+			_, _ = w.Write([]byte("\n\n"))
+		}
+		writeEvent(map[string]any{
+			"id": "chatcmpl_test", "model": "grok-4.5",
+			"choices": []any{map[string]any{
+				"delta": map[string]any{"tool_calls": []any{
+					map[string]any{"index": 0, "id": "call_custom", "type": "function", "function": map[string]any{}},
+				}},
+				"finish_reason": nil,
+			}},
+		})
+		writeEvent(map[string]any{
+			"id": "chatcmpl_test", "model": "grok-4.5",
+			"choices": []any{map[string]any{
+				"delta": map[string]any{"tool_calls": []any{
+					map[string]any{"index": 0, "function": map[string]any{"name": aliases["custom"], "arguments": `{"input":"patch text"}`}},
+					map[string]any{"index": 1, "id": "call_namespace", "type": "function", "function": map[string]any{"name": aliases["namespace"], "arguments": `{"path":"README.md"}`}},
+					map[string]any{"index": 2, "id": "call_search", "type": "function", "function": map[string]any{"name": aliases["tool_search"], "arguments": `{"query":"files","limit":2}`}},
+				}},
+				"finish_reason": nil,
+			}},
+		})
+		writeEvent(map[string]any{
+			"id":      "chatcmpl_test",
+			"choices": []any{map[string]any{"delta": map[string]any{}, "finish_reason": "tool_calls"}},
+			"usage":   map[string]any{"prompt_tokens": 5, "completion_tokens": 3, "total_tokens": 8},
+		})
+		_, _ = io.WriteString(w, "data: [DONE]\n\n")
+	}))
+	defer server.Close()
+
+	account := &auth.Account{UpstreamType: auth.UpstreamGrok, APIKey: "test", BaseURL: server.URL + "/v1"}
+	account.SetGrokRoutingState(auth.GrokRoutingState{Models: []auth.GrokModelRoute{{ModelID: "grok-4.5", BaseURL: server.URL + "/v1", APIBackend: auth.GrokProtocolChatCompletions}}})
+	body := []byte(`{
+		"model":"grok-4.5","stream":true,
+		"tools":[
+			{"type":"custom","name":"run_patch","description":"synthetic custom tool"},
+			{"type":"namespace","name":"workspace","tools":[{"type":"function","name":"read_file","description":"synthetic namespace function","parameters":{"type":"object","properties":{"path":{"type":"string"}}}}]},
+			{"type":"tool_search"}
+		],
+		"input":[
+			{"type":"additional_tools","tools":[{"type":"custom","name":"deferred_run","description":"synthetic deferred custom tool"}]},
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"use the tools"}]}
+		]
+	}`)
+	resp, err := ExecuteGrokProtocolRequest(context.Background(), account, GrokProtocolResponses, nil, body, "", nil)
+	if err != nil {
+		t.Fatalf("ExecuteGrokProtocolRequest: %v", err)
+	}
+	defer resp.Body.Close()
+	stream, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(captured, []byte(`"additional_tools"`)) || gjson.GetBytes(captured, "messages.#").Int() != 1 {
+		t.Fatalf("additional_tools was not lifted before Chat conversion: %s", captured)
+	}
+	if got := gjson.GetBytes(captured, "tools.#").Int(); got != 4 {
+		t.Fatalf("converted tool count = %d, want 4; body=%s", got, captured)
+	}
+
+	events := grokResponseSSEEvents(stream)
+	eventIndex := func(eventType, callID string) int {
+		for i, event := range events {
+			if event.Get("type").String() != eventType {
+				continue
+			}
+			gotCallID := event.Get("call_id").String()
+			if gotCallID == "" {
+				gotCallID = event.Get("item.call_id").String()
+			}
+			if callID == "" || gotCallID == callID {
+				return i
+			}
+		}
+		return -1
+	}
+	customAdded := eventIndex("response.output_item.added", "call_custom")
+	customInputDone := eventIndex("response.custom_tool_call_input.done", "call_custom")
+	customDone := eventIndex("response.output_item.done", "call_custom")
+	namespaceArgsDone := eventIndex("response.function_call_arguments.done", "call_namespace")
+	namespaceDone := eventIndex("response.output_item.done", "call_namespace")
+	searchDone := eventIndex("response.output_item.done", "call_search")
+	completedIndex := eventIndex("response.completed", "")
+	if customAdded < 0 || customInputDone <= customAdded || customDone <= customInputDone ||
+		namespaceArgsDone < 0 || namespaceDone <= namespaceArgsDone || searchDone < 0 || completedIndex <= searchDone {
+		t.Fatalf("restored tool lifecycle is incomplete or out of order: %s", stream)
+	}
+	if eventIndex("response.function_call_arguments.done", "call_search") >= 0 {
+		t.Fatalf("tool_search arguments.done leaked downstream: %s", stream)
+	}
+	if got := events[customAdded].Get("item.type").String(); got != "custom_tool_call" {
+		t.Fatalf("custom added type = %q", got)
+	}
+	if got := events[customInputDone].Get("input").String(); got != "patch text" {
+		t.Fatalf("custom input = %q", got)
+	}
+	if got := events[namespaceDone].Get("item.name").String(); got != "read_file" || events[namespaceDone].Get("item.namespace").String() != "workspace" {
+		t.Fatalf("namespace call was not restored: %s", events[namespaceDone].Raw)
+	}
+	if got := events[searchDone].Get("item.type").String(); got != "tool_search_call" || events[searchDone].Get("item.execution").String() != "client" || events[searchDone].Get("item.arguments.query").String() != "files" {
+		t.Fatalf("tool_search call was not restored: %s", events[searchDone].Raw)
+	}
+	completed := events[completedIndex]
+	if completed.Get(`response.output.#(call_id=="call_custom").type`).String() != "custom_tool_call" ||
+		completed.Get(`response.output.#(call_id=="call_namespace").namespace`).String() != "workspace" ||
+		completed.Get(`response.output.#(call_id=="call_search").type`).String() != "tool_search_call" {
+		t.Fatalf("completed output lost restored tool identities: %s", completed.Raw)
+	}
+}
+
+func TestExecuteGrokProtocolRequestBridgesCustomToolThroughMessages(t *testing.T) {
+	var captured []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/messages" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		captured, _ = io.ReadAll(r.Body)
+		alias := gjson.GetBytes(captured, "tools.0.name").String()
+		if alias == "" || gjson.GetBytes(captured, "tools.0.input_schema.required.0").String() != "input" {
+			t.Errorf("custom tool was not converted for Messages: %s", captured)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		writeEvent := func(event any) {
+			encoded, err := json.Marshal(event)
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			_, _ = w.Write([]byte("data: "))
+			_, _ = w.Write(encoded)
+			_, _ = w.Write([]byte("\n\n"))
+		}
+		writeEvent(map[string]any{"type": "message_start", "message": map[string]any{"id": "msg_test", "model": "grok-4.5", "usage": map[string]any{"input_tokens": 2}}})
+		writeEvent(map[string]any{"type": "content_block_start", "index": 0, "content_block": map[string]any{"type": "tool_use", "id": "call_messages", "name": alias}})
+		writeEvent(map[string]any{"type": "content_block_delta", "index": 0, "delta": map[string]any{"type": "input_json_delta", "partial_json": `{"input":"message patch"}`}})
+		writeEvent(map[string]any{"type": "message_delta", "delta": map[string]any{"stop_reason": "tool_use"}, "usage": map[string]any{"output_tokens": 1}})
+		writeEvent(map[string]any{"type": "message_stop"})
+	}))
+	defer server.Close()
+
+	account := &auth.Account{UpstreamType: auth.UpstreamGrok, APIKey: "test", BaseURL: server.URL + "/v1"}
+	account.SetGrokRoutingState(auth.GrokRoutingState{Models: []auth.GrokModelRoute{{ModelID: "grok-4.5", BaseURL: server.URL + "/v1", APIBackend: auth.GrokProtocolMessages}}})
+	body := []byte(`{
+		"model":"grok-4.5","stream":true,
+		"tools":[{"type":"custom","name":"run_patch","description":"synthetic custom tool"}],
+		"input":[{"type":"message","role":"user","content":"use the tool"}]
+	}`)
+	resp, err := ExecuteGrokProtocolRequest(context.Background(), account, GrokProtocolResponses, nil, body, "", nil)
+	if err != nil {
+		t.Fatalf("ExecuteGrokProtocolRequest: %v", err)
+	}
+	defer resp.Body.Close()
+	stream, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	events := grokResponseSSEEvents(stream)
+	var inputDone, itemDone, completed gjson.Result
+	for _, event := range events {
+		switch event.Get("type").String() {
+		case "response.custom_tool_call_input.done":
+			inputDone = event
+		case "response.output_item.done":
+			itemDone = event
+		case "response.completed":
+			completed = event
+		}
+	}
+	if inputDone.Get("input").String() != "message patch" || itemDone.Get("item.type").String() != "custom_tool_call" || completed.Get("response.output.0.type").String() != "custom_tool_call" {
+		t.Fatalf("Messages custom tool was not restored: %s", stream)
 	}
 }
 
@@ -471,7 +687,10 @@ func TestMessagesAdapterRequiresMessageStopAndKeepsSparseTools(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !bytes.Contains(data, []byte(`"call_id":"call3"`)) || !bytes.Contains(data, []byte(`"type":"response.completed"`)) {
+	if !bytes.Contains(data, []byte(`"call_id":"call3"`)) ||
+		!bytes.Contains(data, []byte(`"type":"response.function_call_arguments.done"`)) ||
+		!bytes.Contains(data, []byte(`"type":"response.output_item.done"`)) ||
+		!bytes.Contains(data, []byte(`"type":"response.completed"`)) {
 		t.Fatalf("sparse tool terminal lost: %s", data)
 	}
 
@@ -484,6 +703,24 @@ func TestMessagesAdapterRequiresMessageStopAndKeepsSparseTools(t *testing.T) {
 	}
 	if bytes.Contains(data, []byte(`"type":"response.completed"`)) || !bytes.Contains(data, []byte(ErrorCodeUpstreamStreamBreak)) {
 		t.Fatalf("missing message_stop was treated as success: %s", data)
+	}
+
+	truncated := io.NopCloser(bytes.NewBufferString(
+		"data: {\"type\":\"message_start\",\"message\":{\"id\":\"m1\",\"model\":\"grok\",\"usage\":{\"input_tokens\":1}}}\n\n" +
+			"data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"tool_use\",\"id\":\"call_partial\",\"name\":\"lookup\"}}\n\n" +
+			"data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"query\\\":\"}}\n\n" +
+			"data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"max_tokens\"},\"usage\":{\"output_tokens\":1}}\n\n" +
+			"data: {\"type\":\"message_stop\"}\n\n"))
+	data, err = io.ReadAll(newMessagesToResponsesReader(truncated, "grok"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(data, []byte(`"type":"response.function_call_arguments.done"`)) || bytes.Contains(data, []byte(`"type":"response.output_item.done"`)) {
+		t.Fatalf("truncated Messages tool input was marked complete: %s", data)
+	}
+	completed := completedGrokResponseEvent(t, data)
+	if got := gjson.GetBytes(completed, "response.output.0.status").String(); got != "incomplete" {
+		t.Fatalf("truncated Messages tool status = %q, want incomplete: %s", got, completed)
 	}
 }
 
@@ -566,17 +803,48 @@ func TestChatAdapterFinishWithoutUsageChunkStillCompletesAtEOF(t *testing.T) {
 	}
 }
 
+func TestChatAdapterDoesNotCompleteTruncatedToolInput(t *testing.T) {
+	source := io.NopCloser(bytes.NewBufferString(
+		"data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_partial\",\"function\":{\"name\":\"lookup\",\"arguments\":\"{\\\"query\\\":\"}}]},\"finish_reason\":null}]}\n\n" +
+			"data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"length\"}],\"usage\":{\"prompt_tokens\":1,\"completion_tokens\":1,\"total_tokens\":2}}\n\n"))
+	stream, err := io.ReadAll(newChatToResponsesReader(source, "grok"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(stream, []byte(`"status":"incomplete"`)) {
+		t.Fatalf("truncated response did not remain incomplete: %s", stream)
+	}
+	if bytes.Contains(stream, []byte(`"type":"response.function_call_arguments.done"`)) || bytes.Contains(stream, []byte(`"type":"response.output_item.done"`)) {
+		t.Fatalf("truncated tool input was marked complete: %s", stream)
+	}
+	completed := completedGrokResponseEvent(t, stream)
+	if got := gjson.GetBytes(completed, "response.output.0.status").String(); got != "incomplete" {
+		t.Fatalf("truncated tool item status = %q, want incomplete: %s", got, completed)
+	}
+}
+
 func completedGrokResponseEvent(t *testing.T, stream []byte) []byte {
 	t.Helper()
-	for _, frame := range bytes.Split(stream, []byte("\n\n")) {
-		payload := bytes.TrimSpace(frame)
-		payload = bytes.TrimSpace(bytes.TrimPrefix(payload, []byte("data:")))
-		if gjson.GetBytes(payload, "type").String() == "response.completed" {
-			return append([]byte(nil), payload...)
+	for _, event := range grokResponseSSEEvents(stream) {
+		if event.Get("type").String() == "response.completed" {
+			return []byte(event.Raw)
 		}
 	}
 	t.Fatalf("response.completed missing from stream: %s", stream)
 	return nil
+}
+
+func grokResponseSSEEvents(stream []byte) []gjson.Result {
+	var events []gjson.Result
+	for _, frame := range bytes.Split(stream, []byte("\n\n")) {
+		payload := bytes.TrimSpace(frame)
+		payload = bytes.TrimSpace(bytes.TrimPrefix(payload, []byte("data:")))
+		if !gjson.ValidBytes(payload) {
+			continue
+		}
+		events = append(events, gjson.ParseBytes(append([]byte(nil), payload...)))
+	}
+	return events
 }
 
 func TestChatAdapterFinalOutputPreservesFirstEventOrderAndToolIdentity(t *testing.T) {


### PR DESCRIPTION
## Summary

- Normalize Codex `custom`, `namespace`, `tool_search`, and `additional_tools` before converting Responses requests to Chat Completions or Messages.
- Preserve request-local aliases through conversion and restore special tool calls after the upstream response is adapted back to Responses SSE.
- Emit complete function-call lifecycle events while keeping truncated tool inputs marked `incomplete`.

## Problem

Cross-protocol Grok routes converted canonical Responses requests before running the existing Grok tool preflight. The converter therefore rejected Codex-only tool declarations and history. On the response path, alias restoration wrapped raw Chat/Messages streams before they were adapted into Responses events, so it could not recognize the resulting tool calls.

Related report: https://github.com/Wei-Shaw/sub2api/issues/4710

## Tests

- Added Responses -> Chat end-to-end coverage for custom, namespace, tool-search, deferred tools, split tool metadata, restored events, and final output.
- Added Responses -> Messages end-to-end custom-tool coverage.
- Added completed and truncated tool lifecycle coverage for both adapters.
- `go test ./proxy -count=1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved tool-call handling across supported request and response formats.
  * Added clearer completion statuses for completed and incomplete tool interactions.
  * Preserved native requests while improving cross-format request conversion.
  * Applied reasoning-effort limits during request preparation.

* **Bug Fixes**
  * Improved response handling for wrapped or transformed responses.
  * Correctly handles truncated tool input without marking it complete.
  * Strengthened validation and restoration of tool names and aliases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->