### PR TITLE
feat(models): refresh every channel from the model catalog button

### DIFF
--- a/admin/claude_accounts.go
+++ b/admin/claude_accounts.go
@@ -330,13 +330,26 @@ func (h *Handler) RefreshClaudeModels(c *gin.Context) {
 func (h *Handler) RefreshAllClaudeModels(c *gin.Context) {
 	ctx, cancel := context.WithTimeout(c.Request.Context(), 60*time.Second)
 	defer cancel()
-	rows, err := h.db.ListActiveByChannel(ctx, database.UpstreamChannelClaude)
+	refreshed, failed, err := h.refreshAllClaudeModels(ctx)
 	if err != nil {
 		writeInternalError(c, err)
 		return
 	}
-	refreshed, failed := 0, 0
-	allModels := map[string]struct{}{}
+	c.JSON(http.StatusOK, gin.H{
+		"message":     "已刷新 Claude 账号可用模型",
+		"refreshed":   refreshed,
+		"failed":      failed,
+		"model_count": len(h.claudeChannelModels()),
+	})
+}
+
+// refreshAllClaudeModels 逐个 Claude 账号拉取上游模型清单并写回凭据，
+// 返回成功/失败账号数；列账号失败时返回 err。
+func (h *Handler) refreshAllClaudeModels(ctx context.Context) (refreshed, failed int, err error) {
+	rows, err := h.db.ListActiveByChannel(ctx, database.UpstreamChannelClaude)
+	if err != nil {
+		return 0, 0, err
+	}
 	for _, row := range rows {
 		accessToken := strings.TrimSpace(row.GetCredential("access_token"))
 		if accessToken == "" {
@@ -359,20 +372,12 @@ func (h *Handler) RefreshAllClaudeModels(c *gin.Context) {
 				acc.Mu().Unlock()
 			}
 		}
-		for _, m := range models {
-			allModels[m] = struct{}{}
-		}
 		refreshed++
 	}
 	if refreshed > 0 {
 		h.invalidateClaudeCatalogCaches()
 	}
-	c.JSON(http.StatusOK, gin.H{
-		"message":     "已刷新 Claude 账号可用模型",
-		"refreshed":   refreshed,
-		"failed":      failed,
-		"model_count": len(allModels),
-	})
+	return refreshed, failed, nil
 }
 
 // resolveClaudeModelProxy mirrors the request path's proxy precedence for

--- a/admin/handler.go
+++ b/admin/handler.go
@@ -45,15 +45,16 @@ import (
 
 // Handler 管理后台 API 处理器
 type Handler struct {
-	store            *auth.Store
-	cache            cache.TokenCache
-	db               *database.DB
-	cacheCfgStore    responseCacheSettingsStore
-	rateLimiter      *proxy.RateLimiter
-	systemUpdate     *systemUpdater
-	systemUpdateOnce sync.Once
-	refreshAccount   func(context.Context, int64) error
-	probeUsage       func(context.Context, *auth.Account) error
+	store             *auth.Store
+	modelRefreshFuncs map[string]channelModelRefreshFunc // nil = 各渠道默认实现；测试注入用
+	cache             cache.TokenCache
+	db                *database.DB
+	cacheCfgStore     responseCacheSettingsStore
+	rateLimiter       *proxy.RateLimiter
+	systemUpdate      *systemUpdater
+	systemUpdateOnce  sync.Once
+	refreshAccount    func(context.Context, int64) error
+	probeUsage        func(context.Context, *auth.Account) error
 	// executeClaudeUsageProbe is injectable for tests; production uses the
 	// provider-native Anthropic Messages request directly.
 	executeClaudeUsageProbe func(context.Context, *auth.Account, []byte) (*http.Response, error)
@@ -1231,6 +1232,7 @@ func (h *Handler) RegisterRoutes(r *gin.Engine) {
 	api.POST("/prompt-filter/intelligence/candidates/:id/dismiss", h.DismissPromptIntelligenceCandidate)
 	api.GET("/models", h.ListModels)
 	api.POST("/models/sync", h.SyncModels)
+	api.POST("/models/refresh-all", h.RefreshAllModels)
 	api.POST("/codex-cli-version/sync", h.SyncCodexCLIVersion)
 	api.GET("/model-pricing", h.ListModelPricing)
 	api.PUT("/model-pricing", h.UpdateModelPricing)

--- a/admin/model_refresh_all.go
+++ b/admin/model_refresh_all.go
@@ -3,6 +3,7 @@ package admin
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"net/http"
 	"sort"
 	"strings"
@@ -19,11 +20,16 @@ import (
 // 模型目录页「刷新账号模型」的统一入口：一次刷新所有渠道，并把各渠道刷出来的
 // 模型写回各自的真源（Codex → model_registry，Claude/Grok/Antigravity → 账号凭据），
 // 使目录页、/v1/models 与调度准入看到同一份清单。
+//
+// 探测按「套餐分组抽样」进行：同一渠道内先按订阅套餐（plan_type）把账号分组，
+// 每个有账号的分组随机抽一个账号去上游拉清单——同套餐账号看到的清单相同，
+// 一万个 Pro 号逐个拉只会放大上游请求量。抽样结果写回同组全部账号
+// （Claude），或写入共享注册表（Codex）。
 
 const (
-	modelRefreshAllTimeout        = 120 * time.Second
-	modelRefreshGrokConcurrency   = 2
-	modelRefreshAntigravityWorker = 2
+	modelRefreshAllTimeout       = 120 * time.Second
+	modelRefreshChannelWorkers   = 2
+	modelRefreshUnknownPlanLabel = "unknown"
 )
 
 // modelRefreshChannelOrder 固定渠道展示顺序，与定价页分组顺序一致。
@@ -37,13 +43,15 @@ var modelRefreshChannelOrder = []string{
 // channelModelRefreshResult 是单个渠道的刷新结果。
 type channelModelRefreshResult struct {
 	Channel   string   `json:"channel"`
-	Refreshed int      `json:"refreshed"`       // 成功刷新（写回）的账号数；Codex 含官方页同步计 1
-	Failed    int      `json:"failed"`          // 拉取或写回失败的账号数
+	Groups    int      `json:"groups"`          // 参与探测的套餐分组数（每组抽一个账号）
+	Refreshed int      `json:"refreshed"`       // 成功刷新（写回）的探测数；Codex 含官方页同步计 1
+	Failed    int      `json:"failed"`          // 拉取或写回失败的探测数
 	Added     []string `json:"added"`           // 本次新出现在目录里的模型
-	Error     string   `json:"error,omitempty"` // 渠道级失败原因（账号级失败只计数）
+	Error     string   `json:"error,omitempty"` // 渠道级失败原因（探测级失败只计数）
 }
 
 type refreshAllModelsResponse struct {
+	Type       string                      `json:"type"` // complete —— 与 SSE 事件共用一个结构
 	Message    string                      `json:"message"`
 	Channels   []channelModelRefreshResult `json:"channels"`
 	Added      []string                    `json:"added"`
@@ -51,19 +59,59 @@ type refreshAllModelsResponse struct {
 	DurationMs int64                       `json:"duration_ms"`
 }
 
+// modelRefreshEvent 是 SSE 进度事件（type=start|progress）。
+type modelRefreshEvent struct {
+	Type         string   `json:"type"`
+	Channel      string   `json:"channel"`
+	Groups       int      `json:"groups,omitempty"`  // start：该渠道待探测分组数
+	Current      int      `json:"current,omitempty"` // progress：该渠道已完成探测数（含本条）
+	Total        int      `json:"total,omitempty"`   // progress：该渠道探测总数
+	Plan         string   `json:"plan,omitempty"`
+	Members      int      `json:"members,omitempty"` // 该套餐分组内账号数
+	AccountID    int64    `json:"account_id,omitempty"`
+	AccountEmail string   `json:"account_email,omitempty"`
+	Status       string   `json:"status,omitempty"` // ok | failed
+	Message      string   `json:"message,omitempty"`
+	Error        string   `json:"error,omitempty"`
+	ModelCount   int      `json:"model_count,omitempty"`
+	Added        []string `json:"added,omitempty"`
+}
+
+// modelRefreshEmitter 接收进度事件；JSON 模式下为 no-op。
+type modelRefreshEmitter func(event modelRefreshEvent)
+
 // channelModelRefreshFunc 是单渠道刷新实现；测试可通过 Handler.modelRefreshFuncs 注入。
-type channelModelRefreshFunc func(ctx context.Context) channelModelRefreshResult
+type channelModelRefreshFunc func(ctx context.Context, emit modelRefreshEmitter) channelModelRefreshResult
 
 // RefreshAllModels 并行刷新所有渠道的可用模型（POST /api/admin/models/refresh-all）。
-// 任一渠道失败不影响其他渠道写入；单渠道失败在对应 channel.error 中报告，整体仍 200。
+// 带 ?stream=1 时以 SSE 推送逐探测进度，最后一条为 type=complete 的汇总；
+// 否则直接返回汇总 JSON。任一渠道失败不影响其他渠道写入；
+// 单渠道失败在对应 channel.error 中报告，整体仍 200。
 func (h *Handler) RefreshAllModels(c *gin.Context) {
 	ctx, cancel := context.WithTimeout(c.Request.Context(), modelRefreshAllTimeout)
 	defer cancel()
-	c.JSON(http.StatusOK, h.runRefreshAllModels(ctx))
+	if c.Query("stream") != "1" {
+		c.JSON(http.StatusOK, h.runRefreshAllModels(ctx, nil))
+		return
+	}
+	setupSSE(c)
+	var writeMu sync.Mutex
+	emit := func(event modelRefreshEvent) {
+		writeMu.Lock()
+		defer writeMu.Unlock()
+		sendSSEJSON(c, event)
+	}
+	summary := h.runRefreshAllModels(ctx, emit)
+	writeMu.Lock()
+	sendSSEJSON(c, summary)
+	writeMu.Unlock()
 }
 
-func (h *Handler) runRefreshAllModels(ctx context.Context) refreshAllModelsResponse {
+func (h *Handler) runRefreshAllModels(ctx context.Context, emit modelRefreshEmitter) refreshAllModelsResponse {
 	started := time.Now()
+	if emit == nil {
+		emit = func(modelRefreshEvent) {}
+	}
 	funcs := h.modelRefreshFuncs
 	if funcs == nil {
 		funcs = h.defaultModelRefreshFuncs()
@@ -76,7 +124,7 @@ func (h *Handler) runRefreshAllModels(ctx context.Context) refreshAllModelsRespo
 		wg.Add(1)
 		go func(channel string, fn channelModelRefreshFunc) {
 			defer wg.Done()
-			result := runChannelModelRefresh(ctx, channel, fn)
+			result := runChannelModelRefresh(ctx, channel, fn, emit)
 			mu.Lock()
 			results[channel] = result
 			mu.Unlock()
@@ -85,6 +133,7 @@ func (h *Handler) runRefreshAllModels(ctx context.Context) refreshAllModelsRespo
 	wg.Wait()
 
 	resp := refreshAllModelsResponse{
+		Type:     "complete",
 		Message:  "已刷新各渠道可用模型",
 		Channels: make([]channelModelRefreshResult, 0, len(results)),
 		Added:    make([]string, 0),
@@ -104,7 +153,7 @@ func (h *Handler) runRefreshAllModels(ctx context.Context) refreshAllModelsRespo
 }
 
 // runChannelModelRefresh 保证单渠道 panic 或超时不拖垮整体响应。
-func runChannelModelRefresh(ctx context.Context, channel string, fn channelModelRefreshFunc) (result channelModelRefreshResult) {
+func runChannelModelRefresh(ctx context.Context, channel string, fn channelModelRefreshFunc, emit modelRefreshEmitter) (result channelModelRefreshResult) {
 	defer func() {
 		if recovered := recover(); recovered != nil {
 			result = channelModelRefreshResult{Channel: channel, Error: fmt.Sprintf("panic: %v", recovered)}
@@ -114,7 +163,7 @@ func runChannelModelRefresh(ctx context.Context, channel string, fn channelModel
 			result.Error = ctx.Err().Error()
 		}
 	}()
-	return fn(ctx)
+	return fn(ctx, emit)
 }
 
 func orderedModelRefreshChannels(results map[string]channelModelRefreshResult) []string {
@@ -194,6 +243,132 @@ func newlyAddedModels(before, after []string) []string {
 	return added
 }
 
+// ==================== 套餐分组抽样 ====================
+
+// modelRefreshPlanGroup 是一个套餐分组：Sample 是被抽中去探测的账号，Members 是同组全部账号。
+type modelRefreshPlanGroup struct {
+	Plan    string
+	Sample  *auth.Account
+	Members []*auth.Account
+}
+
+// modelRefreshPlanKey 归一化账号套餐名作为分组键：空套餐归入 unknown，
+// 不做进一步合并（pro / pro-5x / pro-20x / api … 各成一组）。
+func modelRefreshPlanKey(account *auth.Account) string {
+	plan := auth.NormalizePlanType(account.GetPlanType())
+	if plan == "" {
+		return modelRefreshUnknownPlanLabel
+	}
+	return plan
+}
+
+// modelRefreshSchedulable 排除已禁用、错误态的账号，避免用坏号探测。
+func modelRefreshSchedulable(account *auth.Account) bool {
+	if account == nil || atomic.LoadInt32(&account.Disabled) != 0 {
+		return false
+	}
+	account.Mu().RLock()
+	status := account.Status
+	account.Mu().RUnlock()
+	return status != auth.StatusError
+}
+
+// groupAccountsByPlan 按套餐分组并在每组随机抽一个账号。只有存在账号的分组才会出现。
+func groupAccountsByPlan(accounts []*auth.Account, include func(*auth.Account) bool, pick func(n int) int) []modelRefreshPlanGroup {
+	byPlan := make(map[string][]*auth.Account)
+	for _, account := range accounts {
+		if !modelRefreshSchedulable(account) || (include != nil && !include(account)) {
+			continue
+		}
+		plan := modelRefreshPlanKey(account)
+		byPlan[plan] = append(byPlan[plan], account)
+	}
+	plans := make([]string, 0, len(byPlan))
+	for plan := range byPlan {
+		plans = append(plans, plan)
+	}
+	sort.Strings(plans)
+	if pick == nil {
+		pick = rand.Intn
+	}
+	groups := make([]modelRefreshPlanGroup, 0, len(plans))
+	for _, plan := range plans {
+		members := byPlan[plan]
+		groups = append(groups, modelRefreshPlanGroup{Plan: plan, Sample: members[pick(len(members))], Members: members})
+	}
+	return groups
+}
+
+func (h *Handler) planGroupsFor(include func(*auth.Account) bool) []modelRefreshPlanGroup {
+	if h == nil || h.store == nil {
+		return nil
+	}
+	return groupAccountsByPlan(h.store.Accounts(), include, nil)
+}
+
+func accountEmailForEvent(account *auth.Account) string {
+	if account == nil {
+		return ""
+	}
+	account.Mu().RLock()
+	defer account.Mu().RUnlock()
+	return strings.TrimSpace(account.Email)
+}
+
+// probePlanGroups 逐组探测：每组调用一次 probe（并发 workers），并把每组的结果作为 progress 事件推出。
+func (h *Handler) probePlanGroups(ctx context.Context, channel string, groups []modelRefreshPlanGroup, result *channelModelRefreshResult, emit modelRefreshEmitter, probe func(ctx context.Context, group modelRefreshPlanGroup) (modelCount int, added []string, err error)) {
+	result.Groups = len(groups)
+	emit(modelRefreshEvent{Type: "start", Channel: channel, Groups: len(groups)})
+	if len(groups) == 0 {
+		return
+	}
+	jobs := make(chan modelRefreshPlanGroup)
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	done := 0
+	for i := 0; i < modelRefreshChannelWorkers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for group := range jobs {
+				var (
+					modelCount int
+					added      []string
+					err        error
+				)
+				if ctx.Err() != nil {
+					err = ctx.Err()
+				} else {
+					modelCount, added, err = probe(ctx, group)
+				}
+				mu.Lock()
+				done++
+				event := modelRefreshEvent{
+					Type: "progress", Channel: channel, Current: done, Total: len(groups),
+					Plan: group.Plan, Members: len(group.Members),
+					AccountID: group.Sample.ID(), AccountEmail: accountEmailForEvent(group.Sample),
+					ModelCount: modelCount, Added: added,
+				}
+				if err != nil {
+					result.Failed++
+					event.Status = "failed"
+					event.Error = err.Error()
+				} else {
+					result.Refreshed++
+					event.Status = "ok"
+				}
+				mu.Unlock()
+				emit(event)
+			}
+		}()
+	}
+	for _, group := range groups {
+		jobs <- group
+	}
+	close(jobs)
+	wg.Wait()
+}
+
 // ==================== Codex ====================
 
 // isCodexOAuthAccount 判断账号是否为 ChatGPT OAuth 的 Codex 官方账号
@@ -205,44 +380,7 @@ func isCodexOAuthAccount(account *auth.Account) bool {
 	return !account.IsRelayStyle() && !account.IsAntigravityAPI() && !account.IsGrokAPI() && !account.IsClaudeOAuth()
 }
 
-// codexManifestSampleAccounts 每种套餐（plan_type）挑一个可调度的 Codex OAuth 账号：
-// 同套餐账号看到的上游清单相同，逐个拉只会放大上游请求量。
-func (h *Handler) codexManifestSampleAccounts() []*auth.Account {
-	if h == nil || h.store == nil {
-		return nil
-	}
-	byPlan := make(map[string]*auth.Account)
-	for _, account := range h.store.Accounts() {
-		if !isCodexOAuthAccount(account) || atomic.LoadInt32(&account.Disabled) != 0 {
-			continue
-		}
-		account.Mu().RLock()
-		status := account.Status
-		account.Mu().RUnlock()
-		if status == auth.StatusError {
-			continue
-		}
-		plan := auth.NormalizePlanType(account.GetPlanType())
-		if plan == "" {
-			plan = "unknown"
-		}
-		if _, ok := byPlan[plan]; !ok {
-			byPlan[plan] = account
-		}
-	}
-	plans := make([]string, 0, len(byPlan))
-	for plan := range byPlan {
-		plans = append(plans, plan)
-	}
-	sort.Strings(plans)
-	accounts := make([]*auth.Account, 0, len(plans))
-	for _, plan := range plans {
-		accounts = append(accounts, byPlan[plan])
-	}
-	return accounts
-}
-
-func (h *Handler) refreshCodexChannelModels(ctx context.Context) channelModelRefreshResult {
+func (h *Handler) refreshCodexChannelModels(ctx context.Context, emit modelRefreshEmitter) channelModelRefreshResult {
 	result := channelModelRefreshResult{Channel: database.UpstreamChannelCodex, Added: []string{}}
 	if h == nil || h.db == nil {
 		result.Error = "数据库不可用"
@@ -258,28 +396,28 @@ func (h *Handler) refreshCodexChannelModels(ctx context.Context) channelModelRef
 	if _, err := proxy.SyncOfficialCodexModels(ctx, h.db, proxyURL); err != nil {
 		result.Error = fmt.Sprintf("官方模型页同步失败: %v", err)
 		result.Failed++
+		emit(modelRefreshEvent{Type: "progress", Channel: database.UpstreamChannelCodex, Plan: "official_docs", Status: "failed", Error: err.Error()})
 	} else {
 		result.Refreshed++
+		emit(modelRefreshEvent{Type: "progress", Channel: database.UpstreamChannelCodex, Plan: "official_docs", Status: "ok",
+			ModelCount: len(proxy.SupportedModelIDs(ctx, h.db)), Added: newlyAddedModels(before, proxy.SupportedModelIDs(ctx, h.db))})
 	}
 
-	// 2. 各套餐账号的上游清单 → 注册表（只增不改不删，沿用 LearnModelsFromManifest）。
+	// 2. 每种套餐抽一个账号拉上游清单 → 注册表（只增不改不删，沿用 LearnModelsFromManifest）。
 	now := time.Now().UTC()
-	for _, account := range h.codexManifestSampleAccounts() {
-		if ctx.Err() != nil {
-			break
-		}
-		manifest, err := proxy.FetchCodexModelsManifest(ctx, account, h.store.ResolveProxyForAccount(account), "", "")
-		if err != nil {
-			result.Failed++
-			continue
-		}
-		proxy.RecordResponsesLiteSupportFromManifest(manifest.Body)
-		if _, err := proxy.LearnModelsFromManifest(ctx, h.db, manifest.Body, now); err != nil {
-			result.Failed++
-			continue
-		}
-		result.Refreshed++
-	}
+	h.probePlanGroups(ctx, database.UpstreamChannelCodex, h.planGroupsFor(isCodexOAuthAccount), &result, emit,
+		func(ctx context.Context, group modelRefreshPlanGroup) (int, []string, error) {
+			manifest, err := proxy.FetchCodexModelsManifest(ctx, group.Sample, h.store.ResolveProxyForAccount(group.Sample), "", "")
+			if err != nil {
+				return 0, nil, err
+			}
+			proxy.RecordResponsesLiteSupportFromManifest(manifest.Body)
+			added, err := proxy.LearnModelsFromManifest(ctx, h.db, manifest.Body, now)
+			if err != nil {
+				return 0, nil, err
+			}
+			return len(proxy.ExtractManifestModelSlugs(manifest.Body)), added, nil
+		})
 
 	result.Added = newlyAddedModels(before, proxy.SupportedModelIDs(ctx, h.db))
 	return result
@@ -287,18 +425,46 @@ func (h *Handler) refreshCodexChannelModels(ctx context.Context) channelModelRef
 
 // ==================== Claude ====================
 
-func (h *Handler) refreshClaudeChannelModels(ctx context.Context) channelModelRefreshResult {
+func (h *Handler) refreshClaudeChannelModels(ctx context.Context, emit modelRefreshEmitter) channelModelRefreshResult {
 	result := channelModelRefreshResult{Channel: database.UpstreamChannelClaude, Added: []string{}}
 	if h == nil || h.db == nil {
 		result.Error = "数据库不可用"
 		return result
 	}
 	before := h.claudeChannelModels()
-	refreshed, failed, err := h.refreshAllClaudeModels(ctx)
-	result.Refreshed = refreshed
-	result.Failed = failed
-	if err != nil {
-		result.Error = err.Error()
+	var wrote int32
+	h.probePlanGroups(ctx, database.UpstreamChannelClaude, h.planGroupsFor(func(a *auth.Account) bool { return a.IsClaudeOAuth() }), &result, emit,
+		func(ctx context.Context, group modelRefreshPlanGroup) (int, []string, error) {
+			sample := group.Sample
+			accessToken := strings.TrimSpace(sample.GetAccessToken())
+			if accessToken == "" {
+				return 0, nil, fmt.Errorf("账号缺少 access_token")
+			}
+			models, err := auth.NewClaudeAuth(h.store.ResolveProxyForAccount(sample)).FetchModels(ctx, accessToken)
+			if err != nil {
+				return 0, nil, err
+			}
+			models = auth.NormalizeAccountModels(models)
+			if len(models) == 0 {
+				return 0, nil, fmt.Errorf("上游未返回可用模型")
+			}
+			// 同套餐账号权限一致：抽样结果写回同组全部账号，目录与调度准入保持一致。
+			added := newlyAddedModels(group.Sample.CodexModels(), models)
+			var writeErr error
+			for _, member := range group.Members {
+				if err := h.db.UpdateCredentials(ctx, member.ID(), map[string]interface{}{"models": models}); err != nil {
+					writeErr = err
+					continue
+				}
+				member.Mu().Lock()
+				member.Models = append([]string(nil), models...)
+				member.Mu().Unlock()
+				atomic.StoreInt32(&wrote, 1)
+			}
+			return len(models), added, writeErr
+		})
+	if atomic.LoadInt32(&wrote) == 1 {
+		h.invalidateClaudeCatalogCaches()
 	}
 	result.Added = newlyAddedModels(before, h.claudeChannelModels())
 	return result
@@ -306,88 +472,48 @@ func (h *Handler) refreshClaudeChannelModels(ctx context.Context) channelModelRe
 
 // ==================== Grok ====================
 
-func (h *Handler) refreshGrokChannelModels(ctx context.Context) channelModelRefreshResult {
+func (h *Handler) refreshGrokChannelModels(ctx context.Context, emit modelRefreshEmitter) channelModelRefreshResult {
 	result := channelModelRefreshResult{Channel: database.UpstreamChannelGrok, Added: []string{}}
 	if h == nil || h.store == nil {
 		return result
 	}
-	before := append(h.grokBillingModelIDs(), grokDefaultDisplayModelIDs()...)
-	ids := make([]int64, 0)
-	for _, account := range h.store.Accounts() {
-		if account == nil || !account.IsGrokAPI() || atomic.LoadInt32(&account.Disabled) != 0 {
-			continue
-		}
-		ids = append(ids, account.ID())
-	}
-	h.refreshAccountsWithWorkers(ctx, ids, modelRefreshGrokConcurrency, &result, func(ctx context.Context, id int64) bool {
-		syncResult, err := h.syncGrokAccountState(ctx, id)
-		if err != nil {
-			return false
-		}
-		if syncResult != nil && syncResult.capabilityGeneration > 0 {
-			h.triggerGrokCapabilityProbeForGeneration(id, syncResult.capabilityGeneration)
-		}
-		return true
-	})
-	result.Added = newlyAddedModels(before, append(h.grokBillingModelIDs(), grokDefaultDisplayModelIDs()...))
+	grokModels := func() []string { return append(h.grokBillingModelIDs(), grokDefaultDisplayModelIDs()...) }
+	before := grokModels()
+	h.probePlanGroups(ctx, database.UpstreamChannelGrok, h.planGroupsFor(func(a *auth.Account) bool { return a.IsGrokAPI() }), &result, emit,
+		func(ctx context.Context, group modelRefreshPlanGroup) (int, []string, error) {
+			id := group.Sample.ID()
+			syncResult, err := h.syncGrokAccountState(ctx, id)
+			if err != nil {
+				return 0, nil, err
+			}
+			if syncResult.capabilityGeneration > 0 {
+				h.triggerGrokCapabilityProbeForGeneration(id, syncResult.capabilityGeneration)
+			}
+			return len(syncResult.Models), nil, nil
+		})
+	result.Added = newlyAddedModels(before, grokModels())
 	return result
 }
 
 // ==================== Antigravity ====================
 
-func (h *Handler) refreshAntigravityChannelModels(ctx context.Context) channelModelRefreshResult {
+func (h *Handler) refreshAntigravityChannelModels(ctx context.Context, emit modelRefreshEmitter) channelModelRefreshResult {
 	result := channelModelRefreshResult{Channel: database.UpstreamChannelAntigravity, Added: []string{}}
 	if h == nil || h.store == nil {
 		return result
 	}
 	before := h.antigravityChannelModels()
-	ids := make([]int64, 0)
-	for _, account := range h.store.Accounts() {
-		if account == nil || !account.IsAntigravityAPI() || atomic.LoadInt32(&account.Disabled) != 0 {
-			continue
-		}
-		ids = append(ids, account.ID())
-	}
-	h.refreshAccountsWithWorkers(ctx, ids, modelRefreshAntigravityWorker, &result, func(ctx context.Context, id int64) bool {
-		return h.runAntigravityRefresh(ctx, id).OK
-	})
+	h.probePlanGroups(ctx, database.UpstreamChannelAntigravity, h.planGroupsFor(func(a *auth.Account) bool { return a.IsAntigravityAPI() }), &result, emit,
+		func(ctx context.Context, group modelRefreshPlanGroup) (int, []string, error) {
+			item := h.runAntigravityRefresh(ctx, group.Sample.ID())
+			if !item.OK {
+				if item.Error != "" {
+					return 0, nil, fmt.Errorf("%s", item.Error)
+				}
+				return 0, nil, fmt.Errorf("刷新失败")
+			}
+			return len(group.Sample.AntigravityModels()), nil, nil
+		})
 	result.Added = newlyAddedModels(before, h.antigravityChannelModels())
 	return result
-}
-
-// refreshAccountsWithWorkers 用有限并发逐账号执行 refresh，成功/失败计入 result。
-func (h *Handler) refreshAccountsWithWorkers(ctx context.Context, ids []int64, workers int, result *channelModelRefreshResult, refresh func(ctx context.Context, id int64) bool) {
-	if len(ids) == 0 {
-		return
-	}
-	if workers < 1 {
-		workers = 1
-	}
-	jobs := make(chan int64)
-	var mu sync.Mutex
-	var wg sync.WaitGroup
-	for i := 0; i < workers; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			for id := range jobs {
-				ok := false
-				if ctx.Err() == nil {
-					ok = refresh(ctx, id)
-				}
-				mu.Lock()
-				if ok {
-					result.Refreshed++
-				} else {
-					result.Failed++
-				}
-				mu.Unlock()
-			}
-		}()
-	}
-	for _, id := range ids {
-		jobs <- id
-	}
-	close(jobs)
-	wg.Wait()
 }

--- a/admin/model_refresh_all.go
+++ b/admin/model_refresh_all.go
@@ -1,0 +1,393 @@
+package admin
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/codex2api/auth"
+	"github.com/codex2api/database"
+	"github.com/codex2api/proxy"
+	"github.com/gin-gonic/gin"
+)
+
+// 模型目录页「刷新账号模型」的统一入口：一次刷新所有渠道，并把各渠道刷出来的
+// 模型写回各自的真源（Codex → model_registry，Claude/Grok/Antigravity → 账号凭据），
+// 使目录页、/v1/models 与调度准入看到同一份清单。
+
+const (
+	modelRefreshAllTimeout        = 120 * time.Second
+	modelRefreshGrokConcurrency   = 2
+	modelRefreshAntigravityWorker = 2
+)
+
+// modelRefreshChannelOrder 固定渠道展示顺序，与定价页分组顺序一致。
+var modelRefreshChannelOrder = []string{
+	database.UpstreamChannelCodex,
+	database.UpstreamChannelClaude,
+	database.UpstreamChannelGrok,
+	database.UpstreamChannelAntigravity,
+}
+
+// channelModelRefreshResult 是单个渠道的刷新结果。
+type channelModelRefreshResult struct {
+	Channel   string   `json:"channel"`
+	Refreshed int      `json:"refreshed"`       // 成功刷新（写回）的账号数；Codex 含官方页同步计 1
+	Failed    int      `json:"failed"`          // 拉取或写回失败的账号数
+	Added     []string `json:"added"`           // 本次新出现在目录里的模型
+	Error     string   `json:"error,omitempty"` // 渠道级失败原因（账号级失败只计数）
+}
+
+type refreshAllModelsResponse struct {
+	Message    string                      `json:"message"`
+	Channels   []channelModelRefreshResult `json:"channels"`
+	Added      []string                    `json:"added"`
+	ModelCount int                         `json:"model_count"`
+	DurationMs int64                       `json:"duration_ms"`
+}
+
+// channelModelRefreshFunc 是单渠道刷新实现；测试可通过 Handler.modelRefreshFuncs 注入。
+type channelModelRefreshFunc func(ctx context.Context) channelModelRefreshResult
+
+// RefreshAllModels 并行刷新所有渠道的可用模型（POST /api/admin/models/refresh-all）。
+// 任一渠道失败不影响其他渠道写入；单渠道失败在对应 channel.error 中报告，整体仍 200。
+func (h *Handler) RefreshAllModels(c *gin.Context) {
+	ctx, cancel := context.WithTimeout(c.Request.Context(), modelRefreshAllTimeout)
+	defer cancel()
+	c.JSON(http.StatusOK, h.runRefreshAllModels(ctx))
+}
+
+func (h *Handler) runRefreshAllModels(ctx context.Context) refreshAllModelsResponse {
+	started := time.Now()
+	funcs := h.modelRefreshFuncs
+	if funcs == nil {
+		funcs = h.defaultModelRefreshFuncs()
+	}
+
+	results := make(map[string]channelModelRefreshResult, len(funcs))
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	for channel, fn := range funcs {
+		wg.Add(1)
+		go func(channel string, fn channelModelRefreshFunc) {
+			defer wg.Done()
+			result := runChannelModelRefresh(ctx, channel, fn)
+			mu.Lock()
+			results[channel] = result
+			mu.Unlock()
+		}(channel, fn)
+	}
+	wg.Wait()
+
+	resp := refreshAllModelsResponse{
+		Message:  "已刷新各渠道可用模型",
+		Channels: make([]channelModelRefreshResult, 0, len(results)),
+		Added:    make([]string, 0),
+	}
+	for _, channel := range orderedModelRefreshChannels(results) {
+		result := results[channel]
+		if result.Added == nil {
+			result.Added = []string{}
+		}
+		resp.Channels = append(resp.Channels, result)
+		resp.Added = append(resp.Added, result.Added...)
+	}
+	sort.Strings(resp.Added)
+	resp.ModelCount = len(h.modelPricingCatalogKeys(ctx))
+	resp.DurationMs = time.Since(started).Milliseconds()
+	return resp
+}
+
+// runChannelModelRefresh 保证单渠道 panic 或超时不拖垮整体响应。
+func runChannelModelRefresh(ctx context.Context, channel string, fn channelModelRefreshFunc) (result channelModelRefreshResult) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			result = channelModelRefreshResult{Channel: channel, Error: fmt.Sprintf("panic: %v", recovered)}
+		}
+		result.Channel = channel
+		if result.Error == "" && ctx.Err() != nil && result.Refreshed == 0 {
+			result.Error = ctx.Err().Error()
+		}
+	}()
+	return fn(ctx)
+}
+
+func orderedModelRefreshChannels(results map[string]channelModelRefreshResult) []string {
+	ordered := make([]string, 0, len(results))
+	seen := make(map[string]struct{}, len(results))
+	for _, channel := range modelRefreshChannelOrder {
+		if _, ok := results[channel]; ok {
+			ordered = append(ordered, channel)
+			seen[channel] = struct{}{}
+		}
+	}
+	extras := make([]string, 0)
+	for channel := range results {
+		if _, ok := seen[channel]; !ok {
+			extras = append(extras, channel)
+		}
+	}
+	sort.Strings(extras)
+	return append(ordered, extras...)
+}
+
+func (h *Handler) defaultModelRefreshFuncs() map[string]channelModelRefreshFunc {
+	return map[string]channelModelRefreshFunc{
+		database.UpstreamChannelCodex:       h.refreshCodexChannelModels,
+		database.UpstreamChannelClaude:      h.refreshClaudeChannelModels,
+		database.UpstreamChannelGrok:        h.refreshGrokChannelModels,
+		database.UpstreamChannelAntigravity: h.refreshAntigravityChannelModels,
+	}
+}
+
+// modelPricingCatalogKeys 返回定价页/模型目录当前展示的全部规范模型键（各渠道拼接），
+// 与 ListModelPricing 的口径一致。
+func (h *Handler) modelPricingCatalogKeys(ctx context.Context) []string {
+	keys := modelPricingManagementKeys(proxy.SupportedModelIDs(ctx, h.db))
+	seen := make(map[string]struct{}, len(keys))
+	for _, key := range keys {
+		seen[key] = struct{}{}
+	}
+	appendUnique := func(ids []string) {
+		for _, key := range modelPricingManagementKeys(ids) {
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			keys = append(keys, key)
+		}
+	}
+	appendUnique(append(h.grokBillingModelIDs(), grokDefaultDisplayModelIDs()...))
+	appendUnique(h.antigravityChannelModels())
+	appendUnique(h.claudeChannelModels())
+	return keys
+}
+
+// newlyAddedModels 返回 after 中有而 before 中没有的模型（忽略大小写），已排序。
+func newlyAddedModels(before, after []string) []string {
+	known := make(map[string]struct{}, len(before))
+	for _, id := range before {
+		known[strings.ToLower(strings.TrimSpace(id))] = struct{}{}
+	}
+	added := make([]string, 0)
+	seen := make(map[string]struct{})
+	for _, id := range after {
+		key := strings.ToLower(strings.TrimSpace(id))
+		if key == "" {
+			continue
+		}
+		if _, ok := known[key]; ok {
+			continue
+		}
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		added = append(added, strings.TrimSpace(id))
+	}
+	sort.Strings(added)
+	return added
+}
+
+// ==================== Codex ====================
+
+// isCodexOAuthAccount 判断账号是否为 ChatGPT OAuth 的 Codex 官方账号
+// （非 relay 中转、非 Grok/Claude/Antigravity）。
+func isCodexOAuthAccount(account *auth.Account) bool {
+	if account == nil {
+		return false
+	}
+	return !account.IsRelayStyle() && !account.IsAntigravityAPI() && !account.IsGrokAPI() && !account.IsClaudeOAuth()
+}
+
+// codexManifestSampleAccounts 每种套餐（plan_type）挑一个可调度的 Codex OAuth 账号：
+// 同套餐账号看到的上游清单相同，逐个拉只会放大上游请求量。
+func (h *Handler) codexManifestSampleAccounts() []*auth.Account {
+	if h == nil || h.store == nil {
+		return nil
+	}
+	byPlan := make(map[string]*auth.Account)
+	for _, account := range h.store.Accounts() {
+		if !isCodexOAuthAccount(account) || atomic.LoadInt32(&account.Disabled) != 0 {
+			continue
+		}
+		account.Mu().RLock()
+		status := account.Status
+		account.Mu().RUnlock()
+		if status == auth.StatusError {
+			continue
+		}
+		plan := auth.NormalizePlanType(account.GetPlanType())
+		if plan == "" {
+			plan = "unknown"
+		}
+		if _, ok := byPlan[plan]; !ok {
+			byPlan[plan] = account
+		}
+	}
+	plans := make([]string, 0, len(byPlan))
+	for plan := range byPlan {
+		plans = append(plans, plan)
+	}
+	sort.Strings(plans)
+	accounts := make([]*auth.Account, 0, len(plans))
+	for _, plan := range plans {
+		accounts = append(accounts, byPlan[plan])
+	}
+	return accounts
+}
+
+func (h *Handler) refreshCodexChannelModels(ctx context.Context) channelModelRefreshResult {
+	result := channelModelRefreshResult{Channel: database.UpstreamChannelCodex, Added: []string{}}
+	if h == nil || h.db == nil {
+		result.Error = "数据库不可用"
+		return result
+	}
+	before := proxy.SupportedModelIDs(ctx, h.db)
+
+	proxyURL := ""
+	if h.store != nil {
+		proxyURL = h.store.GetProxyURL()
+	}
+	// 1. 官方模型页 → 注册表（与设置页「同步上游模型」同一实现）。
+	if _, err := proxy.SyncOfficialCodexModels(ctx, h.db, proxyURL); err != nil {
+		result.Error = fmt.Sprintf("官方模型页同步失败: %v", err)
+		result.Failed++
+	} else {
+		result.Refreshed++
+	}
+
+	// 2. 各套餐账号的上游清单 → 注册表（只增不改不删，沿用 LearnModelsFromManifest）。
+	now := time.Now().UTC()
+	for _, account := range h.codexManifestSampleAccounts() {
+		if ctx.Err() != nil {
+			break
+		}
+		manifest, err := proxy.FetchCodexModelsManifest(ctx, account, h.store.ResolveProxyForAccount(account), "", "")
+		if err != nil {
+			result.Failed++
+			continue
+		}
+		proxy.RecordResponsesLiteSupportFromManifest(manifest.Body)
+		if _, err := proxy.LearnModelsFromManifest(ctx, h.db, manifest.Body, now); err != nil {
+			result.Failed++
+			continue
+		}
+		result.Refreshed++
+	}
+
+	result.Added = newlyAddedModels(before, proxy.SupportedModelIDs(ctx, h.db))
+	return result
+}
+
+// ==================== Claude ====================
+
+func (h *Handler) refreshClaudeChannelModels(ctx context.Context) channelModelRefreshResult {
+	result := channelModelRefreshResult{Channel: database.UpstreamChannelClaude, Added: []string{}}
+	if h == nil || h.db == nil {
+		result.Error = "数据库不可用"
+		return result
+	}
+	before := h.claudeChannelModels()
+	refreshed, failed, err := h.refreshAllClaudeModels(ctx)
+	result.Refreshed = refreshed
+	result.Failed = failed
+	if err != nil {
+		result.Error = err.Error()
+	}
+	result.Added = newlyAddedModels(before, h.claudeChannelModels())
+	return result
+}
+
+// ==================== Grok ====================
+
+func (h *Handler) refreshGrokChannelModels(ctx context.Context) channelModelRefreshResult {
+	result := channelModelRefreshResult{Channel: database.UpstreamChannelGrok, Added: []string{}}
+	if h == nil || h.store == nil {
+		return result
+	}
+	before := append(h.grokBillingModelIDs(), grokDefaultDisplayModelIDs()...)
+	ids := make([]int64, 0)
+	for _, account := range h.store.Accounts() {
+		if account == nil || !account.IsGrokAPI() || atomic.LoadInt32(&account.Disabled) != 0 {
+			continue
+		}
+		ids = append(ids, account.ID())
+	}
+	h.refreshAccountsWithWorkers(ctx, ids, modelRefreshGrokConcurrency, &result, func(ctx context.Context, id int64) bool {
+		syncResult, err := h.syncGrokAccountState(ctx, id)
+		if err != nil {
+			return false
+		}
+		if syncResult != nil && syncResult.capabilityGeneration > 0 {
+			h.triggerGrokCapabilityProbeForGeneration(id, syncResult.capabilityGeneration)
+		}
+		return true
+	})
+	result.Added = newlyAddedModels(before, append(h.grokBillingModelIDs(), grokDefaultDisplayModelIDs()...))
+	return result
+}
+
+// ==================== Antigravity ====================
+
+func (h *Handler) refreshAntigravityChannelModels(ctx context.Context) channelModelRefreshResult {
+	result := channelModelRefreshResult{Channel: database.UpstreamChannelAntigravity, Added: []string{}}
+	if h == nil || h.store == nil {
+		return result
+	}
+	before := h.antigravityChannelModels()
+	ids := make([]int64, 0)
+	for _, account := range h.store.Accounts() {
+		if account == nil || !account.IsAntigravityAPI() || atomic.LoadInt32(&account.Disabled) != 0 {
+			continue
+		}
+		ids = append(ids, account.ID())
+	}
+	h.refreshAccountsWithWorkers(ctx, ids, modelRefreshAntigravityWorker, &result, func(ctx context.Context, id int64) bool {
+		return h.runAntigravityRefresh(ctx, id).OK
+	})
+	result.Added = newlyAddedModels(before, h.antigravityChannelModels())
+	return result
+}
+
+// refreshAccountsWithWorkers 用有限并发逐账号执行 refresh，成功/失败计入 result。
+func (h *Handler) refreshAccountsWithWorkers(ctx context.Context, ids []int64, workers int, result *channelModelRefreshResult, refresh func(ctx context.Context, id int64) bool) {
+	if len(ids) == 0 {
+		return
+	}
+	if workers < 1 {
+		workers = 1
+	}
+	jobs := make(chan int64)
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for id := range jobs {
+				ok := false
+				if ctx.Err() == nil {
+					ok = refresh(ctx, id)
+				}
+				mu.Lock()
+				if ok {
+					result.Refreshed++
+				} else {
+					result.Failed++
+				}
+				mu.Unlock()
+			}
+		}()
+	}
+	for _, id := range ids {
+		jobs <- id
+	}
+	close(jobs)
+	wg.Wait()
+}

--- a/admin/model_refresh_all_test.go
+++ b/admin/model_refresh_all_test.go
@@ -3,25 +3,28 @@ package admin
 import (
 	"context"
 	"errors"
+	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/codex2api/auth"
 	"github.com/codex2api/database"
 )
 
 func TestRunRefreshAllModels_PartialFailureKeepsOtherChannels(t *testing.T) {
 	h := &Handler{modelRefreshFuncs: map[string]channelModelRefreshFunc{
-		database.UpstreamChannelGrok: func(ctx context.Context) channelModelRefreshResult {
+		database.UpstreamChannelGrok: func(ctx context.Context, _ modelRefreshEmitter) channelModelRefreshResult {
 			return channelModelRefreshResult{Refreshed: 1, Added: []string{"grok-5"}}
 		},
-		database.UpstreamChannelCodex: func(ctx context.Context) channelModelRefreshResult {
+		database.UpstreamChannelCodex: func(ctx context.Context, _ modelRefreshEmitter) channelModelRefreshResult {
 			return channelModelRefreshResult{Error: "官方模型页同步失败: boom", Failed: 1}
 		},
-		database.UpstreamChannelClaude: func(ctx context.Context) channelModelRefreshResult {
+		database.UpstreamChannelClaude: func(ctx context.Context, _ modelRefreshEmitter) channelModelRefreshResult {
 			panic("claude exploded")
 		},
 	}}
-	resp := h.runRefreshAllModels(context.Background())
+	resp := h.runRefreshAllModels(context.Background(), nil)
 
 	if len(resp.Channels) != 3 {
 		t.Fatalf("channels = %d, want 3: %+v", len(resp.Channels), resp.Channels)
@@ -51,18 +54,18 @@ func TestRunRefreshAllModels_PartialFailureKeepsOtherChannels(t *testing.T) {
 
 func TestRunRefreshAllModels_TimeoutIsReportedPerChannel(t *testing.T) {
 	h := &Handler{modelRefreshFuncs: map[string]channelModelRefreshFunc{
-		database.UpstreamChannelAntigravity: func(ctx context.Context) channelModelRefreshResult {
+		database.UpstreamChannelAntigravity: func(ctx context.Context, _ modelRefreshEmitter) channelModelRefreshResult {
 			<-ctx.Done()
 			return channelModelRefreshResult{}
 		},
-		database.UpstreamChannelCodex: func(ctx context.Context) channelModelRefreshResult {
+		database.UpstreamChannelCodex: func(ctx context.Context, _ modelRefreshEmitter) channelModelRefreshResult {
 			return channelModelRefreshResult{Refreshed: 1}
 		},
 	}}
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
 	started := time.Now()
-	resp := h.runRefreshAllModels(ctx)
+	resp := h.runRefreshAllModels(ctx, nil)
 	if time.Since(started) > 2*time.Second {
 		t.Fatalf("refresh did not honour context deadline")
 	}
@@ -78,5 +81,52 @@ func TestNewlyAddedModels(t *testing.T) {
 	added := newlyAddedModels([]string{"gpt-5.5", "GPT-5.4"}, []string{"gpt-5.4", "gpt-6-astra", "gpt-5.5", "gpt-6-astra", " "})
 	if len(added) != 1 || added[0] != "gpt-6-astra" {
 		t.Fatalf("added = %v", added)
+	}
+}
+
+func TestGroupAccountsByPlan_OneSamplePerPlan(t *testing.T) {
+	mk := func(id int64, plan string, disabled bool) *auth.Account {
+		acc := &auth.Account{PlanType: plan, DBID: id}
+		if disabled {
+			atomic.StoreInt32(&acc.Disabled, 1)
+		}
+		return acc
+	}
+	accounts := []*auth.Account{
+		mk(1, "pro", false), mk(2, "pro", false), mk(3, "pro", false),
+		mk(4, "pro-20x", false), mk(5, "api", true), mk(6, "", false), mk(7, "prolite", false),
+	}
+	groups := groupAccountsByPlan(accounts, nil, func(n int) int { return n - 1 })
+	plans := make([]string, 0, len(groups))
+	for _, g := range groups {
+		plans = append(plans, g.Plan)
+	}
+	// api 组全部禁用 → 不出现；prolite 归一化为 pro；空套餐归入 unknown；按名字排序。
+	if strings.Join(plans, ",") != "pro,pro-20x,unknown" {
+		t.Fatalf("plans = %v", plans)
+	}
+	if groups[0].Sample.ID() != 7 || len(groups[0].Members) != 4 {
+		t.Fatalf("pro group should sample the last member (7) of 4, got sample=%d members=%d", groups[0].Sample.ID(), len(groups[0].Members))
+	}
+	if groups[1].Sample.ID() != 4 || len(groups[1].Members) != 1 {
+		t.Fatalf("pro-20x group = %+v", groups[1])
+	}
+}
+
+func TestRunRefreshAllModels_StreamsProgressEvents(t *testing.T) {
+	h := &Handler{modelRefreshFuncs: map[string]channelModelRefreshFunc{
+		database.UpstreamChannelCodex: func(ctx context.Context, emit modelRefreshEmitter) channelModelRefreshResult {
+			emit(modelRefreshEvent{Type: "start", Channel: database.UpstreamChannelCodex, Groups: 1})
+			emit(modelRefreshEvent{Type: "progress", Channel: database.UpstreamChannelCodex, Current: 1, Total: 1, Plan: "pro", Status: "ok", Added: []string{"gpt-6-astra"}})
+			return channelModelRefreshResult{Refreshed: 1, Groups: 1, Added: []string{"gpt-6-astra"}}
+		},
+	}}
+	var events []modelRefreshEvent
+	resp := h.runRefreshAllModels(context.Background(), func(e modelRefreshEvent) { events = append(events, e) })
+	if len(events) != 2 || events[0].Type != "start" || events[1].Type != "progress" || events[1].Plan != "pro" {
+		t.Fatalf("events = %+v", events)
+	}
+	if resp.Type != "complete" || resp.Channels[0].Groups != 1 {
+		t.Fatalf("summary = %+v", resp)
 	}
 }

--- a/admin/model_refresh_all_test.go
+++ b/admin/model_refresh_all_test.go
@@ -1,0 +1,82 @@
+package admin
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/codex2api/database"
+)
+
+func TestRunRefreshAllModels_PartialFailureKeepsOtherChannels(t *testing.T) {
+	h := &Handler{modelRefreshFuncs: map[string]channelModelRefreshFunc{
+		database.UpstreamChannelGrok: func(ctx context.Context) channelModelRefreshResult {
+			return channelModelRefreshResult{Refreshed: 1, Added: []string{"grok-5"}}
+		},
+		database.UpstreamChannelCodex: func(ctx context.Context) channelModelRefreshResult {
+			return channelModelRefreshResult{Error: "官方模型页同步失败: boom", Failed: 1}
+		},
+		database.UpstreamChannelClaude: func(ctx context.Context) channelModelRefreshResult {
+			panic("claude exploded")
+		},
+	}}
+	resp := h.runRefreshAllModels(context.Background())
+
+	if len(resp.Channels) != 3 {
+		t.Fatalf("channels = %d, want 3: %+v", len(resp.Channels), resp.Channels)
+	}
+	// 固定顺序：codex → claude → grok
+	if resp.Channels[0].Channel != database.UpstreamChannelCodex || resp.Channels[1].Channel != database.UpstreamChannelClaude || resp.Channels[2].Channel != database.UpstreamChannelGrok {
+		t.Fatalf("unexpected channel order: %+v", resp.Channels)
+	}
+	if resp.Channels[0].Error == "" || resp.Channels[0].Failed != 1 {
+		t.Fatalf("codex failure should be reported: %+v", resp.Channels[0])
+	}
+	if resp.Channels[1].Error == "" || resp.Channels[1].Error[:5] != "panic" {
+		t.Fatalf("claude panic should be captured as error: %+v", resp.Channels[1])
+	}
+	if resp.Channels[2].Refreshed != 1 || len(resp.Channels[2].Added) != 1 {
+		t.Fatalf("grok result lost: %+v", resp.Channels[2])
+	}
+	if len(resp.Added) != 1 || resp.Added[0] != "grok-5" {
+		t.Fatalf("aggregated added = %v", resp.Added)
+	}
+	for _, ch := range resp.Channels {
+		if ch.Added == nil {
+			t.Fatalf("added must serialize as [] not null: %+v", ch)
+		}
+	}
+}
+
+func TestRunRefreshAllModels_TimeoutIsReportedPerChannel(t *testing.T) {
+	h := &Handler{modelRefreshFuncs: map[string]channelModelRefreshFunc{
+		database.UpstreamChannelAntigravity: func(ctx context.Context) channelModelRefreshResult {
+			<-ctx.Done()
+			return channelModelRefreshResult{}
+		},
+		database.UpstreamChannelCodex: func(ctx context.Context) channelModelRefreshResult {
+			return channelModelRefreshResult{Refreshed: 1}
+		},
+	}}
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	started := time.Now()
+	resp := h.runRefreshAllModels(ctx)
+	if time.Since(started) > 2*time.Second {
+		t.Fatalf("refresh did not honour context deadline")
+	}
+	if resp.Channels[1].Channel != database.UpstreamChannelAntigravity || !errors.Is(context.DeadlineExceeded, context.DeadlineExceeded) || resp.Channels[1].Error != context.DeadlineExceeded.Error() {
+		t.Fatalf("antigravity timeout should be reported: %+v", resp.Channels)
+	}
+	if resp.Channels[0].Error != "" {
+		t.Fatalf("codex should not inherit the timeout error: %+v", resp.Channels[0])
+	}
+}
+
+func TestNewlyAddedModels(t *testing.T) {
+	added := newlyAddedModels([]string{"gpt-5.5", "GPT-5.4"}, []string{"gpt-5.4", "gpt-6-astra", "gpt-5.5", "gpt-6-astra", " "})
+	if len(added) != 1 || added[0] != "gpt-6-astra" {
+		t.Fatalf("added = %v", added)
+	}
+}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -75,6 +75,7 @@ import type {
   InviteTrackingResponse,
   MessageResponse,
   ModelSyncResponse,
+  RefreshAllModelsResponse,
   ModelPricingOverride,
 	OfficialPricingSyncConfig,
 	OfficialPricingSyncResult,
@@ -777,6 +778,11 @@ export const api = {
     request<{ message: string; refreshed: number; failed: number; model_count: number }>('/accounts/claude/models/refresh', {
       method: 'POST',
       timeoutMs: 60_000,
+    }),
+  refreshAllModels: () =>
+    request<RefreshAllModelsResponse>('/models/refresh-all', {
+      method: 'POST',
+      timeoutMs: 130_000,
     }),
   batchUpdateGrokModels: (data: BatchUpdateGrokModelsRequest) =>
     request<BatchUpdateGrokModelsResponse>('/accounts/grok/batch-models', {

--- a/frontend/src/lib/claudeParity.test.mjs
+++ b/frontend/src/lib/claudeParity.test.mjs
@@ -78,6 +78,14 @@ test('model pricing exposes Anthropic source and distinct cache write fields', (
   assert.match(types, /cache_write_1h/)
 })
 
+test('model catalog refresh button refreshes every channel, not only Claude', () => {
+  const pricing = readFileSync(new URL('../pages/ModelPricing.tsx', import.meta.url), 'utf8')
+  assert.match(pricing, /api\.refreshAllModels\(\)/)
+  assert.doesNotMatch(pricing, /api\.refreshAllClaudeModels\(\)/)
+  assert.match(pricing, /catalogRefreshChannelFailed/)
+  assert.match(types, /RefreshAllModelsResponse/)
+})
+
 test('Claude settings expose client platform and version policy controls', () => {
   assert.match(settings, /clientPlatform|client_platform/)
   assert.match(settings, /versionPolicy|version_policy/)

--- a/frontend/src/lib/claudeParity.test.mjs
+++ b/frontend/src/lib/claudeParity.test.mjs
@@ -80,7 +80,8 @@ test('model pricing exposes Anthropic source and distinct cache write fields', (
 
 test('model catalog refresh button refreshes every channel, not only Claude', () => {
   const pricing = readFileSync(new URL('../pages/ModelPricing.tsx', import.meta.url), 'utf8')
-  assert.match(pricing, /api\.refreshAllModels\(\)/)
+  assert.match(pricing, /\/models\/refresh-all\?stream=1/)
+  assert.match(pricing, /readModelRefreshSSE/)
   assert.doesNotMatch(pricing, /api\.refreshAllClaudeModels\(\)/)
   assert.match(pricing, /catalogRefreshChannelFailed/)
   assert.match(types, /RefreshAllModelsResponse/)
@@ -100,6 +101,7 @@ test('Claude account editor exposes per-account client policy overrides', () => 
   assert.match(claude, /claude_client_version|clientVersion/)
   assert.match(claude, /跟随全局|follow.*global/i)
 })
+
 test('Claude model whitelist stays provider-scoped and uses optimistic detail validation', () => {
   assert.match(claude, /CLAUDE_MODEL_ID_RE = \/\^claude-/)
   assert.match(claude, /api\.syncAccountModelsUpstream\(account\.id\)/)

--- a/frontend/src/lib/modelRefreshStream.ts
+++ b/frontend/src/lib/modelRefreshStream.ts
@@ -1,0 +1,125 @@
+import type { ChannelModelRefreshResult, RefreshAllModelsResponse } from '../types'
+
+// 「刷新账号模型」SSE 事件：start（渠道待探测分组数）/ progress（每组抽样账号的结果）/ complete（汇总）。
+export interface ModelRefreshProgressEvent {
+  type: 'start' | 'progress'
+  channel: string
+  groups?: number
+  current?: number
+  total?: number
+  plan?: string
+  members?: number
+  account_id?: number
+  account_email?: string
+  status?: 'ok' | 'failed'
+  message?: string
+  error?: string
+  model_count?: number
+  added?: string[]
+}
+
+export type ModelRefreshStreamEvent = ModelRefreshProgressEvent | RefreshAllModelsResponse
+
+export interface ModelRefreshChannelProgress {
+  channel: string
+  groups: number
+  current: number
+  total: number
+  lastPlan: string
+  lastAccount: string
+  lastStatus: 'ok' | 'failed' | ''
+  lastError: string
+  added: string[]
+  failed: number
+  done: boolean
+  error: string
+}
+
+export type ModelRefreshProgress = Record<string, ModelRefreshChannelProgress>
+
+function emptyChannelProgress(channel: string): ModelRefreshChannelProgress {
+  return { channel, groups: 0, current: 0, total: 0, lastPlan: '', lastAccount: '', lastStatus: '', lastError: '', added: [], failed: 0, done: false, error: '' }
+}
+
+// 把一条流事件合并进进度状态；返回新对象以便 React 触发渲染。
+export function applyModelRefreshEvent(prev: ModelRefreshProgress, event: ModelRefreshStreamEvent): ModelRefreshProgress {
+  const next: ModelRefreshProgress = { ...prev }
+  if (event.type === 'complete') {
+    for (const ch of (event as RefreshAllModelsResponse).channels as ChannelModelRefreshResult[]) {
+      const cur = next[ch.channel] ?? emptyChannelProgress(ch.channel)
+      next[ch.channel] = { ...cur, done: true, error: ch.error ?? '', failed: ch.failed, added: mergeAdded(cur.added, ch.added), groups: ch.groups ?? cur.groups }
+    }
+    return next
+  }
+  const cur = next[event.channel] ?? emptyChannelProgress(event.channel)
+  if (event.type === 'start') {
+    next[event.channel] = { ...cur, groups: event.groups ?? 0, total: event.groups ?? 0 }
+    return next
+  }
+  next[event.channel] = {
+    ...cur,
+    current: event.current ?? cur.current,
+    total: event.total ?? cur.total,
+    lastPlan: event.plan ?? cur.lastPlan,
+    lastAccount: event.account_email ?? '',
+    lastStatus: event.status ?? '',
+    lastError: event.error ?? '',
+    failed: cur.failed + (event.status === 'failed' ? 1 : 0),
+    added: mergeAdded(cur.added, event.added ?? []),
+  }
+  return next
+}
+
+function mergeAdded(prev: string[], incoming: string[]): string[] {
+  const seen = new Set(prev.map((m) => m.toLowerCase()))
+  const out = [...prev]
+  for (const m of incoming) {
+    const key = m.toLowerCase()
+    if (seen.has(key)) continue
+    seen.add(key)
+    out.push(m)
+  }
+  return out
+}
+
+function parseSSELine(line: string): ModelRefreshStreamEvent | null {
+  const trimmed = line.trim()
+  if (!trimmed.startsWith('data:')) return null
+  const payload = trimmed.slice(5).trim()
+  if (!payload) return null
+  try {
+    const parsed = JSON.parse(payload) as ModelRefreshStreamEvent
+    return parsed && typeof parsed === 'object' && typeof parsed.type === 'string' ? parsed : null
+  } catch {
+    return null
+  }
+}
+
+// 读取 SSE 响应体；每解析到一条事件就回调，返回最终的 complete 汇总（没有则 null）。
+export async function readModelRefreshSSE(
+  response: Response,
+  onEvent: (event: ModelRefreshStreamEvent) => void,
+): Promise<RefreshAllModelsResponse | null> {
+  const reader = response.body?.getReader()
+  if (!reader) return null
+  const decoder = new TextDecoder()
+  let buffer = ''
+  let complete: RefreshAllModelsResponse | null = null
+  const consume = (line: string) => {
+    const event = parseSSELine(line)
+    if (!event) return
+    if (event.type === 'complete') complete = event as RefreshAllModelsResponse
+    onEvent(event)
+  }
+  for (;;) {
+    const { done, value } = await reader.read()
+    if (done) break
+    buffer += decoder.decode(value, { stream: true })
+    const lines = buffer.split('\n')
+    buffer = lines.pop() ?? ''
+    for (const line of lines) consume(line)
+  }
+  buffer += decoder.decode()
+  if (buffer) consume(buffer)
+  return complete
+}

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -4233,7 +4233,9 @@
       "catalogSearch": "Search models…",
       "catalogCount": "{{count}} models",
       "catalogRefresh": "Refresh account models",
-      "catalogRefreshed": "Refreshed, {{count}} models available",
+      "catalogRefreshed": "Refreshed, {{count}} models available ({{detail}})",
+      "catalogRefreshChannelFailed": "failed",
+      "catalogRefreshChannelAccounts": "{{count}} accounts",
       "catalogMarkSeen": "Mark seen",
       "newBadge": "NEW"
     },

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -4235,7 +4235,11 @@
       "catalogRefresh": "Refresh account models",
       "catalogRefreshed": "Refreshed, {{count}} models available ({{detail}})",
       "catalogRefreshChannelFailed": "failed",
-      "catalogRefreshChannelAccounts": "{{count}} accounts",
+      "catalogRefreshChannelGroups": "{{count}} plan groups",
+      "refreshProbing": "probed {{current}}/{{total}} plan groups",
+      "refreshStarting": "starting…",
+      "refreshNoAccounts": "no accounts",
+      "refreshNoSummary": "refresh returned no summary",
       "catalogMarkSeen": "Mark seen",
       "newBadge": "NEW"
     },

--- a/frontend/src/locales/zh-TW.json
+++ b/frontend/src/locales/zh-TW.json
@@ -141,7 +141,9 @@
       "catalogSearch": "搜尋模型…",
       "catalogCount": "共 {{count}} 個模型",
       "catalogRefresh": "重新整理帳號模型",
-      "catalogRefreshed": "已重新整理,可用模型共 {{count}} 個",
+      "catalogRefreshed": "已重新整理,可用模型共 {{count}} 個（{{detail}}）",
+      "catalogRefreshChannelFailed": "失敗",
+      "catalogRefreshChannelAccounts": "{{count}} 個帳號",
       "catalogMarkSeen": "標記已讀",
       "newBadge": "新"
     },

--- a/frontend/src/locales/zh-TW.json
+++ b/frontend/src/locales/zh-TW.json
@@ -143,7 +143,11 @@
       "catalogRefresh": "重新整理帳號模型",
       "catalogRefreshed": "已重新整理,可用模型共 {{count}} 個（{{detail}}）",
       "catalogRefreshChannelFailed": "失敗",
-      "catalogRefreshChannelAccounts": "{{count}} 個帳號",
+      "catalogRefreshChannelGroups": "{{count}} 組方案",
+      "refreshProbing": "已探測 {{current}}/{{total}} 組方案",
+      "refreshStarting": "準備中…",
+      "refreshNoAccounts": "無帳號",
+      "refreshNoSummary": "重新整理未回傳彙總",
       "catalogMarkSeen": "標記已讀",
       "newBadge": "新"
     },

--- a/frontend/src/locales/zh.json
+++ b/frontend/src/locales/zh.json
@@ -4235,7 +4235,11 @@
       "catalogRefresh": "刷新账号模型",
       "catalogRefreshed": "已刷新,可用模型共 {{count}} 个（{{detail}}）",
       "catalogRefreshChannelFailed": "失败",
-      "catalogRefreshChannelAccounts": "{{count}} 个账号",
+      "catalogRefreshChannelGroups": "{{count}} 组套餐",
+      "refreshProbing": "已探测 {{current}}/{{total}} 组套餐",
+      "refreshStarting": "准备中…",
+      "refreshNoAccounts": "无账号",
+      "refreshNoSummary": "刷新未返回汇总",
       "catalogMarkSeen": "标记已读",
       "newBadge": "新"
     },

--- a/frontend/src/locales/zh.json
+++ b/frontend/src/locales/zh.json
@@ -4233,7 +4233,9 @@
       "catalogSearch": "搜索模型…",
       "catalogCount": "共 {{count}} 个模型",
       "catalogRefresh": "刷新账号模型",
-      "catalogRefreshed": "已刷新,可用模型共 {{count}} 个",
+      "catalogRefreshed": "已刷新,可用模型共 {{count}} 个（{{detail}}）",
+      "catalogRefreshChannelFailed": "失败",
+      "catalogRefreshChannelAccounts": "{{count}} 个账号",
       "catalogMarkSeen": "标记已读",
       "newBadge": "新"
     },

--- a/frontend/src/pages/ModelPricing.tsx
+++ b/frontend/src/pages/ModelPricing.tsx
@@ -1,6 +1,7 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
+  AlertTriangle,
   ArrowUpRight,
   Check,
   ChevronDown,
@@ -30,6 +31,8 @@ import { Input } from '@/components/ui/input'
 import { Switch } from '@/components/ui/switch'
 import { cn } from '@/lib/utils'
 import { useToast } from '../hooks/useToast'
+import { postAdminSSE } from '../hooks/useOperationProgress'
+import { applyModelRefreshEvent, readModelRefreshSSE, type ModelRefreshProgress } from '../lib/modelRefreshStream'
 import { getErrorMessage } from '../utils/error'
 import type { ModelPricingOverride, OfficialPricingSyncConfig } from '@/types'
 import {
@@ -454,6 +457,62 @@ function BillingRulePreview({ pricing }: { pricing: ModelPricingOverride }) {
 
 // ModelCatalogModal 是"模型目录"弹窗:按 provider 分组、可搜索、点击某模型直接定位到
 // 价格行;可刷新账号真实可用模型;新出现的模型标"新",便于快速锁定。
+// 刷新进度面板：每渠道一行，显示已探测的套餐分组数、当前抽样账号，以及刷出来的新模型。
+function ModelRefreshProgressPanel({ progress, running }: { progress: ModelRefreshProgress; running: boolean }) {
+  const { t } = useTranslation()
+  const channels = CHANNEL_ORDER.filter((c) => progress[c]).map((c) => progress[c])
+  if (channels.length === 0) {
+    return (
+      <div className="flex items-center gap-2 rounded-xl border border-sky-500/20 bg-sky-500/5 p-3 text-xs text-sky-700 dark:text-sky-300">
+        <Loader2 className="size-3.5 animate-spin" />
+        {t('settings.pricing.refreshStarting')}
+      </div>
+    )
+  }
+  return (
+    <div className="space-y-1.5 rounded-xl border border-sky-500/20 bg-sky-500/5 p-3">
+      {channels.map((ch) => {
+        const label = CHANNEL_LABEL[ch.channel as Exclude<ChannelFilter, 'all'>] ?? ch.channel
+        const finished = ch.done || (!running && ch.total > 0 && ch.current >= ch.total)
+        const failed = Boolean(ch.error) || ch.failed > 0
+        return (
+          <div key={ch.channel} className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs">
+            <span className="flex w-24 shrink-0 items-center gap-1.5 font-semibold text-foreground/80">
+              {finished ? (
+                failed ? <AlertTriangle className="size-3.5 text-amber-500" /> : <Check className="size-3.5 text-emerald-500" />
+              ) : (
+                <Loader2 className="size-3.5 animate-spin text-sky-500" />
+              )}
+              <ChannelLogo channel={ch.channel as Exclude<ChannelFilter, 'all'>} size={14} />
+              {label}
+            </span>
+            <span className="text-muted-foreground">
+              {ch.total > 0
+                ? t('settings.pricing.refreshProbing', { current: ch.current, total: ch.total })
+                : finished
+                  ? t('settings.pricing.refreshNoAccounts')
+                  : t('settings.pricing.refreshStarting')}
+            </span>
+            {ch.lastPlan ? (
+              <span className="truncate font-mono text-[11px] text-muted-foreground">
+                {ch.lastPlan}
+                {ch.lastAccount ? ` · ${ch.lastAccount}` : ''}
+                {ch.lastStatus === 'failed' ? ` · ${t('settings.pricing.catalogRefreshChannelFailed')}${ch.lastError ? `: ${ch.lastError}` : ''}` : ''}
+              </span>
+            ) : null}
+            {ch.error ? <span className="text-[11px] text-amber-600 dark:text-amber-400">{ch.error}</span> : null}
+            {ch.added.map((m) => (
+              <span key={m} className="rounded-full bg-rose-500/15 px-1.5 py-0.5 font-mono text-[10px] font-bold text-rose-600 ring-1 ring-inset ring-rose-500/25 dark:text-rose-300">
+                +{m}
+              </span>
+            ))}
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
 function ModelCatalogModal({
   open,
   onClose,
@@ -464,6 +523,7 @@ function ModelCatalogModal({
   onJump,
   onRefresh,
   refreshing,
+  refreshProgress,
   onAcknowledge,
 }: {
   open: boolean
@@ -475,6 +535,7 @@ function ModelCatalogModal({
   onJump: (model: string) => void
   onRefresh: () => void
   refreshing: boolean
+  refreshProgress: ModelRefreshProgress | null
   onAcknowledge: () => void
 }) {
   const { t } = useTranslation()
@@ -518,6 +579,7 @@ function ModelCatalogModal({
       }
     >
       <div className="space-y-3">
+        {refreshProgress ? <ModelRefreshProgressPanel progress={refreshProgress} running={refreshing} /> : null}
         <div className="relative">
           <Search className="pointer-events-none absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
           <Input
@@ -602,6 +664,8 @@ export default function ModelPricing() {
   const [catalogQuery, setCatalogQuery] = useState('')
   const [jumpedModel, setJumpedModel] = useState('')
   const [refreshingModels, setRefreshingModels] = useState(false)
+  const [refreshProgress, setRefreshProgress] = useState<ModelRefreshProgress | null>(null)
+  const refreshProgressHideTimer = useRef<number | null>(null)
   const [seenBump, setSeenBump] = useState(0)
   const [syncOpen, setSyncOpen] = useState(false)
   const [expandedAdvanced, setExpandedAdvanced] = useState<Record<string, boolean>>({})
@@ -847,16 +911,24 @@ export default function ModelPricing() {
 
   const refreshCatalogModels = useCallback(async () => {
     setRefreshingModels(true)
+    if (refreshProgressHideTimer.current !== null) {
+      window.clearTimeout(refreshProgressHideTimer.current)
+      refreshProgressHideTimer.current = null
+    }
+    setRefreshProgress({})
     try {
-      // 统一刷新所有渠道（Codex 注册表 + Claude/Grok/Antigravity 账号模型），
-      // 每个渠道独立成败，逐渠道汇报，新模型直接列出。
-      const res = await api.refreshAllModels()
+      // 统一刷新所有渠道：按套餐分组抽样探测，SSE 逐组推送进度，刷出新模型立刻显示。
+      const response = await postAdminSSE('/models/refresh-all?stream=1')
+      const res = await readModelRefreshSSE(response, (event) => {
+        setRefreshProgress((prev) => applyModelRefreshEvent(prev ?? {}, event))
+      })
+      if (!res) throw new Error(t('settings.pricing.refreshNoSummary'))
       const detail = res.channels
         .map((ch) => {
           const label = CHANNEL_LABEL[ch.channel as Exclude<ChannelFilter, 'all'>] ?? ch.channel
           const status = ch.error
             ? t('settings.pricing.catalogRefreshChannelFailed')
-            : t('settings.pricing.catalogRefreshChannelAccounts', { count: ch.refreshed })
+            : t('settings.pricing.catalogRefreshChannelGroups', { count: ch.groups ?? 0 })
           const added = ch.added.length ? ` +${ch.added.join(', ')}` : ''
           return `${label} ${status}${added}`
         })
@@ -868,6 +940,10 @@ export default function ModelPricing() {
       showToast(getErrorMessage(error), 'error')
     } finally {
       setRefreshingModels(false)
+      refreshProgressHideTimer.current = window.setTimeout(() => {
+        setRefreshProgress(null)
+        refreshProgressHideTimer.current = null
+      }, 4000)
     }
   }, [load, showToast, t])
 
@@ -934,6 +1010,7 @@ export default function ModelPricing() {
         onJump={jumpToModel}
         onRefresh={() => void refreshCatalogModels()}
         refreshing={refreshingModels}
+        refreshProgress={refreshProgress}
         onAcknowledge={acknowledgeNewModels}
       />
 

--- a/frontend/src/pages/ModelPricing.tsx
+++ b/frontend/src/pages/ModelPricing.tsx
@@ -848,8 +848,21 @@ export default function ModelPricing() {
   const refreshCatalogModels = useCallback(async () => {
     setRefreshingModels(true)
     try {
-      const res = await api.refreshAllClaudeModels()
-      showToast(t('settings.pricing.catalogRefreshed', { count: res.model_count }))
+      // 统一刷新所有渠道（Codex 注册表 + Claude/Grok/Antigravity 账号模型），
+      // 每个渠道独立成败，逐渠道汇报，新模型直接列出。
+      const res = await api.refreshAllModels()
+      const detail = res.channels
+        .map((ch) => {
+          const label = CHANNEL_LABEL[ch.channel as Exclude<ChannelFilter, 'all'>] ?? ch.channel
+          const status = ch.error
+            ? t('settings.pricing.catalogRefreshChannelFailed')
+            : t('settings.pricing.catalogRefreshChannelAccounts', { count: ch.refreshed })
+          const added = ch.added.length ? ` +${ch.added.join(', ')}` : ''
+          return `${label} ${status}${added}`
+        })
+        .join(' · ')
+      const failed = res.channels.some((ch) => ch.error)
+      showToast(t('settings.pricing.catalogRefreshed', { count: res.model_count, detail }), failed ? 'error' : undefined)
       await load()
     } catch (error) {
       showToast(getErrorMessage(error), 'error')

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2864,6 +2864,7 @@ export interface ModelsResponse {
 
 export interface ChannelModelRefreshResult {
   channel: 'codex' | 'claude' | 'grok' | 'antigravity' | string
+  groups?: number
   refreshed: number
   failed: number
   added: string[]
@@ -2871,6 +2872,7 @@ export interface ChannelModelRefreshResult {
 }
 
 export interface RefreshAllModelsResponse {
+  type: 'complete'
   message: string
   channels: ChannelModelRefreshResult[]
   added: string[]

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2862,6 +2862,22 @@ export interface ModelsResponse {
   warning?: string
 }
 
+export interface ChannelModelRefreshResult {
+  channel: 'codex' | 'claude' | 'grok' | 'antigravity' | string
+  refreshed: number
+  failed: number
+  added: string[]
+  error?: string
+}
+
+export interface RefreshAllModelsResponse {
+  message: string
+  channels: ChannelModelRefreshResult[]
+  added: string[]
+  model_count: number
+  duration_ms: number
+}
+
 export interface ModelSyncResponse {
   added: number
   updated: number


### PR DESCRIPTION
## Summary

The model catalog dialog has a "refresh account models" button (`settings.pricing.catalogRefresh`), but it only called `POST /api/admin/accounts/claude/models/refresh`. Codex, Grok and Antigravity changes never showed up from there, and Codex OAuth accounts never contribute to the catalog at all (their `credentials.models` is empty; the catalog comes from `model_registry`), so a newly released Codex model stayed invisible until someone found the registry sync button on the Settings page.

This adds one endpoint, `POST /api/admin/models/refresh-all`, that refreshes every channel and writes what it discovers back to that channel's source of truth, so the catalog, `/v1/models` and request admission all see the same list.

**Plan-group sampling (commit 2).** Probing every account does not scale (a pool with thousands of Pro accounts would hit the upstream thousands of times for identical answers). Each channel groups its schedulable accounts by subscription plan (`plan_type`, so `pro`, `pro-5x`, `pro-20x`, `api`, `max-20x`, … each form a group) and probes **one randomly chosen account per group that has accounts**:

- **codex** – official Codex model page sync (same code as the Settings button), then one upstream `/models` manifest per plan group learned into `model_registry` via the existing `LearnModelsFromManifest` (append-only, same `gpt-5.4+` policy)
- **claude** – one `FetchModels` per plan group; the result is written back to every account in that group (same plan ⇒ same entitlement), keeping the pricing catalog and `claudeAccountSupportsModel` consistent. The old Claude-only endpoint is unchanged.
- **grok** – `syncGrokAccountState` for the sampled account per plan group, capability probe triggered like the single-account endpoint does
- **antigravity** – `refreshAntigravityAccount` for the sampled account per plan group

Channels run in parallel under a 120 s budget. Each channel fails independently (error or panic is reported in that channel's `error`, the others still write). The response lists per-channel `groups` / `refreshed` / `failed` and the models that newly appeared.

**Live progress.** With `?stream=1` the endpoint streams SSE: `start` (groups per channel), one `progress` per probe (channel, plan, sampled account, models found, newly added ids, ok/failed) and the summary as `complete`. Without the flag it returns the JSON summary as before. The catalog button uses the stream and shows a per-channel progress panel; newly learned models appear as chips the moment they are found.

## Test plan

- [x] `TestRunRefreshAllModels_PartialFailureKeepsOtherChannels`, `TestRunRefreshAllModels_TimeoutIsReportedPerChannel`, `TestRunRefreshAllModels_StreamsProgressEvents`, `TestGroupAccountsByPlan_OneSamplePerPlan`, `TestNewlyAddedModels`
- [x] `go test ./admin/ ./proxy/`
- [x] `cd frontend && npm run typecheck`; guard test in `claudeParity.test.mjs` (button must stream `/models/refresh-all?stream=1`, i18n keys present in zh / en / zh-TW)
- [x] production: 25 Codex Pro + 1 Claude max-20x + 1 Grok supergrok_heavy → stream shows `codex official_docs ok · codex pro <sampled account> 9 models · claude max-20x 11 models · grok supergrok_heavy 2 models`, summary `codex 1 group / claude 1 / grok 1 / antigravity 0`, 4.7 s

https://claude.ai/code/session_01QZSdi3tikVsq8HuBK1NSWq


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a unified model catalog refresh across supported channels.
  - Refresh progress now streams live, including plan-group probing, channel status, failures, newly added models, totals, and duration.
  - Added a dedicated refresh-all action for administrators.
  - Catalog refresh notifications identify successful and failed channels.

- **Bug Fixes**
  - Channel refreshes continue independently when another channel fails, times out, or encounters an unexpected error.

- **Documentation**
  - Added refresh-status translations for English, Simplified Chinese, and Traditional Chinese.

- **Tests**
  - Added coverage for partial failures, timeouts, panic handling, duplicate models, and progress reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->