### PR TITLE
fix(auth): prevent account-store scheduler deadlocks

### DIFF
--- a/auth/store.go
+++ b/auth/store.go
@@ -3007,6 +3007,7 @@ func (a *Account) GetLastUsedAt() time.Time {
 // Store 多账号管理器（数据库 + Token 缓存）
 type Store struct {
 	mu                                 sync.RWMutex
+	accountMutationMu                  sync.Mutex // serializes account-set and scheduler mutations without nesting their locks
 	accounts                           []*Account
 	accountsByID                       map[int64]*Account // DBID -> Account 索引，与 accounts 同步维护，供 O(1) 查找
 	globalProxy                        string
@@ -5511,8 +5512,6 @@ func (s *Store) NextExcludingWithFilter(apiKeyID int64, exclude map[int64]bool, 
 	}
 
 	for attempts := 0; attempts < 16; attempts++ {
-		s.mu.RLock()
-
 		var best *Account
 		bestSchedulerPriority := minSchedulerPriority - 1
 		bestPriority := -1
@@ -5521,7 +5520,7 @@ func (s *Store) NextExcludingWithFilter(apiKeyID int64, exclude map[int64]bool, 
 		var bestLimit int64
 		maxConcurrency := atomic.LoadInt64(&s.maxConcurrency)
 
-		for _, acc := range s.accounts {
+		for _, acc := range s.Accounts() {
 			if exclude != nil && exclude[acc.DBID] {
 				continue
 			}
@@ -5557,8 +5556,6 @@ func (s *Store) NextExcludingWithFilter(apiKeyID int64, exclude map[int64]bool, 
 				best = acc
 			}
 		}
-		s.mu.RUnlock()
-
 		if best == nil {
 			return nil
 		}
@@ -5679,8 +5676,6 @@ func (s *Store) acquireLazyCandidate(acc *Account, maxConcurrency int64) bool {
 
 func (s *Store) nextExcludingWithFilterLazy(apiKeyID int64, exclude map[int64]bool, filter AccountFilter) *Account {
 	for attempts := 0; attempts < 16; attempts++ {
-		s.mu.RLock()
-
 		var best *Account
 		var metadataRefreshCandidate *Account
 		bestSchedulerPriority := minSchedulerPriority - 1
@@ -5689,7 +5684,7 @@ func (s *Store) nextExcludingWithFilterLazy(apiKeyID int64, exclude map[int64]bo
 		var bestLoad int64 = math.MaxInt64
 		maxConcurrency := atomic.LoadInt64(&s.maxConcurrency)
 
-		for _, acc := range s.accounts {
+		for _, acc := range s.Accounts() {
 			if exclude != nil && exclude[acc.DBID] {
 				continue
 			}
@@ -5731,8 +5726,6 @@ func (s *Store) nextExcludingWithFilterLazy(apiKeyID int64, exclude map[int64]bo
 				best = acc
 			}
 		}
-		s.mu.RUnlock()
-
 		if best == nil {
 			if metadataRefreshCandidate != nil && s.ensureLazyDispatchReady(metadataRefreshCandidate) {
 				continue
@@ -6018,9 +6011,9 @@ func (s *Store) nextAccountForFreshAffinity(key string, apiKeyID int64, exclude 
 	}
 	maxConcurrency := atomic.LoadInt64(&s.maxConcurrency)
 
-	s.mu.RLock()
-	candidates := make([]affinityCandidate, 0, len(s.accounts))
-	for _, acc := range s.accounts {
+	accounts := s.Accounts()
+	candidates := make([]affinityCandidate, 0, len(accounts))
+	for _, acc := range accounts {
 		if exclude != nil && exclude[acc.DBID] {
 			continue
 		}
@@ -6050,7 +6043,6 @@ func (s *Store) nextAccountForFreshAffinity(key string, apiKeyID int64, exclude 
 			weight:            hasher.Sum64(),
 		})
 	}
-	s.mu.RUnlock()
 
 	if len(candidates) == 0 {
 		return nil
@@ -6287,10 +6279,7 @@ func (s *Store) hasDispatchCandidateWithFilter(apiKeyID int64, exclude map[int64
 	filter = s.withUsableEgressFilter(filter)
 
 	maxConcurrency := atomic.LoadInt64(&s.maxConcurrency)
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
-	for _, acc := range s.accounts {
+	for _, acc := range s.Accounts() {
 		if acc == nil {
 			continue
 		}
@@ -7337,8 +7326,13 @@ func (s *Store) AddAccounts(accounts []*Account) {
 		return
 	}
 
+	s.accountMutationMu.Lock()
+	defer s.accountMutationMu.Unlock()
+
 	now := time.Now().UnixNano()
 	added := make([]*Account, 0, len(accounts))
+	ignoreUsageLimit := s.IgnoreUsageLimitStatus()
+	maxConcurrency := atomic.LoadInt64(&s.maxConcurrency)
 	for _, acc := range accounts {
 		if acc == nil {
 			continue
@@ -7347,6 +7341,12 @@ func (s *Store) AddAccounts(accounts []*Account) {
 		if atomic.LoadInt64(&acc.AddedAt) == 0 {
 			atomic.StoreInt64(&acc.AddedAt, now)
 		}
+		acc.mu.Lock()
+		acc.grokRuntimeSink = s
+		acc.recomputeEffectiveIgnoreUsageLimitStatus(ignoreUsageLimit)
+		acc.recomputeEffectiveGroupBaseConcurrency(s)
+		acc.recomputeSchedulerLocked(maxConcurrency)
+		acc.mu.Unlock()
 		added = append(added, acc)
 	}
 	if len(added) == 0 {
@@ -7354,18 +7354,6 @@ func (s *Store) AddAccounts(accounts []*Account) {
 	}
 
 	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	ignoreUsageLimit := s.IgnoreUsageLimitStatus()
-	maxConcurrency := atomic.LoadInt64(&s.maxConcurrency)
-	for _, acc := range added {
-		acc.mu.Lock()
-		acc.grokRuntimeSink = s
-		acc.recomputeEffectiveIgnoreUsageLimitStatus(ignoreUsageLimit)
-		acc.recomputeEffectiveGroupBaseConcurrency(s)
-		acc.recomputeSchedulerLocked(maxConcurrency)
-		acc.mu.Unlock()
-	}
 	s.accounts = append(s.accounts, added...)
 	if s.accountsByID == nil {
 		s.rebuildAccountIndex()
@@ -7374,6 +7362,8 @@ func (s *Store) AddAccounts(accounts []*Account) {
 			s.accountsByID[acc.DBID] = acc
 		}
 	}
+	s.mu.Unlock()
+
 	if scheduler := s.getFastScheduler(); scheduler != nil {
 		scheduler.UpdateMany(added)
 	}
@@ -7381,20 +7371,28 @@ func (s *Store) AddAccounts(accounts []*Account) {
 
 // RemoveAccount 从内存池移除账号
 func (s *Store) RemoveAccount(dbID int64) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	s.accountMutationMu.Lock()
+	defer s.accountMutationMu.Unlock()
 
+	removed := false
+	s.mu.Lock()
 	for i, acc := range s.accounts {
 		if acc.DBID == dbID {
 			s.accounts = append(s.accounts[:i], s.accounts[i+1:]...)
 			s.rebuildAccountIndex()
-			s.fastSchedulerRemove(dbID)
-			// 清理 RefreshScheduler 中可能残留的任务
-			if scheduler := s.GetRefreshScheduler(); scheduler != nil {
-				scheduler.CancelTask(dbID)
-			}
-			return
+			removed = true
+			break
 		}
+	}
+	s.mu.Unlock()
+	if !removed {
+		return
+	}
+
+	s.fastSchedulerRemove(dbID)
+	// 清理 RefreshScheduler 中可能残留的任务
+	if scheduler := s.GetRefreshScheduler(); scheduler != nil {
+		scheduler.CancelTask(dbID)
 	}
 }
 
@@ -9548,19 +9546,20 @@ func (s *Store) RemoveAccounts(dbIDs []int64) {
 		return
 	}
 
+	s.accountMutationMu.Lock()
+	defer s.accountMutationMu.Unlock()
+
 	removeSet := make(map[int64]struct{}, len(dbIDs))
 	for _, id := range dbIDs {
 		removeSet[id] = struct{}{}
 	}
 
+	removedIDs := make([]int64, 0, len(removeSet))
 	s.mu.Lock()
 	kept := s.accounts[:0]
 	for _, acc := range s.accounts {
 		if _, remove := removeSet[acc.DBID]; remove {
-			s.fastSchedulerRemove(acc.DBID)
-			if scheduler := s.GetRefreshScheduler(); scheduler != nil {
-				scheduler.CancelTask(acc.DBID)
-			}
+			removedIDs = append(removedIDs, acc.DBID)
 		} else {
 			kept = append(kept, acc)
 		}
@@ -9568,6 +9567,14 @@ func (s *Store) RemoveAccounts(dbIDs []int64) {
 	s.accounts = kept
 	s.rebuildAccountIndex()
 	s.mu.Unlock()
+
+	refreshScheduler := s.GetRefreshScheduler()
+	for _, dbID := range removedIDs {
+		s.fastSchedulerRemove(dbID)
+		if refreshScheduler != nil {
+			refreshScheduler.CancelTask(dbID)
+		}
+	}
 }
 
 func (s *Store) parallelProbeUsage(ctx context.Context) {

--- a/auth/store_lock_order_test.go
+++ b/auth/store_lock_order_test.go
@@ -1,0 +1,229 @@
+package auth
+
+import (
+	"testing"
+	"time"
+
+	"github.com/codex2api/database"
+)
+
+func newStoreLockOrderFixture(t *testing.T) (*Store, *FastScheduler, *Account) {
+	t.Helper()
+
+	store := NewStore(nil, nil, &database.SystemSettings{
+		MaxConcurrency:       2,
+		FastSchedulerEnabled: true,
+	})
+	account := &Account{
+		DBID:        1,
+		AccessToken: "token",
+		Status:      StatusReady,
+		PlanType:    "plus",
+	}
+	store.AddAccount(account)
+
+	scheduler := store.getFastScheduler()
+	if scheduler == nil {
+		t.Fatal("fast scheduler is not enabled")
+	}
+	return store, scheduler, account
+}
+
+func runStoreSchedulerLockOrderRace(
+	t *testing.T,
+	store *Store,
+	scheduler *FastScheduler,
+	mutate func(),
+) {
+	t.Helper()
+
+	filterEntered := make(chan struct{})
+	allowStoreRead := make(chan struct{})
+	acquireDone := make(chan struct{})
+	go func() {
+		defer close(acquireDone)
+		scheduler.AcquireExcludingWithFilter(0, nil, func(*Account) bool {
+			close(filterEntered)
+			<-allowStoreRead
+			store.mu.RLock()
+			store.mu.RUnlock()
+			return false
+		})
+	}()
+
+	select {
+	case <-filterEntered:
+	case <-time.After(time.Second):
+		t.Fatal("scheduler filter did not start")
+	}
+
+	// Hold Store.mu while the mutation queues for it. Once the filter is
+	// released, the queued writer gets Store.mu first. Account mutations must
+	// release that lock before waiting for FastScheduler.mu, otherwise the two
+	// goroutines form the production deadlock.
+	store.mu.Lock()
+	mutationStarted := make(chan struct{})
+	mutationDone := make(chan struct{})
+	go func() {
+		close(mutationStarted)
+		mutate()
+		close(mutationDone)
+	}()
+	<-mutationStarted
+	time.Sleep(20 * time.Millisecond)
+	close(allowStoreRead)
+	store.mu.Unlock()
+
+	select {
+	case <-mutationDone:
+	case <-time.After(time.Second):
+		t.Fatal("account mutation deadlocked with scheduler acquisition")
+	}
+	select {
+	case <-acquireDone:
+	case <-time.After(time.Second):
+		t.Fatal("scheduler acquisition did not finish")
+	}
+}
+
+func TestAddAccountsDoesNotInvertStoreAndSchedulerLocks(t *testing.T) {
+	store, scheduler, _ := newStoreLockOrderFixture(t)
+	added := &Account{
+		DBID:        2,
+		AccessToken: "token-2",
+		Status:      StatusReady,
+		PlanType:    "plus",
+	}
+
+	runStoreSchedulerLockOrderRace(t, store, scheduler, func() {
+		store.AddAccounts([]*Account{added})
+	})
+
+	if got := store.FindByID(added.DBID); got != added {
+		t.Fatalf("added account = %p, want %p", got, added)
+	}
+}
+
+func TestRemoveAccountDoesNotInvertStoreAndSchedulerLocks(t *testing.T) {
+	store, scheduler, account := newStoreLockOrderFixture(t)
+
+	runStoreSchedulerLockOrderRace(t, store, scheduler, func() {
+		store.RemoveAccount(account.DBID)
+	})
+
+	if got := store.FindByID(account.DBID); got != nil {
+		t.Fatalf("removed account still present: %p", got)
+	}
+}
+
+func TestRemoveAccountsDoesNotInvertStoreAndSchedulerLocks(t *testing.T) {
+	store, scheduler, account := newStoreLockOrderFixture(t)
+
+	runStoreSchedulerLockOrderRace(t, store, scheduler, func() {
+		store.RemoveAccounts([]int64{account.DBID})
+	})
+
+	if got := store.FindByID(account.DBID); got != nil {
+		t.Fatalf("removed account still present: %p", got)
+	}
+}
+
+func newStoreRecursiveReadFixture(t *testing.T) *Store {
+	t.Helper()
+
+	store := NewStore(nil, nil, &database.SystemSettings{MaxConcurrency: 2})
+	store.AddAccount(&Account{
+		DBID:        1,
+		AccessToken: "token",
+		Status:      StatusReady,
+		PlanType:    "plus",
+	})
+	return store
+}
+
+func runStoreRecursiveReadLockRace(t *testing.T, store *Store, call func(AccountFilter)) {
+	t.Helper()
+
+	filterEntered := make(chan struct{})
+	allowNestedRead := make(chan struct{})
+	callDone := make(chan struct{})
+	go func() {
+		defer close(callDone)
+		call(func(*Account) bool {
+			close(filterEntered)
+			<-allowNestedRead
+			_ = store.GetProxyURL()
+			return false
+		})
+	}()
+
+	select {
+	case <-filterEntered:
+	case <-time.After(time.Second):
+		t.Fatal("account filter did not start")
+	}
+
+	writerStarted := make(chan struct{})
+	writerDone := make(chan struct{})
+	go func() {
+		close(writerStarted)
+		store.SetProxyURL("http://writer.invalid")
+		close(writerDone)
+	}()
+	<-writerStarted
+	time.Sleep(20 * time.Millisecond)
+	close(allowNestedRead)
+
+	select {
+	case <-callDone:
+	case <-time.After(time.Second):
+		t.Fatal("account filter deadlocked on a recursive Store read")
+	}
+	select {
+	case <-writerDone:
+	case <-time.After(time.Second):
+		t.Fatal("queued Store writer did not finish")
+	}
+}
+
+func TestAccountFiltersRunOutsideStoreReadLock(t *testing.T) {
+	tests := []struct {
+		name string
+		call func(*Store, AccountFilter)
+	}{
+		{
+			name: "candidate check",
+			call: func(store *Store, filter AccountFilter) {
+				store.hasDispatchCandidateWithFilter(0, nil, filter)
+			},
+		},
+		{
+			name: "fallback scheduler",
+			call: func(store *Store, filter AccountFilter) {
+				store.NextExcludingWithFilter(0, nil, filter)
+			},
+		},
+		{
+			name: "lazy scheduler",
+			call: func(store *Store, filter AccountFilter) {
+				store.nextExcludingWithFilterLazy(0, nil, filter)
+			},
+		},
+		{
+			name: "affinity spread",
+			call: func(store *Store, filter AccountFilter) {
+				store.affinitySpreadEnabled.Store(true)
+				store.nextAccountForFreshAffinity("session", 0, nil, filter)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			store := newStoreRecursiveReadFixture(t)
+			runStoreRecursiveReadLockRace(t, store, func(filter AccountFilter) {
+				tc.call(store, filter)
+			})
+		})
+	}
+}


### PR DESCRIPTION
## What broke

The account store and fast scheduler could acquire their locks in opposite orders:

```text
request dispatch
FastScheduler.mu
  -> account filter
  -> ResolveProxyForAccount
  -> Store.mu.RLock
```

```text
account add/remove
Store.mu.Lock
  -> FastScheduler.UpdateMany/Remove
  -> FastScheduler.mu
```

Once both paths overlapped, neither side could make progress.

There was a second deadlock in the fallback/lazy/affinity paths. Those paths ran account filters while already holding `Store.mu.RLock`. The egress filter can call `ResolveProxyForAccount`, which tries to take the same read lock again. Go's `RWMutex` blocks new readers after a writer starts waiting, so the goroutine can end up waiting on its own nested `RLock` while the writer waits for the outer read lock to be released.

This is not a slow-path issue. Under load it can freeze all requests that need the account store indefinitely. `/v1` and authenticated account-management APIs stop responding, while static files and lightweight health checks may continue to return 200. That makes the process look healthy and prevents automatic recovery; even graceful shutdown can time out behind the blocked requests.

## Fix

- Serialize account-set mutations with a dedicated `accountMutationMu`.
- Keep `Store.mu` limited to updating the account slice and ID index.
- Update `FastScheduler` and `RefreshScheduler` only after releasing `Store.mu`.
- Take an account pointer snapshot before running filters in fallback, lazy, candidate-check, and fresh-affinity selection paths.
- Never execute an account filter while holding the global store read lock.

Account pointers remain valid after the snapshot; removal only removes them from future snapshots. Existing per-account synchronization still protects mutable account state.

## Tests

Added deterministic regression coverage for both lock classes:

- add vs. fast-scheduler filter lock inversion
- single-account removal vs. scheduler lock inversion
- batch removal vs. scheduler lock inversion
- candidate check with a queued store writer
- fallback scheduler with a queued store writer
- lazy scheduler with a queued store writer
- fresh-affinity selection with a queued store writer

The filter tests deadlock on the previous implementation and complete after this change.

```text
go test ./...
go test -race ./auth -run 'Test(AccountFiltersRunOutsideStoreReadLock|AddAccountsDoesNotInvertStoreAndSchedulerLocks|RemoveAccountDoesNotInvertStoreAndSchedulerLocks|RemoveAccountsDoesNotInvertStoreAndSchedulerLocks)' -count=50
```

This should be treated as a correctness and availability fix. A health endpoint returning 200 does not make the process healthy when every authenticated request that touches the account pool is permanently blocked.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when adding or removing accounts concurrently.
  - Prevented potential deadlocks during account selection, scheduling, and filtering.
  - Reduced lock contention to keep account operations responsive.

- **Tests**
  - Added coverage for concurrent account updates, scheduler interactions, fallback selection, lazy scheduling, and affinity-based selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->