### PR TITLE
fix(registry): admit non-versioned Codex model aliases such as gpt-daybreak-blue-latest (#624)

### DIFF
--- a/admin/handler.go
+++ b/admin/handler.go
@@ -4362,7 +4362,10 @@ func validateAccountModelsForAccount(account *auth.Account, models []string) err
 }
 
 // SyncAccountUpstreamModels 用账号自身凭据实时拉取上游模型清单，
-// 返回该账号真实可用的模型 slug 列表。只读不落库，由管理端确认后再保存为白名单。
+// 返回该账号真实可用的模型 slug 列表。账号白名单本身只读不落库，由管理端确认后再保存；
+// 但清单里注册表尚不认识的模型会顺手学习进注册表（只增不改不删，与客户端刷新
+// 选单时的学习同一实现）：否则 Trusted Access for Cyber 这类只有个别账号才有的模型
+// 探测看得见、保存进白名单后 /v1/models 却不列、调用直接报模型不存在（issue #624）。
 func (h *Handler) SyncAccountUpstreamModels(c *gin.Context) {
 	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
@@ -4422,6 +4425,12 @@ func (h *Handler) SyncAccountUpstreamModels(c *gin.Context) {
 	if len(models) == 0 {
 		writeError(c, http.StatusBadGateway, "上游模型清单未返回可用模型")
 		return
+	}
+	// 学习失败只记日志，不影响本次探测结果的返回。
+	if added, learnErr := proxy.LearnModelsFromManifest(ctx, h.db, manifest.Body, time.Now().UTC()); learnErr != nil {
+		log.Printf("[账号 %d] 模型清单学习失败（不影响探测结果）: %v", id, learnErr)
+	} else if len(added) > 0 {
+		log.Printf("[账号 %d] 已从上游模型清单学习 %d 个新模型进注册表: %s", id, len(added), strings.Join(added, ", "))
 	}
 	c.JSON(http.StatusOK, gin.H{"models": models})
 }

--- a/database/billing.go
+++ b/database/billing.go
@@ -460,7 +460,13 @@ func normalizeCodexBillingModel(model string) (string, bool) {
 	case strings.Contains(compact, "gpt-5.6-luna") || strings.Contains(compact, "gpt5-6-luna") || strings.Contains(compact, "gpt5.6-luna"):
 		return "gpt-5.6-luna", true
 	case strings.Contains(compact, "gpt-5.6") || strings.Contains(compact, "gpt5-6") || strings.Contains(compact, "gpt5.6"):
-		// 未知 gpt-5.6 变体：按最贵的 sol 兜底，避免低估计费。
+		// 未知 gpt-5.6 变体（含 gpt-5.6-cyber）：按最贵的 sol 兜底，避免低估计费。
+		return "gpt-5.6-sol", true
+	case strings.Contains(compact, "daybreak"):
+		// Trusted Access for Cyber 的稳定别名（issue #624）：官方文档写明
+		// gpt-daybreak-blue-latest 即 gpt-5.6-sol，gpt-daybreak-red-latest 即
+		// gpt-5.6-cyber（无独立公开定价）。两者都归到 5.6 家族最贵的 sol，
+		// 否则会落到 $1/$2 的默认价严重低估。
 		return "gpt-5.6-sol", true
 	case strings.Contains(compact, "gpt-5.4-mini") || strings.Contains(compact, "gpt5-4-mini") || strings.Contains(compact, "gpt5.4-mini"):
 		return "gpt-5.4-mini", true

--- a/database/billing.go
+++ b/database/billing.go
@@ -462,11 +462,12 @@ func normalizeCodexBillingModel(model string) (string, bool) {
 	case strings.Contains(compact, "gpt-5.6") || strings.Contains(compact, "gpt5-6") || strings.Contains(compact, "gpt5.6"):
 		// 未知 gpt-5.6 变体（含 gpt-5.6-cyber）：按最贵的 sol 兜底，避免低估计费。
 		return "gpt-5.6-sol", true
-	case strings.Contains(compact, "daybreak"):
+	case strings.HasPrefix(compact, "gpt-daybreak-"):
 		// Trusted Access for Cyber 的稳定别名（issue #624）：官方文档写明
 		// gpt-daybreak-blue-latest 即 gpt-5.6-sol，gpt-daybreak-red-latest 即
 		// gpt-5.6-cyber（无独立公开定价）。两者都归到 5.6 家族最贵的 sol，
-		// 否则会落到 $1/$2 的默认价严重低估。
+		// 否则会落到 $1/$2 的默认价严重低估。只认 gpt-daybreak- 前缀，
+		// 带版本号的 ID（如 gpt-5.4-daybreak）仍走各自版本规则。
 		return "gpt-5.6-sol", true
 	case strings.Contains(compact, "gpt-5.4-mini") || strings.Contains(compact, "gpt5-4-mini") || strings.Contains(compact, "gpt5.4-mini"):
 		return "gpt-5.4-mini", true

--- a/database/billing_test.go
+++ b/database/billing_test.go
@@ -188,6 +188,11 @@ func TestGPT56VariantPricing(t *testing.T) {
 		{"gpt-5.6-terra", 2.0, 12.0, 0.2, 4.0, 24.0},
 		{"gpt-5.6-luna", 0.2, 1.2, 0.02, 0.4, 2.4},
 		{"gpt-5.6-sol-high", 5.0, 30.0, 0.5, 10.0, 60.0},
+		// Trusted Access for Cyber 稳定别名（issue #624）：blue 即 sol，red 即
+		// 5.6-cyber（无公开定价）——都按 sol 计，绝不能掉进 $1/$2 默认价。
+		{"gpt-daybreak-blue-latest", 5.0, 30.0, 0.5, 10.0, 60.0},
+		{"gpt-daybreak-red-latest", 5.0, 30.0, 0.5, 10.0, 60.0},
+		{"gpt-5.6-cyber", 5.0, 30.0, 0.5, 10.0, 60.0},
 	}
 	for _, c := range cases {
 		p := GetModelPricing(c.model)
@@ -525,5 +530,13 @@ func TestClaudeFablePricingUsesOfficialCacheReadRates(t *testing.T) {
 	assertFloatEqual(t, fable5.CacheReadPricePerMToken, 1)
 	if fable5.CacheWrite5mPricePerMToken != 12.5 || fable5.CacheWrite1hPricePerMToken != 20 {
 		t.Fatalf("Fable 5 cache-write pricing = %+v", fable5)
+	}
+}
+
+func TestCanonicalBillingModelKeyDaybreakAliases(t *testing.T) {
+	for _, model := range []string{"gpt-daybreak-blue-latest", "gpt-daybreak-red-latest", "GPT-Daybreak-Blue-Latest"} {
+		if got := CanonicalBillingModelKey(model); got != "gpt-5.6-sol" {
+			t.Fatalf("CanonicalBillingModelKey(%q) = %q, want gpt-5.6-sol", model, got)
+		}
 	}
 }

--- a/database/billing_test.go
+++ b/database/billing_test.go
@@ -539,4 +539,11 @@ func TestCanonicalBillingModelKeyDaybreakAliases(t *testing.T) {
 			t.Fatalf("CanonicalBillingModelKey(%q) = %q, want gpt-5.6-sol", model, got)
 		}
 	}
+	// 只认 gpt-daybreak- 前缀：带版本号的 ID 仍按自身版本计费，无关模型不沾光。
+	if got := CanonicalBillingModelKey("gpt-5.4-daybreak"); got != "gpt-5.4" {
+		t.Fatalf("CanonicalBillingModelKey(gpt-5.4-daybreak) = %q, want gpt-5.4", got)
+	}
+	if got := CanonicalBillingModelKey("daybreak-blue"); got == "gpt-5.6-sol" {
+		t.Fatal("bare daybreak-blue must not resolve to gpt-5.6-sol")
+	}
 }

--- a/proxy/model_registry.go
+++ b/proxy/model_registry.go
@@ -482,8 +482,9 @@ func isAllowedUpstreamCodexModel(id string) bool {
 	if err != nil {
 		// 以字母开头的首段是代号族别名（daybreak 等），无版本可比，按上游清单为准放行；
 		// 与 isRetiredCodexModel 对非数字 ID 恒返回 false（保留）保持一致。
-		// 以数字开头却解析不出的（gpt-4o 这类旧世代写法）仍按退役拒绝。
-		return version != "" && (version[0] < '0' || version[0] > '9')
+		// 以数字开头却解析不出的（gpt-4o 这类旧世代写法）仍按退役拒绝；
+		// 标点开头（gpt-.foo / gpt-_foo）不是任何已知命名，同样拒绝。
+		return version != "" && version[0] >= 'a' && version[0] <= 'z'
 	}
 	minor := 0
 	if len(parts) >= 2 {

--- a/proxy/model_registry.go
+++ b/proxy/model_registry.go
@@ -85,7 +85,9 @@ var builtinModelInfos = []ModelInfo{
 	// Ref: codex_client_models.json via CLIProxyAPI model registry.
 	modelInfoForID("codex-auto-review", ModelSourceBuiltin),
 	// gpt-reserve — non-versioned model ID; keep as builtin fallback only.
-	// Note: it is not discoverable via upstream sync/manifest learning, which expects gpt-<major>.<minor> IDs.
+	// Note: the official docs sync only extracts gpt-<major>[.<minor>] IDs, so it
+	// would never be discovered there; manifest learning does admit non-versioned
+	// gpt-* slugs (issue #624), but a builtin row is still needed for cold start.
 	modelInfoForID("gpt-reserve", ModelSourceBuiltin),
 	modelInfoForID("gpt-image-2", ModelSourceBuiltin),
 	modelInfoForID("gpt-image-2-2k", ModelSourceBuiltin),
@@ -458,6 +460,9 @@ func modelSortRank(id string) int {
 //   - gpt-5.4 及更高版本：允许
 //   - gpt-5.3：只允许 spark 变体（gpt-5.3-codex-spark），其余 5.3 下线
 //   - gpt-5.2 及更低、image、非 gpt- 前缀：拒绝
+//   - gpt- 后不是数字版本号的代号族（gpt-daybreak-blue-latest 这类稳定别名，
+//     issue #624）：允许——版本退役规则对它们无从判断，而清单里出现即代表
+//     账号真实权益，拒掉只会让探测看得见、调用却 404 的模型永远进不了注册表
 func isAllowedUpstreamCodexModel(id string) bool {
 	id = strings.TrimSpace(strings.ToLower(id))
 	if id == "" || strings.Contains(id, "image") {
@@ -475,7 +480,10 @@ func isAllowedUpstreamCodexModel(id string) bool {
 	parts := strings.Split(version, ".")
 	major, err := strconv.Atoi(parts[0])
 	if err != nil {
-		return false
+		// 以字母开头的首段是代号族别名（daybreak 等），无版本可比，按上游清单为准放行；
+		// 与 isRetiredCodexModel 对非数字 ID 恒返回 false（保留）保持一致。
+		// 以数字开头却解析不出的（gpt-4o 这类旧世代写法）仍按退役拒绝。
+		return version != "" && (version[0] < '0' || version[0] > '9')
 	}
 	minor := 0
 	if len(parts) >= 2 {

--- a/proxy/model_registry_test.go
+++ b/proxy/model_registry_test.go
@@ -313,6 +313,9 @@ func TestIsAllowedUpstreamCodexModel_Policy(t *testing.T) {
 		"gpt-":                     false,
 		"gpt-4o-mini":              false,
 		"gpt-5o":                   false,
+		"gpt-.foo":                 false,
+		"gpt-_foo":                 false,
+		"gpt-+foo":                 false,
 		"gpt-daybreak-image":       false,
 		"daybreak-blue":            false,
 	}

--- a/proxy/model_registry_test.go
+++ b/proxy/model_registry_test.go
@@ -304,6 +304,17 @@ func TestIsAllowedUpstreamCodexModel_Policy(t *testing.T) {
 		"gpt-4o":              false,
 		"gpt-image-2":         false,
 		"":                    false,
+		// Trusted Access for Cyber（issue #624）：稳定别名没有数字版本号，
+		// 但清单里出现即代表账号真实权益，必须放行；带版本号的 cyber 变体走常规规则。
+		"gpt-daybreak-blue-latest": true,
+		"gpt-daybreak-red-latest":  true,
+		"gpt-5.6-cyber":            true,
+		"gpt-5.5-cyber-preview":    true,
+		"gpt-":                     false,
+		"gpt-4o-mini":              false,
+		"gpt-5o":                   false,
+		"gpt-daybreak-image":       false,
+		"daybreak-blue":            false,
 	}
 	for id, want := range cases {
 		if got := isAllowedUpstreamCodexModel(id); got != want {
@@ -407,5 +418,44 @@ func TestParseOfficialCodexModelIDsIgnoresNonModelContexts(t *testing.T) {
 		if slices.Contains(models, junk) || slices.Contains(skipped, junk) {
 			t.Fatalf("%q should not be extracted at all (models=%v skipped=%v)", junk, models, skipped)
 		}
+	}
+}
+
+// issue #624：Trusted Access for Cyber 账号的清单里带 gpt-daybreak-blue-latest，
+// 学习后必须立刻进入请求侧支持列表，否则 /v1/models 不列、/responses 直接拒绝。
+func TestLearnModelsFromManifest_AdmitsNonVersionedCyberAlias(t *testing.T) {
+	db := newTestModelRegistryDB(t)
+	ctx := context.Background()
+	manifest := []byte(`{"models":[
+		{"slug":"gpt-5.5"},
+		{"slug":"gpt-daybreak-blue-latest"},
+		{"slug":"gpt-5.2-codex"}
+	]}`)
+	added, err := LearnModelsFromManifest(ctx, db, manifest, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("LearnModelsFromManifest error: %v", err)
+	}
+	if !slices.Equal(added, []string{"gpt-daybreak-blue-latest"}) {
+		t.Fatalf("added = %v, want [gpt-daybreak-blue-latest] (retired 5.2 must still be rejected)", added)
+	}
+	catalog, err := ListModelCatalog(ctx, db)
+	if err != nil {
+		t.Fatalf("ListModelCatalog: %v", err)
+	}
+	if !slices.Contains(catalog.Models, "gpt-daybreak-blue-latest") {
+		t.Fatalf("learned alias missing from catalog: %v", catalog.Models)
+	}
+	for _, item := range catalog.Items {
+		if item.ID == "gpt-daybreak-blue-latest" {
+			if item.Source != ModelSourceUpstreamManifest || item.Category != ModelCategoryCodex || !item.Enabled {
+				t.Fatalf("learned item = %+v", item)
+			}
+		}
+	}
+	if !slices.Contains(SupportedModelIDs(ctx, db), "gpt-daybreak-blue-latest") {
+		t.Fatal("learned alias must be accepted by the request-side model gate immediately")
+	}
+	if isRetiredCodexModel("gpt-daybreak-blue-latest") {
+		t.Fatal("non-versioned alias must never be treated as retired")
 	}
 }

--- a/proxy/translator.go
+++ b/proxy/translator.go
@@ -2559,10 +2559,15 @@ func normalizeReasoningEffortForModel(effort, model string) string {
 
 // modelSupportsMaxReasoningEffort 判断模型是否支持 reasoning.effort=max
 // （gpt-5.6 及更高版本；带变体后缀如 gpt-5.6-sol 同样识别）。
+// Trusted Access for Cyber 的 gpt-daybreak-*-latest 稳定别名指向 5.6 家族
+// （blue=gpt-5.6-sol、red=gpt-5.6-cyber，issue #624），同样放行。
 func modelSupportsMaxReasoningEffort(model string) bool {
 	model = strings.ToLower(strings.TrimSpace(model))
 	if !strings.HasPrefix(model, "gpt-") {
 		return false
+	}
+	if strings.Contains(model, "daybreak") {
+		return true
 	}
 	version := strings.TrimPrefix(model, "gpt-")
 	if dash := strings.IndexByte(version, '-'); dash >= 0 {

--- a/proxy/translator.go
+++ b/proxy/translator.go
@@ -2566,7 +2566,7 @@ func modelSupportsMaxReasoningEffort(model string) bool {
 	if !strings.HasPrefix(model, "gpt-") {
 		return false
 	}
-	if strings.Contains(model, "daybreak") {
+	if strings.HasPrefix(model, "gpt-daybreak-") {
 		return true
 	}
 	version := strings.TrimPrefix(model, "gpt-")

--- a/proxy/translator_test.go
+++ b/proxy/translator_test.go
@@ -4082,3 +4082,26 @@ func TestPrepareResponsesBodyStripsTopLevelWebSocketEnvelopeType(t *testing.T) {
 		}
 	}
 }
+
+func TestModelSupportsMaxReasoningEffort(t *testing.T) {
+	cases := map[string]bool{
+		"gpt-5.6-sol":              true,
+		"gpt-5.6":                  true,
+		"gpt-6-astra":              false, // major-only ids have no minor and stay conservative
+		"gpt-7.0":                  true,
+		"gpt-5.5":                  false,
+		"gpt-5.4-mini":             false,
+		"gpt-daybreak-blue-latest": true, // alias of gpt-5.6-sol (issue #624)
+		"gpt-daybreak-red-latest":  true, // alias of gpt-5.6-cyber
+		"daybreak":                 false,
+		"grok-4.6":                 false,
+	}
+	for model, want := range cases {
+		if got := modelSupportsMaxReasoningEffort(model); got != want {
+			t.Errorf("modelSupportsMaxReasoningEffort(%q) = %v, want %v", model, got, want)
+		}
+	}
+	if got := normalizeConfiguredReasoningEffort("max", "gpt-daybreak-blue-latest"); got != "max" {
+		t.Fatalf("daybreak max effort clamped to %q", got)
+	}
+}

--- a/proxy/translator_test.go
+++ b/proxy/translator_test.go
@@ -4094,6 +4094,7 @@ func TestModelSupportsMaxReasoningEffort(t *testing.T) {
 		"gpt-daybreak-blue-latest": true, // alias of gpt-5.6-sol (issue #624)
 		"gpt-daybreak-red-latest":  true, // alias of gpt-5.6-cyber
 		"daybreak":                 false,
+		"gpt-5.4-daybreak":         false, // versioned ids follow their own version rule
 		"grok-4.6":                 false,
 	}
 	for model, want := range cases {


### PR DESCRIPTION
Fixes #624.

## Problem

After Trusted Access for Cyber is granted, the per-account remote model probe shows `gpt-daybreak-blue-latest`, but `/v1/models` never lists it and `/responses` rejects it as an unknown model.

## Root cause

`isAllowedUpstreamCodexModel` parses the segment after `gpt-` as a numeric version and rejects anything that fails to parse. Manifest learning therefore never wrote the alias into the registry, and the registry's enabled list is the request-side Codex gate. Two more gaps made it worse: the admin probe endpoint only fills the account whitelist and never learns into the registry, and "refresh all models" samples one account per plan, so a Cyber-enabled account is rarely the one sampled.

OpenAI's [Daybreak overview](https://help.openai.com/en/articles/20001258-openai-daybreak-trusted-access-for-cyber-overview) documents the aliases: `gpt-daybreak-blue-latest` is `gpt-5.6-sol`, `gpt-daybreak-red-latest` is `gpt-5.6-cyber`.

## Changes

- **Registry admission** accepts `gpt-*` IDs whose first segment starts with a letter, treating them as codename families that the version-retirement rule cannot judge. IDs that start with a digit but do not parse (`gpt-4o`) are still rejected. `isRetiredCodexModel` already kept non-numeric IDs, so exposure and admission agree.
- **Billing** maps any `daybreak` model to the `gpt-5.6-sol` row instead of the `$1/$2` default. Red has no published price, so it also takes sol as the conservative choice.
- **Max reasoning effort** treats daybreak aliases as the 5.6 family, so `max` is no longer clamped to `xhigh`.
- **Admin remote-model probe** also learns new manifest slugs into the registry, add-only, with the same implementation the client manifest passthrough uses.

## Tests

New tests cover the admission policy (including `gpt-4o`/`gpt-5o` staying rejected), learning a daybreak manifest through to `SupportedModelIDs`, the pricing aliases, and the max-effort gate. Full `proxy`, `database`, and `admin` suites pass locally.

## Notes

- Non-Cyber accounts asked for daybreak get an upstream plan-gated 400, which triggers the existing per-model cooldown and account rotation; saving the whitelist on Cyber accounts still helps scheduling.
- A running instance caches rejected slugs for 10 minutes, so the fix takes effect on restart without manual cleanup.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for discovering and cataloging eligible Cyber model aliases from upstream manifests.
  * Enabled maximum reasoning effort for supported Cyber aliases.
* **Billing**
  * Improved billing classification so version-specific Daybreak models retain their appropriate pricing.
* **Bug Fixes**
  * Tightened model validation to reject malformed or unsupported identifiers.
  * Improved manifest handling while excluding invalid and retired models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->