### PR TITLE
feat(admin): add guarded ChatGPT subscription upgrades

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,6 +61,10 @@ CODEX_PORT=8080
 # 快速调度器（可选，也可在管理后台运行时开启）
 # FAST_SCHEDULER_ENABLED=true
 
+# 实验性 ChatGPT 订阅升级管理 API（默认关闭）
+# 使用未公开的 ChatGPT Web 端点，只应在管理员人工确认报价后单账号调用。
+# CODEX2API_SUBSCRIPTION_UPGRADES_ENABLED=false
+
 # 生图工作台图库目录；Docker 标准版 compose 已将 /data 挂载为持久化卷
 IMAGE_ASSET_DIR=/data/images
 

--- a/admin/handler.go
+++ b/admin/handler.go
@@ -163,6 +163,13 @@ type Handler struct {
 	// Agent Identity 导入互斥锁：串行化 runtime_id 的数据库查重与插入，
 	// 防止并发请求在“检查不存在”后同时建号。
 	agentIdentityImportMu sync.Mutex
+
+	// Paid subscription mutations are experimental and disabled by default.
+	subscriptionUpgradeEnabled       bool
+	subscriptionUpgradeClientFactory func(*auth.Account, string) subscriptionUpgradeUpstream
+	subscriptionUpgradeQuoteMu       sync.Mutex
+	subscriptionUpgradeQuotes        map[string]subscriptionUpgradeQuoteRecord
+	subscriptionUpgradeLocks         sync.Map
 }
 
 type responseCacheSettingsStore interface {
@@ -931,22 +938,27 @@ func parseUsageChannel(c *gin.Context) string {
 // NewHandler 创建管理后台处理器
 func NewHandler(store *auth.Store, db *database.DB, tc cache.TokenCache, rl *proxy.RateLimiter, adminSecretEnv string) *Handler {
 	handler := &Handler{
-		store:                store,
-		cache:                tc,
-		db:                   db,
-		cacheCfgStore:        db,
-		rateLimiter:          rl,
-		cpuSampler:           newCPUSampler(),
-		startedAt:            time.Now(),
-		databaseDriver:       db.Driver(),
-		databaseLabel:        db.Label(),
-		cacheDriver:          tc.Driver(),
-		cacheLabel:           tc.Label(),
-		adminSecretEnv:       adminSecretEnv,
-		imageProxy:           proxy.NewHandler(store, db, nil, nil),
-		chartCacheData:       make(map[string]*chartCacheEntry),
-		accountListCache:     make(map[string]*accountListSnapshot),
-		accountAnalysisCache: make(map[string]*accountAnalysisCacheEntry),
+		store:                      store,
+		cache:                      tc,
+		db:                         db,
+		cacheCfgStore:              db,
+		rateLimiter:                rl,
+		cpuSampler:                 newCPUSampler(),
+		startedAt:                  time.Now(),
+		databaseDriver:             db.Driver(),
+		databaseLabel:              db.Label(),
+		cacheDriver:                tc.Driver(),
+		cacheLabel:                 tc.Label(),
+		adminSecretEnv:             adminSecretEnv,
+		imageProxy:                 proxy.NewHandler(store, db, nil, nil),
+		chartCacheData:             make(map[string]*chartCacheEntry),
+		accountListCache:           make(map[string]*accountListSnapshot),
+		accountAnalysisCache:       make(map[string]*accountAnalysisCacheEntry),
+		subscriptionUpgradeEnabled: subscriptionUpgradeFeatureEnabled(),
+		subscriptionUpgradeQuotes:  make(map[string]subscriptionUpgradeQuoteRecord),
+		subscriptionUpgradeClientFactory: func(account *auth.Account, proxyURL string) subscriptionUpgradeUpstream {
+			return proxy.NewChatGPTSubscriptionUpgradeClient(account, proxyURL)
+		},
 	}
 	if handler.imageProxy != nil {
 		handler.imageProxy.SetRuntimeCache(tc)
@@ -1025,6 +1037,10 @@ func (h *Handler) RegisterRoutes(r *gin.Engine) {
 	api.GET("/accounts/page-stats", h.GetAccountPageStats)
 	api.GET("/accounts/live", h.GetAccountLiveState)
 	api.GET("/accounts/:id", h.GetAccount)
+	api.GET("/accounts/:id/subscription", h.GetAccountSubscription)
+	api.POST("/accounts/:id/subscription/upgrade-quotes", h.CreateSubscriptionUpgradeQuote)
+	api.POST("/accounts/:id/subscription/upgrades", h.CreateSubscriptionUpgrade)
+	api.GET("/subscription-upgrades/:operation_id", h.GetSubscriptionUpgradeOperation)
 	api.POST("/accounts", h.AddAccount)
 	api.POST("/accounts/at", h.AddATAccount)
 	api.POST("/accounts/codex/agent-identity", h.ImportCodexAgentIdentity)

--- a/admin/subscription_upgrade.go
+++ b/admin/subscription_upgrade.go
@@ -1,0 +1,344 @@
+package admin
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/codex2api/auth"
+	"github.com/codex2api/database"
+	"github.com/codex2api/proxy"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+)
+
+const subscriptionUpgradeQuoteTTL = 2 * time.Minute
+
+type subscriptionUpgradeUpstream interface {
+	Read(context.Context, proxy.SubscriptionUpgradeCredentials) (*proxy.ChatGPTSubscription, error)
+	Quote(context.Context, proxy.SubscriptionUpgradeCredentials, string, string) (*proxy.SubscriptionUpgradeQuote, error)
+	Submit(context.Context, proxy.SubscriptionUpgradeCredentials, proxy.SubscriptionUpgradeSubmission) (*proxy.SubscriptionUpgradeSubmitResult, error)
+}
+
+type subscriptionUpgradeQuoteRecord struct {
+	ID             string
+	AccountID      int64
+	SourcePlan     string
+	TargetPlan     string
+	ExpectedPlan   string
+	Currency       string
+	AmountDueMinor int64
+	ExpiresAt      time.Time
+}
+
+func subscriptionUpgradeFeatureEnabled() bool {
+	enabled, err := strconv.ParseBool(strings.TrimSpace(os.Getenv("CODEX2API_SUBSCRIPTION_UPGRADES_ENABLED")))
+	return err == nil && enabled
+}
+
+func (h *Handler) subscriptionUpgradeReady(c *gin.Context) bool {
+	if h == nil || !h.subscriptionUpgradeEnabled {
+		c.JSON(http.StatusNotFound, gin.H{"error": "subscription upgrade feature is disabled"})
+		return false
+	}
+	if h.store == nil || h.db == nil || h.subscriptionUpgradeClientFactory == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "subscription upgrade service is unavailable"})
+		return false
+	}
+	return true
+}
+
+func (h *Handler) subscriptionUpgradeAccount(c *gin.Context) (*auth.Account, bool) {
+	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil || id <= 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid account id"})
+		return nil, false
+	}
+	account := h.store.FindByID(id)
+	if account == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "account not found"})
+		return nil, false
+	}
+	credentials := subscriptionUpgradeCredentials(account)
+	if credentials.AccessToken == "" || credentials.WorkspaceID == "" {
+		c.JSON(http.StatusConflict, gin.H{"error": "account has no usable ChatGPT OAuth workspace credentials"})
+		return nil, false
+	}
+	return account, true
+}
+
+func subscriptionUpgradeCredentials(account *auth.Account) proxy.SubscriptionUpgradeCredentials {
+	if account == nil {
+		return proxy.SubscriptionUpgradeCredentials{}
+	}
+	return proxy.SubscriptionUpgradeCredentials{
+		AccessToken: account.GetAccessToken(),
+		WorkspaceID: account.EffectiveAccountID(),
+		DeviceID:    uuid.NewSHA1(uuid.NameSpaceURL, []byte(fmt.Sprintf("codex2api:subscription-upgrade:%d", account.DBID))).String(),
+	}
+}
+
+func subscriptionUpgradeTransition(sourcePlan, targetPlan string) (string, bool) {
+	sourcePlan = strings.ToLower(strings.TrimSpace(sourcePlan))
+	switch strings.ToLower(strings.TrimSpace(targetPlan)) {
+	case "chatgptprolite":
+		return "prolite", sourcePlan == "plus"
+	case "chatgptpro":
+		return "pro", sourcePlan == "prolite"
+	default:
+		return "", false
+	}
+}
+
+func (h *Handler) GetAccountSubscription(c *gin.Context) {
+	if !h.subscriptionUpgradeReady(c) {
+		return
+	}
+	account, ok := h.subscriptionUpgradeAccount(c)
+	if !ok {
+		return
+	}
+	client := h.subscriptionUpgradeClientFactory(account, account.GetProxyURL())
+	subscription, err := client.Read(c.Request.Context(), subscriptionUpgradeCredentials(account))
+	if err != nil {
+		c.JSON(http.StatusBadGateway, gin.H{"error": "failed to read upstream subscription"})
+		return
+	}
+	c.JSON(http.StatusOK, subscription)
+}
+
+func (h *Handler) CreateSubscriptionUpgradeQuote(c *gin.Context) {
+	if !h.subscriptionUpgradeReady(c) {
+		return
+	}
+	account, ok := h.subscriptionUpgradeAccount(c)
+	if !ok {
+		return
+	}
+	var request struct {
+		TargetPlan string `json:"target_plan" binding:"required"`
+		Currency   string `json:"currency" binding:"required"`
+	}
+	if err := c.ShouldBindJSON(&request); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "target_plan and currency are required"})
+		return
+	}
+	credentials := subscriptionUpgradeCredentials(account)
+	client := h.subscriptionUpgradeClientFactory(account, account.GetProxyURL())
+	subscription, err := client.Read(c.Request.Context(), credentials)
+	if err != nil || subscription == nil {
+		c.JSON(http.StatusBadGateway, gin.H{"error": "failed to read upstream subscription"})
+		return
+	}
+	expectedPlan, allowed := subscriptionUpgradeTransition(subscription.PlanType, request.TargetPlan)
+	if !allowed || subscription.IsDelinquent {
+		c.JSON(http.StatusConflict, gin.H{"error": "requested subscription transition is not allowed"})
+		return
+	}
+	requestedCurrency := strings.ToUpper(strings.TrimSpace(request.Currency))
+	if observedCurrency := strings.ToUpper(strings.TrimSpace(subscription.BillingCurrency)); observedCurrency != "" && observedCurrency != requestedCurrency {
+		c.JSON(http.StatusConflict, gin.H{"error": "requested currency does not match the current subscription"})
+		return
+	}
+	quote, err := client.Quote(c.Request.Context(), credentials, request.TargetPlan, requestedCurrency)
+	if err != nil || quote == nil {
+		c.JSON(http.StatusBadGateway, gin.H{"error": "failed to preview subscription upgrade"})
+		return
+	}
+	now := time.Now().UTC()
+	record := subscriptionUpgradeQuoteRecord{
+		ID: uuid.NewString(), AccountID: account.DBID, SourcePlan: strings.ToLower(subscription.PlanType),
+		TargetPlan: strings.ToLower(request.TargetPlan), ExpectedPlan: expectedPlan,
+		Currency: strings.ToUpper(quote.Currency), AmountDueMinor: quote.AmountDueMinor,
+		ExpiresAt: now.Add(subscriptionUpgradeQuoteTTL),
+	}
+	h.subscriptionUpgradeQuoteMu.Lock()
+	h.subscriptionUpgradeQuotes[record.ID] = record
+	h.subscriptionUpgradeQuoteMu.Unlock()
+	c.JSON(http.StatusOK, gin.H{
+		"quote_id": record.ID, "source_plan": record.SourcePlan, "target_plan": record.TargetPlan,
+		"currency": record.Currency, "amount_due_minor": record.AmountDueMinor,
+		"recurring_amount_minor": quote.RecurringAmountMinor, "tax_amount_minor": quote.TaxAmountMinor,
+		"renewal_date": quote.RenewalDate, "default_payment_method_present": quote.DefaultPaymentMethodPresent,
+		"line_items": quote.LineItems, "expires_at": record.ExpiresAt,
+	})
+}
+
+func (h *Handler) CreateSubscriptionUpgrade(c *gin.Context) {
+	if !h.subscriptionUpgradeReady(c) {
+		return
+	}
+	account, ok := h.subscriptionUpgradeAccount(c)
+	if !ok {
+		return
+	}
+	var request struct {
+		QuoteID        string `json:"quote_id" binding:"required"`
+		Currency       string `json:"currency" binding:"required"`
+		MaxAmountMinor int64  `json:"max_amount_minor" binding:"required"`
+		Confirmed      bool   `json:"confirmed"`
+	}
+	if err := c.ShouldBindJSON(&request); err != nil || !request.Confirmed || request.MaxAmountMinor <= 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "explicit confirmation, currency, quote_id, and a positive max_amount_minor are required"})
+		return
+	}
+	idempotencyKey := strings.TrimSpace(c.GetHeader("Idempotency-Key"))
+	if idempotencyKey == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Idempotency-Key header is required"})
+		return
+	}
+	keyHash := subscriptionUpgradeIdempotencyHash(idempotencyKey)
+	// Resolve a completed/in-flight operation before reading the ephemeral
+	// quote. This keeps retries idempotent across process restarts, where the
+	// short-lived in-memory quote is intentionally lost.
+	if existing, err := h.db.GetSubscriptionUpgradeOperationByIdempotencyHash(c.Request.Context(), account.DBID, keyHash); err == nil {
+		c.JSON(http.StatusOK, existing)
+		return
+	} else if !errors.Is(err, sql.ErrNoRows) {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to read upgrade operation journal"})
+		return
+	}
+	h.subscriptionUpgradeQuoteMu.Lock()
+	quote, exists := h.subscriptionUpgradeQuotes[request.QuoteID]
+	if exists && time.Now().After(quote.ExpiresAt) {
+		delete(h.subscriptionUpgradeQuotes, request.QuoteID)
+		exists = false
+	}
+	h.subscriptionUpgradeQuoteMu.Unlock()
+	if !exists || quote.AccountID != account.DBID {
+		c.JSON(http.StatusConflict, gin.H{"error": "upgrade quote is missing or expired"})
+		return
+	}
+	lockValue, _ := h.subscriptionUpgradeLocks.LoadOrStore(account.DBID, &sync.Mutex{})
+	lock := lockValue.(*sync.Mutex)
+	lock.Lock()
+	defer lock.Unlock()
+
+	credentials := subscriptionUpgradeCredentials(account)
+	client := h.subscriptionUpgradeClientFactory(account, account.GetProxyURL())
+	subscription, err := client.Read(c.Request.Context(), credentials)
+	if err != nil || subscription == nil || strings.ToLower(subscription.PlanType) != quote.SourcePlan || subscription.IsDelinquent {
+		c.JSON(http.StatusConflict, gin.H{"error": "subscription changed since quote"})
+		return
+	}
+	fresh, err := client.Quote(c.Request.Context(), credentials, quote.TargetPlan, quote.Currency)
+	if err != nil || fresh == nil {
+		c.JSON(http.StatusBadGateway, gin.H{"error": "failed to refresh subscription quote"})
+		return
+	}
+	confirmedCurrency := strings.ToUpper(strings.TrimSpace(request.Currency))
+	if confirmedCurrency != quote.Currency || strings.ToUpper(fresh.Currency) != confirmedCurrency || fresh.AmountDueMinor <= 0 || fresh.AmountDueMinor > request.MaxAmountMinor {
+		c.JSON(http.StatusConflict, gin.H{"error": "fresh quote exceeds the confirmed currency or amount cap", "fresh_amount_due_minor": fresh.AmountDueMinor, "currency": fresh.Currency})
+		return
+	}
+	operation := database.SubscriptionUpgradeOperation{
+		ID: uuid.NewString(), AccountID: account.DBID, IdempotencyKeyHash: keyHash,
+		SourcePlan: quote.SourcePlan, TargetPlan: quote.TargetPlan, Currency: confirmedCurrency,
+		AmountDueMinor: fresh.AmountDueMinor, Status: "submitting",
+	}
+	if err := h.db.CreateSubscriptionUpgradeOperation(c.Request.Context(), operation); err != nil {
+		if errors.Is(err, database.ErrSubscriptionUpgradeIdempotencyConflict) {
+			existing, getErr := h.db.GetSubscriptionUpgradeOperationByIdempotencyHash(c.Request.Context(), account.DBID, keyHash)
+			if getErr == nil {
+				c.JSON(http.StatusOK, existing)
+				return
+			}
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create upgrade operation journal"})
+		return
+	}
+	if h.recordAccountEvent != nil {
+		h.recordAccountEvent(account.DBID, "subscription_upgrade_confirmed", fmt.Sprintf("target=%s amount_minor=%d currency=%s operation=%s", quote.TargetPlan, fresh.AmountDueMinor, confirmedCurrency, operation.ID))
+	}
+	// The payment method identifier is intentionally memory-only and is no
+	// longer needed after the durable pre-submit journal exists.
+	h.subscriptionUpgradeQuoteMu.Lock()
+	delete(h.subscriptionUpgradeQuotes, request.QuoteID)
+	h.subscriptionUpgradeQuoteMu.Unlock()
+	result, submitErr := client.Submit(c.Request.Context(), credentials, proxy.SubscriptionUpgradeSubmission{
+		TargetPlan: quote.TargetPlan, FlowID: uuid.NewString(), MutationID: uuid.NewString(),
+		IdempotencyKey: idempotencyKey, PaymentMethodID: fresh.PaymentMethodID,
+	})
+	if submitErr != nil {
+		h.updateSubscriptionUpgradeOperation(c.Request.Context(), operation.ID, "ambiguous_transport", "paid submission outcome is ambiguous; do not retry", 0)
+		h.respondSubscriptionUpgradeOperation(c, operation.ID, http.StatusAccepted)
+		return
+	}
+	if result != nil && result.RequiresUserAction {
+		h.updateSubscriptionUpgradeOperation(c.Request.Context(), operation.ID, "requires_user_action", "complete upstream payment authentication before verification", http.StatusOK)
+		h.respondSubscriptionUpgradeOperation(c, operation.ID, http.StatusAccepted)
+		return
+	}
+	verified, verifyErr := client.Read(c.Request.Context(), credentials)
+	status, detail := "verification_pending", "paid submission accepted; upstream entitlement not yet observed"
+	if verifyErr == nil && verified != nil && strings.EqualFold(verified.PlanType, quote.ExpectedPlan) {
+		status, detail = "succeeded", "upstream entitlement verified"
+	} else if subscriptionUpgradeUnauthorized(verifyErr) {
+		status, detail = "verification_requires_reauthentication", "upstream invalidated the OAuth credential family after accepting the upgrade; reauthorize without repeating payment"
+		// A separately stored ChatGPT Web Session can mint a new OAuth family.
+		// Re-saving the invalidated AT/RT cannot. Refresh at most once and only
+		// re-run the read-only verification; the paid POST is never repeated.
+		if account.HasSessionToken() && h.refreshAccount != nil {
+			if refreshErr := h.refreshAccount(c.Request.Context(), account.DBID); refreshErr == nil {
+				refreshedAccount := h.store.FindByID(account.DBID)
+				if refreshedAccount != nil {
+					refreshedClient := h.subscriptionUpgradeClientFactory(refreshedAccount, refreshedAccount.GetProxyURL())
+					refreshedSubscription, refreshedErr := refreshedClient.Read(c.Request.Context(), subscriptionUpgradeCredentials(refreshedAccount))
+					if refreshedErr == nil && refreshedSubscription != nil && strings.EqualFold(refreshedSubscription.PlanType, quote.ExpectedPlan) {
+						status, detail = "succeeded", "upstream entitlement verified after silent reauthorization from the stored web session"
+					}
+				}
+			}
+		}
+	}
+	h.updateSubscriptionUpgradeOperation(c.Request.Context(), operation.ID, status, detail, http.StatusOK)
+	h.respondSubscriptionUpgradeOperation(c, operation.ID, http.StatusAccepted)
+}
+
+func subscriptionUpgradeIdempotencyHash(key string) string {
+	sum := sha256.Sum256([]byte(key))
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func subscriptionUpgradeUnauthorized(err error) bool {
+	var upstreamErr *proxy.SubscriptionUpstreamHTTPError
+	return errors.As(err, &upstreamErr) && (upstreamErr.StatusCode == http.StatusUnauthorized || upstreamErr.StatusCode == http.StatusForbidden)
+}
+
+func (h *Handler) updateSubscriptionUpgradeOperation(ctx context.Context, id, status, detail string, httpStatus int) {
+	_ = h.db.UpdateSubscriptionUpgradeOperation(ctx, id, status, detail, httpStatus)
+}
+
+func (h *Handler) respondSubscriptionUpgradeOperation(c *gin.Context, id string, status int) {
+	operation, err := h.db.GetSubscriptionUpgradeOperation(c.Request.Context(), id)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to read upgrade operation journal"})
+		return
+	}
+	c.JSON(status, operation)
+}
+
+func (h *Handler) GetSubscriptionUpgradeOperation(c *gin.Context) {
+	if !h.subscriptionUpgradeReady(c) {
+		return
+	}
+	operation, err := h.db.GetSubscriptionUpgradeOperation(c.Request.Context(), strings.TrimSpace(c.Param("operation_id")))
+	if errors.Is(err, sql.ErrNoRows) {
+		c.JSON(http.StatusNotFound, gin.H{"error": "subscription upgrade operation not found"})
+		return
+	}
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to read upgrade operation journal"})
+		return
+	}
+	c.JSON(http.StatusOK, operation)
+}

