### PR TITLE
fix(images): surface model reply and recognize natural-language refusals on no-output image terminals (#589)

### DIFF
--- a/proxy/images.go
+++ b/proxy/images.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"github.com/codex2api/auth"
 	"github.com/codex2api/database"
@@ -1687,6 +1688,7 @@ func (h *Handler) forwardImagesRequest(c *gin.Context, inboundEndpoint, requestM
 				// Check retryability BEFORE writing error response to avoid
 				// double-write when the error is transient.
 				markImageModelUnavailable(h.store, account, requestModel, readErr)
+				logImageNoOutputOutcome(account, inboundEndpoint, requestModel, readErr)
 				accountID := account.ID()
 				resp.Body.Close()
 				h.store.Release(account)
@@ -1749,6 +1751,7 @@ func (h *Handler) forwardImagesRequest(c *gin.Context, inboundEndpoint, requestM
 			// Stream disconnects and upstream image generation failures can be
 			// transient (e.g. upstream model overload, network hiccup).
 			markImageModelUnavailable(h.store, account, requestModel, readErr)
+			logImageNoOutputOutcome(account, inboundEndpoint, requestModel, readErr)
 			accountID := account.ID()
 			resp.Body.Close()
 			h.store.Release(account)
@@ -2209,18 +2212,69 @@ func collectImageModelText(builder *strings.Builder, payload []byte) {
 	}
 }
 
-func isImageContentPolicyRefusal(text string) bool {
-	lower := strings.ToLower(text)
-	for _, marker := range []string{
-		"content policy", "content_policy", "content filter", "content_filter",
-		"safety system", "safety policy", "safety violation", "moderation",
-		"安全系统", "安全策略", "安全政策", "内容政策", "内容审核", "违规内容", "不适合生成",
-	} {
+// imageModelReplyPreviewMaxRunes 限制回填进错误信息/用量日志的模型文本长度。
+const imageModelReplyPreviewMaxRunes = 240
+
+// imageModelReplyPreview 把模型的文本回复压成一行可安全外发的摘要：折叠空白、
+// 脱敏、按 rune 截断（不能按字节截，中文回复会被切成乱码）。
+func imageModelReplyPreview(text string) string {
+	text = strings.Join(strings.Fields(text), " ")
+	if text == "" {
+		return ""
+	}
+	preview := security.SafeTruncate(security.SanitizeLog(text), imageModelReplyPreviewMaxRunes)
+	if utf8.RuneCountInString(text) > imageModelReplyPreviewMaxRunes {
+		preview += "…"
+	}
+	return preview
+}
+
+func imageTextContainsAny(lower string, markers ...string) bool {
+	for _, marker := range markers {
 		if strings.Contains(lower, marker) {
 			return true
 		}
 	}
 	return false
+}
+
+// isImageContentPolicyRefusal 判断"有文本、无图片"的终态是不是模型的内容拒绝。
+// 两类证据任一成立即判定：
+//  1. 文本点名了审核/安全/内容政策等术语。
+//  2. 自然语言拒绝：既有"无法/不能"类拒绝措辞，又点名了政策类主题（真实人物、
+//     版权、成人内容等）。模型用中文回复时几乎不会出现第 1 类术语，这种拒绝
+//     以前会被当成上游故障换号重试，最后回一句看不出原因的 502（issue #589
+//     里三个账号连环 502 很可能就是这样来的）。
+//
+// 只有拒绝措辞、没有主题的文本（"I can't generate images right now"）不算：那更
+// 像账号缺图片工具的能力缺失，应当换号重试而不是按用户错误终止。
+func isImageContentPolicyRefusal(text string) bool {
+	lower := strings.ToLower(text)
+	if imageTextContainsAny(lower,
+		"content policy", "content_policy", "content filter", "content_filter",
+		"safety system", "safety policy", "safety violation", "moderation",
+		"usage policies", "usage policy", "against our policies", "against my guidelines",
+		"安全系统", "安全策略", "安全政策", "内容政策", "内容审核", "违规内容", "不适合生成",
+		"使用政策", "使用规范", "内容规范",
+	) {
+		return true
+	}
+	refusal := imageTextContainsAny(lower,
+		"can't", "cannot", "can not", "unable to", "not able to", "won't be able", "not allowed to",
+		"无法", "不能", "不会为", "不可以", "不被允许", "不允许",
+	)
+	if !refusal {
+		return false
+	}
+	return imageTextContainsAny(lower,
+		"real people", "real person", "real individual", "actual person", "public figure", "celebrit",
+		"likeness", "copyright", "trademark", "intellectual property", "explicit", "sexual", "nudity",
+		"violence", "violent", "gore", "graphic content", "hateful", "harassment", "self-harm",
+		"minors", "underage", "children",
+		"真实人物", "真人", "公众人物", "名人", "明星", "肖像", "版权", "商标", "知识产权",
+		"未成年", "儿童", "色情", "裸露", "成人内容", "暴力", "血腥", "仇恨", "骚扰", "自残",
+		"敏感内容", "敏感题材", "不符合", "违反",
+	)
 }
 
 func classifyImageNoOutput(text string) error {
@@ -2240,15 +2294,21 @@ func classifyImageNoOutput(text string) error {
 			statusCode: http.StatusBadRequest,
 			errorType:  "image_generation_user_error",
 			code:       "content_policy_violation",
-			message:    security.SafeTruncate(security.SanitizeLog(text), imageModelTextMaxBytes),
+			message:    imageModelReplyPreview(text),
 		}
+	}
+	// 把模型说了什么带回给调用方和用量日志。以前这里只回一句固定文案，用户和
+	// 运维都看不到上游到底为什么没出图（issue #589）。
+	message := "Upstream did not execute image generation"
+	if preview := imageModelReplyPreview(text); preview != "" {
+		message += "; model replied: " + preview
 	}
 	return &imageNoOutputError{
 		kind:       imageNoOutputUnavailable,
 		statusCode: http.StatusBadGateway,
 		errorType:  "upstream_error",
 		code:       "image_generation_unavailable",
-		message:    "Upstream did not execute image generation",
+		message:    message,
 	}
 }
 
@@ -2357,6 +2417,17 @@ func markImageModelUnavailable(store *auth.Store, account *auth.Account, model s
 		return
 	}
 	markImageModelCapabilityUnavailable(store, account, model)
+}
+
+// logImageNoOutputOutcome 把"上游收到请求却没出图"的终态连同模型文本打进服务日志，
+// 让运维不用翻用量日志也能看到上游给出的理由（issue #589）。
+func logImageNoOutputOutcome(account *auth.Account, inboundEndpoint, model string, err error) {
+	outcome := imageNoOutputDetails(err)
+	if outcome == nil || account == nil {
+		return
+	}
+	log.Printf("%s 上游未产出图片 (account=%d model=%s kind=%s status=%d): %s",
+		inboundEndpoint, account.ID(), model, outcome.kind, outcome.statusCode, outcome.Error())
 }
 
 func markImageModelUnavailableFromHTTP(store *auth.Store, account *auth.Account, model string, statusCode int, body []byte) {

--- a/proxy/images_test.go
+++ b/proxy/images_test.go
@@ -13,6 +13,7 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/codex2api/auth"
 	"github.com/codex2api/config"
@@ -647,6 +648,7 @@ func TestCollectImagesResponseClassifiesNoOutputOutcomes(t *testing.T) {
 		statusCode int
 		retry      bool
 		code       string
+		message    string
 	}{
 		{
 			name:       "explicit safety refusal text",
@@ -662,6 +664,25 @@ func TestCollectImagesResponseClassifiesNoOutputOutcomes(t *testing.T) {
 			statusCode: http.StatusBadGateway,
 			retry:      true,
 			code:       "image_generation_unavailable",
+			// issue #589：模型说了什么必须带回给调用方，不能只回一句固定文案。
+			message: "Upstream did not execute image generation; model replied: Try describing the scene in more detail.",
+		},
+		{
+			name:       "chinese natural-language policy refusal",
+			upstream:   `data: {"type":"response.output_text.delta","delta":"抱歉，我无法生成真实公众人物的照片。"}` + "\n\n" + `data: {"type":"response.completed","response":{"output":[{"type":"message","content":[{"type":"output_text","text":"抱歉，我无法生成真实公众人物的照片。"}]}]}}` + "\n\n",
+			kind:       imageNoOutputSafety,
+			statusCode: http.StatusBadRequest,
+			code:       "content_policy_violation",
+			message:    "抱歉，我无法生成真实公众人物的照片。",
+		},
+		{
+			name:       "capability-loss wording without a policy subject stays retryable",
+			upstream:   `data: {"type":"response.completed","response":{"output":[{"type":"message","content":[{"type":"output_text","text":"I can't generate images right now."}]}]}}` + "\n\n",
+			kind:       imageNoOutputUnavailable,
+			statusCode: http.StatusBadGateway,
+			retry:      true,
+			code:       "image_generation_unavailable",
+			message:    "model replied: I can't generate images right now.",
 		},
 		{
 			name:       "empty completed response",
@@ -699,11 +720,58 @@ func TestCollectImagesResponseClassifiesNoOutputOutcomes(t *testing.T) {
 			if statusCode != tt.statusCode || payload["error"].(gin.H)["code"] != tt.code {
 				t.Fatalf("response = (%d, %#v), want status=%d code=%s", statusCode, payload, tt.statusCode, tt.code)
 			}
+			if tt.message != "" {
+				if got, _ := payload["error"].(gin.H)["message"].(string); !strings.Contains(got, tt.message) {
+					t.Fatalf("message = %q, want it to contain %q", got, tt.message)
+				}
+			}
 			generalRetries := 0
 			if got := shouldRetryImageStreamError(err, &generalRetries, 0, 0, maxImageAttempts); got != tt.retry {
 				t.Fatalf("retry = %t, want %t", got, tt.retry)
 			}
 		})
+	}
+}
+
+func TestIsImageContentPolicyRefusalHeuristics(t *testing.T) {
+	cases := []struct {
+		text string
+		want bool
+	}{
+		{"This request was blocked by our content policy.", true},
+		{"抱歉，我无法生成真实公众人物的照片。", true},
+		{"我不能创建包含未成年人的图片。", true},
+		{"I can't create images of real people, but I can draw a stylized character instead.", true},
+		{"Sorry, I cannot generate explicit or sexual content.", true},
+		{"这个请求不符合使用规范，无法生成。", true},
+		// 只有拒绝措辞、没有政策主题：更像账号缺图片工具，必须保持可换号重试。
+		{"I can't generate images right now.", false},
+		{"抱歉，我目前无法生成图片。", false},
+		{"Try describing the scene in more detail.", false},
+		{"Here is a description of the scene you asked for.", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		if got := isImageContentPolicyRefusal(tc.text); got != tc.want {
+			t.Errorf("isImageContentPolicyRefusal(%q) = %t, want %t", tc.text, got, tc.want)
+		}
+	}
+}
+
+func TestImageModelReplyPreviewIsSingleLineAndRuneBounded(t *testing.T) {
+	if got := imageModelReplyPreview("  first line\n\n  second\tline  "); got != "first line second line" {
+		t.Fatalf("preview = %q, want whitespace collapsed", got)
+	}
+	long := strings.Repeat("图", imageModelReplyPreviewMaxRunes+50)
+	got := imageModelReplyPreview(long)
+	if !utf8.ValidString(got) {
+		t.Fatalf("preview must not cut a rune in half: %q", got)
+	}
+	if !strings.HasSuffix(got, "…") || utf8.RuneCountInString(got) != imageModelReplyPreviewMaxRunes+1 {
+		t.Fatalf("preview = %d runes (ellipsis=%t), want %d runes plus an ellipsis", utf8.RuneCountInString(got), strings.HasSuffix(got, "…"), imageModelReplyPreviewMaxRunes)
+	}
+	if got := imageModelReplyPreview(""); got != "" {
+		t.Fatalf("empty preview = %q", got)
 	}
 }
 


### PR DESCRIPTION
## 问题（issue #589）

生图工作台 gpt-image-2-4k/2k 三个账号连环 502，错误详情只有 `Upstream did not execute image generation`。

本地 pgredis2004 用 Pro/Plus 账号跑公共 Images API 4K/2K、真人名字提示词、管理台 4K 作业全部 200，不是通用故障。真正的缺陷在 `classifyImageNoOutput` 的 unavailable 分支：上游 `response.completed` 只有模型文本、没有 `image_generation_call` 时，网关把模型说的话整段丢掉只回固定文案，用户和运维都看不到原因。而且 `isImageContentPolicyRefusal` 只认 "content policy / 安全策略" 等术语，模型用中文自然语言拒绝时识别不到，被当成上游故障逐账号换号重试，每个账号各留一条 502，与截图形态一致。

## 改动

- **错误信息带回模型文本**：unavailable 分支 message 追加 `; model replied: <预览>`（折叠空白、脱敏、按 rune 截 240 加省略号），同时进入 API 响应、生图台 error_message 与 usage_logs.error_message；safety 分支复用同一预览。
- **自然语言拒绝识别**：新增"拒绝措辞 且 政策主题"双条件（真实人物/版权/未成年/色情/暴力等中英文），命中按 400 `content_policy_violation` 终止，不再跨账号空转。只有拒绝措辞没有主题的文本（"I can't generate images right now"）保持 502 可换号，因为更像账号缺图片工具。
- **服务日志**：`forwardImagesRequest` 流式/非流式两条分支新增"上游未产出图片"日志，含 account/model/kind/文本。

不持久冷却账号的既有语义不变（该类终态是提示词依赖的）。

## 验证

- 分类表新增中文拒绝与能力缺失两例并断言 message；新增启发式正反例与预览截断单测。
- `go test ./proxy/ ./admin/` 全绿，gofmt/vet 干净。
- pgredis2004 用本改动重建，2K 生图返回 2560x1440 PNG，成功路径不触发新日志。

Closes #589

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of image-generation requests that return no image.
  - More accurately distinguishes content-policy refusals from unavailable image-generation capabilities, including multilingual refusal messages.
  - Error messages now provide a concise preview of the model’s response to clarify what happened.

- **Improvements**
  - Enhanced diagnostics for failed image-generation outcomes, making issues easier to understand and troubleshoot.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->