### PR TITLE
fix(claude): stop routing models an account's plan does not include

### DIFF
--- a/auth/claude_account_models.go
+++ b/auth/claude_account_models.go
@@ -1,0 +1,48 @@
+package auth
+
+import (
+	"context"
+	"strings"
+)
+
+// DropAccountModel 把某个模型从账号的显式模型白名单中移除并持久化，用于上游明确
+// 表示该账号套餐不支持该模型（如 credits_required）的场景。白名单为空表示
+// "放行全部 claude-*"，此时无法用移除表达排除，返回 false 交由冷却兜底。
+func (s *Store) DropAccountModel(ctx context.Context, acc *Account, model string) (bool, error) {
+	if s == nil || acc == nil {
+		return false, nil
+	}
+	target := strings.ToLower(strings.TrimSpace(model))
+	if target == "" {
+		return false, nil
+	}
+	acc.mu.RLock()
+	current := append([]string(nil), acc.Models...)
+	dbID := acc.DBID
+	acc.mu.RUnlock()
+	if len(current) == 0 {
+		return false, nil
+	}
+	remaining := make([]string, 0, len(current))
+	removed := false
+	for _, m := range current {
+		if strings.ToLower(strings.TrimSpace(m)) == target {
+			removed = true
+			continue
+		}
+		remaining = append(remaining, m)
+	}
+	if !removed {
+		return false, nil
+	}
+	if s.db != nil && dbID > 0 {
+		if err := s.db.UpdateCredentials(ctx, dbID, map[string]interface{}{"models": remaining}); err != nil {
+			return false, err
+		}
+	}
+	acc.mu.Lock()
+	acc.Models = remaining
+	acc.mu.Unlock()
+	s.fastSchedulerUpdate(acc)
+	return true, nil
+}

--- a/auth/model_cooldown_guard_test.go
+++ b/auth/model_cooldown_guard_test.go
@@ -1,0 +1,72 @@
+package auth
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestMarkModelCooldownWithBackoff_DoesNotShortenActiveLongerCooldown(t *testing.T) {
+	store := NewStore(nil, nil, nil)
+	defer store.Stop()
+	acc := &Account{DBID: 251, UpstreamType: UpstreamClaude}
+
+	long := store.MarkModelCooldownWithBackoff(acc, "claude-fable-5-1", 30*time.Minute, "credits_required", false)
+	short := store.MarkModelCooldownWithBackoff(acc, "claude-fable-5-1", 2*time.Second, "rate_limited_model", true)
+
+	if short.ResetAt.Before(long.ResetAt) {
+		t.Fatalf("a later short cooldown must not shorten the active 30m one: short=%s long=%s", short.ResetAt, long.ResetAt)
+	}
+	if short.Reason != "credits_required" {
+		t.Fatalf("reason must stay the longer cooldown's reason, got %q", short.Reason)
+	}
+	acc.mu.RLock()
+	stored := acc.ModelCooldowns["claude-fable-5-1"]
+	acc.mu.RUnlock()
+	if stored.ResetAt.Before(long.ResetAt) || stored.Reason != "credits_required" {
+		t.Fatalf("stored cooldown = %+v", stored)
+	}
+}
+
+func TestMarkModelCooldownWithBackoff_ExtendsExpiredCooldown(t *testing.T) {
+	store := NewStore(nil, nil, nil)
+	defer store.Stop()
+	acc := &Account{DBID: 251, UpstreamType: UpstreamClaude, ModelCooldowns: map[string]ModelCooldown{
+		"claude-fable-5-1": {Model: "claude-fable-5-1", Reason: "credits_required", ResetAt: time.Now().Add(-time.Minute)},
+	}}
+	got := store.MarkModelCooldownWithBackoff(acc, "claude-fable-5-1", 2*time.Second, "rate_limited_model", true)
+	if got.Reason != "rate_limited_model" || !got.ResetAt.After(time.Now()) {
+		t.Fatalf("an expired cooldown must be replaced normally, got %+v", got)
+	}
+}
+
+func TestDropAccountModel(t *testing.T) {
+	store := NewStore(nil, nil, nil)
+	defer store.Stop()
+	acc := &Account{DBID: 251, UpstreamType: UpstreamClaude, Models: []string{"claude-fable-5-1", "claude-opus-5", "Claude-Fable-5"}}
+	store.mu.Lock()
+	store.accounts = []*Account{acc}
+	store.mu.Unlock()
+
+	removed, err := store.DropAccountModel(context.Background(), acc, "claude-fable-5-1")
+	if err != nil || !removed {
+		t.Fatalf("removed=%v err=%v", removed, err)
+	}
+	acc.mu.RLock()
+	models := append([]string(nil), acc.Models...)
+	acc.mu.RUnlock()
+	if len(models) != 2 || models[0] != "claude-opus-5" || models[1] != "Claude-Fable-5" {
+		t.Fatalf("models after drop = %v", models)
+	}
+
+	removed, err = store.DropAccountModel(context.Background(), acc, "claude-sonnet-5")
+	if err != nil || removed {
+		t.Fatalf("model not in whitelist must be a no-op: removed=%v err=%v", removed, err)
+	}
+
+	open := &Account{DBID: 252, UpstreamType: UpstreamClaude}
+	removed, err = store.DropAccountModel(context.Background(), open, "claude-fable-5-1")
+	if err != nil || removed {
+		t.Fatalf("empty whitelist (allow-all) must not be rewritten: removed=%v err=%v", removed, err)
+	}
+}

