### PR TITLE
feat(models): add gpt-reserve model to built-in model list

### DIFF
--- a/proxy/model_registry.go
+++ b/proxy/model_registry.go
@@ -82,6 +82,7 @@ var builtinModelInfos = []ModelInfo{
 	// Pricing: gpt-5.4 standard ($2.50/$15.00), priority ($5.00/$30.00).
 	// Ref: codex_client_models.json via CLIProxyAPI model registry.
 	modelInfoForID("codex-auto-review", ModelSourceBuiltin),
+	modelInfoForID("gpt-reserve", ModelSourceBuiltin),
 	modelInfoForID("gpt-image-2", ModelSourceBuiltin),
 	modelInfoForID("gpt-image-2-2k", ModelSourceBuiltin),
 	modelInfoForID("gpt-image-2-4k", ModelSourceBuiltin),

--- a/proxy/model_registry.go
+++ b/proxy/model_registry.go
@@ -82,6 +82,8 @@ var builtinModelInfos = []ModelInfo{
 	// Pricing: gpt-5.4 standard ($2.50/$15.00), priority ($5.00/$30.00).
 	// Ref: codex_client_models.json via CLIProxyAPI model registry.
 	modelInfoForID("codex-auto-review", ModelSourceBuiltin),
+	// gpt-reserve — non-versioned model ID; keep as builtin fallback only.
+	// Note: it is not discoverable via upstream sync/manifest learning, which expects gpt-<major>.<minor> IDs.
 	modelInfoForID("gpt-reserve", ModelSourceBuiltin),
 	modelInfoForID("gpt-image-2", ModelSourceBuiltin),
 	modelInfoForID("gpt-image-2-2k", ModelSourceBuiltin),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `gpt-reserve` to the built-in model catalog.
  * The model now appears in supported model listings, including fallback catalogs when the registry is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->