### PR TITLE
fix(compaction): normalize direct trigger object input

### DIFF
--- a/proxy/compact_via_responses.go
+++ b/proxy/compact_via_responses.go
@@ -55,7 +55,7 @@ func normalizeCompactionTriggerFinal(body []byte, addIfMissing bool) []byte {
 		if triggerCount == 0 && !addIfMissing {
 			return body
 		}
-		if triggerCount == 1 && len(items) > 0 && isDirectCompactionTrigger(items[len(items)-1]) {
+		if triggerCount == 1 && len(items) > 0 && isCanonicalCompactionTrigger(items[len(items)-1]) {
 			return body
 		}
 
@@ -76,6 +76,16 @@ func normalizeCompactionTriggerFinal(body []byte, addIfMissing bool) []byte {
 		}
 		normalized = append(normalized, trigger)
 		encoded, err := json.Marshal(normalized)
+		if err != nil {
+			return body
+		}
+		out, err := sjson.SetRawBytes(body, "input", encoded)
+		if err != nil {
+			return body
+		}
+		return out
+	case input.IsObject() && isDirectCompactionTrigger(input):
+		encoded, err := json.Marshal([]json.RawMessage{trigger})
 		if err != nil {
 			return body
 		}
@@ -121,6 +131,10 @@ func normalizeCompactionTriggerFinal(body []byte, addIfMissing bool) []byte {
 func isDirectCompactionTrigger(item gjson.Result) bool {
 	return item.IsObject() &&
 		strings.EqualFold(strings.TrimSpace(item.Get("type").String()), "compaction_trigger")
+}
+
+func isCanonicalCompactionTrigger(item gjson.Result) bool {
+	return item.IsObject() && item.Get("type").String() == "compaction_trigger"
 }
 
 // collectCompactResponsesSSE 把 body-signal 压缩的上游 /responses SSE 流聚合成

--- a/proxy/compact_via_responses_test.go
+++ b/proxy/compact_via_responses_test.go
@@ -77,6 +77,35 @@ func TestNormalizeCompactionTriggerFinal_IgnoresNestedToolOutput(t *testing.T) {
 	}
 }
 
+func TestNormalizeCompactionTriggerFinal_WrapsDirectObjectInput(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.6-sol","input":{"type":"compaction_trigger"}}`)
+	out := normalizeCompactionTriggerFinal(body, false)
+
+	items := gjson.GetBytes(out, "input").Array()
+	if len(items) != 1 {
+		t.Fatalf("direct trigger object should become a one-item input array, got %d: %s", len(items), out)
+	}
+	if got := items[0].Get("type").String(); got != "compaction_trigger" {
+		t.Fatalf("input[0].type = %q, want compaction_trigger; body=%s", got, out)
+	}
+}
+
+func TestNormalizeCompactionTriggerFinal_CanonicalizesTriggerType(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.6-sol","input":[
+		{"type":"message","role":"user","content":"compact this"},
+		{"type":" COMPACTION_TRIGGER "}
+	]}`)
+	out := normalizeCompactionTriggerFinal(body, false)
+
+	items := gjson.GetBytes(out, "input").Array()
+	if len(items) != 2 {
+		t.Fatalf("input length = %d, want 2; body=%s", len(items), out)
+	}
+	if got := items[1].Get("type").String(); got != "compaction_trigger" {
+		t.Fatalf("final trigger type = %q, want canonical compaction_trigger; body=%s", got, out)
+	}
+}
+
 func TestAppendCompactionTriggerToResponsesBody_PreservesObjectInput(t *testing.T) {
 	body := []byte(`{"model":"gpt-5.6-sol","input":{"type":"message","role":"user","content":"compact this"}}`)
 	out := appendCompactionTriggerToResponsesBody(body)


### PR DESCRIPTION
## What changed

- normalize a top-level `input: {"type":"compaction_trigger"}` into the same one-item array shape used by the rest of the Responses path
- rewrite case/whitespace variants of the trigger type to the canonical wire value
- keep nested `compaction_trigger` values untouched

## Why

The request classifier already treats a direct top-level trigger object as a compact request, but the final normalizer only handled arrays. That left one accepted input shape outside the final wire invariant added in #546.

The same gap applied to case-insensitive trigger detection: the gateway recognized the item, then returned early without making the type value canonical.

## Tests

- direct trigger object input
- non-canonical trigger type
- `go test ./...`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compaction-trigger handling when input is provided as a single object.
  * Ensured trigger types with inconsistent casing or surrounding whitespace are normalized consistently.
  * Preserved a canonical compaction trigger as the final input item without unnecessary changes.

* **Tests**
  * Added coverage for single-object inputs and trigger-type normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->