--- a/auth/store.go
+++ b/auth/store.go
@@ -9455,6 +9455,15 @@ func (s *Store) MarkModelCooldownWithBackoff(acc *Account, model string, duratio
 	if reason == "" {
 		reason = "rate_limited"
 	}
+	// 已有更长且仍在生效的冷却（如 credits_required 的 30 分钟）不得被后续更短的
+	// 通用限流冷却覆盖缩短，否则账号会在几秒后被重新选中并再次撞上同一错误。
+	if current.ResetAt.After(now) && current.ResetAt.After(resetAt) {
+		resetAt = current.ResetAt
+		if current.Reason != "" {
+			reason = current.Reason
+		}
+		level = current.BackoffLevel
+	}
 	cooldown := ModelCooldown{
 		Model:        key,
 		Reason:       reason,

--- a/proxy/claude_upstream.go
+++ b/proxy/claude_upstream.go
@@ -914,6 +914,15 @@ func HandleClaudeModelBillingRejection(store *auth.Store, account *auth.Account,
 	}
 	// 模型级冷却,原因 credits_required;不做退避升级(固定窗口周期性复探,买 credits 后自然恢复)。
 	store.MarkModelCooldownWithBackoff(account, m, claudeCreditsRequiredCooldown, "credits_required", false)
+	// 套餐不含该模型时把它从账号白名单里移除,调度器此后不再把该模型派给这个账号。
+	// 白名单为空(放行全部)时无法表达排除,只能靠上面的冷却。
+	dropCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if removed, err := store.DropAccountModel(dropCtx, account, m); err != nil {
+		log.Printf("[账号 %d] 移除不支持的模型 %s 失败: %v", account.ID(), m, err)
+	} else if removed {
+		log.Printf("[账号 %d] 上游 credits_required,已把模型 %s 从账号模型白名单移除", account.ID(), m)
+	}
 	return true
 }
 

--- a/proxy/claude_usage_state_test.go
+++ b/proxy/claude_usage_state_test.go
@@ -361,3 +361,25 @@ func TestClaudeNativeClientCompatibilityDoesNotCoolAccount(t *testing.T) {
 		t.Fatalf("compatibility failure changed account state: cooldown=%v kind=%q", acc.HasActiveCooldown(), got.failureKind)
 	}
 }