--- a/admin/subscription_upgrade.go
+++ b/admin/subscription_upgrade.go
@@ -169,7 +169,8 @@ func (h *Handler) CreateSubscriptionUpgradeQuote(c *gin.Context) {
 		"currency": record.Currency, "amount_due_minor": record.AmountDueMinor,
 		"recurring_amount_minor": quote.RecurringAmountMinor, "tax_amount_minor": quote.TaxAmountMinor,
 		"renewal_date": quote.RenewalDate, "default_payment_method_present": quote.DefaultPaymentMethodPresent,
-		"line_items": quote.LineItems, "expires_at": record.ExpiresAt,
+		"silent_reauthorization_available": account.HasSessionToken(),
+		"line_items":                       quote.LineItems, "expires_at": record.ExpiresAt,
 	})
 }
 

--- a/admin/subscription_upgrade_test.go
+++ b/admin/subscription_upgrade_test.go
@@ -84,6 +84,9 @@ func TestSubscriptionUpgradeTokenInvalidationRequiresReauthenticationWithoutSeco
 	quoteContext.Params = gin.Params{{Key: "id", Value: "20"}}
 	quoteContext.Request = httptest.NewRequest(http.MethodPost, "/api/admin/accounts/20/subscription/upgrade-quotes", strings.NewReader(`{"target_plan":"chatgptpro","currency":"PHP"}`))
 	handler.CreateSubscriptionUpgradeQuote(quoteContext)
