### PR TITLE
fix(proxy): recover Claude requests with invalid thinking signatures and respect the cache_control limit

### DIFF
--- a/proxy/claude_thinking_signature.go
+++ b/proxy/claude_thinking_signature.go
@@ -1,0 +1,154 @@
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// claudeMinThinkingSignatureLen 是可信 thinking 签名的最短长度。真实签名在
+// Claude 4+ 上有数百字符；客户端会话文件损坏时会出现空串或 ~24 字符的截断
+// 签名（anthropics/claude-code#21726），上游对这类块直接返回
+// "Invalid `signature` in `thinking` block"。
+const claudeMinThinkingSignatureLen = 48
+
+// claudeThinkingSignatureErrorBodyLimit 限制为识别签名错误而读取的上游错误体大小。
+const claudeThinkingSignatureErrorBodyLimit = 64 << 10
+
+// dropUnsignedClaudeThinkingBlocks 在发送前移除 assistant 消息里签名为空或明显
+// 截断的 thinking 块。文档允许省略历史 thinking，且丢弃一个必然被上游拒绝的块
+// 不会改变可用信息。返回处理后的请求体与移除数量；无改动时原样返回输入。
+func dropUnsignedClaudeThinkingBlocks(body []byte) ([]byte, int) {
+	return filterClaudeThinkingBlocks(body, func(block gjson.Result) bool {
+		if block.Get("type").String() != "thinking" {
+			return true
+		}
+		return len(strings.TrimSpace(block.Get("signature").String())) >= claudeMinThinkingSignatureLen
+	})
+}
+
+// stripClaudeThinkingBlocks 移除所有 assistant 消息中的 thinking / redacted_thinking
+// 块，用于上游报告签名无效后的同账号重试。
+func stripClaudeThinkingBlocks(body []byte) ([]byte, int) {
+	return filterClaudeThinkingBlocks(body, func(block gjson.Result) bool {
+		t := block.Get("type").String()
+		return t != "thinking" && t != "redacted_thinking"
+	})
+}
+
+// filterClaudeThinkingBlocks 对每条 content 为数组的 assistant 消息按 keep 过滤块。
+func filterClaudeThinkingBlocks(body []byte, keep func(gjson.Result) bool) ([]byte, int) {
+	if len(body) == 0 || !gjson.ValidBytes(body) {
+		return body, 0
+	}
+	messages := gjson.GetBytes(body, "messages")
+	if !messages.IsArray() {
+		return body, 0
+	}
+	out := body
+	removed := 0
+	for i, msg := range messages.Array() {
+		if msg.Get("role").String() != "assistant" {
+			continue
+		}
+		content := msg.Get("content")
+		if !content.IsArray() {
+			continue
+		}
+		var kept []string
+		dropped := 0
+		for _, block := range content.Array() {
+			if keep(block) {
+				kept = append(kept, block.Raw)
+			} else {
+				dropped++
+			}
+		}
+		if dropped == 0 {
+			continue
+		}
+		raw := "[" + strings.Join(kept, ",") + "]"
+		next, err := sjson.SetRawBytes(out, "messages."+strconv.Itoa(i)+".content", []byte(raw))
+		if err != nil {
+			return body, 0
+		}
+		out = next
+		removed += dropped
+	}
+	if removed == 0 {
+		return body, 0
+	}
+	return out, removed
+}
+
+// isClaudeThinkingSignatureError 识别 Anthropic 对无效 thinking 签名的 400。
+func isClaudeThinkingSignatureError(statusCode int, body []byte) bool {
+	if statusCode != http.StatusBadRequest || len(body) == 0 {
+		return false
+	}
+	message := strings.ToLower(gjson.GetBytes(body, "error.message").String() + " " + gjson.GetBytes(body, "message").String())
+	return strings.Contains(message, "invalid `signature`") && strings.Contains(message, "thinking")
+}
+
+// executeClaudeWithThinkingSignatureRetry 执行一次上游调用；若上游以
+// "Invalid `signature` in `thinking` block" 拒绝且请求里确实带有 thinking 块，
+// 则剥掉全部 thinking 块后在同一账号上重试一次。任何其它结果原样返回，
+// 错误体会被重新装回响应供调用方读取。
+func executeClaudeWithThinkingSignatureRetry(ctx context.Context, body []byte, exec func(context.Context, []byte) (*http.Response, error)) (*http.Response, error) {
+	resp, err := exec(ctx, body)
+	if err != nil || resp == nil || resp.StatusCode != http.StatusBadRequest {
+		return resp, err
+	}
+	errBody, readErr := io.ReadAll(io.LimitReader(resp.Body, claudeThinkingSignatureErrorBodyLimit))
+	_ = resp.Body.Close()
+	if readErr != nil {
+		resp.Body = io.NopCloser(bytes.NewReader(errBody))
+		return resp, nil
+	}
+	if !isClaudeThinkingSignatureError(resp.StatusCode, errBody) {
+		resp.Body = io.NopCloser(bytes.NewReader(errBody))
+		return resp, nil
+	}
+	stripped, n := stripClaudeThinkingBlocks(body)
+	if n == 0 {
+		resp.Body = io.NopCloser(bytes.NewReader(errBody))
+		return resp, nil
+	}
+	log.Printf("[claude-thinking-signature] 上游拒绝 thinking 签名，剥离 %d 个 thinking 块后同账号重试一次", n)
+	retryResp, retryErr := exec(ctx, stripped)
+	if retryErr != nil {
+		return nil, retryErr
+	}
+	return retryResp, nil
+}
+
+// claudeCacheControlBlockCount 统计请求中已声明 cache_control 的块数
+// (system 块、messages 内容块、tools)。Anthropic 最多允许 4 个。
+func claudeCacheControlBlockCount(body []byte) int {
+	count := 0
+	countIn := func(items gjson.Result) {
+		if !items.IsArray() {
+			return
+		}
+		for _, item := range items.Array() {
+			if item.Get("cache_control").Exists() {
+				count++
+			}
+		}
+	}
+	countIn(gjson.GetBytes(body, "system"))
+	countIn(gjson.GetBytes(body, "tools"))
+	if messages := gjson.GetBytes(body, "messages"); messages.IsArray() {
+		for _, msg := range messages.Array() {
+			countIn(msg.Get("content"))
+		}
+	}
+	return count
+}

