### PR TITLE
fix(compaction): keep compaction_trigger as final input item

### DIFF
--- a/proxy/compact_via_responses.go
+++ b/proxy/compact_via_responses.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"strings"
 
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
@@ -21,40 +22,105 @@ import (
 // body-signal 压缩形态。compact 预处理为旧专用端点剥除了 store/stream/include，
 // 而 /responses 上游要求 stream=true 且 store=false（实测缺 store 直接
 // 400 "Store must be set to false"），这里补回，并在 input 末尾追加
-// compaction_trigger（已存在时不重复注入）。
+// compaction_trigger。客户端已经携带触发器时也会归一到 input 最后一项。
 func appendCompactionTriggerToResponsesBody(body []byte) []byte {
 	out, _ := sjson.SetBytes(body, "stream", true)
 	out, _ = sjson.SetBytes(out, "store", false)
 	if !gjson.GetBytes(out, "include").Exists() {
 		out, _ = sjson.SetBytes(out, "include", []string{codexReasoningEncryptedContentInclude})
 	}
-	if requestBodyHasCompactionTrigger(out) {
-		return out
-	}
-	trigger := []byte(`{"type":"compaction_trigger"}`)
-	input := gjson.GetBytes(out, "input")
+	return normalizeCompactionTriggerFinal(out, true)
+}
+
+// normalizeCompactionTriggerFinal keeps at most one direct input-level
+// compaction_trigger and moves it behind every history/message/tool item.
+// Upstream rejects a trigger followed by any other input item with
+// "The 'compaction_trigger' item must be the final input item."
+//
+// addIfMissing is true only when rewriting the legacy /responses/compact
+// endpoint to body-signal compaction. Plain /responses preparation uses false:
+// it repairs the order only when the client already supplied a trigger.
+func normalizeCompactionTriggerFinal(body []byte, addIfMissing bool) []byte {
+	trigger := json.RawMessage(`{"type":"compaction_trigger"}`)
+	input := gjson.GetBytes(body, "input")
 	switch {
 	case input.IsArray():
-		out, _ = sjson.SetRawBytes(out, "input.-1", trigger)
-	case input.Type == gjson.String:
-		// input 为字符串时先转成标准 message item，再追加触发器。
-		msg, err := json.Marshal(map[string]any{
-			"type": "message",
-			"role": "user",
-			"content": []any{
-				map[string]any{"type": "input_text", "text": input.String()},
-			},
-		})
-		if err != nil {
-			return out
+		items := input.Array()
+		triggerCount := 0
+		for _, item := range items {
+			if isDirectCompactionTrigger(item) {
+				triggerCount++
+			}
 		}
-		items := append(append([]byte("["), msg...), ',')
-		items = append(append(items, trigger...), ']')
-		out, _ = sjson.SetRawBytes(out, "input", items)
+		if triggerCount == 0 && !addIfMissing {
+			return body
+		}
+		if triggerCount == 1 && len(items) > 0 && isDirectCompactionTrigger(items[len(items)-1]) {
+			return body
+		}
+
+		normalized := make([]json.RawMessage, 0, len(items)+1)
+		for _, item := range items {
+			if isDirectCompactionTrigger(item) {
+				continue
+			}
+			raw := strings.TrimSpace(item.Raw)
+			if raw == "" {
+				encoded, err := json.Marshal(item.Value())
+				if err != nil {
+					return body
+				}
+				raw = string(encoded)
+			}
+			normalized = append(normalized, json.RawMessage(raw))
+		}
+		normalized = append(normalized, trigger)
+		encoded, err := json.Marshal(normalized)
+		if err != nil {
+			return body
+		}
+		out, err := sjson.SetRawBytes(body, "input", encoded)
+		if err != nil {
+			return body
+		}
+		return out
+	case addIfMissing:
+		normalized := make([]json.RawMessage, 0, 2)
+		switch {
+		case input.Type == gjson.String:
+			// input 为字符串时先转成标准 message item，再追加触发器。
+			msg, err := json.Marshal(map[string]any{
+				"type": "message",
+				"role": "user",
+				"content": []any{
+					map[string]any{"type": "input_text", "text": input.String()},
+				},
+			})
+			if err != nil {
+				return body
+			}
+			normalized = append(normalized, json.RawMessage(msg))
+		case input.IsObject() && !isDirectCompactionTrigger(input):
+			normalized = append(normalized, json.RawMessage(input.Raw))
+		}
+		normalized = append(normalized, trigger)
+		encoded, err := json.Marshal(normalized)
+		if err != nil {
+			return body
+		}
+		out, err := sjson.SetRawBytes(body, "input", encoded)
+		if err != nil {
+			return body
+		}
+		return out
 	default:
-		out, _ = sjson.SetRawBytes(out, "input", append(append([]byte("["), trigger...), ']'))
+		return body
 	}
-	return out
+}
+
+func isDirectCompactionTrigger(item gjson.Result) bool {
+	return item.IsObject() &&
+		strings.EqualFold(strings.TrimSpace(item.Get("type").String()), "compaction_trigger")
 }
 
 // collectCompactResponsesSSE 把 body-signal 压缩的上游 /responses SSE 流聚合成

--- a/proxy/compact_via_responses_test.go
+++ b/proxy/compact_via_responses_test.go
@@ -44,6 +44,55 @@ func TestAppendCompactionTriggerToResponsesBody_NoDuplicateTrigger(t *testing.T)
 	}
 }
 
