### PR TITLE
fix(grok): normalize non-object tool parameter schema roots; surface string-form upstream error bodies

### DIFF
--- a/proxy/grok_namespace_tools.go
+++ b/proxy/grok_namespace_tools.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"io"
 	"reflect"
+	"sort"
 	"strconv"
 	"strings"
 )
@@ -105,6 +106,157 @@ func grokFunctionToolForCustom(tool map[string]any, name string) map[string]any 
 	return converted
 }
 
+// grokPermissiveObjectSchema 是无法保真转换时的降级形态:宽松 object,仅保留
+// 原 schema 的 description。宁可让模型自由发挥、由客户端做最终参数校验,也不能
+// 让整段对话因 schema 形态被上游 400 掐死。
+func grokPermissiveObjectSchema(root map[string]any) map[string]any {
+	out := map[string]any{"type": "object", "additionalProperties": true}
+	if description, ok := root["description"].(string); ok && strings.TrimSpace(description) != "" {
+		out["description"] = description
+	}
+	return out
+}
+
+// grokObjectishSchemaBranch 判断联合分支是否可并入 object 根:显式 object,或
+// 未声明 type 但带 properties。
+func grokObjectishSchemaBranch(branch map[string]any) bool {
+	if kind, ok := branch["type"].(string); ok {
+		return kind == "object"
+	}
+	if _, ok := branch["type"]; ok {
+		return false
+	}
+	_, hasProperties := branch["properties"]
+	return hasProperties
+}
+
+// mergeGrokUnionRootSchema 把 anyOf/oneOf/allOf 根合并成单一 object:
+// properties 取各 object 分支的并集(先到先得),required 按语义收敛——
+// 联合(任一分支成立)取交集,allOf(全部成立)取并集;非 object 分支丢弃。
+// 没有任何 object 分支时整体降级为宽松 object。
+func mergeGrokUnionRootSchema(root map[string]any, branches []any, requireAll bool) map[string]any {
+	merged := map[string]any{"type": "object"}
+	if description, ok := root["description"].(string); ok && strings.TrimSpace(description) != "" {
+		merged["description"] = description
+	}
+	properties := map[string]any{}
+	var required map[string]bool
+	objectBranches := 0
+	for _, rawBranch := range branches {
+		branch, ok := rawBranch.(map[string]any)
+		if !ok || !grokObjectishSchemaBranch(branch) {
+			continue
+		}
+		objectBranches++
+		if _, has := merged["description"]; !has {
+			if description, ok := branch["description"].(string); ok && strings.TrimSpace(description) != "" {
+				merged["description"] = description
+			}
+		}
+		if props, ok := branch["properties"].(map[string]any); ok {
+			for key, value := range props {
+				if _, exists := properties[key]; !exists {
+					properties[key] = value
+				}
+			}
+		}
+		branchRequired := map[string]bool{}
+		if list, ok := branch["required"].([]any); ok {
+			for _, item := range list {
+				if key, ok := item.(string); ok {
+					branchRequired[key] = true
+				}
+			}
+		}
+		if required == nil {
+			required = branchRequired
+		} else if requireAll {
+			for key := range branchRequired {
+				required[key] = true
+			}
+		} else {
+			for key := range required {
+				if !branchRequired[key] {
+					delete(required, key)
+				}
+			}
+		}
+	}
+	if objectBranches == 0 {
+		return grokPermissiveObjectSchema(root)
+	}
+	if len(properties) > 0 {
+		merged["properties"] = properties
+	}
+	if len(required) > 0 {
+		keys := make([]string, 0, len(required))
+		for key := range required {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		values := make([]any, len(keys))
+		for index, key := range keys {
+			values[index] = key
+		}
+		merged["required"] = values
+	}
+	return merged
+}
+
+// normalizeGrokToolParameterSchema 把函数工具参数 schema 归一成 Grok 上游接受
+// 的形态:根节点必须是单一 object(上游对联合/非 object 根返回 400
+// "tool parameter root must be an object type")。返回 (归一后 schema, 是否改写)。
+// 合规的 object 根保持原样,嵌套结构一律不动,避免扰动上游缓存前缀。
+func normalizeGrokToolParameterSchema(schema map[string]any) (map[string]any, bool) {
+	if schema == nil {
+		return schema, false
+	}
+	if typeList, ok := schema["type"].([]any); ok {
+		hasObject := false
+		for _, item := range typeList {
+			if kind, ok := item.(string); ok && kind == "object" {
+				hasObject = true
+				break
+			}
+		}
+		if !hasObject {
+			return grokPermissiveObjectSchema(schema), true
+		}
+		out := make(map[string]any, len(schema))
+		for key, value := range schema {
+			out[key] = value
+		}
+		out["type"] = "object"
+		return out, true
+	}
+	if kind, ok := schema["type"].(string); ok {
+		if kind == "object" {
+			return schema, false
+		}
+		return grokPermissiveObjectSchema(schema), true
+	}
+	for _, key := range []string{"anyOf", "oneOf"} {
+		if branches, ok := schema[key].([]any); ok && len(branches) > 0 {
+			return mergeGrokUnionRootSchema(schema, branches, false), true
+		}
+	}
+	if branches, ok := schema["allOf"].([]any); ok && len(branches) > 0 {
+		return mergeGrokUnionRootSchema(schema, branches, true), true
+	}
+	if _, ok := schema["properties"]; ok {
+		out := make(map[string]any, len(schema)+1)
+		for key, value := range schema {
+			out[key] = value
+		}
+		out["type"] = "object"
+		return out, true
+	}
+	if len(schema) == 0 {
+		return map[string]any{"type": "object"}, true
+	}
+	return grokPermissiveObjectSchema(schema), true
+}
+
 func normalizeGrokFunctionTool(tool map[string]any, name string) map[string]any {
 	converted := make(map[string]any, len(tool))
 	for key, value := range tool {
@@ -125,6 +277,11 @@ func normalizeGrokFunctionTool(tool map[string]any, name string) map[string]any 
 		"metadata", "x_provider", "cache_control", "cacheControl",
 	} {
 		delete(converted, key)
+	}
+	if params, ok := converted["parameters"].(map[string]any); ok {
+		if normalized, changed := normalizeGrokToolParameterSchema(params); changed {
+			converted["parameters"] = normalized
+		}
 	}
 	return converted
 }

--- a/proxy/grok_namespace_tools_test.go
+++ b/proxy/grok_namespace_tools_test.go
@@ -575,3 +575,77 @@ func TestNormalizeGrokUpstreamToolsCleansHistory(t *testing.T) {
 		t.Fatalf("function_call_output status not stripped: %s", gjson.GetBytes(out, "input.2").Raw)
 	}
 }