--- a/proxy/claude_thinking_signature_test.go
+++ b/proxy/claude_thinking_signature_test.go
@@ -1,0 +1,167 @@
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+const validThinkingSig = "EqQBCgIYAhIM1gbcDa9GJwZA2bAbcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij"
+
+func TestDropUnsignedClaudeThinkingBlocks(t *testing.T) {
+	body := []byte(`{"model":"claude-opus-5","messages":[
+		{"role":"user","content":"hi"},
+		{"role":"assistant","content":[
+			{"type":"thinking","thinking":"a","signature":""},
+			{"type":"thinking","thinking":"b","signature":"EqQBCgIYAhIM1gbcDa9GJwZA2b"},
+			{"type":"thinking","thinking":"c","signature":"` + validThinkingSig + `"},
+			{"type":"redacted_thinking","data":"opaque"},
+			{"type":"text","text":"ok"},
+			{"type":"tool_use","id":"toolu_1","name":"echo","input":{"text":"hi"}}
+		]},
+		{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"hi"}]}
+	]}`)
+	out, dropped := dropUnsignedClaudeThinkingBlocks(body)
+	if dropped != 2 {
+		t.Fatalf("dropped = %d, want 2 (empty + truncated signature)", dropped)
+	}
+	blocks := gjson.GetBytes(out, "messages.1.content").Array()
+	types := make([]string, 0, len(blocks))
+	for _, b := range blocks {
+		types = append(types, b.Get("type").String())
+	}
+	want := "thinking,redacted_thinking,text,tool_use"
+	if got := strings.Join(types, ","); got != want {
+		t.Fatalf("remaining blocks = %s, want %s", got, want)
+	}
+	if got := gjson.GetBytes(out, "messages.1.content.0.thinking").String(); got != "c" {
+		t.Fatalf("kept the wrong thinking block: %q", got)
+	}
+	if gjson.GetBytes(out, "messages.0.content").String() != "hi" || gjson.GetBytes(out, "messages.2.content.0.type").String() != "tool_result" {
+		t.Fatal("non-assistant messages must be untouched")
+	}
+}
+
+func TestDropUnsignedClaudeThinkingBlocks_NoChangeReturnsSameBody(t *testing.T) {
+	body := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"c","signature":"` + validThinkingSig + `"},{"type":"text","text":"ok"}]}]}`)
+	out, dropped := dropUnsignedClaudeThinkingBlocks(body)
+	if dropped != 0 || !bytes.Equal(out, body) {
+		t.Fatalf("valid signatures must be left byte-for-byte intact (dropped=%d)", dropped)
+	}
+}
+
+func TestStripClaudeThinkingBlocks(t *testing.T) {
+	body := []byte(`{"messages":[
+		{"role":"assistant","content":[{"type":"thinking","thinking":"c","signature":"` + validThinkingSig + `"},{"type":"redacted_thinking","data":"x"},{"type":"text","text":"ok"}]},
+		{"role":"user","content":"next"},
+		{"role":"assistant","content":"plain string"}
+	]}`)
+	out, stripped := stripClaudeThinkingBlocks(body)
+	if stripped != 2 {
+		t.Fatalf("stripped = %d, want 2", stripped)
+	}
+	if got := gjson.GetBytes(out, "messages.0.content.#").Int(); got != 1 {
+		t.Fatalf("assistant content blocks = %d, want 1 (text only)", got)
+	}
+	if gjson.GetBytes(out, "messages.2.content").String() != "plain string" {
+		t.Fatal("string content must be untouched")
+	}
+}
+
+func TestIsClaudeThinkingSignatureError(t *testing.T) {
+	sigErr := []byte(`{"type":"error","error":{"type":"invalid_request_error","message":"messages.1.content.0: Invalid ` + "`signature`" + ` in ` + "`thinking`" + ` block"}}`)
+	if !isClaudeThinkingSignatureError(400, sigErr) {
+		t.Fatal("signature error must be recognised")
+	}
+	if isClaudeThinkingSignatureError(400, []byte(`{"type":"error","error":{"type":"invalid_request_error","message":"A maximum of 4 blocks with cache_control may be provided"}}`)) {
+		t.Fatal("other invalid_request errors must not match")
+	}
+	if isClaudeThinkingSignatureError(500, sigErr) {
+		t.Fatal("non-400 must not match")
+	}
+}
+
+func fakeHTTPResponse(status int, body string) *http.Response {
+	return &http.Response{StatusCode: status, Header: http.Header{"Content-Type": []string{"application/json"}}, Body: io.NopCloser(strings.NewReader(body))}
+}
+
+func TestExecuteClaudeWithThinkingSignatureRetry_StripsAndRetriesOnce(t *testing.T) {
+	sigErr := `{"type":"error","error":{"type":"invalid_request_error","message":"messages.1.content.0: Invalid ` + "`signature`" + ` in ` + "`thinking`" + ` block"}}`
+	body := []byte(`{"model":"claude-opus-5","messages":[{"role":"user","content":"hi"},{"role":"assistant","content":[{"type":"thinking","thinking":"c","signature":"` + validThinkingSig + `"},{"type":"tool_use","id":"t1","name":"echo","input":{}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":"hi"}]}]}`)
+	var sent [][]byte
+	exec := func(_ context.Context, b []byte) (*http.Response, error) {
+		sent = append(sent, b)
+		if len(sent) == 1 {
+			return fakeHTTPResponse(400, sigErr), nil
+		}
+		return fakeHTTPResponse(200, `{"type":"message","content":[{"type":"text","text":"ok"}]}`), nil
+	}
+	resp, err := executeClaudeWithThinkingSignatureRetry(context.Background(), body, exec)
+	if err != nil || resp == nil || resp.StatusCode != 200 {
+		t.Fatalf("resp=%v err=%v, want 200 after retry", resp, err)
+	}
+	if len(sent) != 2 {
+		t.Fatalf("upstream called %d times, want 2", len(sent))
+	}
+	if gjson.GetBytes(sent[1], "messages.1.content.#").Int() != 1 || gjson.GetBytes(sent[1], "messages.1.content.0.type").String() != "tool_use" {
+		t.Fatalf("retry body must have thinking stripped, got %s", sent[1])
+	}
+}
+
+func TestExecuteClaudeWithThinkingSignatureRetry_NoRetryWithoutThinking(t *testing.T) {
+	sigErr := `{"type":"error","error":{"type":"invalid_request_error","message":"messages.1.content.0: Invalid ` + "`signature`" + ` in ` + "`thinking`" + ` block"}}`
+	body := []byte(`{"model":"claude-opus-5","messages":[{"role":"user","content":"hi"}]}`)
+	calls := 0
+	exec := func(_ context.Context, _ []byte) (*http.Response, error) {
+		calls++
+		return fakeHTTPResponse(400, sigErr), nil
+	}
+	resp, err := executeClaudeWithThinkingSignatureRetry(context.Background(), body, exec)
+	if err != nil || resp.StatusCode != 400 || calls != 1 {
+		t.Fatalf("resp=%v err=%v calls=%d; want original 400 passed through with one call", resp, err, calls)
+	}
+	got, _ := io.ReadAll(resp.Body)
+	if string(got) != sigErr {
+		t.Fatalf("error body must be preserved for the caller, got %s", got)
+	}
+}
+
+func TestExecuteClaudeWithThinkingSignatureRetry_OtherErrorsPassThrough(t *testing.T) {
+	body := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"c","signature":"` + validThinkingSig + `"}]}]}`)
+	calls := 0
+	exec := func(_ context.Context, _ []byte) (*http.Response, error) {
+		calls++
+		return fakeHTTPResponse(429, `{"type":"error","error":{"type":"rate_limit_error","message":"slow down"}}`), nil
+	}
+	resp, _ := executeClaudeWithThinkingSignatureRetry(context.Background(), body, exec)
+	if resp.StatusCode != 429 || calls != 1 {
+		t.Fatalf("status=%d calls=%d; non-signature errors must not trigger a retry", resp.StatusCode, calls)
+	}
+}
+
+func TestInjectClaudeCodeSystemPrompt_OmitsCacheControlAtLimit(t *testing.T) {
+	block := `{"type":"text","text":"x","cache_control":{"type":"ephemeral"}}`
+	body := []byte(`{"system":[` + block + `,` + block + `],"tools":[{"name":"a","input_schema":{},"cache_control":{"type":"ephemeral"}}],"messages":[{"role":"user","content":[` + block + `]}]}`)
+	out := injectClaudeCodeSystemPrompt(body)
+	first := gjson.GetBytes(out, "system.0")
+	if !strings.HasPrefix(first.Get("text").String(), claudeCodeSystemPreamble) {
+		t.Fatalf("preamble must still be injected: %s", first.Raw)
+	}
+	if first.Get("cache_control").Exists() {
+		t.Fatal("client already has 4 cache_control blocks; injected preamble must not add a 5th")
+	}
+}
+
+func TestInjectClaudeCodeSystemPrompt_KeepsCacheControlBelowLimit(t *testing.T) {
+	block := `{"type":"text","text":"x","cache_control":{"type":"ephemeral"}}`
+	body := []byte(`{"system":[` + block + `],"messages":[{"role":"user","content":"hi"}]}`)
+	out := injectClaudeCodeSystemPrompt(body)
+	if !gjson.GetBytes(out, "system.0.cache_control").Exists() {
+		t.Fatal("with only 1 client cache_control block the preamble keeps its cache_control")
+	}
+}

--- a/proxy/claude_upstream.go
+++ b/proxy/claude_upstream.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"log"
 	"math"
 	"net/http"
 	"regexp"
@@ -46,6 +47,22 @@ const (
 // claudeCodeSystemBlockJSON 是注入到 system 数组首位的块(带 ephemeral 缓存标记,
 // 与官方客户端一致)。
 const claudeCodeSystemBlockJSON = `{"type":"text","text":"You are Claude Code, Anthropic's official CLI for Claude.","cache_control":{"type":"ephemeral"}}`
+
+// claudeCodeSystemBlockNoCacheJSON 是不带 cache_control 的同一声明块。Anthropic 最多
+// 接受 4 个 cache_control 块；客户端已用满时再注入带缓存标记的前言会被整体拒绝。
+const claudeCodeSystemBlockNoCacheJSON = `{"type":"text","text":"You are Claude Code, Anthropic's official CLI for Claude."}`
+
+// claudeMaxCacheControlBlocks 是 Anthropic Messages API 允许的 cache_control 块上限。
+const claudeMaxCacheControlBlocks = 4
+
+// claudeCodeSystemBlockFor 在客户端未用满 cache_control 配额时返回带缓存标记的
+// 声明块，否则返回无标记版本。
+func claudeCodeSystemBlockFor(body []byte) string {
+	if claudeCacheControlBlockCount(body) >= claudeMaxCacheControlBlocks {
+		return claudeCodeSystemBlockNoCacheJSON
+	}
+	return claudeCodeSystemBlockJSON
+}
 
 // defaultClaudeModelIDs 是未设白名单时对外暴露的当前 Claude 模型集(别名形式,
 // Anthropic 侧会解析到带日期的具体版本)。模型演进时可在此维护,或用账号 Models
@@ -531,6 +548,12 @@ func prepareClaudeRequestBody(body []byte, cfg auth.ClaudeSecurityConfig) ([]byt
 	if err != nil {
 		return nil, err
 	}
+	// 客户端会话文件损坏时会回传空/截断签名的 thinking 块，上游必然 400；
+	// 文档允许省略历史 thinking，发送前直接丢弃。
+	if cleaned, dropped := dropUnsignedClaudeThinkingBlocks(normalized); dropped > 0 {
+		log.Printf("[claude-thinking-signature] 丢弃 %d 个签名为空或截断的 thinking 块", dropped)
+		normalized = cleaned
+	}
 	return injectClaudeCodeSystemPrompt(normalized), nil
 }
 
@@ -583,10 +606,11 @@ func injectClaudeCodeSystemPrompt(body []byte) []byte {
 		return body
 	}
 	system := gjson.GetBytes(body, "system")
+	preambleBlock := claudeCodeSystemBlockFor(body)
 
 	switch {
 	case !system.Exists() || system.Type == gjson.Null:
-		out, err := sjson.SetRawBytes(body, "system", []byte("["+claudeCodeSystemBlockJSON+"]"))
+		out, err := sjson.SetRawBytes(body, "system", []byte("["+preambleBlock+"]"))
 		if err != nil {
 			return body
 		}
@@ -602,7 +626,7 @@ func injectClaudeCodeSystemPrompt(body []byte) []byte {
 		if err != nil {
 			return body
 		}
-		raw := "[" + claudeCodeSystemBlockJSON + "," + string(textBlock) + "]"
+		raw := "[" + preambleBlock + "," + string(textBlock) + "]"
 		out, err := sjson.SetRawBytes(body, "system", []byte(raw))
 		if err != nil {
 			return body
@@ -620,9 +644,9 @@ func injectClaudeCodeSystemPrompt(body []byte) []byte {
 		inner = strings.TrimSuffix(inner, "]")
 		var newArr string
 		if strings.TrimSpace(inner) == "" {
-			newArr = "[" + claudeCodeSystemBlockJSON + "]"
+			newArr = "[" + preambleBlock + "]"
 		} else {
-			newArr = "[" + claudeCodeSystemBlockJSON + "," + inner + "]"
+			newArr = "[" + preambleBlock + "," + inner + "]"
 		}
 		out, err := sjson.SetRawBytes(body, "system", []byte(newArr))
 		if err != nil {

--- a/proxy/handler_anthropic.go
+++ b/proxy/handler_anthropic.go
@@ -675,7 +675,11 @@ func (h *Handler) Messages(c *gin.Context) {
 			resp, reqErr = executeHTTPWithContinuousRetryKeepalive(upstreamCtx, func() (*http.Response, error) {
 				claudeFpMode := account.EffectiveClaudeFingerprintMode(h.store.ClaudeFingerprintModeDefault())
 				clientPolicy := h.store.ClaudeClientPolicyForAccount(account)
-				r, e := ExecuteClaudeMessagesRequestWithPolicy(upstreamCtx, account, claudeRequestBody, proxyURL, downstreamHeaders, claudeFpMode, clientPolicy, claudeSecurityConfig)
+				// 上游以无效 thinking 签名拒绝时，剥离 thinking 块后在同一账号重试一次，
+				// 不进入换号重试（换号无法修复客户端带来的坏签名）。
+				r, e := executeClaudeWithThinkingSignatureRetry(upstreamCtx, claudeRequestBody, func(ctx context.Context, body []byte) (*http.Response, error) {
+					return ExecuteClaudeMessagesRequestWithPolicy(ctx, account, body, proxyURL, downstreamHeaders, claudeFpMode, clientPolicy, claudeSecurityConfig)
+				})
 				if e == nil {
 					markClaudeNativeRoute(r)
 				}


### PR DESCRIPTION
## Summary

- drop assistant `thinking` blocks whose `signature` is empty or truncated before the request reaches Anthropic; clients that persist session transcripts without signatures (anthropics/claude-code#21726, seen with `claude-cli/2.1.258 (external, sdk-cli)` / `agent-sdk/0.3.246`) otherwise fail every follow-up request with `messages.N.content.0: Invalid `signature` in `thinking` block`
- when Anthropic still rejects a request with that error, strip all `thinking` / `redacted_thinking` blocks and retry once on the **same** account instead of rotating accounts (the bad signature comes from the client, so rotation cannot fix it); the docs allow omitting prior-turn thinking, and adaptive-thinking models accept a tool-use turn without it
- inject the Claude Code system preamble without `cache_control` when the client already uses the maximum of 4 `cache_control` blocks, which previously produced `A maximum of 4 blocks with cache_control may be provided`

## Root cause notes

Verified against the live API on Claude Opus 5 before writing the fix: modifying the summarized thinking text (zero-width characters, NFC changes, visible edits) and replaying a signature from another conversation are all accepted, while an empty or 24-character signature reproduces the exact production error text. So the failure is not caused by the gateway's Unicode sanitization or by account switching; it is the client replaying blocks whose signatures were never persisted.

## Test plan

- [x] new unit tests in `proxy/claude_thinking_signature_test.go` (drop / strip / error detection / retry-once / cache_control limit), written red-first
- [x] `go test ./proxy/ -count=1` and `go vet ./proxy/` pass on top of `main`
- [x] deployed on a production gateway: requests with empty, truncated, and corrupted-but-full-length signatures now return 200 (the last one via the strip-and-retry path, logged as `[claude-thinking-signature]`); a request carrying 4 client `cache_control` blocks returns 200

https://claude.ai/code/session_01R2UHu3k9ZvaACfQY7BciXZ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability for Claude requests containing extended thinking content.
  - Automatically retries once after an invalid thinking-signature error by removing incompatible thinking blocks.
  - Filters malformed or incomplete thinking signatures before sending requests.
  - Preserves the original upstream error when no retry is appropriate and avoids retrying unrelated errors.
  - Prevents excessive cache metadata in Claude system prompts, improving compatibility with cache-control limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->