### PR TITLE
feat(antigravity): 自动开通 project、解析 Google 配额状态、流式下发文本

### DIFF
--- a/auth/antigravity_client.go
+++ b/auth/antigravity_client.go
@@ -63,7 +63,31 @@ var DefaultAntigravityEndpoints = AntigravityEndpoints{
 	AICredits: []string{
 		"https://daily-cloudcode-pa.googleapis.com/v1internal:loadCodeAssist",
 	},
+	// onboardUser provisions the Cloud Code companion project for a Google
+	// account that has never used Antigravity. loadCodeAssist returns an empty
+	// cloudaicompanionProject for those accounts, and without a project the
+	// account can never be dispatched. The native client onboards on the daily
+	// host; production is kept as a fallback only.
+	OnboardUser: []string{
+		"https://daily-cloudcode-pa.googleapis.com/v1internal:onboardUser",
+		"https://cloudcode-pa.googleapis.com/v1internal:onboardUser",
+	},
 }
+
+const (
+	// antigravityOnboardPollAttempts / antigravityOnboardPollInterval bound the
+	// long-running-operation poll for onboardUser. The operation normally
+	// completes within one or two polls; five attempts two seconds apart is the
+	// budget used by the native client.
+	antigravityOnboardPollAttempts = 5
+	antigravityOnboardPollInterval = 2 * time.Second
+	// antigravityOnboardDefaultTier is used when loadCodeAssist advertised no
+	// default tier at all.
+	antigravityOnboardDefaultTier = "free-tier"
+	// antigravityOnboardAPIClient mirrors the X-Goog-Api-Client header the
+	// native Node client sends on the onboarding call.
+	antigravityOnboardAPIClient = "gl-node/22.21.1"
+)
 
 type antigravityOAuthClient struct {
 	Key          string
@@ -83,6 +107,9 @@ type AntigravityClient struct {
 	activeKey  string
 	userAgent  string
 	now        func() time.Time
+	// sleep is the poll delay used while waiting for onboardUser to finish.
+	// Injectable so tests do not spend real seconds.
+	sleep func(context.Context, time.Duration) error
 }
 
 type antigravityTokenResponse struct {
@@ -95,14 +122,21 @@ type antigravityTokenResponse struct {
 }
 
 type antigravityTierPayload struct {
-	ID               string `json:"id"`
-	Name             string `json:"name"`
-	QuotaTier        string `json:"quotaTier"`
-	Slug             string `json:"slug"`
-	IsDefault        bool   `json:"is_default"`
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	QuotaTier string `json:"quotaTier"`
+	Slug      string `json:"slug"`
+	// Cloud Code emits camelCase (isDefault); the snake_case alias is kept so
+	// stored snapshots and any proto-JSON variant still parse.
+	IsDefault        bool `json:"isDefault"`
+	IsDefaultSnake   bool `json:"is_default"`
 	AvailableCredits []struct {
 		CreditAmount any `json:"creditAmount"`
 	} `json:"availableCredits"`
+}
+
+func (t antigravityTierPayload) isDefaultTier() bool {
+	return t.IsDefault || t.IsDefaultSnake
 }
 
 type antigravityLoadProjectResponse struct {
@@ -113,6 +147,34 @@ type antigravityLoadProjectResponse struct {
 	IneligibleTiers []struct {
 		ReasonCode string `json:"reasonCode"`
 	} `json:"ineligibleTiers"`
+}
+
+// antigravityOnboardResponse is the long-running operation envelope returned
+// by v1internal:onboardUser. The provisioned project appears under response
+// either as a bare string or as an object carrying id.
+type antigravityOnboardResponse struct {
+	Done     bool `json:"done"`
+	Response struct {
+		Project json.RawMessage `json:"cloudaicompanionProject"`
+	} `json:"response"`
+}
+
+func (r antigravityOnboardResponse) projectID() string {
+	raw := bytes.TrimSpace(r.Response.Project)
+	if len(raw) == 0 || bytes.Equal(raw, []byte("null")) {
+		return ""
+	}
+	var asString string
+	if err := json.Unmarshal(raw, &asString); err == nil {
+		return strings.TrimSpace(asString)
+	}
+	var asObject struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(raw, &asObject); err == nil {
+		return strings.TrimSpace(asObject.ID)
+	}
+	return ""
 }
 
 type antigravityQuotaResponse struct {
@@ -160,7 +222,7 @@ type antigravityErrorPayload struct {
 	Error struct {
 		Message string `json:"message"`
 		Details []struct {
-			Reason string `json:"reason"`
+			Reason   string `json:"reason"`
 			Metadata struct {
 				ValidationURL string `json:"validation_url"`
 				AppealURL     string `json:"appeal_url"`
@@ -563,8 +625,99 @@ func (c *AntigravityClient) fetchIdentityContext(ctx context.Context, credential
 	if entitlements.ProjectID == "" {
 		entitlements.ProjectID = projectID
 	}
+	if entitlementErr == nil && entitlements.ProjectID == "" {
+		// loadCodeAssist succeeded but the account has no companion project
+		// yet. Provision one the way the native client does; otherwise the
+		// account is stored healthy but is never dispatchable.
+		onboarded, onboardErr := c.onboardProject(ctx, credential.AccessToken, entitlements)
+		if onboardErr != nil {
+			entitlementErr = fmt.Errorf("Antigravity project provisioning (onboardUser) failed: %w", onboardErr)
+		} else {
+			entitlements.ProjectID = onboarded
+		}
+	}
 	credential.ProjectID = entitlements.ProjectID
 	return profile, entitlements, entitlementErr, nil
+}
+
+// antigravityOnboardTierID picks the tier onboardUser should provision:
+// the advertised default tier first, then the current tier, then free-tier.
+func antigravityOnboardTierID(entitlements AntigravityEntitlements) string {
+	for _, tier := range entitlements.AllowedTiers {
+		if tier.IsDefault && strings.TrimSpace(tier.ID) != "" {
+			return strings.TrimSpace(tier.ID)
+		}
+	}
+	if entitlements.CurrentTier != nil && strings.TrimSpace(entitlements.CurrentTier.ID) != "" {
+		return strings.TrimSpace(entitlements.CurrentTier.ID)
+	}
+	return antigravityOnboardDefaultTier
+}
+
+// onboardProject calls v1internal:onboardUser and polls the returned
+// long-running operation until it reports done with a project id.
+func (c *AntigravityClient) onboardProject(ctx context.Context, accessToken string, entitlements AntigravityEntitlements) (string, error) {
+	if len(c.endpoints.OnboardUser) == 0 {
+		return "", errors.New("no onboardUser endpoint configured")
+	}
+	payload := map[string]any{
+		"tierId": antigravityOnboardTierID(entitlements),
+		"metadata": map[string]any{
+			"ideType":    "ANTIGRAVITY",
+			"platform":   "PLATFORM_UNSPECIFIED",
+			"pluginType": "GEMINI",
+		},
+	}
+	var lastErr error
+	for _, endpoint := range c.endpoints.OnboardUser {
+		for attempt := range antigravityOnboardPollAttempts {
+			if attempt > 0 {
+				if err := c.sleepFor(ctx, antigravityOnboardPollInterval); err != nil {
+					return "", err
+				}
+			}
+			var response antigravityOnboardResponse
+			status, err := c.postJSONWithHeaders(ctx, endpoint, accessToken, payload, &response, map[string]string{
+				"X-Goog-Api-Client": antigravityOnboardAPIClient,
+			})
+			if err != nil {
+				lastErr = err
+				if status != http.StatusTooManyRequests && status < http.StatusInternalServerError {
+					// Non-retryable on this host; a 404 means the host does not
+					// serve onboardUser, so try the next endpoint.
+					break
+				}
+				continue
+			}
+			if projectID := response.projectID(); projectID != "" {
+				return projectID, nil
+			}
+			if !response.Done {
+				lastErr = errors.New("onboardUser operation is still pending")
+				continue
+			}
+			lastErr = errors.New("onboardUser completed without a project id")
+			break
+		}
+	}
+	if lastErr == nil {
+		lastErr = errors.New("onboardUser did not return a project id")
+	}
+	return "", lastErr
+}
+
+func (c *AntigravityClient) sleepFor(ctx context.Context, d time.Duration) error {
+	if c.sleep != nil {
+		return c.sleep(ctx, d)
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 func antigravityPartialSyncResult(credential AntigravityCredential, profile AntigravityProfile, entitlements AntigravityEntitlements, entitlementErr error) AntigravitySyncResult {
@@ -753,7 +906,7 @@ func convertAntigravityTier(tier *antigravityTierPayload) *AntigravityTier {
 	}
 	return &AntigravityTier{
 		ID: strings.TrimSpace(tier.ID), Name: strings.TrimSpace(tier.Name),
-		QuotaTier: strings.TrimSpace(tier.QuotaTier), Slug: strings.TrimSpace(tier.Slug), IsDefault: tier.IsDefault,
+		QuotaTier: strings.TrimSpace(tier.QuotaTier), Slug: strings.TrimSpace(tier.Slug), IsDefault: tier.isDefaultTier(),
 	}
 }
 
@@ -919,6 +1072,10 @@ func parseAntigravityNumber(value any) (float64, bool) {
 }
 
 func (c *AntigravityClient) postJSON(ctx context.Context, endpoint, accessToken string, payload any, output any) (int, error) {
+	return c.postJSONWithHeaders(ctx, endpoint, accessToken, payload, output, nil)
+}
+
+func (c *AntigravityClient) postJSONWithHeaders(ctx context.Context, endpoint, accessToken string, payload any, output any, extraHeaders map[string]string) (int, error) {
 	body, err := json.Marshal(payload)
 	if err != nil {
 		return 0, err
@@ -930,6 +1087,9 @@ func (c *AntigravityClient) postJSON(ctx context.Context, endpoint, accessToken 
 	req.Header.Set("Authorization", "Bearer "+accessToken)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("User-Agent", c.userAgent)
+	for key, value := range extraHeaders {
+		req.Header.Set(key, value)
+	}
 	err = c.doJSON(req, output)
 	if httpErr := (*antigravityHTTPError)(nil); errors.As(err, &httpErr) {
 		return httpErr.Status, err

--- a/auth/antigravity_client_test.go
+++ b/auth/antigravity_client_test.go
@@ -665,3 +665,141 @@ func TestAntigravitySyncSurfacesTOSViolationAppealLink(t *testing.T) {
 		t.Fatalf("warning still embeds the raw upstream JSON blob: %q", result.Warning)
 	}
 }
+
+func TestAntigravityClientOnboardsProjectWhenLoadCodeAssistHasNone(t *testing.T) {
+	var mu sync.Mutex
+	onboardCalls := 0
+	var onboardBody map[string]any
+	var onboardAPIClient string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/userinfo":
+			_, _ = io.WriteString(w, `{"id":"google-subject","email":"fresh@example.com","verified_email":true,"name":"Fresh"}`)
+		case "/load":
+			// A never-onboarded account: no companion project, camelCase isDefault.
+			_, _ = io.WriteString(w, `{"currentTier":{"id":"free-tier","name":"Free"},"allowedTiers":[{"id":"free-tier","name":"Free","isDefault":true},{"id":"g1-pro-tier","name":"Pro"}]}`)
+		case "/onboard":
+			mu.Lock()
+			onboardCalls++
+			call := onboardCalls
+			onboardAPIClient = r.Header.Get("X-Goog-Api-Client")
+			_ = json.NewDecoder(r.Body).Decode(&onboardBody)
+			mu.Unlock()
+			if call == 1 {
+				_, _ = io.WriteString(w, `{"name":"operations/1","done":false}`)
+				return
+			}
+			_, _ = io.WriteString(w, `{"name":"operations/1","done":true,"response":{"cloudaicompanionProject":{"id":"provisioned-project"}}}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client := newAntigravityClient(server.Client(), AntigravityEndpoints{
+		UserInfoURL: server.URL + "/userinfo",
+		LoadProject: []string{server.URL + "/load"},
+		OnboardUser: []string{server.URL + "/onboard"},
+	})
+	sleeps := 0
+	client.sleep = func(context.Context, time.Duration) error { sleeps++; return nil }
+
+	credential := AntigravityCredential{AccessToken: "access-token"}
+	_, entitlements, entitlementErr, err := client.fetchIdentityContext(context.Background(), &credential, false)
+	if err != nil {
+		t.Fatalf("fetchIdentityContext() error: %v", err)
+	}
+	if entitlementErr != nil {
+		t.Fatalf("entitlement error: %v", entitlementErr)
+	}
+	if entitlements.ProjectID != "provisioned-project" || credential.ProjectID != "provisioned-project" {
+		t.Fatalf("project = %q / %q, want provisioned-project", entitlements.ProjectID, credential.ProjectID)
+	}
+	if onboardCalls != 2 || sleeps != 1 {
+		t.Fatalf("onboard calls = %d, sleeps = %d, want 2 polls with one wait", onboardCalls, sleeps)
+	}
+	if onboardBody["tierId"] != "free-tier" {
+		t.Fatalf("onboard tierId = %#v, want the advertised default tier", onboardBody["tierId"])
+	}
+	metadata, _ := onboardBody["metadata"].(map[string]any)
+	if metadata["ideType"] != "ANTIGRAVITY" || metadata["pluginType"] != "GEMINI" {
+		t.Fatalf("onboard metadata = %#v", onboardBody["metadata"])
+	}
+	if onboardAPIClient != antigravityOnboardAPIClient {
+		t.Fatalf("X-Goog-Api-Client = %q", onboardAPIClient)
+	}
+	if len(entitlements.AllowedTiers) != 2 || !entitlements.AllowedTiers[0].IsDefault || entitlements.AllowedTiers[1].IsDefault {
+		t.Fatalf("camelCase isDefault was not parsed: %+v", entitlements.AllowedTiers)
+	}
+}
+
+func TestAntigravityClientOnboardFailureSurfacesAsEntitlementWarning(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/userinfo":
+			_, _ = io.WriteString(w, `{"id":"google-subject","email":"fresh@example.com","verified_email":true}`)
+		case "/load":
+			_, _ = io.WriteString(w, `{"allowedTiers":[{"id":"free-tier","isDefault":true}]}`)
+		case "/onboard":
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = io.WriteString(w, `{"error":{"code":403,"message":"onboarding denied","status":"PERMISSION_DENIED"}}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client := newAntigravityClient(server.Client(), AntigravityEndpoints{
+		UserInfoURL: server.URL + "/userinfo",
+		LoadProject: []string{server.URL + "/load"},
+		OnboardUser: []string{server.URL + "/onboard"},
+	})
+	client.sleep = func(context.Context, time.Duration) error { return nil }
+
+	credential := AntigravityCredential{AccessToken: "access-token"}
+	_, entitlements, entitlementErr, err := client.fetchIdentityContext(context.Background(), &credential, false)
+	if err != nil {
+		t.Fatalf("fetchIdentityContext() error: %v", err)
+	}
+	if entitlementErr == nil || !strings.Contains(entitlementErr.Error(), "onboardUser") {
+		t.Fatalf("entitlement error = %v, want onboardUser failure", entitlementErr)
+	}
+	if entitlements.ProjectID != "" {
+		t.Fatalf("project = %q, want empty after failed onboarding", entitlements.ProjectID)
+	}
+}
+
+func TestAntigravityClientKeepsPreservedProjectWithoutOnboarding(t *testing.T) {
+	onboardCalls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/userinfo":
+			_, _ = io.WriteString(w, `{"id":"google-subject","email":"user@example.com","verified_email":true}`)
+		case "/load":
+			_, _ = io.WriteString(w, `{"allowedTiers":[{"id":"free-tier","isDefault":true}]}`)
+		case "/onboard":
+			onboardCalls++
+			_, _ = io.WriteString(w, `{"done":true,"response":{"cloudaicompanionProject":"other"}}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client := newAntigravityClient(server.Client(), AntigravityEndpoints{
+		UserInfoURL: server.URL + "/userinfo",
+		LoadProject: []string{server.URL + "/load"},
+		OnboardUser: []string{server.URL + "/onboard"},
+	})
+	credential := AntigravityCredential{AccessToken: "access-token", ProjectID: "existing-project"}
+	_, entitlements, entitlementErr, err := client.fetchIdentityContext(context.Background(), &credential, true)
+	if err != nil || entitlementErr != nil {
+		t.Fatalf("errors: %v / %v", err, entitlementErr)
+	}
+	if entitlements.ProjectID != "existing-project" || onboardCalls != 0 {
+		t.Fatalf("project = %q, onboard calls = %d; a preserved project must not trigger onboarding", entitlements.ProjectID, onboardCalls)
+	}
+}

--- a/auth/antigravity_types.go
+++ b/auth/antigravity_types.go
@@ -341,4 +341,5 @@ type AntigravityEndpoints struct {
 	Quota        []string
 	QuotaSummary []string
 	AICredits    []string
+	OnboardUser  []string
 }

--- a/proxy/antigravity_quota.go
+++ b/proxy/antigravity_quota.go
@@ -1,0 +1,351 @@
+package proxy
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/codex2api/auth"
+	"github.com/tidwall/gjson"
+)
+
+// Cloud Code returns google.rpc.Status envelopes on 429/503. The interesting
+// parts live in error.details[]: an ErrorInfo carrying reason + metadata.model
+// and a RetryInfo carrying retryDelay. Reading them lets the gateway tell a
+// per-account model quota (switch account, cool down for exactly retryDelay)
+// apart from a shared-pool capacity shortage (never switch, never penalise)
+// and from a sub-second rate limit (wait in place instead of burning an
+// account switch).
+type antigravityQuotaKind string
+
+const (
+	antigravityQuotaKindNone           antigravityQuotaKind = ""
+	antigravityQuotaKindRateLimit      antigravityQuotaKind = "rate_limit"
+	antigravityQuotaKindQuotaExhausted antigravityQuotaKind = "quota_exhausted"
+	antigravityQuotaKindModelCapacity  antigravityQuotaKind = "model_capacity"
+)
+
+const (
+	antigravityReasonRateLimitExceeded      = "RATE_LIMIT_EXCEEDED"
+	antigravityReasonQuotaExhausted         = "QUOTA_EXHAUSTED"
+	antigravityReasonModelCapacityExhausted = "MODEL_CAPACITY_EXHAUSTED"
+
+	// antigravityInstantRetryThreshold: a RATE_LIMIT_EXCEEDED whose retryDelay
+	// is below this is cheaper to wait out on the same account than to hand
+	// the request to another account (which would also lose prompt cache).
+	antigravityInstantRetryThreshold = 3 * time.Second
+	antigravityInstantRetryAttempts  = 2
+	// antigravityQuotaExhaustedThreshold: a RATE_LIMIT_EXCEEDED with a retry
+	// delay this long is really a quota window, not a burst limit.
+	antigravityQuotaExhaustedThreshold = 5 * time.Minute
+
+	// MODEL_CAPACITY_EXHAUSTED is a model-wide shortage shared by every
+	// account, so switching accounts cannot help. Retry in place for a bounded
+	// number of one-second waits, then let the request fail over normally.
+	antigravityModelCapacityRetryAttempts = 8
+	antigravityModelCapacityRetryWait     = time.Second
+	antigravityModelCapacityCooldown      = 10 * time.Second
+
+	antigravityDefaultRateLimitCooldown = 30 * time.Second
+	antigravityDefaultQuotaCooldown     = 5 * time.Minute
+	antigravityMaxQuotaCooldown         = 30 * time.Minute
+
+	// antigravityGeminiFamilyCooldownKey is the synthetic model key that a
+	// QUOTA_EXHAUSTED on any Gemini model also cools down. Cloud Code meters
+	// Gemini usage in one shared bucket (retrieveUserQuotaSummary reports a
+	// single "Gemini Models" group), so one exhausted Gemini model means the
+	// account's other Gemini tiers are exhausted too.
+	antigravityGeminiFamilyCooldownKey = "antigravity:gemini"
+)
+
+// antigravitySleep is the wait used for same-endpoint retries. Injectable so
+// tests do not spend real seconds.
+var antigravitySleep = func(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return ctx.Err()
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+type antigravityQuotaError struct {
+	Kind          antigravityQuotaKind
+	Reason        string
+	Model         string
+	Message       string
+	RetryDelay    time.Duration
+	HasRetryDelay bool
+}
+
+// parseAntigravityQuotaError classifies a 429/503 error body. ok is false
+// when the body carries no recognisable quota signal, in which case callers
+// keep their generic handling.
+func parseAntigravityQuotaError(statusCode int, body []byte) (antigravityQuotaError, bool) {
+	if statusCode != http.StatusTooManyRequests && statusCode != http.StatusServiceUnavailable {
+		return antigravityQuotaError{}, false
+	}
+	if len(body) == 0 {
+		return antigravityQuotaError{}, false
+	}
+	result := antigravityQuotaError{
+		Message: strings.TrimSpace(gjson.GetBytes(body, "error.message").String()),
+	}
+	rpcStatus := strings.ToUpper(strings.TrimSpace(gjson.GetBytes(body, "error.status").String()))
+	for _, detail := range gjson.GetBytes(body, "error.details").Array() {
+		typeName := detail.Get("@type").String()
+		switch {
+		case strings.HasSuffix(typeName, "google.rpc.ErrorInfo"):
+			if reason := strings.ToUpper(strings.TrimSpace(detail.Get("reason").String())); reason != "" && result.Reason == "" {
+				result.Reason = reason
+			}
+			if model := strings.TrimSpace(detail.Get("metadata.model").String()); model != "" && result.Model == "" {
+				result.Model = antigravityNormalizeQuotaModel(model)
+			}
+			if !result.HasRetryDelay {
+				if delay, ok := parseAntigravityRetryDelay(detail.Get("metadata.quotaResetDelay")); ok {
+					result.RetryDelay, result.HasRetryDelay = delay, true
+				}
+			}
+		case strings.HasSuffix(typeName, "google.rpc.RetryInfo"):
+			if delay, ok := parseAntigravityRetryDelay(detail.Get("retryDelay")); ok {
+				result.RetryDelay, result.HasRetryDelay = delay, true
+			}
+		}
+	}
+	lowerBody := strings.ToLower(string(body))
+	switch result.Reason {
+	case antigravityReasonModelCapacityExhausted:
+		result.Kind = antigravityQuotaKindModelCapacity
+	case antigravityReasonQuotaExhausted:
+		result.Kind = antigravityQuotaKindQuotaExhausted
+	case antigravityReasonRateLimitExceeded:
+		if result.HasRetryDelay && result.RetryDelay >= antigravityQuotaExhaustedThreshold {
+			result.Kind = antigravityQuotaKindQuotaExhausted
+		} else {
+			result.Kind = antigravityQuotaKindRateLimit
+		}
+	default:
+		switch {
+		case strings.Contains(lowerBody, "model_capacity_exhausted"):
+			result.Kind = antigravityQuotaKindModelCapacity
+		case strings.Contains(lowerBody, "quota_exhausted") || strings.Contains(lowerBody, "quota exhausted") ||
+			strings.Contains(lowerBody, "exhausted your capacity on this model"):
+			result.Kind = antigravityQuotaKindQuotaExhausted
+		case statusCode == http.StatusTooManyRequests && (rpcStatus == "RESOURCE_EXHAUSTED" || result.HasRetryDelay):
+			result.Kind = antigravityQuotaKindRateLimit
+		default:
+			return antigravityQuotaError{}, false
+		}
+	}
+	return result, true
+}
+
+// parseAntigravityRetryDelay accepts the proto-JSON duration string form
+// ("4m50s", "0.201506475s") and the object form ({"seconds": 4, "nanos": 5}).
+func parseAntigravityRetryDelay(value gjson.Result) (time.Duration, bool) {
+	if !value.Exists() {
+		return 0, false
+	}
+	switch value.Type {
+	case gjson.String:
+		text := strings.TrimSpace(value.String())
+		if text == "" {
+			return 0, false
+		}
+		if d, err := time.ParseDuration(text); err == nil && d >= 0 {
+			return d, true
+		}
+		return 0, false
+	case gjson.Number:
+		if seconds := value.Float(); seconds >= 0 {
+			return time.Duration(seconds * float64(time.Second)), true
+		}
+		return 0, false
+	case gjson.JSON:
+		seconds := value.Get("seconds")
+		nanos := value.Get("nanos")
+		if !seconds.Exists() && !nanos.Exists() {
+			return 0, false
+		}
+		d := time.Duration(seconds.Float()*float64(time.Second)) + time.Duration(nanos.Int())
+		if d < 0 {
+			return 0, false
+		}
+		return d, true
+	default:
+		return 0, false
+	}
+}
+
+// antigravityRetryAfterDuration parses an HTTP Retry-After header given either
+// as delta-seconds or as an HTTP date.
+func antigravityRetryAfterDuration(value string) (time.Duration, bool) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0, false
+	}
+	if seconds, err := strconv.Atoi(value); err == nil {
+		if seconds <= 0 {
+			return 0, false
+		}
+		return time.Duration(seconds) * time.Second, true
+	}
+	if at, err := http.ParseTime(value); err == nil {
+		if d := time.Until(at); d > 0 {
+			return d, true
+		}
+	}
+	return 0, false
+}
+
+// antigravityNormalizeQuotaModel strips Vertex-style resource prefixes so the
+// model in ErrorInfo.metadata compares equal to the wire model we sent.
+func antigravityNormalizeQuotaModel(model string) string {
+	normalized := strings.ToLower(strings.TrimSpace(model))
+	if idx := strings.LastIndex(normalized, "/models/"); idx >= 0 {
+		normalized = normalized[idx+len("/models/"):]
+	}
+	return strings.TrimPrefix(normalized, "models/")
+}
+
+// antigravitySameEndpointRetryBudget bounds the in-place retries performed
+// inside ExecuteAntigravityResponsesRequest before the response is handed back
+// to the handler for account-level handling.
+type antigravitySameEndpointRetryBudget struct {
+	capacityAttempts int
+	instantAttempts  int
+}
+
+// retryDelay reports whether a retryable Cloud Code failure should be waited
+// out on the same endpoint and account, and for how long.
+func (b *antigravitySameEndpointRetryBudget) retryDelay(statusCode int, body []byte) (time.Duration, bool) {
+	if b == nil {
+		return 0, false
+	}
+	quota, ok := parseAntigravityQuotaError(statusCode, body)
+	if !ok {
+		return 0, false
+	}
+	switch quota.Kind {
+	case antigravityQuotaKindModelCapacity:
+		if b.capacityAttempts >= antigravityModelCapacityRetryAttempts {
+			return 0, false
+		}
+		b.capacityAttempts++
+		wait := antigravityModelCapacityRetryWait
+		if quota.HasRetryDelay && quota.RetryDelay > 0 && quota.RetryDelay < antigravityInstantRetryThreshold {
+			wait = quota.RetryDelay
+		}
+		return wait, true
+	case antigravityQuotaKindRateLimit:
+		if !quota.HasRetryDelay || quota.RetryDelay <= 0 || quota.RetryDelay >= antigravityInstantRetryThreshold {
+			return 0, false
+		}
+		if b.instantAttempts >= antigravityInstantRetryAttempts {
+			return 0, false
+		}
+		b.instantAttempts++
+		return quota.RetryDelay, true
+	default:
+		return 0, false
+	}
+}
+
+// antigravityIsGeminiModel reports whether a public or wire model id belongs
+// to the shared Gemini quota bucket.
+func antigravityIsGeminiModel(model string) bool {
+	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(model)), "gemini")
+}
+
+// antigravityAccountModelRateLimited is the single admission check for an
+// Antigravity account: the public id, the resolved wire id, and (for Gemini)
+// the shared family key must all be clear.
+func antigravityAccountModelRateLimited(account *auth.Account, model, wireModel string) bool {
+	if account == nil {
+		return false
+	}
+	if account.IsModelRateLimited(model) || account.IsModelRateLimited(wireModel) {
+		return true
+	}
+	if antigravityIsGeminiModel(model) || antigravityIsGeminiModel(wireModel) {
+		return account.IsModelRateLimited(antigravityGeminiFamilyCooldownKey)
+	}
+	return false
+}
+
+// antigravityNonPenalizingUpstreamFailure reports failures that say nothing
+// about the account's health: a model-wide capacity shortage is Google's
+// problem, not this credential's, so ReportRequestFailure must not count it.
+func antigravityNonPenalizingUpstreamFailure(account *auth.Account, statusCode int, body []byte) bool {
+	if account == nil || !account.IsAntigravityAPI() {
+		return false
+	}
+	quota, ok := parseAntigravityQuotaError(statusCode, body)
+	return ok && quota.Kind == antigravityQuotaKindModelCapacity
+}
+
+// applyAntigravityCooldown turns a Cloud Code 429/503 into a per-(account,
+// model) cooldown sized from the upstream retry hint. Unrecognised 429 bodies
+// fall back to the generic relay-style cooldown policy.
+func applyAntigravityCooldown(store *auth.Store, account *auth.Account, statusCode int, body []byte, resp *http.Response, model string) codex429Decision {
+	quota, ok := parseAntigravityQuotaError(statusCode, body)
+	if !ok {
+		if statusCode == http.StatusTooManyRequests {
+			return Apply429Cooldown(store, account, body, resp, model)
+		}
+		return codex429Decision{}
+	}
+	decision := codex429Decision{Scope: rateLimitScopeModel, Model: strings.TrimSpace(model)}
+	var cooldown time.Duration
+	switch quota.Kind {
+	case antigravityQuotaKindModelCapacity:
+		decision.Reason = "model_capacity"
+		cooldown = antigravityModelCapacityCooldown
+	case antigravityQuotaKindQuotaExhausted:
+		decision.Reason = "quota_exhausted"
+		cooldown = antigravityDefaultQuotaCooldown
+		if quota.HasRetryDelay && quota.RetryDelay > 0 {
+			cooldown = quota.RetryDelay
+		}
+	default:
+		decision.Reason = "rate_limited_model"
+		cooldown = antigravityDefaultRateLimitCooldown
+		if quota.HasRetryDelay && quota.RetryDelay > 0 {
+			cooldown = quota.RetryDelay
+		}
+	}
+	if resp != nil && !quota.HasRetryDelay {
+		if retryAfter, ok := antigravityRetryAfterDuration(resp.Header.Get("Retry-After")); ok {
+			cooldown = retryAfter
+		}
+	}
+	if cooldown < time.Second {
+		cooldown = time.Second
+	}
+	if cooldown > antigravityMaxQuotaCooldown {
+		cooldown = antigravityMaxQuotaCooldown
+	}
+	resetAt := time.Now().Add(cooldown)
+	decision.ResetAt = resetAt
+	decision.Cooldown = cooldown
+	if store == nil || account == nil || decision.Model == "" {
+		return decision
+	}
+	marked := store.MarkModelCooldownUntil(account, decision.Model, decision.Reason, resetAt)
+	if !marked.ResetAt.IsZero() {
+		decision.ResetAt = marked.ResetAt
+		decision.Cooldown = time.Until(marked.ResetAt)
+	}
+	if quota.Kind == antigravityQuotaKindQuotaExhausted && (antigravityIsGeminiModel(decision.Model) || antigravityIsGeminiModel(quota.Model)) {
+		store.MarkModelCooldownUntil(account, antigravityGeminiFamilyCooldownKey, decision.Reason, resetAt)
+	}
+	return decision
+}

--- a/proxy/antigravity_quota_test.go
+++ b/proxy/antigravity_quota_test.go
@@ -1,0 +1,191 @@
+package proxy
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/codex2api/auth"
+)
+
+const antigravityQuotaExhaustedBody = `{"error":{"code":429,"message":"You have exhausted your capacity on this model.","status":"RESOURCE_EXHAUSTED","details":[{"@type":"type.googleapis.com/google.rpc.ErrorInfo","reason":"QUOTA_EXHAUSTED","domain":"cloudcode-pa.googleapis.com","metadata":{"model":"gemini-3.7-flash-tiered"}},{"@type":"type.googleapis.com/google.rpc.RetryInfo","retryDelay":"4m50s"}]}}`
+
+const antigravityShortRateLimitBody = `{"error":{"code":429,"message":"Resource has been exhausted (e.g. check quota).","status":"RESOURCE_EXHAUSTED","details":[{"@type":"type.googleapis.com/google.rpc.ErrorInfo","reason":"RATE_LIMIT_EXCEEDED","metadata":{"model":"gemini-3.7-flash-tiered"}},{"@type":"type.googleapis.com/google.rpc.RetryInfo","retryDelay":"0.5s"}]}}`
+
+const antigravityModelCapacityBody = `{"error":{"code":503,"message":"The model is overloaded.","status":"UNAVAILABLE","details":[{"@type":"type.googleapis.com/google.rpc.ErrorInfo","reason":"MODEL_CAPACITY_EXHAUSTED","metadata":{"model":"gemini-pro-agent"}}]}}`
+
+func stubAntigravitySleep(t *testing.T) *[]time.Duration {
+	t.Helper()
+	previous := antigravitySleep
+	waits := &[]time.Duration{}
+	antigravitySleep = func(ctx context.Context, d time.Duration) error {
+		*waits = append(*waits, d)
+		return ctx.Err()
+	}
+	t.Cleanup(func() { antigravitySleep = previous })
+	return waits
+}
+
+func TestParseAntigravityQuotaErrorClassifiesGoogleStatusDetails(t *testing.T) {
+	quota, ok := parseAntigravityQuotaError(http.StatusTooManyRequests, []byte(antigravityQuotaExhaustedBody))
+	if !ok || quota.Kind != antigravityQuotaKindQuotaExhausted || quota.Model != "gemini-3.7-flash-tiered" || !quota.HasRetryDelay || quota.RetryDelay != 4*time.Minute+50*time.Second {
+		t.Fatalf("quota exhausted parse = %+v ok=%v", quota, ok)
+	}
+	quota, ok = parseAntigravityQuotaError(http.StatusTooManyRequests, []byte(antigravityShortRateLimitBody))
+	if !ok || quota.Kind != antigravityQuotaKindRateLimit || quota.RetryDelay != 500*time.Millisecond {
+		t.Fatalf("short rate limit parse = %+v ok=%v", quota, ok)
+	}
+	quota, ok = parseAntigravityQuotaError(http.StatusServiceUnavailable, []byte(antigravityModelCapacityBody))
+	if !ok || quota.Kind != antigravityQuotaKindModelCapacity || quota.HasRetryDelay {
+		t.Fatalf("model capacity parse = %+v ok=%v", quota, ok)
+	}
+	// A RATE_LIMIT_EXCEEDED whose delay is a whole quota window is a quota, not a burst.
+	long := strings.Replace(antigravityShortRateLimitBody, `"0.5s"`, `"6m"`, 1)
+	if quota, ok = parseAntigravityQuotaError(http.StatusTooManyRequests, []byte(long)); !ok || quota.Kind != antigravityQuotaKindQuotaExhausted {
+		t.Fatalf("long rate limit parse = %+v ok=%v", quota, ok)
+	}
+	// Proto object form of the duration.
+	object := `{"error":{"status":"RESOURCE_EXHAUSTED","details":[{"@type":"type.googleapis.com/google.rpc.ErrorInfo","reason":"RATE_LIMIT_EXCEEDED"},{"@type":"type.googleapis.com/google.rpc.RetryInfo","retryDelay":{"seconds":2,"nanos":500000000}}]}}`
+	if quota, ok = parseAntigravityQuotaError(http.StatusTooManyRequests, []byte(object)); !ok || quota.RetryDelay != 2500*time.Millisecond {
+		t.Fatalf("object retryDelay parse = %+v ok=%v", quota, ok)
+	}
+	// Unstructured bodies keep the generic handling.
+	if _, ok = parseAntigravityQuotaError(http.StatusServiceUnavailable, []byte(`{"error":{"message":"Internal error encountered.","status":"INTERNAL"}}`)); ok {
+		t.Fatal("unrelated 503 must not be classified as a quota signal")
+	}
+	if _, ok = parseAntigravityQuotaError(http.StatusBadRequest, []byte(antigravityQuotaExhaustedBody)); ok {
+		t.Fatal("non-429/503 statuses must never be classified")
+	}
+}
+
+func TestAntigravityExecutorRetriesSharedCapacityShortageInPlace(t *testing.T) {
+	waits := stubAntigravitySleep(t)
+	var hits int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&hits, 1)
+		w.Header().Set("Content-Type", "application/json")
+		if n <= 2 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = io.WriteString(w, antigravityModelCapacityBody)
+			return
+		}
+		_, _ = io.WriteString(w, `{"candidates":[{"content":{"parts":[{"text":"ok"}]},"finishReason":"STOP"}]}`)
+	}))
+	defer server.Close()
+	previous := antigravityOAuthEndpointBases
+	antigravityOAuthEndpointBases = []string{server.URL}
+	t.Cleanup(func() { antigravityOAuthEndpointBases = previous })
+
+	account := &auth.Account{DBID: 7101, UpstreamType: auth.UpstreamAntigravity, AccessToken: "google-token", AntigravityProjectID: "google-project"}
+	resp, err := ExecuteAntigravityResponsesRequest(context.Background(), account, "gemini-3.1-pro-high", []byte(`{"input":"hello"}`), false, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK || atomic.LoadInt32(&hits) != 3 {
+		t.Fatalf("status=%d hits=%d, want the same endpoint retried twice then 200", resp.StatusCode, hits)
+	}
+	if len(*waits) != 2 || (*waits)[0] != antigravityModelCapacityRetryWait {
+		t.Fatalf("waits = %v, want two one-second in-place waits", *waits)
+	}
+}
+
+func TestAntigravityExecutorWaitsOutSubSecondRateLimitButNotQuota(t *testing.T) {
+	waits := stubAntigravitySleep(t)
+	var hits int32
+	body := antigravityShortRateLimitBody
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&hits, 1)
+		w.Header().Set("Content-Type", "application/json")
+		if n == 1 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = io.WriteString(w, body)
+			return
+		}
+		_, _ = io.WriteString(w, `{"candidates":[{"content":{"parts":[{"text":"ok"}]},"finishReason":"STOP"}]}`)
+	}))
+	defer server.Close()
+	previous := antigravityOAuthEndpointBases
+	antigravityOAuthEndpointBases = []string{server.URL}
+	t.Cleanup(func() { antigravityOAuthEndpointBases = previous })
+	account := &auth.Account{DBID: 7102, UpstreamType: auth.UpstreamAntigravity, AccessToken: "google-token", AntigravityProjectID: "google-project"}
+
+	resp, err := ExecuteAntigravityResponsesRequest(context.Background(), account, "gemini-3.7-flash-high", []byte(`{"input":"hello"}`), false, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK || hits != 2 || len(*waits) != 1 || (*waits)[0] != 500*time.Millisecond {
+		t.Fatalf("status=%d hits=%d waits=%v, want one 500ms in-place wait then success", resp.StatusCode, hits, *waits)
+	}
+
+	// A real quota exhaustion is never waited out in place: with a single
+	// endpoint the 429 goes straight back to the handler.
+	atomic.StoreInt32(&hits, 0)
+	*waits = nil
+	body = antigravityQuotaExhaustedBody
+	server2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = io.WriteString(w, body)
+	}))
+	defer server2.Close()
+	antigravityOAuthEndpointBases = []string{server2.URL}
+	resp, err = ExecuteAntigravityResponsesRequest(context.Background(), account, "gemini-3.7-flash-high", []byte(`{"input":"hello"}`), false, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusTooManyRequests || hits != 1 || len(*waits) != 0 {
+		t.Fatalf("status=%d hits=%d waits=%v, want the quota 429 returned without in-place retries", resp.StatusCode, hits, *waits)
+	}
+}
+
+func TestApplyAntigravityCooldownUsesRetryDelayAndGeminiFamilyKey(t *testing.T) {
+	store := newProxyPremiumTestStore()
+	account := &auth.Account{DBID: 7201, UpstreamType: auth.UpstreamAntigravity, AccessToken: "google-token", AntigravityProjectID: "google-project"}
+
+	decision := applyAntigravityCooldown(store, account, http.StatusTooManyRequests, []byte(antigravityQuotaExhaustedBody), nil, "gemini-3.7-flash-high")
+	if decision.Scope != rateLimitScopeModel || decision.Reason != "quota_exhausted" || decision.Model != "gemini-3.7-flash-high" {
+		t.Fatalf("decision = %+v", decision)
+	}
+	if decision.Cooldown < 4*time.Minute+45*time.Second || decision.Cooldown > 4*time.Minute+50*time.Second {
+		t.Fatalf("cooldown = %s, want the upstream retryDelay of 4m50s", decision.Cooldown)
+	}
+	if !account.IsModelRateLimited("gemini-3.7-flash-high") {
+		t.Fatal("public model was not cooled down")
+	}
+	if !antigravityAccountModelRateLimited(account, "gemini-3.6-flash-low", "gemini-3.6-flash-low") {
+		t.Fatal("sibling Gemini model should be blocked through the shared family key after QUOTA_EXHAUSTED")
+	}
+	if antigravityAccountModelRateLimited(account, "claude-sonnet-4-6", "claude-sonnet-4-6") {
+		t.Fatal("Claude models must not be blocked by the Gemini family key")
+	}
+
+	capacity := &auth.Account{DBID: 7202, UpstreamType: auth.UpstreamAntigravity, AccessToken: "google-token", AntigravityProjectID: "google-project"}
+	decision = applyAntigravityCooldown(store, capacity, http.StatusServiceUnavailable, []byte(antigravityModelCapacityBody), nil, "gemini-3.1-pro-high")
+	if decision.Reason != "model_capacity" || decision.Cooldown > antigravityModelCapacityCooldown || decision.Cooldown <= 0 {
+		t.Fatalf("capacity decision = %+v", decision)
+	}
+	if antigravityAccountModelRateLimited(capacity, "gemini-3.6-flash-low", "gemini-3.6-flash-low") {
+		t.Fatal("a shared capacity shortage must not cool down the whole Gemini family")
+	}
+	if !antigravityNonPenalizingUpstreamFailure(capacity, http.StatusServiceUnavailable, []byte(antigravityModelCapacityBody)) {
+		t.Fatal("MODEL_CAPACITY_EXHAUSTED must not count against the account")
+	}
+	if antigravityNonPenalizingUpstreamFailure(capacity, http.StatusTooManyRequests, []byte(antigravityQuotaExhaustedBody)) {
+		t.Fatal("a real quota exhaustion is still an account-level signal")
+	}
+
+	generic := &auth.Account{DBID: 7203, UpstreamType: auth.UpstreamAntigravity, AccessToken: "google-token", AntigravityProjectID: "google-project"}
+	decision = applyAntigravityCooldown(store, generic, http.StatusTooManyRequests, []byte(`{"error":{"message":"slow down"}}`), &http.Response{Header: http.Header{}}, "gemini-3.7-flash-high")
+	if decision.Reason != "rate_limited_model" {
+		t.Fatalf("unstructured 429 should fall back to the relay policy, got %+v", decision)
+	}
+}

--- a/proxy/antigravity_responses.go
+++ b/proxy/antigravity_responses.go
@@ -5,7 +5,9 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
 	"crypto/tls"
+	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -15,6 +17,7 @@ import (
 	"os"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -50,7 +53,6 @@ var antigravityOAuthEndpointBases = []string{
 const (
 	antigravityOAuthDailyEndpoint    = "https://daily-cloudcode-pa.googleapis.com"
 	antigravityOAuthSandboxEndpoint  = "https://daily-cloudcode-pa.sandbox.googleapis.com"
-	antigravityOfficialSessionID     = "-3750763034362895579"
 	antigravityOfficialBodyUserAgent = "antigravity"
 	antigravityOfficialHTTPUserAgent = "antigravity/hub/2.9.1 windows/amd64"
 	antigravityZeroWidthSpace        = "\u200B"
@@ -127,27 +129,34 @@ func ExecuteAntigravityResponsesRequest(ctx context.Context, account *auth.Accou
 		lastRetryableResponse = nil
 	}
 	useUserProject := antigravityUserProjectHeaderEnabled()
+	payload, _ := json.Marshal(gemini)
+	sameEndpointBudget := &antigravitySameEndpointRetryBudget{}
 	for headerAttempt := 0; headerAttempt < 2; headerAttempt++ {
 		retryWithoutUserProject := false
 		for _, base := range antigravityOAuthEndpointList() {
 			endpoint := strings.TrimRight(base, "/") + "/v1internal:" + method + query
-			payload, _ := json.Marshal(gemini)
-			req, reqErr := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(payload))
-			if reqErr != nil {
-				return nil, reqErr
-			}
-			req.Header.Set("Authorization", "Bearer "+bearer)
-			req.Header.Set("Content-Type", "application/json")
-			req.Header.Set("User-Agent", antigravityOfficialHTTPUserAgent)
-			if useUserProject {
-				req.Header.Set("x-goog-user-project", project)
-			}
-			resp, doErr := client.Do(req)
-			if doErr != nil {
-				last = doErr
-				continue
-			}
-			if resp.StatusCode >= 500 || resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode == http.StatusRequestTimeout {
+			var resp *http.Response
+			for {
+				req, reqErr := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(payload))
+				if reqErr != nil {
+					return nil, reqErr
+				}
+				req.Header.Set("Authorization", "Bearer "+bearer)
+				req.Header.Set("Content-Type", "application/json")
+				req.Header.Set("User-Agent", antigravityOfficialHTTPUserAgent)
+				if useUserProject {
+					req.Header.Set("x-goog-user-project", project)
+				}
+				var doErr error
+				resp, doErr = client.Do(req)
+				if doErr != nil {
+					last = doErr
+					resp = nil
+					break
+				}
+				if resp.StatusCode < 500 && resp.StatusCode != http.StatusTooManyRequests && resp.StatusCode != http.StatusRequestTimeout {
+					break
+				}
 				body, readErr := readBoundedAntigravityBody(resp.Body, antigravityErrorBodyLimit)
 				if readErr != nil {
 					last = fmt.Errorf("antigravity upstream HTTP %d body: %w", resp.StatusCode, readErr)
@@ -158,11 +167,22 @@ func ExecuteAntigravityResponsesRequest(ctx context.Context, account *auth.Accou
 				}
 				resp.Body = io.NopCloser(bytes.NewReader(body))
 				resp.ContentLength = int64(len(body))
+				// A sub-second RATE_LIMIT_EXCEEDED or a shared MODEL_CAPACITY_EXHAUSTED
+				// is cheaper to wait out right here than to switch endpoint or account.
+				if wait, retry := sameEndpointBudget.retryDelay(resp.StatusCode, body); retry {
+					if sleepErr := antigravitySleep(ctx, wait); sleepErr == nil {
+						continue
+					}
+				}
 				if lastRetryableResponse != nil {
 					_ = lastRetryableResponse.Body.Close()
 				}
 				lastResponse = resp
 				lastRetryableResponse = resp
+				resp = nil
+				break
+			}
+			if resp == nil {
 				continue
 			}
 			if resp.StatusCode == http.StatusForbidden {
@@ -529,7 +549,7 @@ func responsesToGeminiInternal(raw []byte, project, model string) (map[string]an
 	if len(systemParts) > 0 {
 		request["systemInstruction"] = map[string]any{"parts": []any{map[string]any{"text": antigravityObfuscateSystemInstruction(strings.Join(systemParts, "\n\n"))}}}
 	}
-	request["sessionId"] = antigravityOfficialSessionID
+	request["sessionId"] = antigravitySessionID(in, contents)
 	if tools, ok := in["tools"].([]any); ok {
 		if declarations := antigravityGeminiFunctionDeclarations(tools); len(declarations) > 0 && antigravityGeminiFunctionToolsEnabled() && antigravityGeminiSupportsFunctionTools(wireModel) {
 			request["tools"] = []any{map[string]any{"functionDeclarations": declarations}}
@@ -1114,6 +1134,67 @@ func lowerStringField(m map[string]any, key string) string {
 	return strings.ToLower(strings.TrimSpace(s))
 }
 
+// antigravitySessionID derives the Cloud Code sessionId for one request. The
+// native client uses one stable id per conversation, so the gateway derives a
+// stable value from the strongest conversation identifier the downstream
+// request carries: an explicit prompt_cache_key or session/user metadata,
+// otherwise the first user turn's text. Distinct conversations therefore get
+// distinct ids while every turn of one conversation keeps the same id. A
+// single constant shared by every account and conversation would be a pool
+// fingerprint, which is why no fixed fallback is used.
+func antigravitySessionID(in map[string]any, contents []any) string {
+	if key := antigravitySessionSeed(in, contents); key != "" {
+		return antigravitySessionIDFromSeed(key)
+	}
+	raw := make([]byte, 8)
+	_, _ = rand.Read(raw)
+	return antigravitySessionIDFromDigest(raw)
+}
+
+func antigravitySessionSeed(in map[string]any, contents []any) string {
+	if in != nil {
+		if key, _ := in["prompt_cache_key"].(string); strings.TrimSpace(key) != "" {
+			return "prompt_cache_key:" + strings.TrimSpace(key)
+		}
+		if metadata, ok := in["metadata"].(map[string]any); ok {
+			for _, field := range []string{"session_id", "conversation_id", "user_id"} {
+				if value, _ := metadata[field].(string); strings.TrimSpace(value) != "" {
+					return "metadata." + field + ":" + strings.TrimSpace(value)
+				}
+			}
+		}
+		if user, _ := in["user"].(string); strings.TrimSpace(user) != "" {
+			return "user:" + strings.TrimSpace(user)
+		}
+	}
+	for _, content := range contents {
+		entry, _ := content.(map[string]any)
+		if entry == nil || entry["role"] != "user" {
+			continue
+		}
+		parts, _ := entry["parts"].([]any)
+		for _, part := range parts {
+			partValue, _ := part.(map[string]any)
+			if text, _ := partValue["text"].(string); strings.TrimSpace(text) != "" {
+				return "first_user_text:" + text
+			}
+		}
+	}
+	return ""
+}
+
+func antigravitySessionIDFromSeed(seed string) string {
+	sum := sha256.Sum256([]byte("codex2api:antigravity:session\x00" + seed))
+	return antigravitySessionIDFromDigest(sum[:8])
+}
+
+// antigravitySessionIDFromDigest renders eight digest bytes the way the native
+// client renders its session ids: a negative-signed decimal of a 63-bit value.
+func antigravitySessionIDFromDigest(digest []byte) string {
+	value := int64(binary.BigEndian.Uint64(digest[:8]) & 0x7FFFFFFFFFFFFFFF)
+	return "-" + strconv.FormatInt(value, 10)
+}
+
 func antigravityRequestID() string {
 	b := make([]byte, 4)
 	_, _ = rand.Read(b)
@@ -1292,6 +1373,9 @@ type antigravitySSEBody struct {
 	sequence   int64
 	started    bool
 	terminal   bool
+	// textStarted records that the assistant message item and its text part
+	// have been opened downstream, so later fragments go out as deltas.
+	textStarted bool
 }
 
 func newAntigravitySSEResponseBody(r io.ReadCloser, model ...string) io.ReadCloser {
@@ -1367,12 +1451,46 @@ func (b *antigravitySSEBody) enqueueFailure(code, message string, statusCode ...
 	b.enqueue("response.failed", map[string]any{"response": response})
 }
 
+// openTextItem emits the assistant message item and its text part once, so
+// text can then stream as incremental deltas.
+func (b *antigravitySSEBody) openTextItem() {
+	if b.textStarted {
+		return
+	}
+	b.enqueueStart()
+	b.textStarted = true
+	b.enqueue("response.output_item.added", map[string]any{
+		"output_index": 0,
+		"item": map[string]any{
+			"id": b.messageID, "type": "message", "status": "in_progress",
+			"role": "assistant", "content": []any{},
+		},
+	})
+	b.enqueue("response.content_part.added", map[string]any{
+		"item_id": b.messageID, "output_index": 0, "content_index": 0,
+		"part": map[string]any{"type": "output_text", "text": "", "annotations": []any{}},
+	})
+}
+
+// emitTextDelta forwards one upstream text fragment downstream immediately.
+// Cloud Code streams incrementally; holding the text until the finish reason
+// made time-to-first-token equal the whole generation time.
+func (b *antigravitySSEBody) emitTextDelta(fragment string) {
+	if fragment == "" || b.terminal {
+		return
+	}
+	b.openTextItem()
+	b.text.WriteString(fragment)
+	b.enqueue("response.output_text.delta", map[string]any{
+		"item_id": b.messageID, "output_index": 0, "content_index": 0, "delta": fragment,
+	})
+}
+
 func (b *antigravitySSEBody) enqueueSuccess(status string, usage map[string]any) {
 	if b.terminal {
 		return
 	}
 	b.enqueueStart()
-	b.terminal = true
 	text := b.text.String()
 	content := map[string]any{"type": "output_text", "text": text, "annotations": []any{}}
 	message := map[string]any{
@@ -1380,23 +1498,10 @@ func (b *antigravitySSEBody) enqueueSuccess(status string, usage map[string]any)
 		"role": "assistant", "content": []any{content},
 	}
 	output := make([]any, 0, 1+len(b.functions))
-	if text != "" || len(b.functions) == 0 {
-		b.enqueue("response.output_item.added", map[string]any{
-			"output_index": 0,
-			"item": map[string]any{
-				"id": b.messageID, "type": "message", "status": "in_progress",
-				"role": "assistant", "content": []any{},
-			},
-		})
-		b.enqueue("response.content_part.added", map[string]any{
-			"item_id": b.messageID, "output_index": 0, "content_index": 0,
-			"part": map[string]any{"type": "output_text", "text": "", "annotations": []any{}},
-		})
-		if text != "" {
-			b.enqueue("response.output_text.delta", map[string]any{
-				"item_id": b.messageID, "output_index": 0, "content_index": 0, "delta": text,
-			})
-		}
+	if b.textStarted || len(b.functions) == 0 {
+		// A response with neither text nor tool calls still needs one empty
+		// message item so the Responses lifecycle stays well-formed.
+		b.openTextItem()
 		b.enqueue("response.output_text.done", map[string]any{
 			"item_id": b.messageID, "output_index": 0, "content_index": 0, "text": text,
 		})
@@ -1406,6 +1511,7 @@ func (b *antigravitySSEBody) enqueueSuccess(status string, usage map[string]any)
 		b.enqueue("response.output_item.done", map[string]any{"output_index": 0, "item": message})
 		output = append(output, message)
 	}
+	b.terminal = true
 	functionOutputStart := len(output)
 	for index, functionCall := range b.functions {
 		outputIndex := functionOutputStart + index
@@ -1497,15 +1603,18 @@ func (b *antigravitySSEBody) Read(p []byte) (int, error) {
 			b.enqueueFailure("unsupported_output", "antigravity upstream returned an unsupported non-text output", http.StatusBadRequest)
 			continue
 		}
-		// Cloud Code/Gemini streaming emits incremental text fragments. Buffer
-		// them until the terminal finish reason so a later safety rejection can
-		// fail closed without leaking already-rejected candidate text.
-		b.text.WriteString(extractGeminiText(env))
-		b.addFunctionCalls(extractGeminiFunctionCalls(env))
-		if b.text.Len()+antigravityFunctionCallsSize(b.functions) > antigravityResponseBodyLimit {
+		// Text streams through as deltas. A safety or error frame that arrives
+		// in the same upstream frame as text is checked above, before any of
+		// that frame's text is forwarded; a rejection that arrives in a later
+		// frame terminates the stream with response.failed instead.
+		fragment := extractGeminiText(env)
+		calls := extractGeminiFunctionCalls(env)
+		if b.text.Len()+len(fragment)+antigravityFunctionCallsSize(b.functions)+antigravityFunctionCallsSize(calls) > antigravityResponseBodyLimit {
 			b.enqueueFailure(ErrorCodeUpstreamError, "antigravity streamed response exceeded the safe size limit")
 			continue
 		}
+		b.emitTextDelta(fragment)
+		b.addFunctionCalls(calls)
 		if finishReason != "" {
 			var usage map[string]any
 			if metadata, ok := env["usageMetadata"].(map[string]any); ok {

--- a/proxy/antigravity_responses_test.go
+++ b/proxy/antigravity_responses_test.go
@@ -125,7 +125,7 @@ func TestAntigravityResponsesUsesOfficialEnvelopeWithoutForcedCredits(t *testing
 		t.Fatalf("userAgent = %#v", got["userAgent"])
 	}
 	request := got["request"].(map[string]any)
-	if request["sessionId"] != antigravityOfficialSessionID {
+	if !isAntigravitySessionID(request["sessionId"]) {
 		t.Fatalf("sessionId = %#v", request["sessionId"])
 	}
 	requestID, _ := got["requestId"].(string)
@@ -766,7 +766,7 @@ func TestAntigravityOAuthWireUsesOfficialIdentity(t *testing.T) {
 		t.Fatalf("body userAgent = %#v", gotBody["userAgent"])
 	}
 	request := gotBody["request"].(map[string]any)
-	if request["sessionId"] != antigravityOfficialSessionID {
+	if !isAntigravitySessionID(request["sessionId"]) {
 		t.Fatalf("sessionId = %#v", request["sessionId"])
 	}
 	if _, exists := gotBody["enabledCreditTypes"]; exists {
@@ -1196,8 +1196,14 @@ func TestAntigravitySSELifecycleAndBufferedTerminal(t *testing.T) {
 			t.Fatalf("missing %s: %s", eventType, got)
 		}
 	}
-	if !strings.Contains(got, `"delta":"hello"`) || !strings.Contains(got, `"output_text":"hello"`) {
-		t.Fatalf("buffered terminal text is incomplete: %s", got)
+	if !strings.Contains(got, `"delta":"hel"`) || !strings.Contains(got, `"delta":"lo"`) || !strings.Contains(got, `"output_text":"hello"`) {
+		t.Fatalf("incremental deltas or terminal text are incomplete: %s", got)
+	}
+	if strings.Index(got, `"delta":"hel"`) > strings.Index(got, `"delta":"lo"`) {
+		t.Fatalf("deltas are out of order: %s", got)
+	}
+	if strings.Count(got, `"type":"response.output_item.added"`) != 1 || strings.Count(got, `"type":"response.content_part.added"`) != 1 {
+		t.Fatalf("message item must be opened exactly once: %s", got)
 	}
 	if strings.Count(got, `"type":"response.completed"`) != 1 {
 		t.Fatalf("completed count = %d, body=%s", strings.Count(got, `"type":"response.completed"`), got)
@@ -1316,8 +1322,8 @@ func TestAntigravitySSESafetyTerminalFails(t *testing.T) {
 	}
 }
 
-func TestAntigravitySSEPriorTextIsNotLeakedWhenLaterSafetyFrameArrives(t *testing.T) {
-	input := "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"sensitive-prefix\"}]}}]}\n\n" +
+func TestAntigravitySSELaterSafetyFrameFailsAfterIncrementalDeltas(t *testing.T) {
+	input := "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"already-streamed\"}]}}]}\n\n" +
 		"data: {\"candidates\":[{\"finishReason\":\"SAFETY\"}]}\n\n"
 	body := newAntigravitySSEResponseBody(io.NopCloser(strings.NewReader(input)))
 	defer body.Close()
@@ -1326,8 +1332,17 @@ func TestAntigravitySSEPriorTextIsNotLeakedWhenLaterSafetyFrameArrives(t *testin
 		t.Fatal(err)
 	}
 	got := string(out)
-	if !strings.Contains(got, `"type":"response.failed"`) || strings.Contains(got, "sensitive-prefix") || strings.Contains(got, `"type":"response.completed"`) {
-		t.Fatalf("later safety frame did not fail closed: %s", got)
+	// Text that arrived before the rejection was already forwarded as a delta;
+	// the stream must still terminate as failed, never as completed, and must
+	// not close the text part as if it were a finished answer.
+	if !strings.Contains(got, `"delta":"already-streamed"`) {
+		t.Fatalf("earlier text was not streamed incrementally: %s", got)
+	}
+	if !strings.Contains(got, `"type":"response.failed"`) || strings.Contains(got, `"type":"response.completed"`) || strings.Contains(got, `"type":"response.output_text.done"`) {
+		t.Fatalf("later safety frame did not terminate the stream as failed: %s", got)
+	}
+	if strings.Index(got, `"type":"response.failed"`) < strings.Index(got, `"delta":"already-streamed"`) {
+		t.Fatalf("failure must follow the streamed delta: %s", got)
 	}
 }
 
@@ -1386,5 +1401,76 @@ func TestAntigravitySSEPromptSafetyWithoutCandidateFails(t *testing.T) {
 	got := string(out)
 	if !strings.Contains(got, "response.failed") || strings.Contains(got, "response.completed") || !strings.Contains(got, "safety policy") {
 		t.Fatalf("prompt safety result = %s", got)
+	}
+}
+
+// isAntigravitySessionID reports whether v has the native session id shape:
+// a "-" followed by a decimal 63-bit value.
+func isAntigravitySessionID(v any) bool {
+	s, ok := v.(string)
+	if !ok || len(s) < 2 || s[0] != '-' {
+		return false
+	}
+	for _, r := range s[1:] {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func TestAntigravitySessionIDIsStablePerConversationAndDistinctAcrossConversations(t *testing.T) {
+	first, err := responsesToGeminiInternal([]byte(`{"input":[{"role":"user","content":"hello there"}],"prompt_cache_key":"thread-a"}`), "project", "gemini-3.7-flash-high")
+	if err != nil {
+		t.Fatal(err)
+	}
+	again, err := responsesToGeminiInternal([]byte(`{"input":[{"role":"user","content":"hello there"},{"role":"assistant","content":"hi"},{"role":"user","content":"more"}],"prompt_cache_key":"thread-a"}`), "project", "gemini-3.7-flash-high")
+	if err != nil {
+		t.Fatal(err)
+	}
+	other, err := responsesToGeminiInternal([]byte(`{"input":[{"role":"user","content":"hello there"}],"prompt_cache_key":"thread-b"}`), "project", "gemini-3.7-flash-high")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sessionOf := func(env map[string]any) string {
+		request := env["request"].(map[string]any)
+		id, _ := request["sessionId"].(string)
+		return id
+	}
+	if !isAntigravitySessionID(sessionOf(first)) {
+		t.Fatalf("sessionId shape = %q", sessionOf(first))
+	}
+	if sessionOf(first) != sessionOf(again) {
+		t.Fatalf("same prompt_cache_key produced different session ids: %q vs %q", sessionOf(first), sessionOf(again))
+	}
+	if sessionOf(first) == sessionOf(other) {
+		t.Fatalf("different prompt_cache_key shared a session id: %q", sessionOf(first))
+	}
+}
+
+func TestAntigravitySessionIDFallsBackToFirstUserTurn(t *testing.T) {
+	sessionOf := func(body string) string {
+		env, err := responsesToGeminiInternal([]byte(body), "project", "gemini-3.7-flash-high")
+		if err != nil {
+			t.Fatal(err)
+		}
+		request := env["request"].(map[string]any)
+		id, _ := request["sessionId"].(string)
+		return id
+	}
+	turnOne := sessionOf(`{"instructions":"be brief","input":[{"role":"user","content":"first question"}]}`)
+	turnTwo := sessionOf(`{"instructions":"be brief","input":[{"role":"user","content":"first question"},{"role":"assistant","content":"answer"},{"role":"user","content":"follow up"}]}`)
+	unrelated := sessionOf(`{"input":[{"role":"user","content":"another conversation"}]}`)
+	if turnOne != turnTwo {
+		t.Fatalf("conversation continuation changed the session id: %q vs %q", turnOne, turnTwo)
+	}
+	if turnOne == unrelated {
+		t.Fatalf("unrelated conversations shared a session id: %q", turnOne)
+	}
+	if !isAntigravitySessionID(turnOne) || turnOne == "-3750763034362895579" {
+		t.Fatalf("session id must be derived, not the legacy constant: %q", turnOne)
+	}
+	if metadataSeeded := sessionOf(`{"input":"x","metadata":{"session_id":"sess-1"}}`); metadataSeeded != antigravitySessionIDFromSeed("metadata.session_id:sess-1") {
+		t.Fatalf("metadata.session_id was not used as the seed: %q", metadataSeeded)
 	}
 }

--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -436,7 +436,7 @@ func antigravityChannelAccountFilter(model string) auth.AccountFilter {
 		if !supported {
 			return false
 		}
-		if account.IsModelRateLimited(model) || account.IsModelRateLimited(wireModel) {
+		if antigravityAccountModelRateLimited(account, model, wireModel) {
 			return false
 		}
 		return true
@@ -484,7 +484,7 @@ func accountFilterForResponsesModelResolver(effectiveModel string, allowCodexAcc
 				return false
 			}
 			wireModel, supported := antigravityResolvePublicModelForAccount(account, effectiveModel)
-			return supported && !account.IsModelRateLimited(effectiveModel) && !account.IsModelRateLimited(wireModel)
+			return supported && !antigravityAccountModelRateLimited(account, effectiveModel, wireModel)
 		}
 		if account.IsRelayStyle() {
 			routedModel := effectiveModel
@@ -4125,7 +4125,7 @@ func (h *Handler) Responses(c *gin.Context) {
 					}
 				}
 
-				if kind := classifyHTTPFailure(resp.StatusCode); kind != "" && !antigravityRefreshFailed {
+				if kind := classifyHTTPFailure(resp.StatusCode); kind != "" && !antigravityRefreshFailed && !antigravityNonPenalizingUpstreamFailure(account, resp.StatusCode, errBody) {
 					h.store.ReportRequestFailure(account, kind, time.Duration(durationMs)*time.Millisecond)
 				}
 				h.store.Release(account)
@@ -6820,7 +6820,7 @@ func (h *Handler) ChatCompletions(c *gin.Context) {
 					log.Printf("Antigravity OAuth refresh failed after upstream 401 (account=%d, endpoint=/v1/chat/completions): %v", account.ID(), refreshErr)
 				}
 			}
-			if kind := classifyHTTPFailure(resp.StatusCode); kind != "" {
+			if kind := classifyHTTPFailure(resp.StatusCode); kind != "" && !antigravityNonPenalizingUpstreamFailure(account, resp.StatusCode, errBody) {
 				h.store.ReportRequestFailure(account, kind, time.Duration(durationMs)*time.Millisecond)
 			}
 			SyncCodexUsageState(h.store, account, resp)
@@ -8003,11 +8003,13 @@ func (h *Handler) applyCooldownForModel(account *auth.Account, statusCode int, b
 		return h.applyGrokCooldownForModel(account, statusCode, body, resp, model)
 	}
 	// Antigravity 401 is recovered by RefreshAntigravityAccount. Do not apply
-	// Codex subscription/payment semantics, but retain relay-style model
-	// cooldowns for real 429s so repeated requests cannot hammer Google.
+	// Codex subscription/payment semantics. 429/503 carry Google's structured
+	// quota status instead, which sizes the per-(account, model) cooldown from
+	// the upstream retry hint and keeps a shared capacity shortage from being
+	// charged to this credential.
 	if account.IsAntigravityAPI() {
-		if statusCode == http.StatusTooManyRequests {
-			return Apply429Cooldown(h.store, account, body, resp, model)
+		if statusCode == http.StatusTooManyRequests || statusCode == http.StatusServiceUnavailable {
+			return applyAntigravityCooldown(h.store, account, statusCode, body, resp, model)
 		}
 		return codex429Decision{}
 	}

--- a/proxy/handler_anthropic.go
+++ b/proxy/handler_anthropic.go
@@ -807,7 +807,7 @@ func (h *Handler) Messages(c *gin.Context) {
 					log.Printf("Antigravity OAuth refresh failed after upstream 401 (account=%d, endpoint=/v1/messages): %v", account.ID(), refreshErr)
 				}
 			}
-			if kind := classifyHTTPFailure(resp.StatusCode); kind != "" {
+			if kind := classifyHTTPFailure(resp.StatusCode); kind != "" && !antigravityNonPenalizingUpstreamFailure(account, resp.StatusCode, errBody) {
 				h.store.ReportRequestFailure(account, kind, time.Duration(durationMs)*time.Millisecond)
 			}
 			// Claude 的 429 credits_required 是模型级计费门槛:只冷却该模型,不按账号级限流处理


### PR DESCRIPTION
对照两个参考实现(`sub2api` 与 `CLIProxyAPI`)审视 Antigravity 渠道后,修掉四个普通用户用普通账号就能撞上的问题。背景见 #608。

## 1. 从没用过 Antigravity 的 Google 账号不再静默不可调度

`loadCodeAssist` 对这类账号返回空的 `cloudaicompanionProject`,而调度准入要求 project 非空。结果是账号加进来状态正常、不报错、却永远轮不到,用户看不出原因。

现在 `fetchIdentityContext` 在拿到空 project 时调用 `v1internal:onboardUser`(daily 优先,production 兜底),按最多 5 次、每次间隔 2 秒轮询长时操作;档位依次取 `allowedTiers[isDefault]` → `currentTier` → `free-tier`。开通失败会作为 entitlement warning 显示出来,而不是留下一个看不见的死账号。

顺带修掉一个隐藏 bug:`isDefault` 的 JSON tag 写成了 `is_default`,而 Cloud Code 实际发的是驼峰,所以上游声明的默认档位从来没被匹配过。现在两种写法都接受。

## 2. 429/503 按 `google.rpc.Status` 解析,不再一律当成限流

`ErrorInfo.reason` 与 `RetryInfo.retryDelay` 能区分三种此前被压平成"2 秒 relay 冷却"的情况:

| 情况 | 处理 |
| --- | --- |
| `RATE_LIMIT_EXCEEDED`,retryDelay < 3s | 同端点同账号原地等待重试,最多 2 次 |
| `RATE_LIMIT_EXCEEDED`,更长 | 按上游给的时长精确冷却该 (账号, 模型) |
| `QUOTA_EXHAUSTED` | 按 retryDelay 冷却;Gemini 模型同时冷却共享家族键 `antigravity:gemini` |
| `MODEL_CAPACITY_EXHAUSTED` | 原地重试 + 短冷却,且**不计入账号失败** |

几个判断的依据:

- **不到 3 秒的限流不值得换号**。换号要付出一次账号切换和整段 prompt cache 的代价,等一下更划算。
- **Gemini 配额是一个桶**。`retrieveUserQuotaSummary` 把所有 Gemini 档位报在同一个 group 里,所以一个档位耗尽意味着同账号其它 Gemini 档位也耗尽了,继续试只是白跑。
- **容量耗尽不是这个号的问题**。`MODEL_CAPACITY_EXHAUSTED` 是全账号共享的模型级短缺,换号帮不上忙,更不该记在这个凭据头上。三条传输路径(`/v1/responses`、`/v1/chat/completions`、`/v1/messages`)都已排除罚号。

无法识别的 429 响应体保持原有 relay 策略不变。

## 3. 流式文本实时下发

此前文本要攒到终态才发,为的是让迟到的安全帧能 fail-closed,代价是首字时间等于整段生成时间。

现在文本按帧发 `output_text.delta`,消息项只开一次。同一帧内携带的拒绝仍然在该帧文本下发之前被拦住;后续帧才到的拒绝以 `response.failed` 收尾,而不是 `completed`。

## 4. sessionId 按会话派生

原先所有账号、所有会话共用一个硬编码常量,这本身就是号池指纹。

现在按请求携带的最强会话标识派生:`prompt_cache_key` → `metadata.session_id`/`conversation_id`/`user_id` → `user` → 首条 user 文本,哈希后渲染成上游那种负号十进制形态。同一会话的多轮保持同一 id,不同会话拿到不同 id;只有完全没有任何标识的请求才回落到随机值。

## 验证

`go test ./auth/ ./proxy/` 全绿。新增测试覆盖:开通轮询与档位选择、驼峰 `isDefault`、配额分类(含 proto 对象形态的 duration)、原地重试预算、冷却时长与家族键、容量短缺不罚号、delta 顺序、sessionId 稳定性。

本地 2004 部署已用本分支重建并通过冒烟。

## 尚未完成

**真实 Antigravity 上游未实测** —— 本地部署当前没有 Antigravity 账号。合并前建议用真号验四点:新号能否自动开出 project、流式首字是否提前、429 后账号页冷却时长是否等于上游 `retryDelay`、503 容量耗尽是否不再罚号。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically provisions a Cloud Code companion project when one is missing.
  * Streams generated text incrementally for faster response display.
  * Maintains consistent conversation sessions across requests.

* **Bug Fixes**
  * Improves handling of rate limits, capacity issues, and quota errors with targeted retries and cooldowns.
  * Prevents temporary upstream capacity failures from unnecessarily penalizing accounts.
  * Preserves existing projects without triggering unnecessary onboarding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->