### PR TITLE
fix(logging): keep structured upstream detail errors

### DIFF
--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -547,10 +547,15 @@ func usageLogErrorMessageImpl(statusCode int, body []byte, trustedText bool) str
 		return ""
 	}
 
+	detailMessage := gjson.GetBytes(body, "detail.message").String()
+	if detail := gjson.GetBytes(body, "detail"); detail.Type == gjson.String {
+		detailMessage = detail.String()
+	}
 	candidates := []string{
 		gjson.GetBytes(body, "error.message").String(),
 		gjson.GetBytes(body, "response.error.message").String(),
 		gjson.GetBytes(body, "response.status_details.error.message").String(),
+		detailMessage,
 		gjson.GetBytes(body, "message").String(),
 	}
 	message := ""

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -1947,6 +1947,32 @@ func TestUsageLogErrorMessageExtractsStructuredError(t *testing.T) {
 	}
 }
 
+func TestUsageLogErrorMessageExtractsDetailErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "string detail",
+			body: `{"detail":"The requested model is not available for this account."}`,
+			want: "The requested model is not available for this account.",
+		},
+		{
+			name: "object detail",
+			body: `{"detail":{"code":"model_not_supported","message":"The requested model is not supported."}}`,
+			want: "model_not_supported · The requested model is not supported.",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := usageLogErrorMessage(http.StatusBadRequest, []byte(tt.body)); got != tt.want {
+				t.Fatalf("usageLogErrorMessage() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestUsageLogAndClientErrorsOmitUnstructuredUpstreamBodies(t *testing.T) {
 	body := []byte(`<html><body>secret request-id and internal route</body></html>`)
 	if got := usageLogErrorMessage(http.StatusBadGateway, body); got != "HTTP 502" {


### PR DESCRIPTION
## What changed

- extract messages from FastAPI-style `detail` errors
- support both `{"detail":"..."}` and `{"detail":{"code":"...","message":"..."}}`
- leave the existing handling of unstructured HTML/plain-text provider pages unchanged

## Why

Some Responses relays return structured 400 errors under `detail` instead of `error.message`. Those responses currently appear in usage logs as only `HTTP 400`, even though the body contains the actual reason. That makes account and protocol failures much harder to separate during production diagnosis.

## Tests

- string `detail`
- object `detail` with code and message
- `go test ./...`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages by extracting details from structured error responses.
  * Added a fallback for errors that provide details as plain text, making logged messages more informative.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->