### PR TITLE
fix(registry): learn gpt-6-astra from the official Codex model page

### DIFF
--- a/proxy/model_registry.go
+++ b/proxy/model_registry.go
@@ -443,17 +443,19 @@ func isAllowedUpstreamCodexModel(id string) bool {
 	if dash := strings.IndexByte(version, '-'); dash >= 0 {
 		version = version[:dash]
 	}
+	// 版本号可能只有大版本（gpt-6-astra、gpt-6），没有小数点时 minor 视为 0，
+	// 不能因为缺少 ".x" 就把新一代型号拒之门外。
 	parts := strings.Split(version, ".")
-	if len(parts) < 2 {
-		return false
-	}
 	major, err := strconv.Atoi(parts[0])
 	if err != nil {
 		return false
 	}
-	minor, err := strconv.Atoi(parts[1])
-	if err != nil {
-		return false
+	minor := 0
+	if len(parts) >= 2 {
+		minor, err = strconv.Atoi(parts[1])
+		if err != nil {
+			return false
+		}
 	}
 	if major > 5 {
 		return true

--- a/proxy/model_registry.go
+++ b/proxy/model_registry.go
@@ -397,7 +397,12 @@ var codexModelIDPattern = regexp.MustCompile(`\bgpt-[0-9]+(?:\.[0-9]+)*(?:-[a-z]
 func ParseOfficialCodexModelIDs(html string) (models []string, skipped []string) {
 	seen := map[string]struct{}{}
 	skippedSeen := map[string]struct{}{}
-	for _, match := range codexModelIDPattern.FindAllString(strings.ToLower(html), -1) {
+	lowered := strings.ToLower(html)
+	for _, loc := range codexModelIDPattern.FindAllStringIndex(lowered, -1) {
+		match := lowered[loc[0]:loc[1]]
+		if !isOfficialCodexModelIDContext(lowered, loc[0], loc[1]) {
+			continue
+		}
 		if isAllowedUpstreamCodexModel(match) {
 			if _, ok := seen[match]; !ok {
 				seen[match] = struct{}{}
@@ -415,6 +420,28 @@ func ParseOfficialCodexModelIDs(html string) (models []string, skipped []string)
 	})
 	sort.Strings(skipped)
 	return models, skipped
+}
+
+// isOfficialCodexModelIDContext 只接受官方模型页里"当作模型 ID 使用"的出现位置：
+// 被引号包裹（astro-island props / JSON，如 &quot;gpt-5.5&quot;）或 `codex -m <id>` 命令。
+// 导航文案（"Using GPT-6 Astra"→gpt-6）、锚点（#gpt-6-astra-in-enterprise）、
+// 图片文件名（gpt-6-astra-texture.webp）都不算模型 ID。
+func isOfficialCodexModelIDContext(lowered string, start, end int) bool {
+	before := lowered[:start]
+	after := lowered[end:]
+	if strings.HasSuffix(before, "codex -m ") {
+		return after == "" || !isModelIDByte(after[0])
+	}
+	for _, quote := range []string{"&quot;", "\"", "'"} {
+		if strings.HasSuffix(before, quote) && strings.HasPrefix(after, quote) {
+			return true
+		}
+	}
+	return false
+}
+
+func isModelIDByte(b byte) bool {
+	return b == '-' || b == '.' || b == '_' || b == '/' || (b >= 'a' && b <= 'z') || (b >= '0' && b <= '9')
 }
 
 func modelSortRank(id string) int {

--- a/proxy/model_registry_test.go
+++ b/proxy/model_registry_test.go
@@ -364,3 +364,21 @@ func TestSyncOfficialCodexModelsEmptyProxyStillAttempts(t *testing.T) {
 		t.Fatalf("unexpected error kind: %v", err)
 	}
 }
+
+func TestIsAllowedUpstreamCodexModelAcceptsMajorOnlyVersions(t *testing.T) {
+	// gpt-6-astra 这类没有小数点的新一代型号必须被允许进入注册表。
+	for _, id := range []string{"gpt-6-astra", "gpt-6", "gpt-7-nova"} {
+		if !isAllowedUpstreamCodexModel(id) {
+			t.Fatalf("%s should be allowed", id)
+		}
+	}
+	for _, id := range []string{"gpt-4", "gpt-4-turbo", "gpt-5", "gpt-5-codex"} {
+		if isAllowedUpstreamCodexModel(id) {
+			t.Fatalf("%s should be rejected", id)
+		}
+	}
+	models, _ := ParseOfficialCodexModelIDs(`<code>codex -m gpt-6-astra</code> gpt-5.4`)
+	if !slices.Contains(models, "gpt-6-astra") {
+		t.Fatalf("parsed models missing gpt-6-astra: %v", models)
+	}
+}

--- a/proxy/model_registry_test.go
+++ b/proxy/model_registry_test.go
@@ -54,7 +54,7 @@ func TestParseOfficialCodexModelIDs(t *testing.T) {
 func TestApplyOfficialCodexModelSyncMergesWithBuiltinImageModel(t *testing.T) {
 	db := newTestModelRegistryDB(t)
 	ctx := context.Background()
-	html := `gpt-5.5 gpt-5.4 gpt-5.4-mini gpt-5.3-codex gpt-5.3-codex-spark gpt-5.2 gpt-5.2-codex gpt-4.1`
+	html := `"gpt-5.5" "gpt-5.4" "gpt-5.4-mini" "gpt-5.3-codex" "gpt-5.3-codex-spark" "gpt-5.2" "gpt-5.2-codex" "gpt-4.1"`
 
 	result, err := ApplyOfficialCodexModelSync(ctx, db, html, time.Date(2026, 4, 24, 0, 0, 0, 0, time.UTC))
 	if err != nil {
@@ -377,8 +377,35 @@ func TestIsAllowedUpstreamCodexModelAcceptsMajorOnlyVersions(t *testing.T) {
 			t.Fatalf("%s should be rejected", id)
 		}
 	}
-	models, _ := ParseOfficialCodexModelIDs(`<code>codex -m gpt-6-astra</code> gpt-5.4`)
+	models, _ := ParseOfficialCodexModelIDs(`<code>codex -m gpt-6-astra</code> &quot;gpt-5.4&quot;`)
 	if !slices.Contains(models, "gpt-6-astra") {
 		t.Fatalf("parsed models missing gpt-6-astra: %v", models)
+	}
+}
+
+func TestParseOfficialCodexModelIDsIgnoresNonModelContexts(t *testing.T) {
+	// 真实官方页里的三类"长得像模型 ID"的噪声：导航文案、锚点、图片文件名。
+	html := `
+		<a href="#gpt-6-astra-in-enterprise">Using GPT-6 Astra</a>
+		<img src="/images/api/models/gpt-6-astra-texture.webp" alt="Astra">
+		<img src="/images/api/models/gpt-5.6-sol.webp">
+		<astro-island props="{&quot;name&quot;:[0,&quot;gpt-6-astra&quot;],&quot;wallpaperUrl&quot;:[0,&quot;/images/api/models/gpt-6-astra-texture.webp&quot;]}"></astro-island>
+		<code>codex -m gpt-5.6-sol</code>
+		<script>{"model":"gpt-5.4-mini"}</script>
+	`
+	models, skipped := ParseOfficialCodexModelIDs(html)
+	want := []string{"gpt-6-astra", "gpt-5.6-sol", "gpt-5.4-mini"}
+	if len(models) != len(want) {
+		t.Fatalf("models = %v, want exactly %v (skipped=%v)", models, want, skipped)
+	}
+	for _, model := range want {
+		if !slices.Contains(models, model) {
+			t.Fatalf("parsed models missing %q in %v", model, models)
+		}
+	}
+	for _, junk := range []string{"gpt-6", "gpt-6-astra-in-enterprise", "gpt-6-astra-texture"} {
+		if slices.Contains(models, junk) || slices.Contains(skipped, junk) {
+			t.Fatalf("%q should not be extracted at all (models=%v skipped=%v)", junk, models, skipped)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

The official Codex model sync never picked up `gpt-6-astra`, so it stayed out of the model catalog and the official pricing sync never assigned it a price (the pricing sync only covers models already in the registry). Two causes, fixed in two commits:

- `isAllowedUpstreamCodexModel` parsed the version as `major.minor` and rejected any id without a minor component (`len(parts) < 2`) before the `major > 5` check ran. `gpt-6-astra` → version `6` → rejected. Now a missing minor is treated as `0`, so `gpt-6*` passes while `gpt-4`, `gpt-5`, `gpt-5-codex` are still rejected.
- Once `gpt-6` ids were allowed, the broad regex scan of the docs page also learned non-model strings: `gpt-6` from the nav copy "Using GPT-6 Astra", `gpt-6-astra-in-enterprise` from a heading anchor, and `gpt-6-astra-texture` from `gpt-6-astra-texture.webp`. `ParseOfficialCodexModelIDs` now only accepts a match that is wrapped in quotes (`&quot;gpt-5.5&quot;` in the astro-island props / JSON) or follows `codex -m `. Every model on the current page appears in both forms, so nothing legitimate is lost. The registry sync only upserts, so anyone who already synced with the first fix alone would need to delete those three rows by hand.

## Test plan

- [x] `TestIsAllowedUpstreamCodexModelAcceptsMajorOnlyVersions`, `TestParseOfficialCodexModelIDsIgnoresNonModelContexts` (both fail before the fix)
- [x] `go test ./proxy/ ./admin/ ./database/`
- [x] parser run against the live https://developers.openai.com/codex/models HTML: exactly `gpt-5.6-sol gpt-5.6-terra gpt-5.6-luna gpt-5.5 gpt-5.4 gpt-5.4-mini gpt-5.3-codex-spark gpt-6-astra gpt-5.6`, no junk
- [x] production: `POST /api/admin/models/sync` adds `gpt-6-astra`; `POST /api/admin/model-pricing/official-sync` then picks up the official $10 / $50 (long context $20 / $75) price

https://claude.ai/code/session_01QZSdi3tikVsq8HuBK1NSWq


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of official Codex model IDs by ignoring navigation text, anchors, image filenames, and unrelated asset paths.
  * Added support for major-only GPT-6 and GPT-7 model versions.
  * Continued rejecting unsupported major-only GPT-4 and GPT-5 versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->