+	if strings.Contains(quoteRecorder.Body.String(), `"silent_reauthorization_available":true`) {
+		t.Fatal("quote must not claim silent reauthorization without a Web Session")
+	}
 	var quoteResponse struct {
 		QuoteID string `json:"quote_id"`
 	}
@@ -155,6 +158,9 @@ func TestSubscriptionUpgradeUsesStoredWebSessionOnlyForReadOnlyRecovery(t *testi
 	quoteContext.Params = gin.Params{{Key: "id", Value: "20"}}
 	quoteContext.Request = httptest.NewRequest(http.MethodPost, "/api/admin/accounts/20/subscription/upgrade-quotes", strings.NewReader(`{"target_plan":"chatgptpro","currency":"PHP"}`))
 	handler.CreateSubscriptionUpgradeQuote(quoteContext)
+	if !strings.Contains(quoteRecorder.Body.String(), `"silent_reauthorization_available":true`) {
+		t.Fatalf("quote does not report stored Web Session readiness: %s", quoteRecorder.Body.String())
+	}
 	var quoteResponse struct {
 		QuoteID string `json:"quote_id"`
 	}

--- a/admin/subscription_upgrade_test.go
+++ b/admin/subscription_upgrade_test.go
@@ -1,0 +1,249 @@
+package admin
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/codex2api/auth"
+	"github.com/codex2api/database"
+	"github.com/codex2api/proxy"
+	"github.com/gin-gonic/gin"
+)
+
+const subscriptionUpgradeTestWorkspaceID = "288c5d93-a113-4ed3-b6a9-08b6a4d35417"
+
+type fakeSubscriptionUpgradeUpstream struct {
+	readResult   *proxy.ChatGPTSubscription
+	readErr      error
+	readResults  []*proxy.ChatGPTSubscription
+	readErrors   []error
+	readCount    int
+	quoteResult  *proxy.SubscriptionUpgradeQuote
+	submitResult *proxy.SubscriptionUpgradeSubmitResult
+	submitErr    error
+	submitCount  int
+}
+
+func (f *fakeSubscriptionUpgradeUpstream) Read(context.Context, proxy.SubscriptionUpgradeCredentials) (*proxy.ChatGPTSubscription, error) {
+	if f.readCount < len(f.readResults) || f.readCount < len(f.readErrors) {
+		index := f.readCount
+		f.readCount++
+		var result *proxy.ChatGPTSubscription
+		var err error
+		if index < len(f.readResults) {
+			result = f.readResults[index]
+		}
+		if index < len(f.readErrors) {
+			err = f.readErrors[index]
+		}
+		return result, err
+	}
+	return f.readResult, f.readErr
+}
+
+func (f *fakeSubscriptionUpgradeUpstream) Quote(context.Context, proxy.SubscriptionUpgradeCredentials, string, string) (*proxy.SubscriptionUpgradeQuote, error) {
+	return f.quoteResult, nil
+}
+
+func TestSubscriptionUpgradeTokenInvalidationRequiresReauthenticationWithoutSecondPaidPost(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	db, err := database.New("sqlite", filepath.Join(t.TempDir(), "codex2api.db"))
+	if err != nil {
+		t.Fatalf("database.New: %v", err)
+	}
+	defer db.Close()
+	store := auth.NewStore(db, nil, &database.SystemSettings{MaxConcurrency: 2})
+	account := &auth.Account{DBID: 20, AccessToken: "test-at", AccountID: subscriptionUpgradeTestWorkspaceID, PlanType: "prolite"}
+	store.AddAccount(account)
+	prolite := &proxy.ChatGPTSubscription{PlanType: "prolite", BillingCurrency: "PHP"}
+	fake := &fakeSubscriptionUpgradeUpstream{
+		readResults: []*proxy.ChatGPTSubscription{prolite, prolite, nil},
+		readErrors:  []error{nil, nil, &proxy.SubscriptionUpstreamHTTPError{StatusCode: http.StatusUnauthorized, Body: "invalidated"}},
+		quoteResult: &proxy.SubscriptionUpgradeQuote{
+			Currency: "PHP", AmountDueMinor: 345196, RecurringAmountMinor: 999000,
+		},
+		submitResult: &proxy.SubscriptionUpgradeSubmitResult{Status: "succeeded"},
+	}
+	handler := &Handler{
+		store:                      store,
+		db:                         db,
+		subscriptionUpgradeEnabled: true,
+		subscriptionUpgradeQuotes:  make(map[string]subscriptionUpgradeQuoteRecord),
+		subscriptionUpgradeClientFactory: func(*auth.Account, string) subscriptionUpgradeUpstream {
+			return fake
+		},
+	}
+
+	quoteRecorder := httptest.NewRecorder()
+	quoteContext, _ := gin.CreateTestContext(quoteRecorder)
+	quoteContext.Params = gin.Params{{Key: "id", Value: "20"}}
+	quoteContext.Request = httptest.NewRequest(http.MethodPost, "/api/admin/accounts/20/subscription/upgrade-quotes", strings.NewReader(`{"target_plan":"chatgptpro","currency":"PHP"}`))
+	handler.CreateSubscriptionUpgradeQuote(quoteContext)
+	var quoteResponse struct {
+		QuoteID string `json:"quote_id"`
+	}
+	if err := json.Unmarshal(quoteRecorder.Body.Bytes(), &quoteResponse); err != nil || quoteResponse.QuoteID == "" {
+		t.Fatalf("quote response = %s, err=%v", quoteRecorder.Body.String(), err)
+	}
+
+	body := `{"quote_id":"` + quoteResponse.QuoteID + `","currency":"PHP","max_amount_minor":350000,"confirmed":true}`
+	invoke := func() *httptest.ResponseRecorder {
+		recorder := httptest.NewRecorder()
+		ctx, _ := gin.CreateTestContext(recorder)
+		ctx.Params = gin.Params{{Key: "id", Value: "20"}}
+		ctx.Request = httptest.NewRequest(http.MethodPost, "/api/admin/accounts/20/subscription/upgrades", strings.NewReader(body))
+		ctx.Request.Header.Set("Idempotency-Key", "upgrade-once")
+		handler.CreateSubscriptionUpgrade(ctx)
+		return recorder
+	}
+	first := invoke()
+	if first.Code != http.StatusAccepted || !strings.Contains(first.Body.String(), "verification_requires_reauthentication") {
+		t.Fatalf("first response status=%d body=%s", first.Code, first.Body.String())
+	}
+	second := invoke()
+	if second.Code != http.StatusOK || !strings.Contains(second.Body.String(), "verification_requires_reauthentication") {
+		t.Fatalf("idempotent response status=%d body=%s", second.Code, second.Body.String())
+	}
+	if fake.submitCount != 1 {
+		t.Fatalf("paid POST count = %d, want exactly one", fake.submitCount)
+	}
+}
+
+func TestSubscriptionUpgradeUsesStoredWebSessionOnlyForReadOnlyRecovery(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	db, err := database.New("sqlite", filepath.Join(t.TempDir(), "codex2api.db"))
+	if err != nil {
+		t.Fatalf("database.New: %v", err)
+	}
+	defer db.Close()
+	store := auth.NewStore(db, nil, &database.SystemSettings{MaxConcurrency: 2})
+	account := &auth.Account{
+		DBID: 20, AccessToken: "old-at", SessionToken: "independent-web-session",
+		AccountID: subscriptionUpgradeTestWorkspaceID, PlanType: "prolite",
+	}
+	store.AddAccount(account)
+	prolite := &proxy.ChatGPTSubscription{PlanType: "prolite", BillingCurrency: "PHP"}
+	fake := &fakeSubscriptionUpgradeUpstream{
+		readResults:  []*proxy.ChatGPTSubscription{prolite, prolite, nil, {PlanType: "pro"}},
+		readErrors:   []error{nil, nil, &proxy.SubscriptionUpstreamHTTPError{StatusCode: http.StatusUnauthorized}, nil},
+		quoteResult:  &proxy.SubscriptionUpgradeQuote{Currency: "PHP", AmountDueMinor: 345196, RecurringAmountMinor: 999000},
+		submitResult: &proxy.SubscriptionUpgradeSubmitResult{Status: "succeeded"},
+	}
+	refreshCount := 0
+	handler := &Handler{
+		store:                      store,
+		db:                         db,
+		subscriptionUpgradeEnabled: true,
+		subscriptionUpgradeQuotes:  make(map[string]subscriptionUpgradeQuoteRecord),
+		subscriptionUpgradeClientFactory: func(*auth.Account, string) subscriptionUpgradeUpstream {
+			return fake
+		},
+		refreshAccount: func(context.Context, int64) error {
+			refreshCount++
+			account.AccessToken = "new-at"
+			return nil
+		},
+	}
+
+	quoteRecorder := httptest.NewRecorder()
+	quoteContext, _ := gin.CreateTestContext(quoteRecorder)
+	quoteContext.Params = gin.Params{{Key: "id", Value: "20"}}
+	quoteContext.Request = httptest.NewRequest(http.MethodPost, "/api/admin/accounts/20/subscription/upgrade-quotes", strings.NewReader(`{"target_plan":"chatgptpro","currency":"PHP"}`))
+	handler.CreateSubscriptionUpgradeQuote(quoteContext)
+	var quoteResponse struct {
+		QuoteID string `json:"quote_id"`
+	}
+	_ = json.Unmarshal(quoteRecorder.Body.Bytes(), &quoteResponse)
+
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Params = gin.Params{{Key: "id", Value: "20"}}
+	ctx.Request = httptest.NewRequest(http.MethodPost, "/api/admin/accounts/20/subscription/upgrades", strings.NewReader(`{"quote_id":"`+quoteResponse.QuoteID+`","currency":"PHP","max_amount_minor":350000,"confirmed":true}`))
+	ctx.Request.Header.Set("Idempotency-Key", "upgrade-with-web-session")
+	handler.CreateSubscriptionUpgrade(ctx)
+
+	if recorder.Code != http.StatusAccepted || !strings.Contains(recorder.Body.String(), `"status":"succeeded"`) {
+		t.Fatalf("response status=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+	if refreshCount != 1 || fake.submitCount != 1 {
+		t.Fatalf("refresh count=%d submit count=%d, want 1 and 1", refreshCount, fake.submitCount)
+	}
+}
+
+func TestSubscriptionUpgradeFeatureIsDisabledByDefault(t *testing.T) {
+	t.Setenv("CODEX2API_SUBSCRIPTION_UPGRADES_ENABLED", "")
+	if subscriptionUpgradeFeatureEnabled() {
+		t.Fatal("subscription upgrade feature must default to disabled")
+	}
+}
+
+func (f *fakeSubscriptionUpgradeUpstream) Submit(context.Context, proxy.SubscriptionUpgradeCredentials, proxy.SubscriptionUpgradeSubmission) (*proxy.SubscriptionUpgradeSubmitResult, error) {
+	f.submitCount++
+	return f.submitResult, f.submitErr
+}
+
+func TestSubscriptionUpgradeRejectsFreshQuoteAboveConfirmedCapWithoutSubmitting(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	db, err := database.New("sqlite", filepath.Join(t.TempDir(), "codex2api.db"))
+	if err != nil {
+		t.Fatalf("database.New: %v", err)
+	}
+	defer db.Close()
+	store := auth.NewStore(db, nil, &database.SystemSettings{MaxConcurrency: 2})
+	account := &auth.Account{DBID: 20, AccessToken: "test-at", AccountID: subscriptionUpgradeTestWorkspaceID, PlanType: "prolite"}
+	store.AddAccount(account)
+	fake := &fakeSubscriptionUpgradeUpstream{
+		readResult: &proxy.ChatGPTSubscription{PlanType: "prolite", BillingCurrency: "PHP"},
+		quoteResult: &proxy.SubscriptionUpgradeQuote{
+			Currency: "PHP", AmountDueMinor: 345196, RecurringAmountMinor: 999000,
+		},
+	}
+	handler := &Handler{
+		store:                      store,
+		db:                         db,
+		subscriptionUpgradeEnabled: true,
+		subscriptionUpgradeQuotes:  make(map[string]subscriptionUpgradeQuoteRecord),
+		subscriptionUpgradeClientFactory: func(*auth.Account, string) subscriptionUpgradeUpstream {
+			return fake
+		},
+	}
+
+	quoteRecorder := httptest.NewRecorder()
+	quoteContext, _ := gin.CreateTestContext(quoteRecorder)
+	quoteContext.Params = gin.Params{{Key: "id", Value: "20"}}
+	quoteContext.Request = httptest.NewRequest(http.MethodPost, "/api/admin/accounts/20/subscription/upgrade-quotes", strings.NewReader(`{"target_plan":"chatgptpro","currency":"PHP"}`))
+	handler.CreateSubscriptionUpgradeQuote(quoteContext)
+	if quoteRecorder.Code != http.StatusOK {
+		t.Fatalf("quote status = %d, body=%s", quoteRecorder.Code, quoteRecorder.Body.String())
+	}
+	var quoteResponse struct {
+		QuoteID string `json:"quote_id"`
+	}
+	if err := json.Unmarshal(quoteRecorder.Body.Bytes(), &quoteResponse); err != nil || quoteResponse.QuoteID == "" {
+		t.Fatalf("decode quote response: %v, body=%s", err, quoteRecorder.Body.String())
+	}
+
+	upgradeRecorder := httptest.NewRecorder()
+	upgradeContext, _ := gin.CreateTestContext(upgradeRecorder)
+	upgradeContext.Params = gin.Params{{Key: "id", Value: "20"}}
+	upgradeContext.Request = httptest.NewRequest(http.MethodPost, "/api/admin/accounts/20/subscription/upgrades", strings.NewReader(`{
+		"quote_id":"`+quoteResponse.QuoteID+`",
+		"currency":"PHP",
+		"max_amount_minor":300000,
+		"confirmed":true
+	}`))
+	upgradeContext.Request.Header.Set("Idempotency-Key", "upgrade-once")
+	handler.CreateSubscriptionUpgrade(upgradeContext)
+
+	if upgradeRecorder.Code != http.StatusConflict {
+		t.Fatalf("upgrade status = %d, body=%s", upgradeRecorder.Code, upgradeRecorder.Body.String())
+	}
+	if fake.submitCount != 0 {
+		t.Fatalf("submit count = %d, want 0", fake.submitCount)
+	}
+}

--- a/auth/store.go
+++ b/auth/store.go
@@ -590,6 +590,15 @@ func (a *Account) GetAccessToken() string {
 	return strings.TrimSpace(a.AccessToken)
 }
 
+func (a *Account) HasSessionToken() bool {
+	if a == nil {
+		return false
+	}
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return strings.TrimSpace(a.SessionToken) != ""
+}
+
 func (a *Account) GetCustomHeaders() map[string]string {
 	if a == nil {
 		return nil

--- a/database/postgres.go
+++ b/database/postgres.go
@@ -1609,6 +1609,9 @@ func (db *DB) migrate(ctx context.Context) error {
 	if _, err = db.conn.ExecContext(migrateCtx, migrateQuery); err != nil {
 		return err
 	}
+	if err := db.ensureSubscriptionUpgradeSchema(ctx); err != nil {
+		return err
+	}
 	return db.runDataMigrationsWithTimeout()
 }
 

--- a/database/sqlite.go
+++ b/database/sqlite.go
@@ -802,6 +802,9 @@ func (db *DB) migrateSQLite(ctx context.Context) error {
 	if err := db.installSchedulerOutboxTriggers(ctx); err != nil {
 		return fmt.Errorf("install scheduler outbox triggers: %w", err)
 	}
+	if err := db.ensureSubscriptionUpgradeSchema(ctx); err != nil {
+		return err
+	}
 
 	return db.runDataMigrationsWithTimeout()
 }

--- a/database/subscription_upgrade.go
+++ b/database/subscription_upgrade.go
@@ -1,0 +1,146 @@
+package database
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+)
+
+var ErrSubscriptionUpgradeIdempotencyConflict = errors.New("subscription upgrade idempotency key already exists")
+
+// SubscriptionUpgradeOperation is an append-oriented payment journal. It must
+// contain no OAuth credentials, cookies, payment method IDs, or card data.
+type SubscriptionUpgradeOperation struct {
+	ID                 string    `json:"operation_id"`
+	AccountID          int64     `json:"account_id"`
+	IdempotencyKeyHash string    `json:"-"`
+	SourcePlan         string    `json:"source_plan"`
+	TargetPlan         string    `json:"target_plan"`
+	Currency           string    `json:"currency"`
+	AmountDueMinor     int64     `json:"amount_due_minor"`
+	Status             string    `json:"status"`
+	SubmitHTTPStatus   int       `json:"submit_http_status,omitempty"`
+	Detail             string    `json:"detail,omitempty"`
+	CreatedAt          time.Time `json:"created_at"`
+	UpdatedAt          time.Time `json:"updated_at"`
+}
+
+func (db *DB) ensureSubscriptionUpgradeSchema(ctx context.Context) error {
+	ddl := `CREATE TABLE IF NOT EXISTS subscription_upgrade_operations (
+		id TEXT PRIMARY KEY,
+		account_id BIGINT NOT NULL,
+		idempotency_key_hash TEXT NOT NULL,
+		source_plan TEXT NOT NULL,
+		target_plan TEXT NOT NULL,
+		currency VARCHAR(16) NOT NULL,
+		amount_due_minor BIGINT NOT NULL,
+		status VARCHAR(64) NOT NULL,
+		submit_http_status INT NOT NULL DEFAULT 0,
+		detail TEXT NOT NULL DEFAULT '',
+		created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		UNIQUE(account_id, idempotency_key_hash)
+	)`
+	if db.isSQLite() {
+		ddl = `CREATE TABLE IF NOT EXISTS subscription_upgrade_operations (
+			id TEXT PRIMARY KEY,
+			account_id INTEGER NOT NULL,
+			idempotency_key_hash TEXT NOT NULL,
+			source_plan TEXT NOT NULL,
+			target_plan TEXT NOT NULL,
+			currency TEXT NOT NULL,
+			amount_due_minor INTEGER NOT NULL,
+			status TEXT NOT NULL,
+			submit_http_status INTEGER NOT NULL DEFAULT 0,
+			detail TEXT NOT NULL DEFAULT '',
+			created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			UNIQUE(account_id, idempotency_key_hash)
+		)`
+	}
+	if _, err := db.conn.ExecContext(ctx, ddl); err != nil {
+		return fmt.Errorf("create subscription upgrade operation table: %w", err)
+	}
+	return nil
+}
+
+func (db *DB) CreateSubscriptionUpgradeOperation(ctx context.Context, operation SubscriptionUpgradeOperation) error {
+	query := `INSERT INTO subscription_upgrade_operations (
+		id, account_id, idempotency_key_hash, source_plan, target_plan,
+		currency, amount_due_minor, status, submit_http_status, detail
+	) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
+	ON CONFLICT (account_id, idempotency_key_hash) DO NOTHING`
+	return db.withSQLiteWriteLock(ctx, func() error {
+		result, err := db.conn.ExecContext(ctx, query,
+			operation.ID, operation.AccountID, operation.IdempotencyKeyHash,
+			operation.SourcePlan, operation.TargetPlan, operation.Currency,
+			operation.AmountDueMinor, operation.Status, operation.SubmitHTTPStatus,
+			operation.Detail,
+		)
+		if err != nil {
+			return err
+		}
+		rows, err := result.RowsAffected()
+		if err != nil {
+			return err
+		}
+		if rows == 0 {
+			return ErrSubscriptionUpgradeIdempotencyConflict
+		}
+		return nil
+	})
+}
+
+func (db *DB) UpdateSubscriptionUpgradeOperation(ctx context.Context, id, status, detail string, submitHTTPStatus int) error {
+	return db.withSQLiteWriteLock(ctx, func() error {
+		result, err := db.conn.ExecContext(ctx, `UPDATE subscription_upgrade_operations
+			SET status=$2, detail=$3, submit_http_status=$4, updated_at=CURRENT_TIMESTAMP
+			WHERE id=$1`, id, status, detail, submitHTTPStatus)
+		if err != nil {
+			return err
+		}
+		rows, err := result.RowsAffected()
+		if err != nil {
+			return err
+		}
+		if rows == 0 {
+			return errors.New("subscription upgrade operation not found")
+		}
+		return nil
+	})
+}
+
+func (db *DB) GetSubscriptionUpgradeOperation(ctx context.Context, id string) (*SubscriptionUpgradeOperation, error) {
+	return db.querySubscriptionUpgradeOperation(ctx, `WHERE id=$1`, id)
+}
+
+func (db *DB) GetSubscriptionUpgradeOperationByIdempotencyHash(ctx context.Context, accountID int64, keyHash string) (*SubscriptionUpgradeOperation, error) {
+	return db.querySubscriptionUpgradeOperation(ctx, `WHERE account_id=$1 AND idempotency_key_hash=$2`, accountID, keyHash)
+}
+
+func (db *DB) querySubscriptionUpgradeOperation(ctx context.Context, where string, args ...any) (*SubscriptionUpgradeOperation, error) {
+	query := `SELECT id, account_id, idempotency_key_hash, source_plan, target_plan,
+		currency, amount_due_minor, status, submit_http_status, detail, created_at, updated_at
+		FROM subscription_upgrade_operations ` + where + ` LIMIT 1`
+	var operation SubscriptionUpgradeOperation
+	var createdRaw, updatedRaw any
+	err := db.conn.QueryRowContext(ctx, query, args...).Scan(
+		&operation.ID, &operation.AccountID, &operation.IdempotencyKeyHash,
+		&operation.SourcePlan, &operation.TargetPlan, &operation.Currency,
+		&operation.AmountDueMinor, &operation.Status, &operation.SubmitHTTPStatus,
+		&operation.Detail, &createdRaw, &updatedRaw,
+	)
+	if err != nil {
+		return nil, err
+	}
+	operation.CreatedAt, err = parseDBTimeValue(createdRaw)
+	if err != nil {
+		return nil, err
+	}
+	operation.UpdatedAt, err = parseDBTimeValue(updatedRaw)
+	if err != nil {
+		return nil, err
+	}
+	return &operation, nil
+}

--- a/database/subscription_upgrade_test.go
+++ b/database/subscription_upgrade_test.go
@@ -1,0 +1,42 @@
+package database
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+)
+
+func TestSubscriptionUpgradeOperationRejectsDuplicateIdempotencyKey(t *testing.T) {
+	db, err := New("sqlite", filepath.Join(t.TempDir(), "codex2api.db"))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer db.Close()
+	ctx := context.Background()
+	first := SubscriptionUpgradeOperation{
+		ID:                 "operation-1",
+		AccountID:          20,
+		IdempotencyKeyHash: "sha256:first-key",
+		SourcePlan:         "prolite",
+		TargetPlan:         "chatgptpro",
+		Currency:           "PHP",
+		AmountDueMinor:     345196,
+		Status:             "submitting",
+	}
+	if err := db.CreateSubscriptionUpgradeOperation(ctx, first); err != nil {
+		t.Fatalf("Create first: %v", err)
+	}
+	duplicate := first
+	duplicate.ID = "operation-2"
+	if err := db.CreateSubscriptionUpgradeOperation(ctx, duplicate); !errors.Is(err, ErrSubscriptionUpgradeIdempotencyConflict) {
+		t.Fatalf("Create duplicate error = %v, want idempotency conflict", err)
+	}
+	got, err := db.GetSubscriptionUpgradeOperationByIdempotencyHash(ctx, 20, first.IdempotencyKeyHash)
+	if err != nil {
+		t.Fatalf("Get by idempotency hash: %v", err)
+	}
+	if got.ID != first.ID || got.AmountDueMinor != 345196 {
+		t.Fatalf("operation = %#v, want original operation", got)
+	}
+}

--- a/docs/subscription-upgrades.md
+++ b/docs/subscription-upgrades.md
@@ -42,7 +42,9 @@ Content-Type: application/json
 
 The response includes the exact amount currently due in minor units, recurring
 price, tax, line items, renewal date, payment-method presence, and a two-minute
-`quote_id`.
+`quote_id`. `silent_reauthorization_available` reports whether Codex2API already
+holds a separate Web Session that can be tried if the paid update invalidates
+the current OAuth credential family. It never exposes that session credential.
 
 After a human reviews that preview, submit a bounded confirmation:
 

--- a/docs/subscription-upgrades.md
+++ b/docs/subscription-upgrades.md
@@ -1,0 +1,132 @@
+# Experimental subscription upgrades
+
+Codex2API can expose an admin-only, quote-first workflow for two individual
+ChatGPT subscription transitions:
+
+- Plus (`plus`) to Pro 5x (`chatgptprolite`, observed entitlement `prolite`)
+- Pro 5x (`prolite`) to Pro 20x (`chatgptpro`, observed entitlement `pro`)
+
+This integration uses undocumented ChatGPT web backend endpoints. It is not a
+stable OpenAI API contract and may change without notice. It is disabled by
+default and must not be used for automatic or batch upgrades.
+
+## Enable the API
+
+Set the following environment variable and restart Codex2API:
+
+```dotenv
+CODEX2API_SUBSCRIPTION_UPGRADES_ENABLED=true
+```
+
+All endpoints remain behind the existing admin authentication middleware.
+
+## API flow
+
+Read the current subscription:
+
+```http
+GET /api/admin/accounts/{id}/subscription
+```
+
+Create a short-lived preview:
+
+```http
+POST /api/admin/accounts/{id}/subscription/upgrade-quotes
+Content-Type: application/json
+
+{
+  "target_plan": "chatgptpro",
+  "currency": "PHP"
+}
+```
+
+The response includes the exact amount currently due in minor units, recurring
+price, tax, line items, renewal date, payment-method presence, and a two-minute
+`quote_id`.
+
+After a human reviews that preview, submit a bounded confirmation:
+
+```http
+POST /api/admin/accounts/{id}/subscription/upgrades
+Idempotency-Key: a-unique-value-for-this-one-upgrade
+Content-Type: application/json
+
+{
+  "quote_id": "...",
+  "currency": "PHP",
+  "max_amount_minor": 350000,
+  "confirmed": true
+}
+```
+
+Immediately before the paid POST, Codex2API re-reads the current plan and
+refreshes the upstream quote. It rejects the operation if the currency changes,
+the plan changes, the account becomes delinquent, or the fresh amount is above
+the confirmed cap.
+
+Read the durable operation journal with:
+
+```http
+GET /api/admin/subscription-upgrades/{operation_id}
+```
+
+The journal stores the amount, currency, transition, sanitized status, and a
+SHA-256 hash of the idempotency key. It never stores OAuth tokens, cookies,
+payment method IDs, Stripe secrets, or card data.
+
+## Payment and verification states
+
+- `succeeded`: the paid request was accepted and the target entitlement was
+  observed.
+- `requires_user_action`: the upstream requested 3DS or another payment action;
+  Codex2API stops and does not retry.
+- `verification_pending`: the paid request was accepted, but the target
+  entitlement is not visible yet. Reconcile with read-only requests; do not
+  repeat payment.
+- `verification_requires_reauthentication`: the paid request was accepted, but
+  the OAuth credential family was subsequently rejected. Reauthorize the
+  account, then verify the existing operation; do not repeat payment.
+- `ambiguous_transport`: the connection failed after submission may have begun.
+  Reconcile the subscription and billing state manually; do not retry the paid
+  POST automatically.
+
+An `Idempotency-Key` is unique per account. Repeating the same request returns
+the existing operation and never sends a second paid POST.
+
+## Login preservation
+
+Saving and restoring the same access token or refresh token cannot avoid login
+when the upstream invalidates that credential family server-side. Codex2API can
+silently recover only when the account also has a separate, still-valid ChatGPT
+Web Session. In that case it attempts one normal account refresh and repeats
+only the read-only entitlement verification. It never repeats the paid POST.
+
+If no valid Web Session exists, `verification_requires_reauthentication` is the
+correct terminal state until an administrator logs the account in again.
+
+## Sanitized canary record (2026-08-27)
+
+A single confirmed Pro 5x to Pro 20x canary was performed before this feature
+was implemented:
+
+- localized recurring price: PHP 9,990/month, including 12% VAT;
+- refreshed amount due: PHP 3,451.96;
+- paid update endpoint returned HTTP 200 exactly once;
+- the existing access and refresh tokens were rejected afterward;
+- no separate Web Session was stored, so manual reauthentication was required;
+- after reauthentication, the upstream subscription reported `plan_type=pro`.
+
+This outcome is why an accepted payment followed by a 401 is represented as
+`verification_requires_reauthentication`, not as payment failure.
+
+## Upstream contract observed by the canary
+
+```text
+GET  /backend-api/subscriptions?account_id={workspace_id}
+GET  /backend-api/subscriptions/update/preview?account_id={workspace_id}&updated_plan={plan}
+GET  /backend-api/checkout_pricing_config/configs/{currency}
+POST /backend-api/subscriptions/update
+```
+
+The generic `/backend-api/payments/checkout` endpoint is not used for upgrades
+of an already-paid subscription.

--- a/proxy/subscription_sync.go
+++ b/proxy/subscription_sync.go
@@ -44,10 +44,13 @@ const subscriptionProbeMinInterval = 6 * time.Hour
 
 // ChatGPTSubscription 是 /backend-api/subscriptions 响应中本服务关心的字段。
 type ChatGPTSubscription struct {
-	PlanType    string `json:"plan_type"`
-	ActiveStart string `json:"active_start"`
-	ActiveUntil string `json:"active_until"`
-	WillRenew   bool   `json:"will_renew"`
+	PlanType        string `json:"plan_type"`
+	ActiveStart     string `json:"active_start"`
+	ActiveUntil     string `json:"active_until"`
+	WillRenew       bool   `json:"will_renew"`
+	BillingCurrency string `json:"billing_currency"`
+	BillingPeriod   string `json:"billing_period"`
+	IsDelinquent    bool   `json:"is_delinquent"`
 }
 
 // ActiveUntilTime 解析 active_until；缺失或格式非法返回零值。

--- a/proxy/subscription_upgrade.go
+++ b/proxy/subscription_upgrade.go
@@ -1,0 +1,322 @@
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/codex2api/auth"
+)
+
+const chatGPTWebBaseURL = "https://chatgpt.com"
+
+// SubscriptionUpgradeCredentials contains only the account-scoped values sent
+// to ChatGPT. Callers must never persist this value in an upgrade journal.
+type SubscriptionUpgradeCredentials struct {
+	AccessToken string
+	WorkspaceID string
+	DeviceID    string
+}
+
+type SubscriptionUpgradeLineItem struct {
+	Kind        string `json:"kind"`
+	AmountMinor int64  `json:"amount_minor"`
+}
+
+type SubscriptionUpgradeQuote struct {
+	Currency                    string                        `json:"currency"`
+	AmountDueMinor              int64                         `json:"amount_due_minor"`
+	RecurringAmountMinor        int64                         `json:"recurring_amount_minor"`
+	TaxAmountMinor              int64                         `json:"tax_amount_minor"`
+	RenewalDate                 string                        `json:"renewal_date,omitempty"`
+	DefaultPaymentMethodPresent bool                          `json:"default_payment_method_present"`
+	LineItems                   []SubscriptionUpgradeLineItem `json:"line_items,omitempty"`
+	PaymentMethodID             string                        `json:"-"`
+}
+
+type SubscriptionUpgradeSubmission struct {
+	TargetPlan      string
+	FlowID          string
+	MutationID      string
+	IdempotencyKey  string
+	PaymentMethodID string
+}
+
+type SubscriptionUpgradeSubmitResult struct {
+	Status             string `json:"status,omitempty"`
+	PaymentStatus      string `json:"payment_status,omitempty"`
+	RequiresUserAction bool   `json:"requires_user_action"`
+}
+
+type SubscriptionUpstreamHTTPError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *SubscriptionUpstreamHTTPError) Error() string {
+	return fmt.Sprintf("subscription upstream returned status %d: %s", e.StatusCode, e.Body)
+}
+
+// SubscriptionUpgradeClient is the ChatGPT web subscription boundary. The
+// injected constructor is useful for tests; NewChatGPTSubscriptionUpgradeClient
+// selects the same browser-fingerprint maintenance transport used by reads.
+type SubscriptionUpgradeClient struct {
+	baseURL string
+	client  *http.Client
+	account *auth.Account
+}
+
+func NewSubscriptionUpgradeClient(baseURL string, client *http.Client) *SubscriptionUpgradeClient {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	return &SubscriptionUpgradeClient{baseURL: strings.TrimRight(baseURL, "/"), client: client}
+}
+
+func NewChatGPTSubscriptionUpgradeClient(account *auth.Account, proxyURL string) *SubscriptionUpgradeClient {
+	return &SubscriptionUpgradeClient{
+		baseURL: chatGPTWebBaseURL,
+		client:  getMaintenanceClient(account, proxyURL, maintenancePurposeSubscription, true),
+		account: account,
+	}
+}
+
+func (c *SubscriptionUpgradeClient) Quote(ctx context.Context, credentials SubscriptionUpgradeCredentials, targetPlan, currency string) (*SubscriptionUpgradeQuote, error) {
+	previewPath := "/backend-api/subscriptions/update/preview?" + url.Values{
+		"account_id":   {credentials.WorkspaceID},
+		"updated_plan": {targetPlan},
+	}.Encode()
+	var preview struct {
+		Currency  string `json:"currency"`
+		AmountDue struct {
+			Amount   int64  `json:"amount"`
+			Currency string `json:"currency"`
+		} `json:"amount_due"`
+		TotalAmount          int64  `json:"total_amount"`
+		TaxAmount            int64  `json:"tax_amount"`
+		RenewalDate          string `json:"renewal_date"`
+		DefaultPaymentMethod any    `json:"default_payment_method"`
+		LineItems            []struct {
+			Kind   string `json:"kind"`
+			Amount int64  `json:"amount"`
+		} `json:"line_items"`
+	}
+	if err := c.doJSON(ctx, http.MethodGet, previewPath, credentials, "", nil, &preview); err != nil {
+		return nil, fmt.Errorf("preview subscription upgrade: %w", err)
+	}
+
+	currency = strings.ToUpper(strings.TrimSpace(currency))
+	var pricing struct {
+		CurrencyConfig map[string]map[string]struct {
+			Amount float64 `json:"amount"`
+		} `json:"currency_config"`
+	}
+	pricingPath := "/backend-api/checkout_pricing_config/configs/" + url.PathEscape(currency)
+	if err := c.doJSON(ctx, http.MethodGet, pricingPath, credentials, "", nil, &pricing); err != nil {
+		return nil, fmt.Errorf("read subscription pricing: %w", err)
+	}
+
+	planKey := targetPricingPlanKey(targetPlan)
+	monthly, ok := pricing.CurrencyConfig[planKey]["month"]
+	if !ok || monthly.Amount <= 0 {
+		return nil, fmt.Errorf("monthly price for target plan %q is unavailable", targetPlan)
+	}
+	amountDue := preview.AmountDue.Amount
+	if amountDue == 0 {
+		amountDue = preview.TotalAmount
+	}
+	quoteCurrency := strings.ToUpper(strings.TrimSpace(preview.Currency))
+	if quoteCurrency == "" {
+		quoteCurrency = strings.ToUpper(strings.TrimSpace(preview.AmountDue.Currency))
+	}
+	quote := &SubscriptionUpgradeQuote{
+		Currency:             quoteCurrency,
+		AmountDueMinor:       amountDue,
+		RecurringAmountMinor: int64(math.Round(monthly.Amount * 100)),
+		TaxAmountMinor:       preview.TaxAmount,
+		RenewalDate:          preview.RenewalDate,
+		LineItems:            make([]SubscriptionUpgradeLineItem, 0, len(preview.LineItems)),
+	}
+	for _, item := range preview.LineItems {
+		quote.LineItems = append(quote.LineItems, SubscriptionUpgradeLineItem{Kind: item.Kind, AmountMinor: item.Amount})
+	}
+	quote.PaymentMethodID = paymentMethodID(preview.DefaultPaymentMethod)
+	quote.DefaultPaymentMethodPresent = quote.PaymentMethodID != ""
+	return quote, nil
+}
+
+func (c *SubscriptionUpgradeClient) Read(ctx context.Context, credentials SubscriptionUpgradeCredentials) (*ChatGPTSubscription, error) {
+	path := "/backend-api/subscriptions?" + url.Values{"account_id": {credentials.WorkspaceID}}.Encode()
+	var subscription ChatGPTSubscription
+	if err := c.doJSON(ctx, http.MethodGet, path, credentials, "", nil, &subscription); err != nil {
+		return nil, fmt.Errorf("read subscription: %w", err)
+	}
+	return &subscription, nil
+}
+
+// Submit performs exactly one paid mutation. It deliberately contains no
+// retry loop: after bytes may have reached the upstream, transport errors are
+// ambiguous and must be reconciled through read-only subscription checks.
+func (c *SubscriptionUpgradeClient) Submit(ctx context.Context, credentials SubscriptionUpgradeCredentials, submission SubscriptionUpgradeSubmission) (*SubscriptionUpgradeSubmitResult, error) {
+	body := struct {
+		AccountID             string  `json:"account_id"`
+		FlowID                string  `json:"flow_id"`
+		UpdatedPlan           string  `json:"updated_plan"`
+		UpdatedSeats          any     `json:"updated_seats"`
+		UpdatedSeatQuantities any     `json:"updated_seat_quantities"`
+		UpdatedPriceInterval  any     `json:"updated_price_interval"`
+		UpdatedPromoID        any     `json:"updated_promo_id"`
+		UpdatedPromoCode      any     `json:"updated_promo_code"`
+		UpdatedPromoCampaign  any     `json:"updated_promo_campaign"`
+		PaymentMethodID       *string `json:"payment_method_id,omitempty"`
+		SetupIntentID         any     `json:"setup_intent_id"`
+		SeatOperation         any     `json:"seat_operation"`
+		ProrationQuoteID      any     `json:"proration_quote_id"`
+		MutationAttemptID     string  `json:"mutation_attempt_id"`
+	}{
+		AccountID:         credentials.WorkspaceID,
+		FlowID:            submission.FlowID,
+		UpdatedPlan:       submission.TargetPlan,
+		MutationAttemptID: submission.MutationID,
+	}
+	if paymentMethodID := strings.TrimSpace(submission.PaymentMethodID); paymentMethodID != "" {
+		body.PaymentMethodID = &paymentMethodID
+	}
+	var payload map[string]any
+	if err := c.doJSON(ctx, http.MethodPost, "/backend-api/subscriptions/update", credentials, submission.IdempotencyKey, body, &payload); err != nil {
+		return nil, err
+	}
+	result := &SubscriptionUpgradeSubmitResult{
+		Status:             scalarString(payload["status"]),
+		PaymentStatus:      scalarString(payload["payment_status"]),
+		RequiresUserAction: responseRequiresUserAction(payload, 0),
+	}
+	return result, nil
+}
+
+func scalarString(value any) string {
+	if value == nil {
+		return ""
+	}
+	return strings.TrimSpace(fmt.Sprint(value))
+}
+
+func responseRequiresUserAction(value any, depth int) bool {
+	if depth > 6 {
+		return false
+	}
+	switch typed := value.(type) {
+	case map[string]any:
+		for key, child := range typed {
+			normalizedKey := strings.ToLower(strings.TrimSpace(key))
+			if normalizedKey == "next_action" && child != nil {
+				return true
+			}
+			if normalizedKey == "status" || normalizedKey == "payment_status" {
+				switch strings.ToLower(scalarString(child)) {
+				case "requires_action", "requires_confirmation", "requires_payment_method":
+					return true
+				}
+			}
+			if responseRequiresUserAction(child, depth+1) {
+				return true
+			}
+		}
+	case []any:
+		for _, child := range typed {
+			if responseRequiresUserAction(child, depth+1) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func targetPricingPlanKey(targetPlan string) string {
+	switch strings.ToLower(strings.TrimSpace(targetPlan)) {
+	case "chatgptpro":
+		return "pro"
+	case "chatgptprolite":
+		return "prolite"
+	default:
+		return strings.TrimPrefix(strings.ToLower(strings.TrimSpace(targetPlan)), "chatgpt")
+	}
+}
+
+func paymentMethodID(value any) string {
+	switch typed := value.(type) {
+	case string:
+		return strings.TrimSpace(typed)
+	case map[string]any:
+		for _, key := range []string{"id", "payment_method_id"} {
+			if raw, ok := typed[key].(string); ok && strings.TrimSpace(raw) != "" {
+				return strings.TrimSpace(raw)
+			}
+		}
+	}
+	return ""
+}
+
+func (c *SubscriptionUpgradeClient) doJSON(ctx context.Context, method, path string, credentials SubscriptionUpgradeCredentials, idempotencyKey string, input, output any) error {
+	var body io.Reader
+	if input != nil {
+		encoded, err := json.Marshal(input)
+		if err != nil {
+			return fmt.Errorf("encode request: %w", err)
+		}
+		body = bytes.NewReader(encoded)
+	}
+	endpoint := c.baseURL + path
+	client := c.client
+	viaResin := false
+	if c.account != nil && strings.HasPrefix(endpoint, chatGPTWebBaseURL) {
+		if finalURL, resinClient, routed := resinMaintenanceTarget(c.account, endpoint); routed {
+			endpoint, client, viaResin = finalURL, resinClient, true
+		}
+	}
+	req, err := http.NewRequestWithContext(ctx, method, endpoint, body)
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+credentials.AccessToken)
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Origin", chatGPTWebBaseURL)
+	req.Header.Set("Referer", chatGPTWebBaseURL+"/")
+	req.Header.Set("User-Agent", subscriptionsBrowserUserAgent)
+	if credentials.DeviceID != "" {
+		req.Header.Set("oai-device-id", credentials.DeviceID)
+	}
+	if idempotencyKey != "" {
+		req.Header.Set("Idempotency-Key", idempotencyKey)
+	}
+	if input != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if viaResin {
+		req.Header.Set("X-Resin-Account", ResinAccountID(c.account))
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("send request: %w", err)
+	}
+	defer resp.Body.Close()
+	responseBody, err := io.ReadAll(io.LimitReader(resp.Body, 128<<10))
+	if err != nil {
+		return fmt.Errorf("read response: %w", err)
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return &SubscriptionUpstreamHTTPError{StatusCode: resp.StatusCode, Body: truncateForLog(responseBody, 300)}
+	}
+	if output != nil && len(bytes.TrimSpace(responseBody)) > 0 {
+		if err := json.Unmarshal(responseBody, output); err != nil {
+			return fmt.Errorf("decode response: %w", err)
+		}
+	}
+	return nil
+}

--- a/proxy/subscription_upgrade_test.go
+++ b/proxy/subscription_upgrade_test.go
@@ -1,0 +1,128 @@
+package proxy
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestSubscriptionUpgradeClientQuoteParsesPHPMinorUnits(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer test-at" {
+			t.Fatalf("Authorization = %q, want Bearer test-at", got)
+		}
+		switch r.URL.Path {
+		case "/backend-api/subscriptions/update/preview":
+			if got := r.URL.Query().Get("account_id"); got != testWorkspaceUUID {
+				t.Fatalf("account_id = %q, want %q", got, testWorkspaceUUID)
+			}
+			if got := r.URL.Query().Get("updated_plan"); got != "chatgptpro" {
+				t.Fatalf("updated_plan = %q, want chatgptpro", got)
+			}
+			_, _ = w.Write([]byte(`{
+				"currency":"php",
+				"amount_due":{"amount":345196,"currency":"php"},
+				"tax_amount":0,
+				"renewal_date":"2026-09-25T14:45:25Z",
+				"default_payment_method":null,
+				"line_items":[
+					{"kind":"new_plan","amount":891964},
+					{"kind":"unused_time_credit","amount":-547004}
+				]
+			}`))
+		case "/backend-api/checkout_pricing_config/configs/PHP":
+			_, _ = w.Write([]byte(`{"currency_config":{"pro":{"month":{"amount":9990}}}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client := NewSubscriptionUpgradeClient(server.URL, server.Client())
+	quote, err := client.Quote(context.Background(), SubscriptionUpgradeCredentials{
+		AccessToken: "test-at",
+		WorkspaceID: testWorkspaceUUID,
+	}, "chatgptpro", "PHP")
+	if err != nil {
+		t.Fatalf("Quote: %v", err)
+	}
+	if quote.Currency != "PHP" || quote.AmountDueMinor != 345196 {
+		t.Fatalf("amount due = %s %d, want PHP 345196", quote.Currency, quote.AmountDueMinor)
+	}
+	if quote.RecurringAmountMinor != 999000 {
+		t.Fatalf("recurring amount = %d, want 999000", quote.RecurringAmountMinor)
+	}
+	if quote.TaxAmountMinor != 0 {
+		t.Fatalf("tax amount = %d, want 0", quote.TaxAmountMinor)
+	}
+	if quote.DefaultPaymentMethodPresent {
+		t.Fatal("default payment method present = true, want false")
+	}
+	if len(quote.LineItems) != 2 || quote.LineItems[1].AmountMinor != -547004 {
+		t.Fatalf("line items = %#v, want unused-time credit -547004", quote.LineItems)
+	}
+}
+
+func TestSubscriptionUpgradeClientReadReportsUnauthorizedForReauthentication(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"detail":"token family invalidated"}`))
+	}))
+	defer server.Close()
+
+	client := NewSubscriptionUpgradeClient(server.URL, server.Client())
+	_, err := client.Read(context.Background(), SubscriptionUpgradeCredentials{
+		AccessToken: "invalidated-at",
+		WorkspaceID: testWorkspaceUUID,
+	})
+	var upstreamErr *SubscriptionUpstreamHTTPError
+	if !errors.As(err, &upstreamErr) || upstreamErr.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("Read error = %v, want typed 401", err)
+	}
+}
+
+func TestSubscriptionUpgradeClientSubmitOmitsEmptyPaymentMethodAndStopsFor3DS(t *testing.T) {
+	var posted map[string]any
+	var postCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/backend-api/subscriptions/update" || r.Method != http.MethodPost {
+			http.NotFound(w, r)
+			return
+		}
+		postCount++
+		if got := r.Header.Get("Idempotency-Key"); got != "upgrade-once" {
+			t.Fatalf("Idempotency-Key = %q, want upgrade-once", got)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&posted); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		_, _ = w.Write([]byte(`{"status":"requires_action","next_action":{"type":"use_stripe_sdk"}}`))
+	}))
+	defer server.Close()
+
+	client := NewSubscriptionUpgradeClient(server.URL, server.Client())
+	result, err := client.Submit(context.Background(), SubscriptionUpgradeCredentials{
+		AccessToken: "test-at",
+		WorkspaceID: testWorkspaceUUID,
+	}, SubscriptionUpgradeSubmission{
+		TargetPlan:     "chatgptpro",
+		FlowID:         "flow-1",
+		MutationID:     "mutation-1",
+		IdempotencyKey: "upgrade-once",
+	})
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	if !result.RequiresUserAction {
+		t.Fatal("RequiresUserAction = false, want true")
+	}
+	if _, exists := posted["payment_method_id"]; exists {
+		t.Fatal("empty payment_method_id must be omitted")
+	}
+	if postCount != 1 {
+		t.Fatalf("POST count = %d, want exactly one", postCount)
+	}
+}