+
+
+// Grok 上游要求函数工具参数 schema 根节点必须是单一 object(联合根会 400
+// "tool parameter root must be an object type")。桥接层必须把联合根合并、
+// 非 object 根降级,且不得改动本就合规的 schema 与嵌套联合。
+func TestGrokFunctionToolRootSchemaNormalizedForUpstream(t *testing.T) {
+	body := []byte(`{
+		"model":"grok-4.6",
+		"tools":[
+			{"type":"function","name":"mcp__codex_app__automation_update","parameters":{
+				"description":"update automation",
+				"anyOf":[
+					{"type":"object","properties":{"action":{"type":"string"},"shared":{"type":"integer"}},"required":["action","shared"]},
+					{"type":"object","properties":{"batch":{"type":"array"},"shared":{"type":"integer"}},"required":["batch","shared"]},
+					{"type":"null"}
+				]
+			}},
+			{"type":"function","name":"string_root","parameters":{"type":"string","description":"raw text"}},
+			{"type":"function","name":"type_list_root","parameters":{"type":["object","null"],"properties":{"a":{"type":"string"}}}},
+			{"type":"function","name":"nested_union_ok","parameters":{"type":"object","properties":{"choice":{"anyOf":[{"type":"string"},{"type":"integer"}]}}}}
+		],
+		"input":[{"type":"message","role":"user","content":"hi"}]
+	}`)
+	result := prepareGrokUpstreamBody(body)
+
+	union := gjson.GetBytes(result.Body, `tools.#(name=="mcp__codex_app__automation_update").parameters`)
+	if union.Get("type").String() != "object" {
+		t.Fatalf("union root not normalized to object: %s", union.Raw)
+	}
+	if union.Get("anyOf").Exists() {
+		t.Fatalf("anyOf must not survive at root: %s", union.Raw)
+	}
+	if !union.Get("properties.action").Exists() || !union.Get("properties.batch").Exists() {
+		t.Fatalf("merged properties missing: %s", union.Raw)
+	}
+	required := union.Get("required").Array()
+	if len(required) != 1 || required[0].String() != "shared" {
+		t.Fatalf("required must keep only keys mandatory in every object branch, got %s", union.Get("required").Raw)
+	}
+	if union.Get("description").String() != "update automation" {
+		t.Fatalf("root description lost: %s", union.Raw)
+	}
+
+	stringRoot := gjson.GetBytes(result.Body, `tools.#(name=="string_root").parameters`)
+	if stringRoot.Get("type").String() != "object" {
+		t.Fatalf("non-object root not degraded to object: %s", stringRoot.Raw)
+	}
+	if stringRoot.Get("description").String() != "raw text" {
+		t.Fatalf("degraded schema must keep description: %s", stringRoot.Raw)
+	}
+
+	typeList := gjson.GetBytes(result.Body, `tools.#(name=="type_list_root").parameters`)
+	if typeList.Get("type").String() != "object" {
+		t.Fatalf("type-array root not collapsed to object: %s", typeList.Raw)
+	}
+	if !typeList.Get("properties.a").Exists() {
+		t.Fatalf("type-array root must keep properties: %s", typeList.Raw)
+	}
+
+	nested := gjson.GetBytes(result.Body, `tools.#(name=="nested_union_ok").parameters`)
+	if !nested.Get("properties.choice.anyOf").Exists() {
+		t.Fatalf("nested anyOf must stay untouched: %s", nested.Raw)
+	}
+}
+
+// 合规的纯 object schema 不应被改写(改写会破坏上游缓存前缀稳定性)。
+func TestGrokFunctionToolObjectRootSchemaUntouched(t *testing.T) {
+	body := []byte(`{"model":"grok-4.6","tools":[{"type":"function","name":"plain","parameters":{"type":"object","properties":{"q":{"type":"string"}},"required":["q"]}}],"input":[{"type":"message","role":"user","content":"hi"}]}`)
+	result := prepareGrokUpstreamBody(body)
+	schema := gjson.GetBytes(result.Body, `tools.0.parameters`)
+	if schema.Get("type").String() != "object" || !schema.Get("properties.q").Exists() || schema.Get("required.0").String() != "q" {
+		t.Fatalf("compliant schema was altered: %s", schema.Raw)
+	}
+}

