### PR TITLE
fix(auth): recover OAuth after upstream token revocation

### DIFF
--- a/docs/session-token-recovery.md
+++ b/docs/session-token-recovery.md
@@ -1,0 +1,28 @@
+# Codex OAuth recovery after account changes
+
+ChatGPT can revoke an OAuth access/refresh-token family after a web-account
+change such as a plan upgrade. Codex2API cannot keep that revoked credential
+family valid. It can, however, recover without an interactive login when the
+account was provisioned with an independent ChatGPT Web `session_token`.
+
+When an official Codex OAuth account with a stored Web Session receives an
+upstream 401, the request path now attempts one forced refresh through the Web
+Session before cooling or rotating away from the account. The normal refresh
+lock still serializes the operation, and the Web Session is never exposed in
+API responses or logs.
+
+## Requirements
+
+- The account must be an official Codex OAuth account, not a relay, Grok, or
+  Antigravity account.
+- `session_token` must be an independent, still-valid ChatGPT Web Session. It
+  must not be the OAuth refresh token and must belong to the same account.
+- The session token must be imported before the account change. The existing
+  credential import accepts `session_token`; keep it in the same account entry
+  as the refresh token.
+
+If the Web Session is missing, expired, challenged by Cloudflare, or belongs to
+another account, the recovery attempt fails safely and the existing 401
+cooldown behavior is retained. Interactive reauthorization is still required
+in that case. This is a best-effort recovery path, not a guarantee that an
+upstream credential revocation can be undone.

--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -1960,6 +1960,13 @@ func classifyHTTPFailure(statusCode int) string {
 	}
 }
 
+func shouldRecoverCodexOAuthWithSessionToken(account *auth.Account, statusCode int, retried map[int64]bool) bool {
+	if account == nil || statusCode != http.StatusUnauthorized || account.IsRelayStyle() || !account.HasSessionToken() {
+		return false
+	}
+	return !retried[account.ID()]
+}
+
 type streamOutcome struct {
 	logStatusCode  int
 	failureKind    string
@@ -3749,6 +3756,7 @@ func (h *Handler) Responses(c *gin.Context) {
 	var wsHTTPFallback websocketHTTPFallbackState
 	invalidEncryptedContentRetried := false
 	antigravityRefreshRetried := map[int64]bool{}
+	sessionTokenRefreshRetried := map[int64]bool{}
 	relayContinuationAttempted := false
 	overflowCompactRetried := false
 	overflowCompactEnabled := autoCompactOverflowEnabled(c)
@@ -4028,6 +4036,22 @@ func (h *Handler) Responses(c *gin.Context) {
 					return
 				}
 				antigravityRefreshFailed := false
+				// A manual ChatGPT subscription change may revoke the OAuth AT/RT
+				// family while leaving an independently stored Web Session valid.
+				// Recover once, before penalizing the account or rotating away from
+				// it. This is deliberately limited to official Codex OAuth accounts;
+				// relay/Grok/Antigravity credentials have different semantics.
+				if shouldRecoverCodexOAuthWithSessionToken(account, resp.StatusCode, sessionTokenRefreshRetried) {
+					sessionTokenRefreshRetried[account.ID()] = true
+					if refreshErr := h.store.RefreshSingle(c.Request.Context(), account.ID()); refreshErr == nil {
+						h.store.Release(account)
+						h.store.UnbindSessionAffinity(affinityKey, account.ID())
+						log.Printf("Codex OAuth token refreshed from independent Web Session after upstream 401 (account=%d)", account.ID())
+						continue
+					} else {
+						log.Printf("Codex Web Session recovery failed after upstream 401 (account=%d): %v", account.ID(), refreshErr)
+					}
+				}
 				if resp.StatusCode == http.StatusUnauthorized && account.IsAntigravityAPI() && account.AntigravityAuthKind() == auth.AntigravityAuthKindOAuth && !antigravityRefreshRetried[account.ID()] {
 					antigravityRefreshRetried[account.ID()] = true
 					if refreshErr := h.store.RefreshAntigravityAccount(c.Request.Context(), account); refreshErr == nil {

--- a/proxy/session_token_recovery_test.go
+++ b/proxy/session_token_recovery_test.go
@@ -1,0 +1,41 @@
+package proxy
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/codex2api/auth"
+)
+
+func TestShouldRecoverCodexOAuthWithSessionToken(t *testing.T) {
+	account := &auth.Account{DBID: 42, SessionToken: "independent-web-session"}
+	retried := map[int64]bool{}
+
+	if !shouldRecoverCodexOAuthWithSessionToken(account, http.StatusUnauthorized, retried) {
+		t.Fatal("expected an official OAuth account with a session token to be recoverable")
+	}
+	retried[account.ID()] = true
+	if shouldRecoverCodexOAuthWithSessionToken(account, http.StatusUnauthorized, retried) {
+		t.Fatal("session-token recovery must be attempted at most once per request")
+	}
+}
+
+func TestShouldNotRecoverRelayOrNonUnauthorizedAccounts(t *testing.T) {
+	retried := map[int64]bool{}
+	cases := []struct {
+		name    string
+		account *auth.Account
+		status  int
+	}{
+		{name: "no session token", account: &auth.Account{DBID: 1}, status: http.StatusUnauthorized},
+		{name: "non unauthorized", account: &auth.Account{DBID: 2, SessionToken: "st"}, status: http.StatusForbidden},
+		{name: "relay", account: &auth.Account{DBID: 3, UpstreamType: auth.UpstreamOpenAIResponses, BaseURL: "https://relay.example", APIKey: "relay-key", SessionToken: "st"}, status: http.StatusUnauthorized},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if shouldRecoverCodexOAuthWithSessionToken(tc.account, tc.status, retried) {
+				t.Fatal("account must not enter Codex Web Session recovery")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- automatically attempt one forced OAuth refresh from an independently stored ChatGPT Web Session after an official Codex account returns upstream 401
- keep relay, Grok, and Antigravity accounts on their existing recovery paths
- add regression coverage for the account/type/status gate and one-attempt limit
- document the requirements and the cases where interactive reauthorization remains unavoidable

## Motivation

ChatGPT may revoke an OAuth AT/RT family after a manual web-account change such as a subscription upgrade. Codex2API already supported Web Session Token fallback when a scheduled token refresh failed, but an in-flight request receiving 401 was cooled immediately and never reached that fallback. Operators therefore had to log in again even when a separate valid Web Session was already available.

This PR does not claim that revoked credentials can be preserved. It provides best-effort, single-attempt recovery only when `session_token` was provisioned beforehand and belongs to the same account. If the Web Session is missing, expired, challenged, or mismatched, the existing safe 401 handling remains in place.

## Safety

- No payment or subscription endpoint is added.
- Recovery is limited to official Codex OAuth accounts and at most once per account per request.
- Session tokens are never returned or logged.
- Existing refresh locks and credential persistence remain authoritative.

## Verification

- `go test ./proxy -run 'TestShould.*SessionToken' -count=1`
- `go vet ./proxy`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a best-effort recovery path for official Codex OAuth accounts when an upstream authorization failure occurs.
  * Automatically attempts one session-based token refresh before cooling down or switching accounts.
  * Safely falls back to existing recovery behavior when the session is missing, expired, challenged, or associated with another account.

* **Documentation**
  * Added guidance on requirements and behavior for session-token recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->