+func TestAppendCompactionTriggerToResponsesBody_MovesExistingTriggerToEnd(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.6-sol","input":[
+		{"type":"message","role":"user","content":"compact this"},
+		{"type":"compaction_trigger"},
+		{"type":"function_call_output","call_id":"call_1","output":"ok"},
+		{"type":"compaction_trigger"}
+	]}`)
+	out := appendCompactionTriggerToResponsesBody(body)
+
+	items := gjson.GetBytes(out, "input").Array()
+	if len(items) != 3 {
+		t.Fatalf("重复触发器应合并为 1 个, got %d 条: %s", len(items), out)
+	}
+	if got := items[1].Get("type").String(); got != "function_call_output" {
+		t.Fatalf("非触发器 input 顺序应保持不变, got %q: %s", got, out)
+	}
+	if got := items[2].Get("type").String(); got != "compaction_trigger" {
+		t.Fatalf("compaction_trigger 必须位于 input 末尾, got %q: %s", got, out)
+	}
+}
+
+func TestNormalizeCompactionTriggerFinal_IgnoresNestedToolOutput(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.6-sol","input":[
+		{"type":"function_call_output","call_id":"call_1","output":{"type":"compaction_trigger"}},
+		{"type":"message","role":"user","content":"continue"}
+	]}`)
+	out := normalizeCompactionTriggerFinal(body, false)
+
+	if string(out) != string(body) {
+		t.Fatalf("nested tool output must not be treated as a protocol trigger: %s", out)
+	}
+}
+
+func TestAppendCompactionTriggerToResponsesBody_PreservesObjectInput(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.6-sol","input":{"type":"message","role":"user","content":"compact this"}}`)
+	out := appendCompactionTriggerToResponsesBody(body)
+
+	items := gjson.GetBytes(out, "input").Array()
+	if len(items) != 2 {
+		t.Fatalf("object input should be preserved before the trigger, got %d: %s", len(items), out)
+	}
+	if got := items[0].Get("type").String(); got != "message" {
+		t.Fatalf("input[0].type = %q, want message; body=%s", got, out)
+	}
+	if got := items[1].Get("type").String(); got != "compaction_trigger" {
+		t.Fatalf("input[1].type = %q, want compaction_trigger; body=%s", got, out)
+	}
+}
+
 func TestAppendCompactionTriggerToResponsesBody_StringInput(t *testing.T) {
 	body := []byte(`{"model":"gpt-5.6-sol","input":"please compact"}`)
 	out := appendCompactionTriggerToResponsesBody(body)

--- a/proxy/executor.go
+++ b/proxy/executor.go
@@ -575,6 +575,9 @@ func ExecuteRequest(ctx context.Context, account *auth.Account, requestBody []by
 		if responsesLite {
 			requestBody = normalizeCodexResponsesLiteBody(requestBody, false)
 		}
+		// 出站前最后兜底：任何中间改写都不能把普通 input 项放到
+		// compaction_trigger 后面，否则上游直接返回 invalid_request_error。
+		requestBody = normalizeCompactionTriggerFinal(requestBody, false)
 		return WebsocketExecuteFunc(ctx, account, requestBody, sessionID, proxyOverride, apiKey, deviceCfg, headers, poolRouteKey)
 	}
 	if wantWebsocket && WebsocketExecuteFunc == nil {
@@ -586,6 +589,7 @@ func ExecuteRequest(ctx context.Context, account *auth.Account, requestBody []by
 	if responsesLite {
 		requestBody = normalizeCodexResponsesLiteBody(requestBody, true)
 	}
+	requestBody = normalizeCompactionTriggerFinal(requestBody, false)
 
 	account.Mu().RLock()
 	accessToken := account.AccessToken
@@ -700,6 +704,7 @@ func ExecuteOpenAIResponsesRequest(ctx context.Context, account *auth.Account, r
 	resetWsAcquireAudit(ctx)
 	responsesLite := gateResponsesLiteForModel(codexResponsesLiteRequested(requestBody, headers), requestBody)
 	requestBody, headers = prepareCodexResponsesLiteTransport(requestBody, headers, false, responsesLite)
+	requestBody = normalizeCompactionTriggerFinal(requestBody, false)
 
 	baseURL, apiKey := account.OpenAIResponsesCredentials()
 	account.Mu().RLock()

--- a/proxy/executor_test.go
+++ b/proxy/executor_test.go
@@ -598,6 +598,68 @@ func TestNormalizeCodexResponsesLiteBodyStripsImageOnlyToolSet(t *testing.T) {
 	}
 }
 
+func TestExecuteRequestWebsocketSendsCompactionTriggerLast(t *testing.T) {
+	previousWS := WebsocketExecuteFunc
+	t.Cleanup(func() { WebsocketExecuteFunc = previousWS })
+
+	var seenBody []byte
+	WebsocketExecuteFunc = func(ctx context.Context, account *auth.Account, requestBody []byte, sessionID string, proxyOverride string, apiKey string, deviceCfg *DeviceProfileConfig, headers http.Header, poolRouteKey string) (*http.Response, error) {
+		seenBody = append([]byte(nil), requestBody...)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"id":"resp_test"}`)),
+		}, nil
+	}
+
+	body := []byte(`{"model":"gpt-5.6-sol","input":[
+		{"type":"compaction_trigger"},
+		{"type":"function_call_output","call_id":"call_1","output":"ok"}
+	]}`)
+	resp, err := ExecuteRequest(context.Background(), &auth.Account{DBID: 1, AccessToken: "token"}, body, "session-1", "", "sk-local", nil, http.Header{}, true)
+	if err != nil {
+		t.Fatalf("ExecuteRequest() error = %v", err)
+	}
+	resp.Body.Close()
+
+	input := gjson.GetBytes(seenBody, "input").Array()
+	if len(input) != 2 || input[1].Get("type").String() != "compaction_trigger" {
+		t.Fatalf("final websocket body must end with compaction_trigger: %s", seenBody)
+	}
+}
+
+func TestExecuteOpenAIResponsesRequestSendsCompactionTriggerLast(t *testing.T) {
+	var seenBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenBody, _ = io.ReadAll(r.Body)
+		_ = r.Body.Close()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"resp_test"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	account := &auth.Account{
+		DBID:         42,
+		UpstreamType: auth.UpstreamOpenAIResponses,
+		BaseURL:      server.URL,
+		APIKey:       "relay-token",
+	}
+	body := []byte(`{"model":"gpt-5.6-sol","input":[
+		{"type":"compaction_trigger"},
+		{"type":"function_call_output","call_id":"call_1","output":"ok"}
+	]}`)
+	resp, err := ExecuteOpenAIResponsesRequest(context.Background(), account, body, "", nil)
+	if err != nil {
+		t.Fatalf("ExecuteOpenAIResponsesRequest() error = %v", err)
+	}
+	resp.Body.Close()
+
+	input := gjson.GetBytes(seenBody, "input").Array()
+	if len(input) != 2 || input[1].Get("type").String() != "compaction_trigger" {
+		t.Fatalf("final relay body must end with compaction_trigger: %s", seenBody)
+	}
+}
+
 func TestApplyOpenAIResponsesRequestHeadersAppliesAccountCustomHeadersLast(t *testing.T) {
 	req, err := http.NewRequest(http.MethodPost, "https://example.com/v1/responses", nil)
 	if err != nil {

--- a/proxy/response_cache_handler_test.go
+++ b/proxy/response_cache_handler_test.go
@@ -78,6 +78,10 @@ func TestResponsesContinuationUnavailableWaitsForRelayRouting(t *testing.T) {
 		if recorder.Code != http.StatusOK || gjson.GetBytes(seenBody, "previous_response_id").String() != "resp_missing" {
 			t.Fatalf("compaction fallback status=%d upstream=%s response=%s", recorder.Code, seenBody, recorder.Body.String())
 		}
+		input := gjson.GetBytes(seenBody, "input").Array()
+		if len(input) == 0 || input[len(input)-1].Get("type").String() != "compaction_trigger" {
+			t.Fatalf("compaction trigger must be the final upstream input item: %s", seenBody)
+		}
 	})
 }
 

--- a/proxy/translator.go
+++ b/proxy/translator.go
@@ -2220,6 +2220,10 @@ func prepareResponsesBodyWithOptions(rawBody []byte, opts responsesBodyPrepareOp
 	if err != nil {
 		return rawBody, expandedInputRaw
 	}
+	result = normalizeCompactionTriggerFinal(result, false)
+	if requestBodyHasCompactionTrigger(result) {
+		expandedInputRaw = gjson.GetBytes(result, "input").Raw
+	}
 	return result, expandedInputRaw
 }
 
@@ -2269,6 +2273,7 @@ func PrepareOpenAIResponsesBody(rawBody []byte) []byte {
 	if err != nil {
 		return rawBody
 	}
+	result = normalizeCompactionTriggerFinal(result, false)
 	return result
 }
 

--- a/proxy/translator_test.go
+++ b/proxy/translator_test.go
@@ -2175,6 +2175,87 @@ func TestPrepareResponsesBody_PassesThroughCompactV2Items(t *testing.T) {
 	}
 }
 
+func TestPrepareResponsesBody_MovesCompactionTriggerToFinalInputItem(t *testing.T) {
+	raw := []byte(`{
+		"model":"gpt-5.6-sol",
+		"input":[
+			{"type":"message","role":"user","content":"compact this"},
+			{"type":"compaction_trigger"},
+			{"type":"function_call_output","call_id":"call_1","output":"ok"}
+		]
+	}`)
+
+	got, _ := PrepareResponsesBody(raw)
+	input := gjson.GetBytes(got, "input").Array()
+	if len(input) != 3 {
+		t.Fatalf("input length = %d, want 3; body=%s", len(input), got)
+	}
+	if gotType := input[1].Get("type").String(); gotType == "compaction_trigger" {
+		t.Fatalf("compaction_trigger must not remain before the final item; body=%s", got)
+	}
+	if gotType := input[2].Get("type").String(); gotType != "compaction_trigger" {
+		t.Fatalf("final input type = %q, want compaction_trigger; body=%s", gotType, got)
+	}
+}
+
+func TestPrepareOpenAIResponsesBody_MovesCompactionTriggerToFinalInputItem(t *testing.T) {
+	raw := []byte(`{
+		"model":"gpt-5.6-sol",
+		"stream":true,
+		"input":[
+			{"type":"compaction_trigger"},
+			{"type":"context_compaction","encrypted_content":"opaque"},
+			{"type":"function_call_output","call_id":"call_1","output":"ok"}
+		]
+	}`)
+
+	got := PrepareOpenAIResponsesBody(raw)
+	input := gjson.GetBytes(got, "input").Array()
+	if len(input) != 3 {
+		t.Fatalf("input length = %d, want 3; body=%s", len(input), got)
+	}
+	if gotType := input[0].Get("type").String(); gotType != "context_compaction" {
+		t.Fatalf("input[0].type = %q, want context_compaction; body=%s", gotType, got)
+	}
+	if gotType := input[2].Get("type").String(); gotType != "compaction_trigger" {
+		t.Fatalf("final input type = %q, want compaction_trigger; body=%s", gotType, got)
+	}
+}
+
+func TestPrepareResponsesBody_CachedHistoryStillKeepsCompactionTriggerFinal(t *testing.T) {
+	raw := []byte(`{
+		"model":"gpt-5.6-sol",
+		"previous_response_id":"resp_previous",
+		"input":[
+			{"type":"compaction_trigger"},
+			{"type":"function_call_output","call_id":"call_1","output":"ok"}
+		]
+	}`)
+	cached := []json.RawMessage{
+		json.RawMessage(`{"type":"message","role":"user","content":"earlier question"}`),
+		json.RawMessage(`{"type":"function_call","call_id":"call_1","name":"run","arguments":"{}"}`),
+	}
+
+	got, expanded := prepareResponsesBodyWithOptions(raw, responsesBodyPrepareOptions{
+		forceStoreFalse:        true,
+		expandPreviousResponse: true,
+		cachedResponseItems:    cached,
+	})
+	input := gjson.GetBytes(got, "input").Array()
+	if len(input) != 4 {
+		t.Fatalf("input length = %d, want 4; body=%s", len(input), got)
+	}
+	if gotType := input[len(input)-1].Get("type").String(); gotType != "compaction_trigger" {
+		t.Fatalf("final input type = %q, want compaction_trigger; body=%s", gotType, got)
+	}
+	if expandedType := gjson.Get(expanded, "#(type==\"compaction_trigger\").type").String(); expandedType != "compaction_trigger" {
+		t.Fatalf("expanded cache input lost compaction_trigger: %s", expanded)
+	}
+	if gotType := gjson.Get(expanded, "3.type").String(); gotType != "compaction_trigger" {
+		t.Fatalf("expanded final input type = %q, want compaction_trigger; expanded=%s", gotType, expanded)
+	}
+}
+
 func TestPrepareCompactResponsesBody_ConvertsPlaintextCompactionToDeveloperMessage(t *testing.T) {
 	raw := []byte(`{
 		"model":"gpt-5.4",


### PR DESCRIPTION
## What happened

Codex Responses requests can carry a `compaction_trigger` before a later input item. This showed up repeatedly with the Codex VS Code client build `26.814.41407` and was rejected upstream with:

`The 'compaction_trigger' item must be the final input item.`

## Fix

- Normalize direct `compaction_trigger` items after response-context expansion.
- Keep one trigger and move it to the end of `input` while preserving all other items in order.
- Apply the same check at the final Codex HTTP/WS and OpenAI Responses relay send boundaries.
- Leave nested objects in tool output untouched.
- Preserve object and string input when the legacy compact endpoint is rewritten.

## Tests

- Added request-body, response-cache continuation, Codex WebSocket, Codex HTTP, and OpenAI Responses relay coverage.
- `go test ./...`
- `go vet ./...`
- frontend build, tests, typecheck, and audit gate


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured compaction triggers are unique and consistently placed at the end of request input.
  - Improved handling of string and object-form inputs while preserving valid request data.
  - Ignored nested tool-output values when detecting existing triggers.
  - Applied consistent behavior across HTTP, WebSocket, cached-history, Codex, and OpenAI Responses requests.

- **Tests**
  - Added coverage for trigger ordering, deduplication, input preservation, and cached histories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->