--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -571,6 +571,14 @@ func usageLogErrorMessageImpl(statusCode int, body []byte, trustedText bool) str
 			break
 		}
 	}
+	if message == "" {
+		// Grok/xAI 风格错误体把说明放在顶层字符串 error 字段:
+		// {"code":"invalid-argument","error":"..."}。仅在 error 是字符串时采用,
+		// 避免把对象形态的整段 JSON 打进 message。
+		if errField := gjson.GetBytes(body, "error"); errField.Type == gjson.String {
+			message = strings.TrimSpace(errField.String())
+		}
+	}
 
 	codeCandidates := []string{
 		gjson.GetBytes(body, "error.code").String(),

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -5814,3 +5814,24 @@ func TestResponsesCompactSuffixOnlyRequestLogsBaseModel(t *testing.T) {
 		t.Fatalf("x-model = %q, want base gpt-5.6-sol (suffix stripped for display)", got)
 	}
 }
+
+// Grok/xAI 的错误体用顶层字符串 error 字段({"code":"...","error":"文本"})。
+// 解析器此前只认 error.message 对象形态,导致这类 400 对用户只显示裸的
+// "Upstream returned status 400",根因全靠翻容器日志。
+func TestUsageLogErrorMessageGrokStringErrorField(t *testing.T) {
+	got := usageLogErrorMessage(400, []byte(`{"code":"invalid-argument","error":"The function name tool_search is reserved for the tool_search tool"}`))
+	want := "invalid-argument · The function name tool_search is reserved for the tool_search tool"
+	if got != want {
+		t.Fatalf("grok string error not extracted: got %q want %q", got, want)
+	}
+
+	// 对象形态不受影响。
+	if got := usageLogErrorMessage(400, []byte(`{"error":{"message":"object form","code":"bad"}}`)); got != "bad · object form" {
+		t.Fatalf("object error form regressed: %q", got)
+	}
+
+	// error 为对象但无 message 时不得把整个 JSON 打进 message。
+	if got := usageLogErrorMessage(400, []byte(`{"error":{"foo":"bar"}}`)); got != "HTTP 400" {
+		t.Fatalf("object error without message must fall back: %q", got)
+	}
+}