### PR DESCRIPTION
## 描述

这是一个征求维护者意见的 Draft PR，为单账号 ChatGPT Plus → Pro 5x 和 Pro 5x → Pro 20x 增加管理员报价与升级 API。

上游订阅端点属于未公开的 ChatGPT Web 合约，可能随时变更，所以整个功能通过 `CODEX2API_SUBSCRIPTION_UPGRADES_ENABLED` 默认关闭，不包含批量、自动触发或付费重试。

## 主要变更

- 增加管理员 API：读取订阅、创建短时报价、确认单次升级、查询操作状态。
- 付费 POST 前强制重读当前套餐并刷新报价，校验币种和管理员确认的最高金额。
- 按账号串行付费操作，必须提供 `Idempotency-Key`；数据库持久化操作日志和唯一约束，重试只返回已有操作。
- 遇到 3DS/用户操作立即停止；付费提交后的传输中断记录为不确定结果，不会自动再次扣款。
- 如果付费后 OAuth 凭据族被上游作废，记录为 `verification_requires_reauthentication`。仅当账号另有有效 Web Session 时，尝试一次常规刷新，随后只重做只读验证，不重发付费 POST。
- SQLite/PostgreSQL 都增加不含凭据的操作日志表；幂等键只存 SHA-256，不持久化 OAuth token、cookie、支付方式 ID、Stripe 密钥或卡信息。
- 增加完整运行状态、API 示例、登录保留边界和脱敏 canary 记录文档。

