### PR TITLE
feat(accounts): 四渠道统一代理字段 + 代理池下拉 portal 化 (#625)

### DIFF
--- a/frontend/src/components/ProxyField.tsx
+++ b/frontend/src/components/ProxyField.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { X, Zap } from "lucide-react";
 
@@ -51,54 +51,84 @@ export function ProxyUrlInput({
   );
 }
 
-// ProxyField 是账号表单里统一的代理选择字段(与 Codex 的 renderProxyInput 同构):
+// ProxyField 是四个渠道(Codex/Grok/Claude/Antigravity)账号表单里唯一的代理选择字段:
 //   第一行:手动填写代理 URL + 「测试」按钮(调 /proxies/test 验证连通与落地地点)
-//   第二行:从代理池下拉选择(池非空时显示,含地点/绑定数/空闲优先)
-// 各渠道的添加/编辑弹窗都用它,避免各页自造导致体验割裂。
+//   第二行:从代理池下拉选择(含地点/绑定数/空闲优先;池为空时给禁用占位与引导)
+//   第三行:当前值命中池内节点时给一句关联提示——账号与节点按 URL 关联,
+//          在「代理」页改节点地址会同步到所有绑定账号,删除则自动解绑。
+// 各渠道的添加/编辑弹窗都必须用它,不要再各页自造导致体验割裂。
 export function ProxyField({
   value,
   onChange,
   proxies,
   label,
+  labelClassName,
   placeholder = "socks5://user:pass@host:port",
   disabled = false,
+  className,
 }: {
   value: string;
   onChange: (value: string) => void;
   proxies: ProxyRow[];
+  /** 字段标题;传空串则不渲染标题(由外层自行摆放)。 */
   label?: string;
+  /** 标题样式覆盖,便于与所在弹窗相邻字段的标题风格对齐。 */
+  labelClassName?: string;
   placeholder?: string;
   disabled?: boolean;
+  className?: string;
 }) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const { showToast } = useToast();
   const [testing, setTesting] = useState(false);
 
+  const trimmed = value.trim();
+  // 当前值是否命中代理池节点:命中即"关联"态,提示用户改节点会级联。
+  const linked = useMemo(
+    () => (trimmed ? proxies.find((p) => p.url === trimmed) : undefined),
+    [proxies, trimmed],
+  );
+
   const testProxy = async () => {
-    const url = value.trim();
-    if (!url) return;
+    const url = trimmed;
+    if (!url) {
+      showToast(t("accounts.proxyUrlRequired"), "error");
+      return;
+    }
     setTesting(true);
     try {
-      const res = await api.testProxy(url);
-      if (res.success) {
-        const loc = [res.country, res.region, res.city].filter(Boolean).join(" ") || res.location || res.ip || "";
+      const lang = i18n.language?.startsWith("zh") ? "zh-CN" : "en";
+      const res = await api.testProxy(url, undefined, lang);
+      if (!res.success) {
         showToast(
-          `${t("accounts.testProxySuccess")}${loc ? ` · ${loc}` : ""}${res.latency_ms ? ` · ${res.latency_ms}ms` : ""}`,
-          "success",
+          t("accounts.proxyTestFailed", { error: res.error || t("accounts.proxyTestUnknownError") }),
+          "error",
         );
-      } else {
-        showToast(res.error || t("accounts.testProxyFailed"), "error");
+        return;
       }
+      const location = res.location || [res.country, res.region, res.city].filter(Boolean).join(" ");
+      showToast(
+        t("accounts.proxyTestSuccess", {
+          ip: res.ip || "-",
+          location: location || "-",
+          latency: res.latency_ms ?? 0,
+        }),
+        "success",
+      );
     } catch (error) {
-      showToast(getErrorMessage(error), "error");
+      showToast(t("accounts.proxyTestFailed", { error: getErrorMessage(error) }), "error");
     } finally {
       setTesting(false);
     }
   };
 
+  const title = label ?? t("accounts.proxyUrl");
+
   return (
-    <div className="space-y-2">
-      <span className="text-xs font-semibold text-muted-foreground">{label ?? t("accounts.proxyUrl")}</span>
+    <div className={cn("space-y-2", className)}>
+      {title ? (
+        <span className={cn("block text-xs font-semibold text-muted-foreground", labelClassName)}>{title}</span>
+      ) : null}
       <div className="flex flex-col gap-2 sm:flex-row sm:items-stretch">
         <ProxyUrlInput
           className="min-w-0 flex-1"
@@ -111,7 +141,7 @@ export function ProxyField({
           type="button"
           variant="outline"
           className="shrink-0 justify-center gap-1.5 sm:min-w-[104px]"
-          disabled={disabled || testing || !value.trim()}
+          disabled={disabled || testing || !trimmed}
           onClick={() => void testProxy()}
         >
           <Zap className={`size-3.5 ${testing ? "animate-pulse" : ""}`} />
@@ -128,6 +158,9 @@ export function ProxyField({
           <span className="opacity-60">▾</span>
         </div>
       )}
+      {linked ? (
+        <p className="text-[11px] leading-relaxed text-muted-foreground">{t("accounts.proxyPoolLinkedHint")}</p>
+      ) : null}
     </div>
   );
 }

--- a/frontend/src/components/ProxyPoolSelect.tsx
+++ b/frontend/src/components/ProxyPoolSelect.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 import { ChevronDown, MapPin, Check } from "lucide-react";
 
@@ -14,9 +15,33 @@ interface ProxyPoolSelectProps {
   className?: string;
 }
 
+const DROPDOWN_GAP = 6;
+const DROPDOWN_MAX_HEIGHT = 256;
+const VIEWPORT_PADDING = 8;
+
+interface DropdownPosition {
+  top: number;
+  left: number;
+  width: number;
+  maxHeight: number;
+  openUp: boolean;
+}
+
+// Radix Dialog 的 remove-scroll 会拦截 portal 菜单上的原生滚轮,手动驱动 scrollTop。
+function applyManualScroll(el: HTMLElement, deltaY: number): boolean {
+  if (el.scrollHeight <= el.clientHeight + 1 || deltaY === 0) return false;
+  const maxTop = el.scrollHeight - el.clientHeight;
+  const next = Math.min(maxTop, Math.max(0, el.scrollTop + deltaY));
+  if (next === el.scrollTop) return false;
+  el.scrollTop = next;
+  return true;
+}
+
 // ProxyPoolSelect 是账号表单里"从代理池选一条代理"的下拉。
 // 自定义渲染:每项用徽章展示 📍地点 + 空闲(绿)/已绑定 N(琥珀),空闲优先置顶;
 // 选中后触发器回显所选代理(label/url + 地点),让用户明确知道选了哪条。
+// 列表通过 portal 以 fixed 定位挂到 body:该字段常出现在弹窗底部,若用 absolute
+// 会被弹窗 body 的 overflow 裁掉、压在 footer 按钮下;空间不够时自动向上翻。
 export function ProxyPoolSelect({
   proxies,
   onSelect,
@@ -26,23 +51,74 @@ export function ProxyPoolSelect({
 }: ProxyPoolSelectProps) {
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
+  const [position, setPosition] = useState<DropdownPosition | null>(null);
   const rootRef = useRef<HTMLDivElement>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  const computePosition = useCallback(() => {
+    const anchor = rootRef.current;
+    if (!anchor) return;
+    const rect = anchor.getBoundingClientRect();
+    const viewportHeight = window.innerHeight;
+    const viewportWidth = window.innerWidth;
+    const spaceBelow = viewportHeight - rect.bottom - DROPDOWN_GAP - VIEWPORT_PADDING;
+    const spaceAbove = rect.top - DROPDOWN_GAP - VIEWPORT_PADDING;
+    const preferUp = spaceBelow < Math.min(DROPDOWN_MAX_HEIGHT, 160) && spaceAbove > spaceBelow;
+    const maxHeight = Math.max(120, Math.min(DROPDOWN_MAX_HEIGHT, preferUp ? spaceAbove : spaceBelow));
+    const width = Math.min(Math.max(rect.width, 240), viewportWidth - VIEWPORT_PADDING * 2);
+    const maxLeft = viewportWidth - width - VIEWPORT_PADDING;
+    const left = Math.min(Math.max(VIEWPORT_PADDING, rect.left), Math.max(VIEWPORT_PADDING, maxLeft));
+    setPosition({
+      top: preferUp ? rect.top - DROPDOWN_GAP : rect.bottom + DROPDOWN_GAP,
+      left,
+      width,
+      maxHeight,
+      openUp: preferUp,
+    });
+  }, []);
+
+  useLayoutEffect(() => {
+    if (!open) {
+      setPosition(null);
+      return;
+    }
+    computePosition();
+  }, [open, computePosition, proxies.length]);
 
   useEffect(() => {
     if (!open) return;
-    const onDown = (e: MouseEvent) => {
-      if (!rootRef.current?.contains(e.target as Node)) setOpen(false);
+    const onDown = (e: PointerEvent) => {
+      const target = e.target as Node | null;
+      if (!target) return;
+      if (rootRef.current?.contains(target) || dropdownRef.current?.contains(target)) return;
+      setOpen(false);
     };
     const onEsc = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setOpen(false);
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        setOpen(false);
+      }
     };
-    document.addEventListener("mousedown", onDown);
+    const onReposition = () => computePosition();
+    const onWheel = (e: WheelEvent) => {
+      const list = dropdownRef.current;
+      const target = e.target as Node | null;
+      if (!list || !target || !list.contains(target)) return;
+      if (applyManualScroll(list, e.deltaY)) e.preventDefault();
+    };
+    document.addEventListener("pointerdown", onDown);
     document.addEventListener("keydown", onEsc);
+    window.addEventListener("resize", onReposition);
+    window.addEventListener("scroll", onReposition, true);
+    document.addEventListener("wheel", onWheel, { passive: false, capture: true });
     return () => {
-      document.removeEventListener("mousedown", onDown);
+      document.removeEventListener("pointerdown", onDown);
       document.removeEventListener("keydown", onEsc);
+      window.removeEventListener("resize", onReposition);
+      window.removeEventListener("scroll", onReposition, true);
+      document.removeEventListener("wheel", onWheel, true);
     };
-  }, [open]);
+  }, [open, computePosition]);
 
   // 空闲(bound_count=0)优先,其余按绑定数升序,负载最轻的排前面。
   const sorted = useMemo(
@@ -75,6 +151,71 @@ export function ProxyPoolSelect({
 
   const selectedLoc = selected?.test_location?.trim();
 
+  const dropdown =
+    open && position
+      ? createPortal(
+          <div
+            ref={dropdownRef}
+            data-select-dropdown="true"
+            role="listbox"
+            className="pointer-events-auto fixed z-[1000] overflow-y-auto overscroll-contain rounded-lg border border-border bg-popover p-1 shadow-lg [scrollbar-width:thin]"
+            style={
+              position.openUp
+                ? {
+                    left: position.left,
+                    width: position.width,
+                    bottom: window.innerHeight - position.top,
+                    maxHeight: position.maxHeight,
+                  }
+                : {
+                    left: position.left,
+                    width: position.width,
+                    top: position.top,
+                    maxHeight: position.maxHeight,
+                  }
+            }
+          >
+            {sorted.map((proxy) => {
+              const count = proxy.bound_count ?? 0;
+              const loc = proxy.test_location?.trim();
+              const name = proxy.label?.trim() || proxy.url;
+              const active = selected?.url === proxy.url;
+              return (
+                <button
+                  key={proxy.url}
+                  type="button"
+                  role="option"
+                  aria-selected={active}
+                  onClick={() => {
+                    onSelect(proxy.url);
+                    setOpen(false);
+                  }}
+                  className={cn(
+                    "flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left transition-colors hover:bg-muted",
+                    active && "bg-primary/8",
+                  )}
+                >
+                  <span className="flex w-4 shrink-0 justify-center">
+                    {active ? <Check className="size-3.5 text-primary" /> : null}
+                  </span>
+                  <span className="min-w-0 flex-1">
+                    <span className="flex items-center gap-1.5">
+                      <span className="truncate text-[13px] font-medium text-foreground">{name}</span>
+                      {count === 0 ? <IdleBadge /> : <BoundBadge count={count} />}
+                    </span>
+                    <span className="flex items-center gap-2 text-[11px] text-muted-foreground">
+                      {loc ? <LocationTag loc={loc} /> : null}
+                      <span className="truncate font-mono opacity-80">{proxy.url}</span>
+                    </span>
+                  </span>
+                </button>
+              );
+            })}
+          </div>,
+          document.body,
+        )
+      : null;
+
   return (
     <div ref={rootRef} className={cn("relative", className)}>
       <button
@@ -82,6 +223,7 @@ export function ProxyPoolSelect({
         disabled={disabled}
         onClick={() => setOpen((v) => !v)}
         aria-expanded={open}
+        aria-haspopup="listbox"
         className={cn(
           "flex h-9 w-full items-center justify-between gap-2 rounded-md border border-input bg-background px-2.5 text-left text-sm outline-none transition-colors focus-visible:border-ring disabled:opacity-50",
           open && "border-ring",
@@ -100,45 +242,7 @@ export function ProxyPoolSelect({
         </span>
         <ChevronDown className={cn("size-4 shrink-0 text-muted-foreground transition-transform", open && "rotate-180")} />
       </button>
-
-      {open ? (
-        <div className="absolute left-0 right-0 top-full z-50 mt-1 max-h-64 overflow-y-auto rounded-lg border border-border bg-popover p-1 shadow-lg">
-          {sorted.map((proxy) => {
-            const count = proxy.bound_count ?? 0;
-            const loc = proxy.test_location?.trim();
-            const name = proxy.label?.trim() || proxy.url;
-            const active = selected?.url === proxy.url;
-            return (
-              <button
-                key={proxy.url}
-                type="button"
-                onClick={() => {
-                  onSelect(proxy.url);
-                  setOpen(false);
-                }}
-                className={cn(
-                  "flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left transition-colors hover:bg-muted",
-                  active && "bg-primary/8",
-                )}
-              >
-                <span className="flex w-4 shrink-0 justify-center">
-                  {active ? <Check className="size-3.5 text-primary" /> : null}
-                </span>
-                <span className="min-w-0 flex-1">
-                  <span className="flex items-center gap-1.5">
-                    <span className="truncate text-[13px] font-medium text-foreground">{name}</span>
-                    {count === 0 ? <IdleBadge /> : <BoundBadge count={count} />}
-                  </span>
-                  <span className="flex items-center gap-2 text-[11px] text-muted-foreground">
-                    {loc ? <LocationTag loc={loc} /> : null}
-                    <span className="truncate font-mono opacity-80">{proxy.url}</span>
-                  </span>
-                </span>
-              </button>
-            );
-          })}
-        </div>
-      ) : null}
+      {dropdown}
     </div>
   );
 }

--- a/frontend/src/components/ProxyPoolSelect.tsx
+++ b/frontend/src/components/ProxyPoolSelect.tsx
@@ -93,11 +93,11 @@ export function ProxyPoolSelect({
       if (rootRef.current?.contains(target) || dropdownRef.current?.contains(target)) return;
       setOpen(false);
     };
+    // Radix Dialog 在 capture 阶段就处理了 Escape;这里只负责收起下拉,
+    // "按 Esc 不要顺带关掉弹窗"由 DialogContent 的 onEscapeKeyDown 依据
+    // data-select-dropdown 是否在场来阻止。
     const onEsc = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        e.stopPropagation();
-        setOpen(false);
-      }
+      if (e.key === "Escape") setOpen(false);
     };
     const onReposition = () => computePosition();
     const onWheel = (e: WheelEvent) => {

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -7,6 +7,14 @@ import { Dialog as DialogPrimitive } from "radix-ui"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 
+// Portaled dropdowns (select / group picker / proxy pool) close themselves on
+// Escape from a bubble-phase document listener, but Radix dismisses the layer in
+// the capture phase first. While one is open, keep the modal and let the
+// dropdown consume the key.
+function hasOpenPortalDropdown() {
+  return typeof document !== "undefined" && document.querySelector('[data-select-dropdown="true"]') !== null
+}
+
 function isInteractivePortalTarget(target: EventTarget | null) {
   return target instanceof Element && Boolean(target.closest('[data-select-dropdown="true"]'))
 }
@@ -55,6 +63,7 @@ function DialogContent({
   className,
   children,
   showCloseButton = true,
+  onEscapeKeyDown,
   onInteractOutside,
   onPointerDownOutside,
   onFocusOutside,
@@ -71,6 +80,12 @@ function DialogContent({
           "fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-1.5rem)] max-h-[calc(100dvh-1.5rem-env(safe-area-inset-top,0px)-env(safe-area-inset-bottom,0px))] translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto rounded-xl border bg-background p-5 shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg sm:p-6",
           className
         )}
+        onEscapeKeyDown={(event) => {
+          onEscapeKeyDown?.(event)
+          if (hasOpenPortalDropdown()) {
+            event.preventDefault()
+          }
+        }}
         onInteractOutside={(event) => {
           onInteractOutside?.(event)
           if (isInteractivePortalTarget(event.target)) {

--- a/frontend/src/components/ui/sheet.tsx
+++ b/frontend/src/components/ui/sheet.tsx
@@ -7,6 +7,14 @@ import { Dialog as DialogPrimitive } from "radix-ui"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 
+// Portaled dropdowns (select / group picker / proxy pool) close themselves on
+// Escape from a bubble-phase document listener, but Radix dismisses the layer in
+// the capture phase first. While one is open, keep the modal and let the
+// dropdown consume the key.
+function hasOpenPortalDropdown() {
+  return typeof document !== "undefined" && document.querySelector('[data-select-dropdown="true"]') !== null
+}
+
 function isInteractivePortalTarget(target: EventTarget | null) {
   return (
     target instanceof Element &&
@@ -57,6 +65,7 @@ function SheetContent({
   children,
   side = "right",
   showCloseButton = true,
+  onEscapeKeyDown,
   onInteractOutside,
   onPointerDownOutside,
   onFocusOutside,
@@ -81,6 +90,12 @@ function SheetContent({
             "left-[max(0.75rem,env(safe-area-inset-left))] sm:left-[max(1rem,env(safe-area-inset-left))] data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left data-[state=open]:fade-in-0 data-[state=closed]:fade-out-0",
           className,
         )}
+        onEscapeKeyDown={(event) => {
+          onEscapeKeyDown?.(event)
+          if (hasOpenPortalDropdown()) {
+            event.preventDefault()
+          }
+        }}
         onInteractOutside={(event) => {
           onInteractOutside?.(event)
           if (isInteractivePortalTarget(event.target)) {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1637,7 +1637,8 @@
     "providerViewClaude": "Claude",
     "testProxySuccess": "Proxy OK",
     "testProxyFailed": "Proxy test failed",
-    "proxyPoolEmpty": "Proxy pool is empty (add proxies on the Proxies page)"
+    "proxyPoolEmpty": "Proxy pool is empty (add proxies on the Proxies page)",
+    "proxyPoolLinkedHint": "Linked to a proxy-pool node by URL: editing the node URL on the Proxies page updates every bound account, and deleting it unbinds them."
   },
   "invite": {
     "entry": "Codex Invite",

--- a/frontend/src/locales/zh-TW.json
+++ b/frontend/src/locales/zh-TW.json
@@ -118,7 +118,8 @@
     "providerViewClaude": "Claude",
     "testProxySuccess": "代理可用",
     "testProxyFailed": "代理測試失敗",
-    "proxyPoolEmpty": "代理池為空(可在「代理」頁新增)"
+    "proxyPoolEmpty": "代理池為空(可在「代理」頁新增)",
+    "proxyPoolLinkedHint": "已關聯代理池節點（按位址綁定）：在「代理」頁修改該節點位址會同步到所有綁定帳號，刪除則自動解除綁定。"
   },
   "settings": {
     "pricing": {

--- a/frontend/src/locales/zh.json
+++ b/frontend/src/locales/zh.json
@@ -1637,7 +1637,8 @@
     "providerViewClaude": "Claude",
     "testProxySuccess": "代理可用",
     "testProxyFailed": "代理测试失败",
-    "proxyPoolEmpty": "代理池为空(可在「代理」页添加)"
+    "proxyPoolEmpty": "代理池为空(可在「代理」页添加)",
+    "proxyPoolLinkedHint": "已关联代理池节点（按地址绑定）：在「代理」页修改该节点地址会同步到所有绑定账号，删除则自动解绑。"
   },
   "invite": {
     "entry": "Codex 邀请",

--- a/frontend/src/pages/Accounts.tsx
+++ b/frontend/src/pages/Accounts.tsx
@@ -4,8 +4,7 @@ import { createPortal } from "react-dom";
 import { useLocation, useNavigate } from "react-router-dom";
 import { api, getAdminKey, resetAdminAuthState } from "../api";
 import type { ProxyRow } from "../api";
-import { ProxyPoolSelect } from "../components/ProxyPoolSelect";
-import { ProxyUrlInput } from "../components/ProxyField";
+import { ProxyField } from "../components/ProxyField";
 import AccountProxyBadge from "../components/AccountProxyBadge";
 import AccountProxyQuickEditor from "../components/AccountProxyQuickEditor";
 import {
@@ -1620,7 +1619,7 @@ const AccountCardItem = memo(function AccountCardItem({
 });
 
 export default function Accounts() {
-  const { t, i18n } = useTranslation();
+  const { t } = useTranslation();
   const pageSizeOptions = DEFAULT_PAGE_SIZE_OPTIONS;
   const [showAdd, setShowAdd] = useState(false);
   // providerView 由路由驱动，刷新浏览器后停留在当前上游视图。
@@ -1816,7 +1815,6 @@ export default function Accounts() {
   const [editCustomHeadersText, setEditCustomHeadersText] = useState("");
   const [editCodexFingerprintMode, setEditCodexFingerprintMode] =
     useState<CodexFingerprintMode>("off");
-  const [testingProxyKey, setTestingProxyKey] = useState<string | null>(null);
   // 代理池条目：账号表单里"从代理池选择"下拉的数据源。加载失败静默留空
   // （选择器为空时自动隐藏，不影响手动填代理）。
   const [proxyPool, setProxyPool] = useState<ProxyRow[]>([]);
@@ -2104,105 +2102,30 @@ export default function Accounts() {
   const selectAllRef = useRef<HTMLInputElement>(null);
   const { toast, showToast } = useToast();
   const { confirm, confirmDialog } = useConfirmDialog();
-  const ipApiLang = i18n.language?.startsWith("zh") ? "zh-CN" : "en";
-
-  const handleTestProxyUrl = async (rawUrl: string, testKey: string) => {
-    const url = rawUrl.trim();
-    if (!url) {
-      showToast(t("accounts.proxyUrlRequired"), "error");
-      return;
-    }
-    if (testingProxyKey !== null) return;
-
-    setTestingProxyKey(testKey);
-    try {
-      const result = await api.testProxy(url, undefined, ipApiLang);
-      if (!result.success) {
-        showToast(
-          t("accounts.proxyTestFailed", {
-            error: result.error || t("accounts.proxyTestUnknownError"),
-          }),
-          "error",
-        );
-        return;
-      }
-
-      const location =
-        result.location ||
-        [result.country, result.region, result.city].filter(Boolean).join(" ");
-      showToast(
-        t("accounts.proxyTestSuccess", {
-          ip: result.ip || "-",
-          location: location || "-",
-          latency: result.latency_ms ?? 0,
-        }),
-      );
-    } catch (error) {
-      showToast(
-        t("accounts.proxyTestFailed", { error: getErrorMessage(error) }),
-        "error",
-      );
-    } finally {
-      setTestingProxyKey((current) => (current === testKey ? null : current));
-    }
-  };
-
+  // 代理字段统一走 ProxyField(手填+测试+代理池下拉),与 Grok/Claude/Antigravity 同构。
   const renderProxyInput = ({
     value,
     onChange,
-    testKey,
     label = t("accounts.proxyUrl"),
     placeholder = t("accounts.proxyUrlPlaceholder"),
     disabled = false,
   }: {
     value: string;
     onChange: (value: string) => void;
-    testKey: string;
     label?: string;
     placeholder?: string;
     disabled?: boolean;
-  }) => {
-    const isTesting = testingProxyKey === testKey;
-    const testDisabled = disabled || !value.trim() || testingProxyKey !== null;
-    const hasProxyPool = proxyPool.length > 0;
-
-    return (
-      <div className="space-y-2.5">
-        <label className="block text-sm font-semibold text-muted-foreground">
-          {label}
-        </label>
-        {/* 第一行：手动填写代理 URL(带清空按钮) + 测试 */}
-        <div className="flex flex-col gap-2 sm:flex-row sm:items-stretch">
-          <ProxyUrlInput
-            className="min-w-0 flex-1"
-            placeholder={placeholder}
-            value={value}
-            disabled={disabled}
-            onChange={onChange}
-          />
-          <Button
-            type="button"
-            variant="outline"
-            className="shrink-0 justify-center gap-1.5 sm:min-w-[108px]"
-            disabled={testDisabled}
-            onClick={() => void handleTestProxyUrl(value, testKey)}
-          >
-            <Zap className={`size-3.5 ${isTesting ? "animate-pulse" : ""}`} />
-            {isTesting ? t("accounts.testingProxy") : t("accounts.testProxy")}
-          </Button>
-        </div>
-        {/* 第二行：从代理池选择（有池条目时单独占一行，与上方 URL 输入左对齐） */}
-        {hasProxyPool ? (
-          <ProxyPoolSelect
-            className="w-full"
-            proxies={proxyPool}
-            disabled={disabled}
-            onSelect={onChange}
-          />
-        ) : null}
-      </div>
-    );
-  };
+  }) => (
+    <ProxyField
+      value={value}
+      onChange={onChange}
+      proxies={proxyPool}
+      label={label}
+      labelClassName="text-sm"
+      placeholder={placeholder}
+      disabled={disabled}
+    />
+  );
 
   const renderCustomHeadersTextarea = ({
     value,
@@ -7710,7 +7633,6 @@ export default function Accounts() {
                 </div>
                 {renderProxyInput({
                   value: addForm.proxy_url,
-                  testKey: "add-refresh-token",
                   onChange: (value) =>
                     setAddForm((form) => ({
                       ...form,
@@ -7744,7 +7666,6 @@ export default function Accounts() {
                 </div>
                 {renderProxyInput({
                   value: addForm.proxy_url,
-                  testKey: "add-session-token",
                   onChange: (value) =>
                     setAddForm((form) => ({
                       ...form,
@@ -7781,7 +7702,6 @@ export default function Accounts() {
                 </div>
                 {renderProxyInput({
                   value: atForm.proxy_url,
-                  testKey: "add-access-token",
                   onChange: (value) =>
                     setAtForm((form) => ({
                       ...form,
@@ -7815,7 +7735,6 @@ export default function Accounts() {
                 </div>
                 {renderProxyInput({
                   value: sessionProxyUrl,
-                  testKey: "add-session-json",
                   label: t("accounts.importProxyLabel"),
                   onChange: setSessionProxyUrl,
                 })}
@@ -8014,7 +7933,6 @@ export default function Accounts() {
                 })}
                 {renderProxyInput({
                   value: openAIForm.proxy_url,
-                  testKey: "add-openai-responses",
                   onChange: (value) =>
                     setOpenAIForm((form) => ({
                       ...form,
@@ -8126,7 +8044,6 @@ export default function Accounts() {
 
                 {renderProxyInput({
                   value: agentIdentityProxyUrl,
-                  testKey: "add-agent-identity",
                   onChange: setAgentIdentityProxyUrl,
                 })}
               </div>
@@ -8154,7 +8071,6 @@ export default function Accounts() {
                     </div>
                     {renderProxyInput({
                       value: oauthProxyUrl,
-                      testKey: "oauth-generate",
                       label: t("accounts.oauthProxyUrl"),
                       placeholder: t("accounts.oauthProxyUrlPlaceholder"),
                       onChange: setOauthProxyUrl,
@@ -8271,7 +8187,6 @@ export default function Accounts() {
             <div className="mb-4 space-y-1.5">
               {renderProxyInput({
                 value: importProxyUrl,
-                testKey: "import-batch",
                 label: t("accounts.importProxyLabel"),
                 onChange: setImportProxyUrl,
               })}
@@ -9154,7 +9069,6 @@ export default function Accounts() {
                     <div className="rounded-xl border border-border/70 bg-card p-4.5 shadow-2xs space-y-4">
                       {renderProxyInput({
                         value: editOpenAIForm.proxy_url,
-                        testKey: "edit-openai-responses",
                         onChange: (value) =>
                           setEditOpenAIForm((form) => ({
                             ...form,
@@ -9193,7 +9107,6 @@ export default function Accounts() {
                         </div>
                         {renderProxyInput({
                           value: editOAuthProxyUrl,
-                          testKey: "edit-oauth-generate",
                           label: t("accounts.oauthProxyUrl"),
                           placeholder: t("accounts.oauthProxyUrlPlaceholder"),
                           onChange: setEditOAuthProxyUrl,
@@ -9623,7 +9536,6 @@ export default function Accounts() {
                         <div className="rounded-xl border border-border/70 bg-card p-4.5 shadow-2xs hover:border-border/90 transition-colors md:col-span-2">
                           {renderProxyInput({
                             value: editProxyUrl,
-                            testKey: "edit-account-proxy",
                             onChange: setEditProxyUrl,
                           })}
                         </div>

--- a/frontend/src/pages/AntigravityAccounts.tsx
+++ b/frontend/src/pages/AntigravityAccounts.tsx
@@ -28,8 +28,7 @@ import {
 } from "lucide-react";
 import { api } from "../api";
 import type { ProxyRow } from "../api";
-import { ProxyPoolSelect } from "../components/ProxyPoolSelect";
-import { ProxyUrlInput } from "../components/ProxyField";
+import { ProxyField } from "../components/ProxyField";
 import type {
   AccountGroup,
   AccountListSummary,
@@ -506,18 +505,15 @@ function AccountMetadataFields({
   const { t } = useTranslation();
   return (
     <div className="grid gap-3 sm:grid-cols-2">
-      <label className="block space-y-1.5">
-        <span className="text-xs font-semibold text-muted-foreground">
-          {t("antigravity.proxyUrl")}
-        </span>
-        <ProxyUrlInput
-          value={proxyUrl}
-          onChange={onProxyUrlChange}
-          placeholder={t("antigravity.proxyUrlPlaceholder")}
-        />
-        {/* 从代理池选择：展示每条代理已绑定账号数/空闲，选中写入上面的输入框。 */}
-        <ProxyPoolSelect proxies={proxies} onSelect={onProxyUrlChange} />
-      </label>
+      {/* 代理字段与其他三个渠道同构:手填 + 测试 + 从代理池选择(含关联提示)。 */}
+      <ProxyField
+        className="space-y-1.5"
+        value={proxyUrl}
+        onChange={onProxyUrlChange}
+        proxies={proxies}
+        label={t("antigravity.proxyUrl")}
+        placeholder={t("antigravity.proxyUrlPlaceholder")}
+      />
       <div className="space-y-1.5">
         <span className="text-xs font-semibold text-muted-foreground">
           {t("accounts.groupsLabel")}

--- a/frontend/src/pages/GrokAccounts.tsx
+++ b/frontend/src/pages/GrokAccounts.tsx
@@ -34,8 +34,7 @@ import {
 } from "lucide-react";
 import { api, getAdminKey } from "../api";
 import type { ProxyRow } from "../api";
-import { ProxyPoolSelect } from "../components/ProxyPoolSelect";
-import { ProxyUrlInput } from "../components/ProxyField";
+import { ProxyField } from "../components/ProxyField";
 import AccountProxyBadge from "../components/AccountProxyBadge";
 import AccountProxyQuickEditor from "../components/AccountProxyQuickEditor";
 import {
@@ -2821,24 +2820,14 @@ function GrokAccounts({
                     />
                   </div>
                   <div>
-                    <label className="mb-2 block text-sm font-medium text-muted-foreground">
-                      {t("grok.proxyUrl")}
-                    </label>
-                    <div className="flex flex-col gap-2 sm:flex-row">
-                      <ProxyUrlInput
-                        className="min-w-0 flex-1"
-                        placeholder="http://user:pass@host:port"
-                        value={form.proxy_url ?? ""}
-                        onChange={(url) => setForm((f) => ({ ...f, proxy_url: url }))}
-                      />
-                      <ProxyPoolSelect
-                        className="shrink-0 sm:w-[180px]"
-                        proxies={proxyPool}
-                        onSelect={(url) =>
-                          setForm((f) => ({ ...f, proxy_url: url }))
-                        }
-                      />
-                    </div>
+                    <ProxyField
+                      value={form.proxy_url ?? ""}
+                      onChange={(url) => setForm((f) => ({ ...f, proxy_url: url }))}
+                      proxies={proxyPool}
+                      label={t("grok.proxyUrl")}
+                      labelClassName="mb-2 text-sm font-medium"
+                      placeholder="http://user:pass@host:port"
+                    />
                   </div>
                 </>
               ) : (
@@ -2941,22 +2930,14 @@ function GrokAccounts({
               </div>
 
               <div>
-                <label className="mb-2 block text-sm font-medium text-muted-foreground">
-                  {t("grok.proxyUrl")}
-                </label>
-                <div className="flex flex-col gap-2 sm:flex-row">
-                  <ProxyUrlInput
-                    className="min-w-0 flex-1"
-                    placeholder="http://user:pass@host:port"
-                    value={form.proxy_url ?? ""}
-                    onChange={(url) => setForm((f) => ({ ...f, proxy_url: url }))}
-                  />
-                  <ProxyPoolSelect
-                    className="shrink-0 sm:w-[180px]"
-                    proxies={proxyPool}
-                    onSelect={(url) => setForm((f) => ({ ...f, proxy_url: url }))}
-                  />
-                </div>
+                <ProxyField
+                  value={form.proxy_url ?? ""}
+                  onChange={(url) => setForm((f) => ({ ...f, proxy_url: url }))}
+                  proxies={proxyPool}
+                  label={t("grok.proxyUrl")}
+                  labelClassName="mb-2 text-sm font-medium"
+                  placeholder="http://user:pass@host:port"
+                />
               </div>
 
               {ssoResult ? (
@@ -3125,22 +3106,14 @@ function GrokAccounts({
               </div>
 
               <div>
-                <label className="mb-2 block text-sm font-medium text-muted-foreground">
-                  {t("grok.proxyUrl")}
-                </label>
-                <div className="flex flex-col gap-2 sm:flex-row">
-                  <ProxyUrlInput
-                    className="min-w-0 flex-1"
-                    placeholder="http://user:pass@host:port"
-                    value={form.proxy_url ?? ""}
-                    onChange={(url) => setForm((f) => ({ ...f, proxy_url: url }))}
-                  />
-                  <ProxyPoolSelect
-                    className="shrink-0 sm:w-[180px]"
-                    proxies={proxyPool}
-                    onSelect={(url) => setForm((f) => ({ ...f, proxy_url: url }))}
-                  />
-                </div>
+                <ProxyField
+                  value={form.proxy_url ?? ""}
+                  onChange={(url) => setForm((f) => ({ ...f, proxy_url: url }))}
+                  proxies={proxyPool}
+                  label={t("grok.proxyUrl")}
+                  labelClassName="mb-2 text-sm font-medium"
+                  placeholder="http://user:pass@host:port"
+                />
               </div>
             </>
           )}
@@ -3852,24 +3825,14 @@ function GrokAccounts({
             ) : null}
 
             <div>
-              <label className="mb-2 block text-sm font-medium text-muted-foreground">
-                {t("grok.proxyUrl")}
-              </label>
-              <div className="flex flex-col gap-2 sm:flex-row">
-                <ProxyUrlInput
-                  className="min-w-0 flex-1"
-                  placeholder="http://user:pass@host:port"
-                  value={editForm.proxy_url}
-                  onChange={(url) => setEditForm((f) => ({ ...f, proxy_url: url }))}
-                />
-                <ProxyPoolSelect
-                  className="shrink-0 sm:w-[180px]"
-                  proxies={proxyPool}
-                  onSelect={(url) =>
-                    setEditForm((f) => ({ ...f, proxy_url: url }))
-                  }
-                />
-              </div>
+              <ProxyField
+                value={editForm.proxy_url}
+                onChange={(url) => setEditForm((f) => ({ ...f, proxy_url: url }))}
+                proxies={proxyPool}
+                label={t("grok.proxyUrl")}
+                labelClassName="mb-2 text-sm font-medium"
+                placeholder="http://user:pass@host:port"
+              />
             </div>
           </div>
         ) : null}


### PR DESCRIPTION
Closes #625

## 背景
issue #625 两点诉求：
1. 代理按「关联」而非「写入」应用到账号 —— 后端本来就是这样：账号与代理池节点按 URL 关联，「代理」页改节点地址走 `RebindAccountProxyURLs` 级联到所有绑定账号，删除节点自动解绑。只是表单只回显裸 URL，看不出这层关联。
2. 三个渠道的添加账号弹窗代理 UI 割裂，Antigravity 缺代理池选择 —— 属实：Codex / Grok / Antigravity 各自造轮子，只有 Claude 用了公共 `ProxyField`；Antigravity 的代理池下拉在 main 上已有但 v2.8.9 未包含。

## 改动
- `ProxyField` 成为四渠道唯一的代理字段（手填 + 测试 + 从代理池选择）。吸收 Codex 版测试逻辑（按语言查 IP 归属、ip/地点/延迟富文案），新增 `labelClassName` / `className` 对齐各弹窗相邻标题；值命中池内节点时显示关联提示（改址级联、删除解绑）。
- Codex `renderProxyInput` 改为 `ProxyField` 薄包装，删除页内 `handleTestProxyUrl` / `testingProxyKey` / `testKey` 管线；Grok 4 处、Antigravity 1 处改用 `ProxyField`。
- `ProxyPoolSelect` 列表改为 portal + fixed 定位（空间不足自动上翻、scroll/resize 重算、手动 wheel 绕过 dialog 滚动锁、带 `data-select-dropdown` 让 dialog 不把点选当外部点击）。之前 absolute 定位会被 Modal body 的 overflow 裁掉、压在 footer 下（快速编辑弹窗实测复现）。
- 三语 locale 新增 `accounts.proxyPoolLinkedHint`。

## 验证
- `tsc --noEmit` 通过。
- 本地 pgredis2004 重建后四个渠道的添加/编辑弹窗与列表快速编辑弹窗实测：下拉不再被裁切、选中后触发器回显、关联提示显示。

## 截图对照
issue 内三张截图分别对应 Codex / Grok / Antigravity 添加弹窗，改后三者布局一致。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Unified proxy entry, testing, and proxy-pool selection across account management pages.
  - Proxy-pool dropdowns now support viewport-aware positioning, scrolling, keyboard dismissal, and outside-click closing.
  - Linked proxy-pool accounts display synchronization and unbinding guidance.
- **Bug Fixes**
  - Proxy testing is prevented for empty values and provides clearer success or error feedback.
  - Proxy-pool selections remain usable near screen edges and while scrolling.
- **Localization**
  - Added linked proxy-pool guidance in English, Simplified Chinese, and Traditional Chinese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->