### PR DESCRIPTION
## Problem / 问题

When a client bridges MCP tools whose parameter JSON Schema root is an `anyOf`/`oneOf` union (e.g. Codex App's `mcp__codex_app__automation_update`), Grok's strict tool deserializer rejects the whole request with:

> `{"code":"invalid-argument","error":"... tool parameter root must be an object type (root schema is an anyOf/oneOf union with a non-object branch)"}`

This hard-400s the entire conversation for grok models while the same tools work on OpenAI models. On top of that, Grok/xAI error bodies put the explanation in a top-level **string** `error` field, which the error extractor didn't recognize — clients and usage logs only saw a bare `Upstream returned status 400`, so diagnosis required container logs.

复现:Codex App(经 CC Switch)+ grok-4.6,只要工具的参数 schema 根是 anyOf/oneOf 联合即必现 400,且下游只看得到裸 400。

## Changes / 修复

1. **`proxy/grok_namespace_tools.go`** — normalize function tool parameter schema roots before dispatching to Grok:
   - `anyOf`/`oneOf` roots: merge object branches into one object schema — `properties` union; `required` keeps only keys mandatory in **every** object branch (union semantics), while `allOf` keeps the union of `required` (all-must-hold semantics); non-object branches are dropped.
   - `type` arrays containing `"object"` collapse to `"object"`, keeping the rest of the schema.
   - Any other non-object root degrades to a permissive object schema that keeps the original `description` — a degraded-but-working tool beats a hard 400; the client still performs the real parameter validation.
   - Compliant object roots and **nested** unions stay byte-identical, so upstream prefix caching is not disturbed. Applied inside `normalizeGrokFunctionTool`, covering both the request path and the preflight path.
2. **`proxy/handler.go`** — `usageLogErrorMessageImpl` additionally accepts the top-level string-form `error` field (only when it is a JSON string), so these upstream messages reach clients and usage logs; object-form handling and the HTML/plain-text fallback are unchanged.

## Tests / 验证

- New regression tests: union-root merging (incl. required intersection semantics), type-array roots, non-object root degradation, nested unions untouched, compliant schemas untouched, string-form error extraction plus object-form regression.
- `go test ./...` passes.

_This patch was AI-assisted (Claude)._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility with Grok function tools by automatically accepting a wider range of parameter schema formats.
  - Preserved valid schemas while safely handling incomplete, combined, or non-object definitions.
  - Improved error reporting for Grok and xAI responses that return error messages as plain text.
  - Maintained existing handling for structured error responses and status-based fallbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->