## 真实 canary 得到的关键结论

- Pro 5x → Pro 20x 的最终刷新报价为 PHP 3,451.96，付费端点 HTTP 200，且只调用一次。
- 该操作后原 AT/RT 被上游拒绝；账号没有独立 Web Session，因此必须手动重新授权。
- 重新授权后上游报告 `plan_type=pro`。这是状态机区分“付费失败”和“付费已接受但需重新授权验证”的原因。

公开文档中已移除账号邮箱、服务器和任何凭据。

## 变更类型

- [ ] Bug 修复
- [x] 新功能
- [x] 文档更新
- [ ] 代码重构

## 测试

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `npm --prefix frontend test` (159 passed)
- [x] `npm --prefix frontend run typecheck`
- [x] `npm --prefix frontend run build`
- [x] `npm --prefix frontend run audit:ci`
- [x] 新增测试覆盖 PHP 主/次单位转换、金额上限、幂等冲突、可选支付方式、3DS 停止、HTTP 200 后 token 作废、Web Session 恢复、且不发第二次付费 POST。

## 审查重点

1. 项目是否愿意接受一个默认关闭、依赖未公开 ChatGPT Web 合约的实验性功能。
2. 是否需要把开关改为管理后台设置，而不是启动环境变量。
3. 多实例部署是否要将账号级互斥扩展为数据库锁；当前数据库唯一约束已防止同一账号+同一幂等键的重复提交，进程内账号锁防止不同幂等键并发。

本 PR 仅请求代码与接口设计审查，不包含生产环境开关、部署或自动升级。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an experimental, opt-in admin workflow for managing supported ChatGPT subscription upgrades.
  * Added subscription viewing, upgrade quotes, confirmed upgrade submission, and operation-status tracking.
  * Added quote validation, confirmation safeguards, idempotency protection, upgrade limits, and payment-action status reporting.
  * Added billing currency, billing period, and delinquency details to subscription information.

* **Documentation**
  * Added administrator guidance covering setup, supported upgrades, safeguards, and limitations.

* **Tests**
  * Added coverage for quoting, authentication recovery, duplicate requests, payment confirmation, and upgrade limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->