### PR TITLE
[codex] fix account state overlays in Safari

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -32,6 +32,10 @@ jobs:
         working-directory: frontend
         run: npm ci
 
+      - name: Test frontend
+        working-directory: frontend
+        run: npm test
+
       - name: Typecheck frontend
         working-directory: frontend
         run: npm run typecheck

--- a/frontend/src/components/AccountStateOverlay.tsx
+++ b/frontend/src/components/AccountStateOverlay.tsx
@@ -4,34 +4,21 @@ import type { TFunction } from "i18next";
 import { cn } from "@/lib/utils";
 import type { AccountRow } from "../types";
 import { formatBeijingTime } from "../utils/time";
+import {
+  isDisabledAccountOverlayAccount,
+  resolveAccountOverlayKind,
+} from "../lib/accountStateOverlay";
+import type { AccountOverlayKind } from "../lib/accountStateOverlay";
 
-export type AccountOverlayKind = "disabled" | "overload";
-
-export function resolveAccountOverlayKind(
-  account: AccountRow,
-): AccountOverlayKind | null {
-  if (account.enabled === false) return "disabled";
-  if (account.status === "overload_paused") return "overload";
-  return null;
-}
-
-export function accountStateSurfaceClass(
-  account: AccountRow,
-  extraWhenActive = "",
-): string {
-  return resolveAccountOverlayKind(account)
-    ? ` account-state-surface${extraWhenActive}`
-    : "";
-}
-
-export function disabledAccountSurfaceClass(
-  account: AccountRow,
-  extraWhenActive = "",
-): string {
-  return account.enabled === false
-    ? ` account-state-surface${extraWhenActive}`
-    : "";
-}
+export {
+  accountStateSurfaceClass,
+  accountStateTableRowClass,
+  disabledAccountSurfaceClass,
+  disabledAccountTableRowClass,
+  isDisabledAccountOverlayAccount,
+  resolveAccountOverlayKind,
+} from "../lib/accountStateOverlay";
+export type { AccountOverlayKind } from "../lib/accountStateOverlay";
 
 function formatCountdownRemaining(untilMs: number, nowMs: number): string {
   const diff = Math.max(0, untilMs - nowMs);
@@ -72,6 +59,7 @@ export function AccountStateOverlay({
   kind,
   label,
   compact = false,
+  markerOnly = false,
   countdownUntil,
   resumingLabel,
   recoverLabel,
@@ -81,6 +69,7 @@ export function AccountStateOverlay({
   kind: AccountOverlayKind;
   label: string;
   compact?: boolean;
+  markerOnly?: boolean;
   countdownUntil?: string;
   resumingLabel?: string;
   recoverLabel?: string;
@@ -107,15 +96,27 @@ export function AccountStateOverlay({
   return (
     <div
       className={cn(
-        "account-state-overlay pointer-events-none absolute inset-0 z-10 overflow-hidden rounded-[inherit]",
+        "account-state-overlay pointer-events-none",
+        markerOnly
+          ? "account-state-overlay--marker-only w-full"
+          : "absolute inset-0 z-10 overflow-hidden rounded-[inherit]",
         isOverload
           ? "account-state-overlay--overload"
           : "account-state-overlay--disabled",
       )}
-      aria-hidden={!isOverload}
+      aria-hidden={markerOnly ? undefined : false}
     >
-      <div className="account-state-overlay__scrim absolute inset-0" />
-      <div className="account-state-overlay__mark absolute inset-0 flex items-center justify-center px-3">
+      {markerOnly ? null : (
+        <div className="account-state-overlay__scrim absolute inset-0" />
+      )}
+      <div
+        className={cn(
+          "account-state-overlay__mark flex items-center justify-center",
+          markerOnly
+            ? "account-state-overlay__mark--inline min-h-6 w-full"
+            : "absolute inset-0 px-3",
+        )}
+      >
         {isOverload && !compact ? (
           <div className="flex min-w-[188px] flex-col items-center gap-2 rounded-2xl border border-orange-300/60 bg-card/95 px-4 py-3 text-orange-800 shadow-[0_1px_2px_hsl(24_80%_20%/0.06),0_10px_28px_hsl(24_80%_20%/0.08)] backdrop-blur-md dark:border-orange-400/25 dark:text-orange-100 dark:shadow-[0_1px_2px_rgb(0_0_0/0.24),0_10px_28px_rgb(0_0_0/0.2)]">
             <div className="flex items-center gap-1.5">
@@ -153,7 +154,7 @@ export function AccountStateOverlay({
         ) : (
           <span
             className={cn(
-              "inline-flex items-center rounded-full border bg-card/95 shadow-[0_1px_2px_hsl(222_40%_11%/0.06),0_8px_24px_hsl(222_40%_11%/0.06)] backdrop-blur-md dark:shadow-[0_1px_2px_rgb(0_0_0/0.24),0_8px_24px_rgb(0_0_0/0.18)]",
+              "inline-flex max-w-full flex-wrap items-center justify-center rounded-full border bg-card/95 shadow-[0_1px_2px_hsl(222_40%_11%/0.06),0_8px_24px_hsl(222_40%_11%/0.06)] backdrop-blur-md dark:shadow-[0_1px_2px_rgb(0_0_0/0.24),0_8px_24px_rgb(0_0_0/0.18)]",
               compact && isOverload
                 ? "gap-2 py-1.5 pl-2 pr-2.5"
                 : compact
@@ -181,7 +182,7 @@ export function AccountStateOverlay({
             </span>
             <span
               className={cn(
-                "font-medium tracking-[0.04em]",
+                "whitespace-nowrap font-medium tracking-[0.04em]",
                 compact && isOverload ? "text-sm" : compact ? "text-[11px]" : "text-xs",
               )}
             >
@@ -190,7 +191,7 @@ export function AccountStateOverlay({
             {countdownText ? (
               <span
                 className={cn(
-                  "font-mono font-semibold tabular-nums tracking-wide",
+                  "whitespace-nowrap font-mono font-semibold tabular-nums tracking-wide",
                   compact && isOverload ? "text-sm" : compact ? "text-[11px]" : "text-xs",
                 )}
                 title={countdownUntil ? formatBeijingTime(countdownUntil) : undefined}
@@ -204,7 +205,7 @@ export function AccountStateOverlay({
                 disabled={busy}
                 onClick={(event) => void handleRecover(event)}
                 className={cn(
-                  "pointer-events-auto inline-flex items-center rounded-full bg-orange-600 font-medium text-white shadow-sm transition-colors hover:bg-orange-500 disabled:cursor-wait disabled:opacity-70 dark:bg-orange-500 dark:hover:bg-orange-400",
+                  "pointer-events-auto inline-flex items-center whitespace-nowrap rounded-full bg-orange-600 font-medium text-white shadow-sm transition-colors hover:bg-orange-500 disabled:cursor-wait disabled:opacity-70 dark:bg-orange-500 dark:hover:bg-orange-400",
                   compact ? "gap-1.5 px-2.5 py-1 text-xs" : "gap-1 px-2 py-0.5 text-[11px]",
                 )}
               >
@@ -228,6 +229,7 @@ export function renderAccountStateOverlay(
   t: TFunction,
   options: {
     compact?: boolean;
+    markerOnly?: boolean;
     onRecover?: () => void | Promise<void>;
   } = {},
 ) {
@@ -237,6 +239,7 @@ export function renderAccountStateOverlay(
     <AccountStateOverlay
       kind={kind}
       compact={options.compact}
+      markerOnly={options.markerOnly}
       label={
         kind === "disabled"
           ? t("accounts.disabledOverlay")
@@ -256,13 +259,14 @@ export function renderAccountStateOverlay(
 export function renderDisabledAccountOverlay(
   account: AccountRow,
   t: TFunction,
-  options: { compact?: boolean } = {},
+  options: { compact?: boolean; markerOnly?: boolean } = {},
 ) {
-  if (account.enabled !== false) return null;
+  if (!isDisabledAccountOverlayAccount(account)) return null;
   return (
     <AccountStateOverlay
       kind="disabled"
       compact={options.compact}
+      markerOnly={options.markerOnly}
       label={t("accounts.disabledOverlay")}
     />
   );

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1278,45 +1278,91 @@
 }
 
 /* 账号状态遮罩：霜面 + 细斜纹淡化内容，徽章保持清晰。
-   不用行级 opacity（会把徽章一起冲淡），也不用 filter（会破坏 tr 定位包含块）。
-   悬停时霜面退让，便于阅读和点击启用 / 恢复等操作。 */
+   卡片使用自身定位边界内的遮罩；表格直接绘制每个单元格的背景，
+   避免依赖 Safari 对 tr / td 绝对定位包含块的处理。 */
 .account-state-surface {
   isolation: isolate;
 }
 
-.account-state-overlay__scrim {
-  background-color: color-mix(in oklab, var(--color-background) 54%, transparent);
-  background-image:
-    linear-gradient(
-      180deg,
-      color-mix(in oklab, var(--color-background) 10%, transparent),
-      color-mix(in oklab, var(--color-foreground) 3.5%, transparent)
-    ),
-    repeating-linear-gradient(
-      -22deg,
-      transparent 0 9px,
-      color-mix(in oklab, var(--color-muted-foreground) 7%, transparent) 9px 10px
-    );
-  transition: opacity 180ms ease;
+.account-state-overlay--disabled,
+.account-state-table-row--disabled {
+  --account-state-background: color-mix(
+    in oklab,
+    var(--color-background) 54%,
+    transparent
+  );
+  --account-state-highlight: color-mix(
+    in oklab,
+    var(--color-background) 10%,
+    transparent
+  );
+  --account-state-shadow: color-mix(
+    in oklab,
+    var(--color-foreground) 3.5%,
+    transparent
+  );
+  --account-state-stripe: color-mix(
+    in oklab,
+    var(--color-muted-foreground) 7%,
+    transparent
+  );
 }
 
-.account-state-overlay--overload .account-state-overlay__scrim {
-  background-color: color-mix(
+.account-state-overlay--overload,
+.account-state-table-row--overload {
+  --account-state-background: color-mix(
     in oklab,
     hsl(28 86% 52%) 16%,
     color-mix(in oklab, var(--color-background) 50%, transparent)
   );
+  --account-state-highlight: color-mix(
+    in oklab,
+    hsl(32 90% 56%) 8%,
+    transparent
+  );
+  --account-state-shadow: color-mix(
+    in oklab,
+    var(--color-foreground) 3%,
+    transparent
+  );
+  --account-state-stripe: color-mix(
+    in oklab,
+    hsl(24 80% 42%) 10%,
+    transparent
+  );
+}
+
+.account-state-overlay__scrim,
+.account-state-table-row > [data-slot="table-cell"] {
+  background-color: var(--account-state-background);
   background-image:
     linear-gradient(
       180deg,
-      color-mix(in oklab, hsl(32 90% 56%) 8%, transparent),
-      color-mix(in oklab, var(--color-foreground) 3%, transparent)
+      var(--account-state-highlight),
+      var(--account-state-shadow)
     ),
     repeating-linear-gradient(
       -22deg,
       transparent 0 9px,
-      color-mix(in oklab, hsl(24 80% 42%) 10%, transparent) 9px 10px
+      var(--account-state-stripe) 9px 10px
     );
+}
+
+.account-state-overlay__scrim {
+  transition: opacity 180ms ease;
+}
+
+.account-state-table-row > [data-slot="table-cell"] > :not(.account-state-overlay--marker-only) {
+  opacity: 0.64;
+  transition: opacity 180ms ease;
+}
+
+.account-state-table-row:hover > [data-slot="table-cell"] > :not(.account-state-overlay--marker-only) {
+  opacity: 0.88;
+}
+
+.account-state-table-row > [data-slot="table-cell"] > .account-state-overlay--marker-only {
+  opacity: 1;
 }
 
 .account-state-overlay__mark {
@@ -1331,12 +1377,18 @@
   opacity: 0.58;
 }
 
-.dark .account-state-overlay__scrim {
-  background-color: color-mix(in oklab, var(--color-background) 48%, transparent);
+.dark .account-state-overlay--disabled,
+.dark .account-state-table-row--disabled {
+  --account-state-background: color-mix(
+    in oklab,
+    var(--color-background) 48%,
+    transparent
+  );
 }
 
-.dark .account-state-overlay--overload .account-state-overlay__scrim {
-  background-color: color-mix(
+.dark .account-state-overlay--overload,
+.dark .account-state-table-row--overload {
+  --account-state-background: color-mix(
     in oklab,
     hsl(28 70% 42%) 18%,
     color-mix(in oklab, var(--color-background) 46%, transparent)

--- a/frontend/src/lib/accountStateOverlay.test.mjs
+++ b/frontend/src/lib/accountStateOverlay.test.mjs
@@ -1,0 +1,213 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import {
+  accountStateSurfaceClass,
+  accountStateTableRowClass,
+  disabledAccountSurfaceClass,
+  disabledAccountTableRowClass,
+  isDisabledAccountOverlayAccount,
+  resolveAccountOverlayKind,
+} from "./accountStateOverlay.ts";
+
+function sourceSlice(source, startMarker, endMarker) {
+  const start = source.indexOf(startMarker);
+  assert.notEqual(start, -1, `missing source marker: ${startMarker}`);
+  const end = source.indexOf(endMarker, start + startMarker.length);
+  assert.notEqual(end, -1, `missing source marker: ${endMarker}`);
+  return source.slice(start, end);
+}
+
+function sourceTail(source, startMarker) {
+  const start = source.indexOf(startMarker);
+  assert.notEqual(start, -1, `missing source marker: ${startMarker}`);
+  return source.slice(start);
+}
+
+function occurrenceCount(source, value) {
+  return source.split(value).length - 1;
+}
+
+test("account overlay kind keeps disabled precedence over overload", () => {
+  assert.equal(
+    resolveAccountOverlayKind({ enabled: false, status: "overload_paused" }),
+    "disabled",
+  );
+  assert.equal(
+    resolveAccountOverlayKind({ enabled: true, status: "overload_paused" }),
+    "overload",
+  );
+  assert.equal(resolveAccountOverlayKind({ enabled: true, status: "active" }), null);
+});
+
+test("disabled-only helpers reject active and overload accounts", () => {
+  const disabled = { enabled: false, status: "active" };
+  const overload = { enabled: true, status: "overload_paused" };
+  const active = { enabled: true, status: "active" };
+
+  assert.equal(isDisabledAccountOverlayAccount(disabled), true);
+  assert.equal(isDisabledAccountOverlayAccount(overload), false);
+  assert.equal(isDisabledAccountOverlayAccount(active), false);
+
+  assert.equal(accountStateSurfaceClass(disabled), " account-state-surface");
+  assert.equal(disabledAccountSurfaceClass(disabled), " account-state-surface");
+  assert.equal(disabledAccountSurfaceClass(overload), "");
+  assert.equal(disabledAccountSurfaceClass(active), "");
+
+  assert.equal(
+    accountStateTableRowClass(disabled),
+    " account-state-table-row account-state-table-row--disabled",
+  );
+  assert.equal(
+    accountStateTableRowClass(overload),
+    " account-state-table-row account-state-table-row--overload",
+  );
+  assert.equal(
+    disabledAccountTableRowClass(disabled),
+    " account-state-table-row account-state-table-row--disabled",
+  );
+  assert.equal(disabledAccountTableRowClass(overload), "");
+  assert.equal(disabledAccountTableRowClass(active), "");
+});
+
+test("table markers replace status content without entering selection cells", () => {
+  const accountsSource = readFileSync(
+    new URL("../pages/Accounts.tsx", import.meta.url),
+    "utf8",
+  );
+  const grokSource = readFileSync(
+    new URL("../pages/GrokAccounts.tsx", import.meta.url),
+    "utf8",
+  );
+
+  const accountsRow = sourceSlice(
+    accountsSource,
+    "const AccountTableRow = memo(function AccountTableRow(",
+    "// AccountMobileCard",
+  );
+  const grokRow = sourceSlice(
+    grokSource,
+    "function GrokAccountTableRow(",
+    "function grokFormatDollars",
+  );
+
+  const accountsSelectionCell = sourceSlice(
+    accountsRow,
+    "<TableCell>",
+    "{visibleColumns.sequence",
+  );
+  const accountsStatusCell = sourceSlice(
+    accountsRow,
+    '<TableCell data-account-state-cell="status">',
+    "{visibleColumns.today",
+  );
+  const grokSelectionCell = sourceSlice(
+    grokRow,
+    '<TableCell className="w-9">',
+    '<TableCell className="font-mono',
+  );
+  const grokStatusCell = sourceSlice(
+    grokRow,
+    '<TableCell data-account-state-cell="status">',
+    "<RequestCountPills account={account} compact />",
+  );
+
+  assert.match(accountsRow, /accountStateTableRowClass\(account\)/);
+  assert.match(grokRow, /disabledAccountTableRowClass\(account\)/);
+  assert.match(
+    accountsRow,
+    /const tableOverlay = renderAccountStateOverlay\(account, t, \{[\s\S]*?markerOnly: true,/,
+  );
+  assert.doesNotMatch(accountsRow, /\brenderDisabledAccountOverlay\(/);
+  assert.match(
+    grokRow,
+    /const tableOverlay = renderDisabledAccountOverlay\(account, t, \{[\s\S]*?markerOnly: true,/,
+  );
+  assert.doesNotMatch(grokRow, /\brenderAccountStateOverlay\(/);
+
+  assert.doesNotMatch(accountsSelectionCell, /\{tableOverlay\b/);
+  assert.doesNotMatch(grokSelectionCell, /\{tableOverlay\b/);
+  assert.match(accountsSelectionCell, /tableOverlayKind/);
+  assert.match(accountsSelectionCell, /className="sr-only"/);
+  assert.match(accountsSelectionCell, /actions\.resetStatus\(account\)/);
+  assert.match(accountsStatusCell, /\{tableOverlay \?\? \(/);
+  assert.match(grokStatusCell, /\{tableOverlay \?\? \(/);
+  assert.match(accountsStatusCell, /<AccountHealthBar/);
+  assert.match(grokStatusCell, /<AccountHealthBar/);
+  assert.equal(occurrenceCount(accountsRow, "{tableOverlay ?? ("), 1);
+  assert.equal(occurrenceCount(grokRow, "{tableOverlay ?? ("), 1);
+});
+
+test("table styling has no positioned scrim on internal table boxes", () => {
+  const cssSource = readFileSync(new URL("../index.css", import.meta.url), "utf8");
+  const tableRules = Array.from(
+    cssSource.matchAll(/[^{}]*\.account-state-table-row[^{}]*\{[^{}]*\}/g),
+    (match) => match[0],
+  );
+  const tableCss = tableRules.join("\n");
+
+  assert.ok(tableRules.length >= 6, "expected account table state rules");
+  assert.match(tableCss, /background-image:/);
+  assert.match(tableCss, /:not\(\.account-state-overlay--marker-only\)/);
+  assert.doesNotMatch(tableCss, /::(?:before|after)/);
+  assert.doesNotMatch(tableCss, /\bposition\s*:/);
+  assert.doesNotMatch(tableCss, /\binset\s*:/);
+});
+
+test("marker-only rendering stays in normal flow and is passed through", () => {
+  const componentSource = readFileSync(
+    new URL("../components/AccountStateOverlay.tsx", import.meta.url),
+    "utf8",
+  );
+  const overlayComponent = sourceSlice(
+    componentSource,
+    "export function AccountStateOverlay(",
+    "export function renderAccountStateOverlay(",
+  );
+  const accountRenderer = sourceSlice(
+    componentSource,
+    "export function renderAccountStateOverlay(",
+    "export function renderDisabledAccountOverlay(",
+  );
+  const disabledRenderer = sourceTail(
+    componentSource,
+    "export function renderDisabledAccountOverlay(",
+  );
+
+  assert.match(
+    overlayComponent,
+    /markerOnly\s*\?\s*"account-state-overlay--marker-only w-full"\s*:\s*"absolute inset-0/,
+  );
+  assert.match(
+    overlayComponent,
+    /markerOnly\s*\?\s*"account-state-overlay__mark--inline[^\"]*"\s*:\s*"absolute inset-0/,
+  );
+  assert.match(
+    overlayComponent,
+    /aria-hidden=\{markerOnly \? undefined : false\}/,
+  );
+  assert.equal(occurrenceCount(accountRenderer, "markerOnly={options.markerOnly}"), 1);
+  assert.equal(occurrenceCount(disabledRenderer, "markerOnly={options.markerOnly}"), 1);
+  assert.match(
+    disabledRenderer,
+    /if \(!isDisabledAccountOverlayAccount\(account\)\) return null;/,
+  );
+});
+
+test("pull request CI runs frontend regression tests", () => {
+  const workflowSource = readFileSync(
+    new URL("../../../.github/workflows/pr-check.yml", import.meta.url),
+    "utf8",
+  );
+  const frontendJob = sourceSlice(
+    workflowSource,
+    "  frontend:\n",
+    "  golangci-lint:\n",
+  );
+
+  assert.match(
+    frontendJob,
+    /- name: Test frontend\s+working-directory: frontend\s+run: npm test/,
+  );
+});

--- a/frontend/src/lib/accountStateOverlay.ts
+++ b/frontend/src/lib/accountStateOverlay.ts
@@ -1,0 +1,48 @@
+import type { AccountRow } from "../types";
+
+export type AccountOverlayKind = "disabled" | "overload";
+
+export function isDisabledAccountOverlayAccount(account: AccountRow): boolean {
+  return account.enabled === false;
+}
+
+export function resolveAccountOverlayKind(
+  account: AccountRow,
+): AccountOverlayKind | null {
+  if (isDisabledAccountOverlayAccount(account)) return "disabled";
+  if (account.status === "overload_paused") return "overload";
+  return null;
+}
+
+export function accountStateSurfaceClass(
+  account: AccountRow,
+  extraWhenActive = "",
+): string {
+  return resolveAccountOverlayKind(account)
+    ? ` account-state-surface${extraWhenActive}`
+    : "";
+}
+
+export function disabledAccountSurfaceClass(
+  account: AccountRow,
+  extraWhenActive = "",
+): string {
+  return isDisabledAccountOverlayAccount(account)
+    ? ` account-state-surface${extraWhenActive}`
+    : "";
+}
+
+function accountStateTableRowClassForKind(kind: AccountOverlayKind): string {
+  return ` account-state-table-row account-state-table-row--${kind}`;
+}
+
+export function accountStateTableRowClass(account: AccountRow): string {
+  const kind = resolveAccountOverlayKind(account);
+  return kind ? accountStateTableRowClassForKind(kind) : "";
+}
+
+export function disabledAccountTableRowClass(account: AccountRow): string {
+  return isDisabledAccountOverlayAccount(account)
+    ? accountStateTableRowClassForKind("disabled")
+    : "";
+}

--- a/frontend/src/pages/Accounts.tsx
+++ b/frontend/src/pages/Accounts.tsx
@@ -175,7 +175,9 @@ import RequestCountPills, {
 import { buildModelCountBreakdown } from "../lib/requestErrorStatus";
 import {
   accountStateSurfaceClass,
+  accountStateTableRowClass,
   renderAccountStateOverlay,
+  resolveAccountOverlayKind,
 } from "../components/AccountStateOverlay";
 import CodexInviteView from "../components/CodexInviteView";
 import Sub2APIImportModal from "../components/Sub2APIImportModal";
@@ -979,6 +981,13 @@ const AccountTableRow = memo(function AccountTableRow({
   t: ReturnType<typeof useTranslation>["t"];
   actions: AccountRowActions;
 }) {
+  const tableOverlayKind = resolveAccountOverlayKind(account);
+  const tableOverlay = renderAccountStateOverlay(account, t, {
+    compact: true,
+    markerOnly: true,
+    onRecover: () => actions.resetStatus(account),
+  });
+
   return (
                           <TableRow
                             key={account.id}
@@ -989,11 +998,7 @@ const AccountTableRow = memo(function AccountTableRow({
                                 : selected
                                   ? "bg-primary/5"
                                   : ""
-                            }${
-                              // 禁用 / 过载暂停用独立遮罩层淡化内容，徽章保持清晰。relative 让遮罩以整行为定位基准。
-                              // 不用 grayscale / 行级 opacity：filter 会破坏定位包含块，opacity 会把徽章一起冲淡。
-                              accountStateSurfaceClass(account, " relative")
-                            }`}
+                            }${accountStateTableRowClass(account)}`}
                             onClick={(event) => {
                               const target = event.target as HTMLElement | null;
                               if (
@@ -1007,17 +1012,38 @@ const AccountTableRow = memo(function AccountTableRow({
                             }}
                           >
                             <TableCell>
-                              {renderAccountStateOverlay(account, t, {
-                                compact: true,
-                                onRecover: () => actions.resetStatus(account),
-                              })}
-                              <input
-                                type="checkbox"
-                                className="size-4 cursor-pointer accent-primary"
-                                checked={selected}
-                                onChange={() => actions.toggleSelect(account.id)}
-                                onClick={(event) => event.stopPropagation()}
-                              />
+                              <div className="flex items-center gap-1">
+                                <input
+                                  type="checkbox"
+                                  className="size-4 cursor-pointer accent-primary"
+                                  checked={selected}
+                                  onChange={() => actions.toggleSelect(account.id)}
+                                  onClick={(event) => event.stopPropagation()}
+                                />
+                                {!visibleColumns.status && tableOverlayKind ? (
+                                  <span className="sr-only">
+                                    {tableOverlayKind === "disabled"
+                                      ? t("accounts.disabledOverlay")
+                                      : t("accounts.overloadOverlay")}
+                                  </span>
+                                ) : null}
+                                {!visibleColumns.status &&
+                                tableOverlayKind === "overload" ? (
+                                  <button
+                                    type="button"
+                                    className="inline-flex size-7 items-center justify-center rounded-md text-orange-700 transition-colors hover:bg-orange-500/10 dark:text-orange-300"
+                                    title={t("accounts.overloadRecover")}
+                                    aria-label={t("accounts.overloadRecover")}
+                                    onClick={(event) => {
+                                      event.preventDefault();
+                                      event.stopPropagation();
+                                      void actions.resetStatus(account);
+                                    }}
+                                  >
+                                    <RotateCcw className="size-3.5" />
+                                  </button>
+                                ) : null}
+                              </div>
                             </TableCell>
                             {visibleColumns.sequence && (
                               <TableCell
@@ -1219,66 +1245,68 @@ const AccountTableRow = memo(function AccountTableRow({
                               </TableCell>
                             )}
                             {visibleColumns.status && (
-                              <TableCell>
-                                <div
-                                  className="min-w-[168px] max-w-[240px] space-y-1.5"
-                                  title={[
-                                    t("accounts.healthSummary", {
-                                      health: formatHealthTier(
-                                        account.health_tier,
-                                        t,
-                                      ),
-                                      score: Math.round(
-                                        getDispatchScore(account),
-                                      ),
-                                      concurrency:
-                                        account.dynamic_concurrency_limit ?? "-",
-                                    }),
-                                    account.status === "error" &&
-                                    account.error_message
-                                      ? account.error_message
-                                      : "",
-                                    (account.model_cooldowns?.length ?? 0) > 0
-                                      ? `model ${account.model_cooldowns?.[0]?.model}${(account.model_cooldowns?.length ?? 0) > 1 ? ` +${(account.model_cooldowns?.length ?? 1) - 1}` : ""}`
-                                      : "",
-                                  ]
-                                    .filter(Boolean)
-                                    .join("\n")}
-                                >
-                                  <div className="flex min-h-6 flex-wrap items-center gap-1.5">
-                                    <StatusBadge
-                                      status={getAccountStatusBadgeStatus(account)}
-                                      detail={
-                                        account.status === "overload_paused"
-                                          ? undefined
-                                          : getAccountRateLimitWindow(account) ??
-                                            undefined
-                                      }
-                                      errorMessage={account.error_message}
-                                    />
-                                    <UsingCreditsBadge account={account} />
-                                    {account.status !== "overload_paused" && (
-                                      <AccountStatusCountdown account={account} />
-                                    )}
-                                    {(account.active_requests ?? 0) > 0 && (
-                                      <span
-                                        className="inline-flex items-center gap-1 rounded-md bg-blue-50 px-1.5 py-0.5 text-[11px] font-medium tabular-nums text-blue-600 ring-1 ring-inset ring-blue-500/20 dark:bg-blue-950 dark:text-blue-400 dark:ring-blue-400/20"
-                                        title={t("accounts.activeRequestsTooltip", {
-                                          count: account.active_requests ?? 0,
-                                        })}
-                                      >
+                              <TableCell data-account-state-cell="status">
+                                {tableOverlay ?? (
+                                  <div
+                                    className="min-w-[168px] max-w-[240px] space-y-1.5"
+                                    title={[
+                                      t("accounts.healthSummary", {
+                                        health: formatHealthTier(
+                                          account.health_tier,
+                                          t,
+                                        ),
+                                        score: Math.round(
+                                          getDispatchScore(account),
+                                        ),
+                                        concurrency:
+                                          account.dynamic_concurrency_limit ?? "-",
+                                      }),
+                                      account.status === "error" &&
+                                      account.error_message
+                                        ? account.error_message
+                                        : "",
+                                      (account.model_cooldowns?.length ?? 0) > 0
+                                        ? `model ${account.model_cooldowns?.[0]?.model}${(account.model_cooldowns?.length ?? 0) > 1 ? ` +${(account.model_cooldowns?.length ?? 1) - 1}` : ""}`
+                                        : "",
+                                    ]
+                                      .filter(Boolean)
+                                      .join("\n")}
+                                  >
+                                    <div className="flex min-h-6 flex-wrap items-center gap-1.5">
+                                      <StatusBadge
+                                        status={getAccountStatusBadgeStatus(account)}
+                                        detail={
+                                          account.status === "overload_paused"
+                                            ? undefined
+                                            : getAccountRateLimitWindow(account) ??
+                                              undefined
+                                        }
+                                        errorMessage={account.error_message}
+                                      />
+                                      <UsingCreditsBadge account={account} />
+                                      {account.status !== "overload_paused" && (
+                                        <AccountStatusCountdown account={account} />
+                                      )}
+                                      {(account.active_requests ?? 0) > 0 && (
                                         <span
-                                          className="size-1.5 animate-pulse rounded-full bg-blue-500 dark:bg-blue-400"
-                                          aria-hidden
-                                        />
-                                        {account.active_requests}
-                                      </span>
-                                    )}
+                                          className="inline-flex items-center gap-1 rounded-md bg-blue-50 px-1.5 py-0.5 text-[11px] font-medium tabular-nums text-blue-600 ring-1 ring-inset ring-blue-500/20 dark:bg-blue-950 dark:text-blue-400 dark:ring-blue-400/20"
+                                          title={t("accounts.activeRequestsTooltip", {
+                                            count: account.active_requests ?? 0,
+                                          })}
+                                        >
+                                          <span
+                                            className="size-1.5 animate-pulse rounded-full bg-blue-500 dark:bg-blue-400"
+                                            aria-hidden
+                                          />
+                                          {account.active_requests}
+                                        </span>
+                                      )}
+                                    </div>
+                                    <AccountHealthBar
+                                      buckets={healthBuckets}
+                                    />
                                   </div>
-                                  <AccountHealthBar
-                                    buckets={healthBuckets}
-                                  />
-                                </div>
+                                )}
                               </TableCell>
                             )}
                             {visibleColumns.today && (
@@ -13192,7 +13220,10 @@ function AccountMobileCard({
                   })}
                 </div>
               </div>
-              <div className="shrink-0">
+              <div
+                className="shrink-0"
+                aria-hidden={Boolean(resolveAccountOverlayKind(account))}
+              >
                 <div className="flex flex-wrap items-center justify-end gap-1.5">
                   <StatusBadge
                     status={getAccountStatusBadgeStatus(account)}
@@ -13481,7 +13512,10 @@ function AccountMobileCard({
                 )}
               </div>
               {(!visibleColumns || visibleColumns.status) && (
-                <div className="flex min-w-[112px] shrink-0 flex-col items-end">
+                <div
+                  className="flex min-w-[112px] shrink-0 flex-col items-end"
+                  aria-hidden={Boolean(resolveAccountOverlayKind(account))}
+                >
                   <StatusBadge
                     status={getAccountStatusBadgeStatus(account)}
                     detail={

--- a/frontend/src/pages/GrokAccounts.tsx
+++ b/frontend/src/pages/GrokAccounts.tsx
@@ -53,6 +53,7 @@ import AccountDetailSheet from "../components/AccountDetailSheet";
 import RequestCountPills from "../components/RequestCountPills";
 import {
   disabledAccountSurfaceClass,
+  disabledAccountTableRowClass,
   renderDisabledAccountOverlay,
 } from "../components/AccountStateOverlay";
 import AccountGroupFilterSelect, {
@@ -4137,13 +4138,17 @@ function GrokAccountTableRow({
   const models = account.models ?? [];
   const host = shortHost(account.base_url);
   const label = accountLabel(account);
+  const tableOverlay = renderDisabledAccountOverlay(account, t, {
+    compact: true,
+    markerOnly: true,
+  });
 
   return (
     <TableRow
       className={cn(
         "cursor-pointer",
         detailOpen ? "bg-primary/8" : selected && "bg-primary/5",
-        disabledAccountSurfaceClass(account, " relative"),
+        disabledAccountTableRowClass(account),
       )}
       onClick={(event) => {
         const target = event.target as HTMLElement | null;
@@ -4158,7 +4163,6 @@ function GrokAccountTableRow({
       }}
     >
       <TableCell className="w-9">
-        {renderDisabledAccountOverlay(account, t, { compact: true })}
         <input
           type="checkbox"
           className="size-4 cursor-pointer rounded border-border accent-primary"
@@ -4233,23 +4237,25 @@ function GrokAccountTableRow({
       <TableCell className="text-center">
         <GrokPlanBadge account={account} />
       </TableCell>
-      <TableCell>
-        <div className="space-y-1.5">
-          <StatusBadge
-            status={disabled ? "paused" : (account.status ?? "unknown")}
-            errorMessage={account.error_message}
-          />
-          {(account.active_requests ?? 0) > 0 && (
-            <span
-              className="inline-flex items-center gap-1 rounded-md bg-blue-50 px-1.5 py-0.5 text-[11px] font-medium tabular-nums text-blue-600 ring-1 ring-inset ring-blue-500/20 dark:bg-blue-950 dark:text-blue-400 dark:ring-blue-400/20"
-              title={t("accounts.activeRequestsTooltip", { count: account.active_requests ?? 0 })}
-            >
-              <span className="size-1.5 animate-pulse rounded-full bg-blue-500 dark:bg-blue-400" aria-hidden />
-              {account.active_requests}
-            </span>
-          )}
-          <AccountHealthBar buckets={healthBuckets} />
-        </div>
+      <TableCell data-account-state-cell="status">
+        {tableOverlay ?? (
+          <div className="space-y-1.5">
+            <StatusBadge
+              status={disabled ? "paused" : (account.status ?? "unknown")}
+              errorMessage={account.error_message}
+            />
+            {(account.active_requests ?? 0) > 0 && (
+              <span
+                className="inline-flex items-center gap-1 rounded-md bg-blue-50 px-1.5 py-0.5 text-[11px] font-medium tabular-nums text-blue-600 ring-1 ring-inset ring-blue-500/20 dark:bg-blue-950 dark:text-blue-400 dark:ring-blue-400/20"
+                title={t("accounts.activeRequestsTooltip", { count: account.active_requests ?? 0 })}
+              >
+                <span className="size-1.5 animate-pulse rounded-full bg-blue-500 dark:bg-blue-400" aria-hidden />
+                {account.active_requests}
+              </span>
+            )}
+            <AccountHealthBar buckets={healthBuckets} />
+          </div>
+        )}
       </TableCell>
       <TableCell>
         <RequestCountPills account={account} compact />


### PR DESCRIPTION
## Summary

- Paint disabled and overload state styling directly on table cells so it cannot escape the row in Safari.
- Keep the card overlay behavior, while rendering table markers in normal document flow and replacing the underlying status content.
- Preserve state semantics when the status column is hidden with screen-reader text and a compact overload recovery action.
- Share a disabled-account predicate across Codex and Grok render paths and add regression coverage to the frontend PR job.

## Root cause

The table implementation used an absolutely positioned scrim whose containing block depended on a table row. WebKit does not consistently establish that containing block for internal table boxes, so the scrim could fall back to the table scroll surface and cover unrelated rows.

## Validation

- `npm test` (132 passing tests)
- `npm run typecheck`
- `npm run build`
- `npm run audit:ci`
- Real browser automation was not run because this environment does not provide `npx`; the table path no longer depends on internal table-box positioning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clear account-state indicators for disabled and overloaded accounts across account tables and cards.
  * Added recovery controls for overloaded accounts.
  * Improved compact, mobile, and marker-only account status displays.

* **Bug Fixes**
  * Prevented duplicate status announcements for assistive technologies.
  * Improved dark-mode styling, row hover behavior, and content masking for account states.

* **Tests**
  * Added frontend regression coverage for account overlays, table styling, accessibility behavior, and CI test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->