### PR TITLE
fix(dispatch): keep reconciliation and health off hot locks

### DIFF
--- a/auth/dispatch_reconcile_test.go
+++ b/auth/dispatch_reconcile_test.go
@@ -192,3 +192,35 @@ func TestAsyncReconcileCoalescesOntoActiveRunCompletion(t *testing.T) {
 		t.Fatalf("Next() = account %d, want newly added account %d", got.ID(), accountID)
 	}
 }
+
+func TestTriggerDispatchStateReconcileAsyncThrottledReturnsNil(t *testing.T) {
+	ctx := context.Background()
+	db, err := database.New("sqlite", filepath.Join(t.TempDir(), "dispatch-reconcile-throttle.db"))
+	if err != nil {
+		t.Fatalf("database.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	store := NewStore(db, nil, &database.SystemSettings{MaxConcurrency: 1})
+	if err := store.Init(ctx); err != nil {
+		t.Fatalf("Store.Init: %v", err)
+	}
+
+	if _, err := store.ReconcileDispatchState(ctx); err != nil {
+		t.Fatalf("ReconcileDispatchState: %v", err)
+	}
+
+	// Inside the throttle window a new run would be a guaranteed no-op, so the
+	// trigger must return nil instead of an instantly-closed channel — callers
+	// use nil to skip their grace wait entirely.
+	if done := store.TriggerDispatchStateReconcileAsync(); done != nil {
+		t.Fatal("TriggerDispatchStateReconcileAsync() inside throttle window != nil")
+	}
+
+	// The throttled trigger must release ownership so a later run can start.
+	done, owner := store.beginDispatchStateReconcile()
+	if !owner {
+		t.Fatal("beginDispatchStateReconcile() after throttled trigger: ownership not released")
+	}
+	store.finishDispatchStateReconcile(done)
+}

--- a/auth/dispatch_reconcile_test.go
+++ b/auth/dispatch_reconcile_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/codex2api/database"
 )
@@ -52,5 +53,76 @@ func TestReconcileDispatchStateLoadsAccountAddedAfterStartup(t *testing.T) {
 	defer store.Release(got)
 	if got.ID() != accountID {
 		t.Fatalf("Next() = account %d, want newly added account %d", got.ID(), accountID)
+	}
+}
+
+func TestTriggerDispatchStateReconcileAsyncLoadsAccount(t *testing.T) {
+	ctx := context.Background()
+	db, err := database.New("sqlite", filepath.Join(t.TempDir(), "dispatch-reconcile-async.db"))
+	if err != nil {
+		t.Fatalf("database.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	store := NewStore(db, nil, &database.SystemSettings{
+		MaxConcurrency:       1,
+		FastSchedulerEnabled: true,
+	})
+	if err := store.Init(ctx); err != nil {
+		t.Fatalf("Store.Init: %v", err)
+	}
+
+	accountID, err := db.InsertOpenAIResponsesAccount(ctx, "async-endpoint", map[string]interface{}{
+		"upstream_type": UpstreamOpenAIResponses,
+		"base_url":      "https://healthy.example",
+		"api_key":       "sk-async",
+		"models":        []string{"gpt-5.6"},
+	}, "")
+	if err != nil {
+		t.Fatalf("InsertOpenAIResponsesAccount: %v", err)
+	}
+
+	done := store.TriggerDispatchStateReconcileAsync()
+	if done == nil {
+		t.Fatal("TriggerDispatchStateReconcileAsync() = nil")
+	}
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("asynchronous dispatch reconciliation did not finish")
+	}
+	got := store.Next()
+	if got == nil {
+		t.Fatal("Next() returned nil after asynchronous dispatch reconciliation")
+	}
+	defer store.Release(got)
+	if got.ID() != accountID {
+		t.Fatalf("Next() = account %d, want newly added account %d", got.ID(), accountID)
+	}
+}
+
+func TestReconcileDispatchStateDoesNotQueueBehindAnotherRun(t *testing.T) {
+	ctx := context.Background()
+	db, err := database.New("sqlite", filepath.Join(t.TempDir(), "dispatch-reconcile-singleflight.db"))
+	if err != nil {
+		t.Fatalf("database.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	store := NewStore(db, nil, &database.SystemSettings{MaxConcurrency: 1})
+	store.dispatchReconcileMu.Lock()
+	defer store.dispatchReconcileMu.Unlock()
+
+	started := time.Now()
+	changed, err := store.ReconcileDispatchState(ctx)
+	if err != nil {
+		t.Fatalf("ReconcileDispatchState: %v", err)
+	}
+	if changed {
+		t.Fatal("ReconcileDispatchState reported a change while another run owned the lock")
+	}
+	if elapsed := time.Since(started); elapsed > 100*time.Millisecond {
+		t.Fatalf("ReconcileDispatchState queued behind another run for %s", elapsed)
 	}
 }

--- a/auth/dispatch_reconcile_test.go
+++ b/auth/dispatch_reconcile_test.go
@@ -111,8 +111,11 @@ func TestReconcileDispatchStateDoesNotQueueBehindAnotherRun(t *testing.T) {
 	t.Cleanup(func() { _ = db.Close() })
 
 	store := NewStore(db, nil, &database.SystemSettings{MaxConcurrency: 1})
-	store.dispatchReconcileMu.Lock()
-	defer store.dispatchReconcileMu.Unlock()
+	done, owner := store.beginDispatchStateReconcile()
+	if !owner {
+		t.Fatal("beginDispatchStateReconcile() owner = false, want true")
+	}
+	defer store.finishDispatchStateReconcile(done)
 
 	started := time.Now()
 	changed, err := store.ReconcileDispatchState(ctx)
@@ -124,5 +127,68 @@ func TestReconcileDispatchStateDoesNotQueueBehindAnotherRun(t *testing.T) {
 	}
 	if elapsed := time.Since(started); elapsed > 100*time.Millisecond {
 		t.Fatalf("ReconcileDispatchState queued behind another run for %s", elapsed)
+	}
+}
+
+func TestAsyncReconcileCoalescesOntoActiveRunCompletion(t *testing.T) {
+	ctx := context.Background()
+	db, err := database.New("sqlite", filepath.Join(t.TempDir(), "dispatch-reconcile-interleaving.db"))
+	if err != nil {
+		t.Fatalf("database.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	store := NewStore(db, nil, &database.SystemSettings{
+		MaxConcurrency:       1,
+		FastSchedulerEnabled: true,
+	})
+	if err := store.Init(ctx); err != nil {
+		t.Fatalf("Store.Init: %v", err)
+	}
+	accountID, err := db.InsertOpenAIResponsesAccount(ctx, "interleaved-endpoint", map[string]interface{}{
+		"upstream_type": UpstreamOpenAIResponses,
+		"base_url":      "https://healthy.example",
+		"api_key":       "sk-interleaved",
+		"models":        []string{"gpt-5.6"},
+	}, "")
+	if err != nil {
+		t.Fatalf("InsertOpenAIResponsesAccount: %v", err)
+	}
+
+	activeDone, owner := store.beginDispatchStateReconcile()
+	if !owner {
+		t.Fatal("beginDispatchStateReconcile() owner = false, want true")
+	}
+	asyncDone := store.TriggerDispatchStateReconcileAsync()
+	if asyncDone != activeDone {
+		t.Fatal("async trigger did not coalesce onto the active reconciliation")
+	}
+	select {
+	case <-asyncDone:
+		t.Fatal("active reconciliation completion closed before the active run finished")
+	default:
+	}
+
+	changed, err := store.reconcileDispatchState(ctx)
+	if err != nil {
+		t.Fatalf("reconcileDispatchState: %v", err)
+	}
+	if !changed {
+		t.Fatal("reconcileDispatchState reported no change for a newly added account")
+	}
+	store.finishDispatchStateReconcile(activeDone)
+	select {
+	case <-asyncDone:
+	case <-time.After(time.Second):
+		t.Fatal("coalesced completion did not close after the active run finished")
+	}
+
+	got := store.Next()
+	if got == nil {
+		t.Fatal("Next() returned nil after the active reconciliation completed")
+	}
+	defer store.Release(got)
+	if got.ID() != accountID {
+		t.Fatalf("Next() = account %d, want newly added account %d", got.ID(), accountID)
 	}
 }

--- a/auth/health_counts_test.go
+++ b/auth/health_counts_test.go
@@ -1,0 +1,38 @@
+package auth
+
+import "testing"
+
+func TestHealthCountsNonBlockingSkipsBusyStoreLock(t *testing.T) {
+	store := &Store{}
+	store.mu.Lock()
+	defer store.mu.Unlock()
+
+	available, total, complete := store.HealthCountsNonBlocking()
+	if available != -1 || total != -1 || complete {
+		t.Fatalf("HealthCountsNonBlocking() = (%d, %d, %v), want (-1, -1, false)", available, total, complete)
+	}
+}
+
+func TestHealthCountsNonBlockingMarksBusyAccountIncomplete(t *testing.T) {
+	account := &Account{AccessToken: "token"}
+	store := &Store{accounts: []*Account{account}}
+	account.mu.Lock()
+	defer account.mu.Unlock()
+
+	available, total, complete := store.HealthCountsNonBlocking()
+	if available != 0 || total != 1 || complete {
+		t.Fatalf("HealthCountsNonBlocking() = (%d, %d, %v), want (0, 1, false)", available, total, complete)
+	}
+}
+
+func TestHealthCountsNonBlockingCountsAvailableAccounts(t *testing.T) {
+	store := &Store{accounts: []*Account{
+		{AccessToken: "available"},
+		{AccessToken: "disabled", Disabled: 1},
+	}}
+
+	available, total, complete := store.HealthCountsNonBlocking()
+	if available != 1 || total != 2 || !complete {
+		t.Fatalf("HealthCountsNonBlocking() = (%d, %d, %v), want (1, 2, true)", available, total, complete)
+	}
+}

--- a/auth/health_counts_test.go
+++ b/auth/health_counts_test.go
@@ -36,3 +36,31 @@ func TestHealthCountsNonBlockingCountsAvailableAccounts(t *testing.T) {
 		t.Fatalf("HealthCountsNonBlocking() = (%d, %d, %v), want (1, 2, true)", available, total, complete)
 	}
 }
+
+func TestHealthCountsNonBlockingSkipsDispatchPausedAccounts(t *testing.T) {
+	store := &Store{accounts: []*Account{
+		{AccessToken: "available"},
+		{AccessToken: "paused", DispatchPaused: 1},
+	}}
+
+	available, total, complete := store.HealthCountsNonBlocking()
+	if available != 1 || total != 2 || !complete {
+		t.Fatalf("HealthCountsNonBlocking() = (%d, %d, %v), want (1, 2, true)", available, total, complete)
+	}
+}
+
+func TestHealthCountsNonBlockingHonorsLazyMode(t *testing.T) {
+	refreshOnly := &Account{RefreshToken: "rt-only"}
+	store := &Store{accounts: []*Account{refreshOnly}}
+
+	available, _, complete := store.HealthCountsNonBlocking()
+	if available != 0 || !complete {
+		t.Fatalf("non-lazy HealthCountsNonBlocking() = (%d, complete=%v), want refresh-only account unavailable", available, complete)
+	}
+
+	store.lazyMode.Store(true)
+	available, total, complete := store.HealthCountsNonBlocking()
+	if available != 1 || total != 1 || !complete {
+		t.Fatalf("lazy HealthCountsNonBlocking() = (%d, %d, %v), want (1, 1, true)", available, total, complete)
+	}
+}

--- a/auth/store.go
+++ b/auth/store.go
@@ -3080,7 +3080,6 @@ type Store struct {
 	// Fast scheduler POC（默认关闭，通过环境变量启用）
 	fastScheduler            atomic.Pointer[FastScheduler]
 	fastSchedulerEnabled     atomic.Bool
-	dispatchReconcileMu      sync.Mutex
 	dispatchReconcileStateMu sync.Mutex
 	dispatchReconcileDone    chan struct{}
 	dispatchReconciledAt     int64
@@ -4998,19 +4997,17 @@ func (s *Store) ReconcileDispatchState(ctx context.Context) (bool, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	now := time.Now()
-	if last := atomic.LoadInt64(&s.dispatchReconciledAt); last > 0 && now.Sub(time.Unix(0, last)) < dispatchStateReconcileInterval {
-		return false, nil
-	}
 
-	// A miss can be observed by many requests at once. Never queue request
-	// goroutines behind a full database reconciliation; one caller is enough
-	// and the async trigger below coalesces the rest.
-	if !s.dispatchReconcileMu.TryLock() {
+	done, owner := s.beginDispatchStateReconcile()
+	if !owner {
 		return false, nil
 	}
-	defer s.dispatchReconcileMu.Unlock()
-	now = time.Now()
+	defer s.finishDispatchStateReconcile(done)
+	return s.reconcileDispatchState(ctx)
+}
+
+func (s *Store) reconcileDispatchState(ctx context.Context) (bool, error) {
+	now := time.Now()
 	if last := atomic.LoadInt64(&s.dispatchReconciledAt); last > 0 && now.Sub(time.Unix(0, last)) < dispatchStateReconcileInterval {
 		return false, nil
 	}
@@ -5111,6 +5108,27 @@ func (s *Store) ReconcileDispatchState(ctx context.Context) (bool, error) {
 	return changed, nil
 }
 
+func (s *Store) beginDispatchStateReconcile() (chan struct{}, bool) {
+	s.dispatchReconcileStateMu.Lock()
+	defer s.dispatchReconcileStateMu.Unlock()
+	if s.dispatchReconcileDone != nil {
+		return s.dispatchReconcileDone, false
+	}
+	done := make(chan struct{})
+	s.dispatchReconcileDone = done
+	return done, true
+}
+
+func (s *Store) finishDispatchStateReconcile(done chan struct{}) {
+	s.dispatchReconcileStateMu.Lock()
+	defer s.dispatchReconcileStateMu.Unlock()
+	if s.dispatchReconcileDone != done {
+		return
+	}
+	s.dispatchReconcileDone = nil
+	close(done)
+}
+
 // TriggerDispatchStateReconcileAsync refreshes the in-memory dispatch
 // projection without putting the request path on the database scan. A miss
 // can fan out across many requests during an upstream outage, so this is
@@ -5120,29 +5138,15 @@ func (s *Store) TriggerDispatchStateReconcileAsync() <-chan struct{} {
 		return nil
 	}
 
-	s.dispatchReconcileStateMu.Lock()
-	if s.dispatchReconcileDone != nil {
-		done := s.dispatchReconcileDone
-		s.dispatchReconcileStateMu.Unlock()
+	done, owner := s.beginDispatchStateReconcile()
+	if !owner {
 		return done
 	}
-	done := make(chan struct{})
-	s.dispatchReconcileDone = done
-	s.dispatchReconcileStateMu.Unlock()
-
-	finish := func() {
-		s.dispatchReconcileStateMu.Lock()
-		if s.dispatchReconcileDone == done {
-			s.dispatchReconcileDone = nil
-			close(done)
-		}
-		s.dispatchReconcileStateMu.Unlock()
-	}
 	if !s.startDBBackgroundTask(func(parent context.Context) {
-		defer finish()
+		defer s.finishDispatchStateReconcile(done)
 		ctx, cancel := context.WithTimeout(parent, dispatchStateReconcileTimeout)
 		defer cancel()
-		if changed, err := s.ReconcileDispatchState(ctx); err != nil {
+		if changed, err := s.reconcileDispatchState(ctx); err != nil {
 			if !errors.Is(err, context.Canceled) {
 				log.Printf("异步调度状态重建失败: %v", err)
 			}
@@ -5150,7 +5154,7 @@ func (s *Store) TriggerDispatchStateReconcileAsync() <-chan struct{} {
 			log.Printf("异步调度状态重建完成")
 		}
 	}) {
-		finish()
+		s.finishDispatchStateReconcile(done)
 	}
 	return done
 }

--- a/auth/store.go
+++ b/auth/store.go
@@ -1236,16 +1236,19 @@ func (a *Account) IsAvailable() bool {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
 
+	return a.isAvailableLocked(time.Now())
+}
+
+func (a *Account) isAvailableLocked(now time.Time) bool {
 	if a.Status == StatusError {
 		return false
 	}
 	if a.healthTierLocked() == HealthTierBanned {
 		return false
 	}
-	if a.Status == StatusCooldown && time.Now().Before(a.CooldownUtil) {
+	if a.Status == StatusCooldown && now.Before(a.CooldownUtil) {
 		return false
 	}
-	now := time.Now()
 	// IgnoreUsageLimitStatus only protects an already active continuation;
 	// fresh sessions remain fenced by the latest local usage observation.
 	if a.usageWindowBlocksFreshDispatchLocked(now) {
@@ -9789,6 +9792,41 @@ func (s *Store) AvailableCount() int {
 		}
 	}
 	return count
+}
+
+// HealthCountsNonBlocking returns best-effort account counts without waiting on
+// hot request-path locks. It is intended for liveness endpoints.
+func (s *Store) HealthCountsNonBlocking() (available int, total int, complete bool) {
+	if s == nil {
+		return 0, 0, true
+	}
+	if !s.mu.TryRLock() {
+		return -1, -1, false
+	}
+	accounts := make([]*Account, len(s.accounts))
+	copy(accounts, s.accounts)
+	s.mu.RUnlock()
+
+	complete = true
+	total = len(accounts)
+	now := time.Now()
+	for _, acc := range accounts {
+		if acc == nil {
+			continue
+		}
+		if atomic.LoadInt32(&acc.Disabled) != 0 || atomic.LoadInt32(&acc.DispatchPaused) != 0 {
+			continue
+		}
+		if !acc.mu.TryRLock() {
+			complete = false
+			continue
+		}
+		if acc.isAvailableLocked(now) {
+			available++
+		}
+		acc.mu.RUnlock()
+	}
+	return available, total, complete
 }
 
 // Accounts 返回所有账号（用于统计）

--- a/auth/store.go
+++ b/auth/store.go
@@ -4965,7 +4965,11 @@ func (s *Store) LoadAccountByID(ctx context.Context, dbID int64) error {
 
 const (
 	dispatchStateReconcileInterval = time.Second
-	dispatchStateReconcileTimeout  = 5 * time.Second
+	// dispatchStateReconcileTimeout bounds the detached background scan. This
+	// is the only runtime path that reloads cross-process account changes, so
+	// the bound must comfortably exceed a full-pool scan on a slow database —
+	// a scan that always times out would starve cross-process pickup forever.
+	dispatchStateReconcileTimeout = 30 * time.Second
 )
 
 func openAIResponsesRuntimeConfigDiffers(acc *Account, row *database.AccountRow) bool {
@@ -5021,11 +5025,15 @@ func (s *Store) reconcileDispatchState(ctx context.Context) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("reconcile account groups: %w", err)
 	}
-	modelCooldowns := make(map[int64][]*database.AccountModelCooldownRow)
-	if cooldownRows, cooldownErr := s.db.ListActiveModelCooldowns(ctx); cooldownErr == nil {
-		for _, cooldown := range cooldownRows {
-			modelCooldowns[cooldown.AccountID] = append(modelCooldowns[cooldown.AccountID], cooldown)
-		}
+	cooldownRows, cooldownErr := s.db.ListActiveModelCooldowns(ctx)
+	if cooldownErr != nil {
+		// Proceeding with an empty map would let newly discovered accounts
+		// enter dispatch without their persisted model cooldowns.
+		return false, fmt.Errorf("reconcile model cooldowns: %w", cooldownErr)
+	}
+	modelCooldowns := make(map[int64][]*database.AccountModelCooldownRow, len(cooldownRows))
+	for _, cooldown := range cooldownRows {
+		modelCooldowns[cooldown.AccountID] = append(modelCooldowns[cooldown.AccountID], cooldown)
 	}
 
 	changed := false
@@ -5141,6 +5149,15 @@ func (s *Store) TriggerDispatchStateReconcileAsync() <-chan struct{} {
 	done, owner := s.beginDispatchStateReconcile()
 	if !owner {
 		return done
+	}
+	// Inside the throttle window a fresh run would be a guaranteed no-op:
+	// return nil so callers skip their grace wait instead of receiving an
+	// instantly-closed channel, and no throwaway goroutine is spawned. The
+	// check sits after ownership acquisition so callers racing an in-flight
+	// run still coalesce onto its completion channel above.
+	if last := atomic.LoadInt64(&s.dispatchReconciledAt); last > 0 && time.Since(time.Unix(0, last)) < dispatchStateReconcileInterval {
+		s.finishDispatchStateReconcile(done)
+		return nil
 	}
 	if !s.startDBBackgroundTask(func(parent context.Context) {
 		defer s.finishDispatchStateReconcile(done)
@@ -5565,28 +5582,31 @@ func (s *Store) accountLazySelectable(acc *Account) bool {
 
 	acc.mu.RLock()
 	defer acc.mu.RUnlock()
-	now := time.Now()
-	if acc.Status == StatusError {
+	return acc.lazySelectableLocked(time.Now())
+}
+
+func (a *Account) lazySelectableLocked(now time.Time) bool {
+	if a.Status == StatusError {
 		return false
 	}
-	if acc.healthTierLocked() == HealthTierBanned {
+	if a.healthTierLocked() == HealthTierBanned {
 		return false
 	}
-	if acc.usageWindowBlocksFreshDispatchLocked(now) {
+	if a.usageWindowBlocksFreshDispatchLocked(now) {
 		return false
 	}
-	if acc.Status == StatusCooldown && now.Before(acc.CooldownUtil) {
+	if a.Status == StatusCooldown && now.Before(a.CooldownUtil) {
 		return false
 	}
-	if acc.quotaAutoPausedLocked(now) {
+	if a.quotaAutoPausedLocked(now) {
 		return false
 	}
-	if acc.isRelayStyleLocked() {
+	if a.isRelayStyleLocked() {
 		return true
 	}
-	return strings.TrimSpace(acc.AccessToken) != "" ||
-		strings.TrimSpace(acc.RefreshToken) != "" ||
-		strings.TrimSpace(acc.SessionToken) != ""
+	return strings.TrimSpace(a.AccessToken) != "" ||
+		strings.TrimSpace(a.RefreshToken) != "" ||
+		strings.TrimSpace(a.SessionToken) != ""
 }
 
 func (s *Store) ensureLazyDispatchReady(acc *Account) bool {
@@ -9814,6 +9834,7 @@ func (s *Store) HealthCountsNonBlocking() (available int, total int, complete bo
 	complete = true
 	total = len(accounts)
 	now := time.Now()
+	lazy := s.GetLazyMode()
 	for _, acc := range accounts {
 		if acc == nil {
 			continue
@@ -9825,7 +9846,10 @@ func (s *Store) HealthCountsNonBlocking() (available int, total int, complete bo
 			complete = false
 			continue
 		}
-		if acc.isAvailableLocked(now) {
+		// Mirror AvailableCount: lazy mode accepts refresh/session-token-only
+		// accounts that hydrate on demand, otherwise a healthy lazy pool would
+		// report zero available.
+		if (lazy && acc.lazySelectableLocked(now)) || (!lazy && acc.isAvailableLocked(now)) {
 			available++
 		}
 		acc.mu.RUnlock()

--- a/auth/store.go
+++ b/auth/store.go
@@ -3075,10 +3075,12 @@ type Store struct {
 	proxyRoundRobin      uint64              // 轮询计数器
 
 	// Fast scheduler POC（默认关闭，通过环境变量启用）
-	fastScheduler        atomic.Pointer[FastScheduler]
-	fastSchedulerEnabled atomic.Bool
-	dispatchReconcileMu  sync.Mutex
-	dispatchReconciledAt int64
+	fastScheduler            atomic.Pointer[FastScheduler]
+	fastSchedulerEnabled     atomic.Bool
+	dispatchReconcileMu      sync.Mutex
+	dispatchReconcileStateMu sync.Mutex
+	dispatchReconcileDone    chan struct{}
+	dispatchReconciledAt     int64
 
 	// Codex 上游 WebSocket 相关（默认全部关闭，不影响现有 HTTP 路径）
 	codexForceWebsocket         atomic.Bool  // 强制 Codex 上游走 WebSocket（复用连接池）
@@ -4959,7 +4961,10 @@ func (s *Store) LoadAccountByID(ctx context.Context, dbID int64) error {
 	return nil
 }
 
-const dispatchStateReconcileInterval = time.Second
+const (
+	dispatchStateReconcileInterval = time.Second
+	dispatchStateReconcileTimeout  = 5 * time.Second
+)
 
 func openAIResponsesRuntimeConfigDiffers(acc *Account, row *database.AccountRow) bool {
 	if acc == nil || row == nil ||
@@ -4995,7 +5000,12 @@ func (s *Store) ReconcileDispatchState(ctx context.Context) (bool, error) {
 		return false, nil
 	}
 
-	s.dispatchReconcileMu.Lock()
+	// A miss can be observed by many requests at once. Never queue request
+	// goroutines behind a full database reconciliation; one caller is enough
+	// and the async trigger below coalesces the rest.
+	if !s.dispatchReconcileMu.TryLock() {
+		return false, nil
+	}
 	defer s.dispatchReconcileMu.Unlock()
 	now = time.Now()
 	if last := atomic.LoadInt64(&s.dispatchReconciledAt); last > 0 && now.Sub(time.Unix(0, last)) < dispatchStateReconcileInterval {
@@ -5096,6 +5106,50 @@ func (s *Store) ReconcileDispatchState(ctx context.Context) (bool, error) {
 		}
 	}
 	return changed, nil
+}
+
+// TriggerDispatchStateReconcileAsync refreshes the in-memory dispatch
+// projection without putting the request path on the database scan. A miss
+// can fan out across many requests during an upstream outage, so this is
+// deliberately single-flight and bounded by a short timeout.
+func (s *Store) TriggerDispatchStateReconcileAsync() <-chan struct{} {
+	if s == nil || s.db == nil {
+		return nil
+	}
+
+	s.dispatchReconcileStateMu.Lock()
+	if s.dispatchReconcileDone != nil {
+		done := s.dispatchReconcileDone
+		s.dispatchReconcileStateMu.Unlock()
+		return done
+	}
+	done := make(chan struct{})
+	s.dispatchReconcileDone = done
+	s.dispatchReconcileStateMu.Unlock()
+
+	finish := func() {
+		s.dispatchReconcileStateMu.Lock()
+		if s.dispatchReconcileDone == done {
+			s.dispatchReconcileDone = nil
+			close(done)
+		}
+		s.dispatchReconcileStateMu.Unlock()
+	}
+	if !s.startDBBackgroundTask(func(parent context.Context) {
+		defer finish()
+		ctx, cancel := context.WithTimeout(parent, dispatchStateReconcileTimeout)
+		defer cancel()
+		if changed, err := s.ReconcileDispatchState(ctx); err != nil {
+			if !errors.Is(err, context.Canceled) {
+				log.Printf("异步调度状态重建失败: %v", err)
+			}
+		} else if changed {
+			log.Printf("异步调度状态重建完成")
+		}
+	}) {
+		finish()
+	}
+	return done
 }
 
 // StartBackgroundRefresh 启动后台定期刷新

--- a/main.go
+++ b/main.go
@@ -498,12 +498,14 @@ func main() {
 		c.Redirect(http.StatusFound, "/admin/")
 	})
 
-	// 健康检查
+	// 健康检查：只做非阻塞的尽力统计，避免账号热路径锁竞争拖死 liveness。
 	r.GET("/health", func(c *gin.Context) {
+		available, total, countsComplete := store.HealthCountsNonBlocking()
 		c.JSON(200, gin.H{
-			"status":    "ok",
-			"available": store.AvailableCount(),
-			"total":     store.AccountCount(),
+			"status":          "ok",
+			"available":       available,
+			"total":           total,
+			"counts_complete": countsComplete,
 		})
 	})
 

--- a/proxy/retry_exclusions.go
+++ b/proxy/retry_exclusions.go
@@ -182,6 +182,7 @@ func (h *Handler) nextRetryAccount(ctx context.Context, affinityKey string, apiK
 		if account != nil {
 			return account, stickyProxyURL
 		}
+		reconcileDone := h.store.TriggerDispatchStateReconcileAsync()
 		if preserveBinding {
 			account, stickyProxyURL = h.store.WaitForContinuationAvailableWithFilter(ctx, affinityKey, 30*time.Second, apiKeyID, exclude, filter)
 		} else {
@@ -190,10 +191,30 @@ func (h *Handler) nextRetryAccount(ctx context.Context, affinityKey string, apiK
 		if account != nil {
 			return account, stickyProxyURL
 		}
-		if changed, err := h.store.ReconcileDispatchState(ctx); err != nil {
-			log.Printf("调度 miss 后同步数据库账号状态失败: %v", err)
-		} else if changed {
-			continue
+		// If the scheduler had no candidates and returned immediately, give
+		// the shared background reconciliation a small bounded grace period.
+		// Requests never queue behind the database scan itself.
+		if reconcileDone != nil {
+			timer := time.NewTimer(250 * time.Millisecond)
+			select {
+			case <-reconcileDone:
+				if preserveBinding {
+					account, stickyProxyURL = h.store.NextForContinuationWithFilter(affinityKey, apiKeyID, exclude, filter)
+				} else {
+					account, stickyProxyURL = h.nextAccountForSessionWithFilter(affinityKey, apiKeyID, exclude, filter)
+				}
+			case <-timer.C:
+			case <-ctx.Done():
+			}
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			if account != nil {
+				return account, stickyProxyURL
+			}
 		}
 		if !exclusions.ResetSoft() {
 			return nil, ""

--- a/proxy/retry_exclusions.go
+++ b/proxy/retry_exclusions.go
@@ -166,10 +166,22 @@ func (h *Handler) nextRetryAccountForContinuation(ctx context.Context, affinityK
 	return h.nextRetryAccount(ctx, affinityKey, apiKeyID, exclusions, filter, true)
 }
 
+// reconcileGraceWait bounds how long a missed request waits for the shared
+// background reconciliation. Waiting on the single-flight done channel never
+// queues work behind the database scan; it only spends this request's own
+// latency budget, so it can afford to cover a realistic full-pool scan.
+const reconcileGraceWait = 2 * time.Second
+
+// maxReconcileReentries caps how many completed reconciliations a single
+// request may ride back into the selection loop, so continuous cross-process
+// churn cannot pin a request in the loop beyond its context lifetime.
+const maxReconcileReentries = 3
+
 func (h *Handler) nextRetryAccount(ctx context.Context, affinityKey string, apiKeyID int64, exclusions *retryAccountExclusions, filter auth.AccountFilter, preserveBinding bool) (*auth.Account, string) {
 	if h == nil || h.store == nil {
 		return nil, ""
 	}
+	reconcileReentries := 0
 	for {
 		exclude := exclusions.ForSelection()
 		var account *auth.Account
@@ -191,18 +203,24 @@ func (h *Handler) nextRetryAccount(ctx context.Context, affinityKey string, apiK
 		if account != nil {
 			return account, stickyProxyURL
 		}
-		// If the scheduler had no candidates and returned immediately, give
-		// the shared background reconciliation a small bounded grace period.
-		// Requests never queue behind the database scan itself.
-		if reconcileDone != nil {
-			timer := time.NewTimer(250 * time.Millisecond)
+		if reconcileDone == nil {
+			// The pre-wait trigger may have been throttled; after a long wait
+			// the in-memory state can be stale again, so give the post-wait
+			// moment one more chance to own or join a reconciliation.
+			reconcileDone = h.store.TriggerDispatchStateReconcileAsync()
+		}
+		// If the scheduler had no candidates and returned immediately, wait a
+		// bounded grace period for the shared background reconciliation, then
+		// re-enter the full selection loop (including the availability wait)
+		// so a repaired pool restores the old queueing semantics instead of
+		// granting a single immediate re-check. Requests never queue behind
+		// the database scan itself.
+		if reconcileDone != nil && reconcileReentries < maxReconcileReentries && ctx.Err() == nil {
+			timer := time.NewTimer(reconcileGraceWait)
+			reconciled := false
 			select {
 			case <-reconcileDone:
-				if preserveBinding {
-					account, stickyProxyURL = h.store.NextForContinuationWithFilter(affinityKey, apiKeyID, exclude, filter)
-				} else {
-					account, stickyProxyURL = h.nextAccountForSessionWithFilter(affinityKey, apiKeyID, exclude, filter)
-				}
+				reconciled = true
 			case <-timer.C:
 			case <-ctx.Done():
 			}
@@ -212,9 +230,13 @@ func (h *Handler) nextRetryAccount(ctx context.Context, affinityKey string, apiK
 				default:
 				}
 			}
-			if account != nil {
-				return account, stickyProxyURL
+			if reconciled && ctx.Err() == nil {
+				reconcileReentries++
+				continue
 			}
+		}
+		if ctx.Err() != nil {
+			return nil, ""
 		}
 		if !exclusions.ResetSoft() {
 			return nil, ""

--- a/proxy/retry_reconcile_reentry_test.go
+++ b/proxy/retry_reconcile_reentry_test.go
@@ -1,0 +1,80 @@
+package proxy
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/codex2api/auth"
+	"github.com/codex2api/database"
+)
+
+func newReconcileReentryStore(t *testing.T, dbName string) (*auth.Store, *database.DB) {
+	t.Helper()
+	db, err := database.New("sqlite", filepath.Join(t.TempDir(), dbName))
+	if err != nil {
+		t.Fatalf("database.New: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	store := auth.NewStore(db, nil, &database.SystemSettings{
+		MaxConcurrency:       1,
+		FastSchedulerEnabled: true,
+	})
+	if err := store.Init(context.Background()); err != nil {
+		t.Fatalf("Store.Init: %v", err)
+	}
+	return store, db
+}
+
+// A scheduler miss must ride the shared background reconciliation back into
+// the full selection loop, so an account that only exists in the database
+// (added by another process) is picked up by the missed request itself.
+func TestNextRetryAccountReentersLoopAfterReconcile(t *testing.T) {
+	ctx := context.Background()
+	store, db := newReconcileReentryStore(t, "retry-reconcile-reentry.db")
+
+	accountID, err := db.InsertOpenAIResponsesAccount(ctx, "reentry-endpoint", map[string]interface{}{
+		"upstream_type": auth.UpstreamOpenAIResponses,
+		"base_url":      "https://healthy.example",
+		"api_key":       "sk-reentry",
+		"models":        []string{"gpt-5.6"},
+	}, "")
+	if err != nil {
+		t.Fatalf("InsertOpenAIResponsesAccount: %v", err)
+	}
+
+	handler := &Handler{store: store}
+	deadlineCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	account, _ := handler.nextRetryAccountForSession(deadlineCtx, "reentry-session", 0, newRetryAccountExclusions(), nil)
+	if account == nil {
+		t.Fatal("nextRetryAccount returned nil; expected the reconcile re-entry to pick up the database-only account")
+	}
+	defer store.Release(account)
+	if account.ID() != accountID {
+		t.Fatalf("nextRetryAccount = account %d, want database-only account %d", account.ID(), accountID)
+	}
+}
+
+// A canceled request must exit the retry loop promptly instead of running
+// another scheduler round or waiting out the reconcile grace period.
+func TestNextRetryAccountReturnsPromptlyOnCanceledContext(t *testing.T) {
+	store, _ := newReconcileReentryStore(t, "retry-reconcile-canceled.db")
+
+	handler := &Handler{store: store}
+	canceledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	started := time.Now()
+	account, _ := handler.nextRetryAccountForSession(canceledCtx, "canceled-session", 0, newRetryAccountExclusions(), nil)
+	if account != nil {
+		store.Release(account)
+		t.Fatal("nextRetryAccount returned an account for a canceled context")
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("nextRetryAccount took %s on a canceled context, want a prompt return", elapsed)
+	}
+}


### PR DESCRIPTION
## What happened

`ReconcileDispatchState` was added to the account-selection miss path in `167ae1d`. That puts three full database reads plus an account-pool rebuild directly behind live traffic:

- `ListActive`
- `ListAccountGroupMemberships`
- `ListActiveModelCooldowns`
- a pass over the full runtime account pool

This is a serious production regression. During an upstream overload, many requests miss at the same time. They first wait in the scheduler, then line up behind `dispatchReconcileMu`. One slow reconciliation turns an upstream incident into an application-wide queue, while `/health` can remain green because it does not exercise the affected path.

We reproduced this on a pool with roughly 7,000 database rows and 2,000+ loaded accounts. Scheduling time climbed into the 19–28 second range, requests accumulated for more than a minute, and graceful shutdown timed out. There was no panic, OOM, database saturation, or container crash.

A full database reconciliation should never be allowed to serialize the request path.

## What this changes

- starts reconciliation in the background as soon as account selection misses
- coalesces concurrent misses into one shared reconciliation
- gives the background run a hard 5-second deadline
- uses `TryLock` so no caller queues behind an active reconciliation
- lets a request wait at most 250ms for a shared run when the scheduler returns immediately
- retries in-memory selection after the shared run completes
- makes `/health` use best-effort `TryRLock` snapshots so liveness never waits on account locks
- reports `counts_complete=false` when health counts are partial instead of hanging

The existing cross-process state repair behavior is preserved. The difference is that a slow database scan can no longer freeze unrelated requests.

## Tests

- async reconciliation still loads accounts added by another process
- a second reconciliation does not wait behind the active run
- `go test ./...`
- `go vet ./...`
- targeted race test for dispatch reconciliation
- frontend typecheck, tests, and production build


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved account selection after scheduler misses by refreshing dispatch status asynchronously.
  - Prevented concurrent refresh attempts from blocking request handling or duplicating work.
  - Improved retry behavior by briefly waiting for newly available account state.

- **Improvements**
  - Made health checks more responsive when account data is busy.
  - Added an indicator showing whether reported account counts are complete.
  - Improved handling of paused, unavailable, and lazily loaded accounts during health checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->