+
+// credits_required 说明该账号套餐没有这个模型：除冷却外还要把模型从账号白名单里移除，
+// 否则调度器会在冷却过期后继续把请求派给它。
+func TestHandleClaudeModelBillingRejection_DropsModelFromWhitelist(t *testing.T) {
+	store := auth.NewStore(nil, nil, nil)
+	defer store.Stop()
+	acc := &auth.Account{DBID: 251, UpstreamType: auth.UpstreamClaude, Models: []string{"claude-fable-5-1", "claude-opus-5"}}
+	store.SetAccountsForTest([]*auth.Account{acc})
+	body := []byte(`{"type":"error","error":{"type":"rate_limit_error","message":"Usage credits are required for this model.","details":{"error_code":"credits_required","model":"claude-fable-5-1","disabled_reason":"org_level_disabled"}}}`)
+	if !HandleClaudeModelBillingRejection(store, acc, "claude-fable-5-1", http.StatusTooManyRequests, body) {
+		t.Fatal("credits_required must be handled")
+	}
+	acc.Mu().RLock()
+	models := append([]string(nil), acc.Models...)
+	acc.Mu().RUnlock()
+	if len(models) != 1 || models[0] != "claude-opus-5" {
+		t.Fatalf("whitelist after rejection = %v, want only claude-opus-5", models)
+	}
+	if !claudeAccountSupportsModel(acc, "claude-opus-5") || claudeAccountSupportsModel(acc, "claude-fable-5-1") {
+		t.Fatal("scheduler eligibility must reflect the pruned whitelist")
+	}
+}


### PR DESCRIPTION
## Summary

A Claude OAuth account on a plan that does not include a model (a Pro account and Claude Fable 5.1 in production: Anthropic answers 429 `rate_limit_error` with `error_code: credits_required`, `disabled_reason: org_level_disabled`) kept being selected for that model every few minutes. Every attempt failed and was retried onto another account, adding latency and noise.

Two causes, both fixed:

- **The account's model whitelist is populated by upstream model discovery, not by plan entitlement**, so a Pro account listed Fable exactly like a Max account. `HandleClaudeModelBillingRejection` now calls the new `Store.DropAccountModel`, which removes the rejected model from the account's explicit whitelist and persists it via `db.UpdateCredentials`, so the scheduler stops routing that model to the account. An empty whitelist means allow-all and cannot express an exclusion, so that case keeps relying on the cooldown.
- **The 30-minute `credits_required` model cooldown was overwritten by the generic 4-second adaptive 429 cooldown** because `MarkModelCooldownWithBackoff` wrote `reset_at` unconditionally (the persisted cooldown row showed `rate_limited_model`, 4 s). It now keeps an active longer cooldown (reset time, reason, backoff level) instead of shortening it; expired cooldowns are replaced as before.

## Notes for review

- `MarkModelCooldownWithBackoff` is shared by every channel's 429 handling (Codex, Grok, Images, Claude); the only behavioural change is "never shorten a still-active longer cooldown". `auth`, `proxy`, `database`, `admin` suites pass.
- Verified in production: after the fix all Fable requests land on the entitled account and the Pro account has produced no further `credits_required` attempts.

## Test plan

- [x] `TestMarkModelCooldownWithBackoff_DoesNotShortenActiveLongerCooldown` / `_ExtendsExpiredCooldown`
- [x] `TestDropAccountModel` (explicit whitelist pruned case-insensitively, non-listed model is a no-op, empty whitelist untouched)
- [x] `TestHandleClaudeModelBillingRejection_DropsModelFromWhitelist`
- [x] `go test ./auth/ ./proxy/` on this branch

https://claude.ai/code/session_01R2UHu3k9ZvaACfQY7BciXZ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Models rejected for insufficient credits are automatically removed from the account’s explicit model whitelist.
  - Accounts with model whitelists now reflect these exclusions in scheduler eligibility.

- **Bug Fixes**
  - Active, longer model cooldowns are preserved instead of being replaced by shorter cooldowns.
  - Existing cooldown reasons and backoff levels remain intact when appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->