### PR TITLE
fix(accounts): clear stale 401/error state on re-import and revive errored duplicates (#618)

### DIFF
--- a/admin/handler.go
+++ b/admin/handler.go
@@ -852,6 +852,13 @@ func (h *Handler) mergeRefreshedDuplicateIntoExistingContext(parent context.Cont
 		log.Printf("合并导入账号 %d 凭证到已有账号 %d 失败: %v", newID, oldID, err)
 		return false
 	}
+	// 新凭证刚在刷新/探针里验证过可用，旧账号此前的 error / 401 unauthorized 态
+	// 已经过时：不清掉的话，重授权后的 RT 被合并进来、新账号被软删，用户看到的
+	// 却是旧账号继续挂着"未授权"直到自适应冷却到期（issue #618）。与 JWT 可解出
+	// 身份、走 upsertOAuthIdentityAccount 的导入路径对齐；限速冷却不受影响。
+	if h.clearReimportedAccountErrorState(ctx, oldRow, "合并凭证") {
+		log.Printf("合并导入账号 %d 凭证时已清除已有账号 %d 的错误/401 状态", newID, oldID)
+	}
 	// 先软删新账号、再重载旧账号：reloadTokenAccount 会异步触发旧账号的
 	// 探针→再合并，若此刻新账号仍活跃，反向查重会把旧账号合并进新账号，
 	// 两边都被软删。软删前置让后续任何查重都看不到新账号。
@@ -2826,7 +2833,11 @@ func accountCredentialWorkspaceRouteKeys(row *database.AccountRow) []string {
 	return tokenCredentialSeedWorkspaceRouteKeys(tokenCredentialSeedFromAccountRow(row))
 }
 
-func (h *Handler) existingCredentialWorkspaceRouteKeys(ctx context.Context) (map[string]bool, error) {
+// existingCredentialWorkspaceRouteOwners 返回「凭证工作区路由键 → 持有该凭证的
+// 活跃账号 ID」。去重命中时调用方凭 ID 回查账号状态，决定是普通跳过还是
+// 复活一个处于异常态的旧账号。同一路由理论上只有一个活跃账号；万一有多个
+// （allow_duplicate 导入过），保留先遇到的那个即可。
+func (h *Handler) existingCredentialWorkspaceRouteOwners(ctx context.Context) (map[string]int64, error) {
 	if h == nil || h.db == nil {
 		return nil, fmt.Errorf("database is not configured")
 	}
@@ -2834,13 +2845,29 @@ func (h *Handler) existingCredentialWorkspaceRouteKeys(ctx context.Context) (map
 	if err != nil {
 		return nil, err
 	}
-	keys := make(map[string]bool, len(rows))
+	owners := make(map[string]int64, len(rows))
 	for _, row := range rows {
 		for _, key := range accountCredentialWorkspaceRouteKeys(row) {
-			keys[key] = true
+			if _, exists := owners[key]; !exists {
+				owners[key] = row.ID
+			}
 		}
 	}
-	return keys, nil
+	return owners, nil
+}
+
+// reviveDuplicateRouteOwner 在按凭证路由去重命中已有账号后，尝试复活它（仅当
+// 该账号处于 error / unauthorized 态）。返回 true 表示已复活，调用方应计入
+// "更新"而非"重复"。
+func (h *Handler) reviveDuplicateRouteOwner(ctx context.Context, ownerID int64, source string) bool {
+	if h == nil || h.db == nil || ownerID <= 0 {
+		return false
+	}
+	row, err := h.db.GetAccountByID(ctx, ownerID)
+	if err != nil || row == nil {
+		return false
+	}
+	return h.reviveReimportedAccount(ctx, row, source)
 }
 
 func (h *Handler) findCredentialWorkspaceRouteDuplicate(ctx context.Context, seed tokenCredentialSeed, excludeID int64) (int64, error) {
@@ -3292,7 +3319,8 @@ func splitAccountCredentialLines(raw string, sanitize bool) []string {
 // accountCredentialDedup 跟踪 RT/ST 原文去重（用于 RT/ST 单账号/批量添加路径）。
 // 身份型（OAuth）去重在文件导入与 AT 路径单独处理，这里只覆盖加入时无法解出身份的 RT/ST。
 type accountCredentialDedup struct {
-	existingRoutes map[string]bool
+	// existingOwners 路由键 → 库里持有该凭证的活跃账号 ID。
+	existingOwners map[string]int64
 	seenRoutes     map[string]bool
 }
 
@@ -3300,17 +3328,16 @@ func (h *Handler) newAccountCredentialDedup(ctx context.Context) *accountCredent
 	d := &accountCredentialDedup{
 		seenRoutes: make(map[string]bool),
 	}
-	existingRoutes, err := h.existingCredentialWorkspaceRouteKeys(ctx)
+	existingOwners, err := h.existingCredentialWorkspaceRouteOwners(ctx)
 	if err != nil {
 		log.Printf("查询已有凭证工作区路由失败: %v", err)
-		existingRoutes = make(map[string]bool)
+		existingOwners = make(map[string]int64)
 	}
-	d.existingRoutes = existingRoutes
+	d.existingOwners = existingOwners
 	return d
 }
 
-// checkAndMark 返回 true 表示该 seed 与已有库或本批次重复（应跳过）；非重复时记录其凭证。
-func (d *accountCredentialDedup) checkAndMark(seed tokenCredentialSeed) bool {
+func (d *accountCredentialDedup) routeKeys(seed tokenCredentialSeed) []string {
 	keys := make([]string, 0, 2)
 	if key := credentialWorkspaceRouteKey("rt", seed.refreshToken, seed.customHeaders); key != "" {
 		keys = append(keys, key)
@@ -3318,15 +3345,26 @@ func (d *accountCredentialDedup) checkAndMark(seed tokenCredentialSeed) bool {
 	if key := credentialWorkspaceRouteKey("st", seed.sessionToken, seed.customHeaders); key != "" {
 		keys = append(keys, key)
 	}
+	return keys
+}
+
+// checkAndMarkOwner 返回该 seed 是否与已有库或本批次重复（应跳过）；非重复时
+// 记录其凭证。重复命中库里已有账号时一并返回该账号 ID（本批次内部重复返回
+// 0），供调用方判断是否复活异常态旧账号。
+func (d *accountCredentialDedup) checkAndMarkOwner(seed tokenCredentialSeed) (bool, int64) {
+	keys := d.routeKeys(seed)
 	for _, key := range keys {
-		if d.existingRoutes[key] || d.seenRoutes[key] {
-			return true
+		if ownerID, ok := d.existingOwners[key]; ok && ownerID > 0 {
+			return true, ownerID
+		}
+		if d.seenRoutes[key] {
+			return true, 0
 		}
 	}
 	for _, key := range keys {
 		d.seenRoutes[key] = true
 	}
-	return false
+	return false, 0
 }
 
 // AddAccount 添加新账号（支持批量：refresh_token/session_token 按行分割）
@@ -3428,6 +3466,7 @@ func (h *Handler) AddAccount(c *gin.Context) {
 	successCount := 0
 	failCount := 0
 	duplicateCount := 0
+	revivedCount := 0
 	createdIDs := &importedAccountIDs{}
 	pending := make([]*auth.Account, 0, len(seeds))
 
@@ -3444,10 +3483,17 @@ func (h *Handler) AddAccount(c *gin.Context) {
 			name = fmt.Sprintf("%s-%d", req.Name, i+1)
 		}
 
-		if dedup != nil && dedup.checkAndMark(seed) {
-			duplicateCount++
-			log.Printf("添加账号 %d 已存在（RT/ST 重复），跳过", i+1)
-			continue
+		if dedup != nil {
+			if duplicate, ownerID := dedup.checkAndMarkOwner(seed); duplicate {
+				// 同一凭证再添加一次且旧账号正挂在 error / 401 态：视为要求复活。
+				if h.reviveDuplicateRouteOwner(ctx, ownerID, "manual_add") {
+					revivedCount++
+					continue
+				}
+				duplicateCount++
+				log.Printf("添加账号 %d 已存在（RT/ST 重复），跳过", i+1)
+				continue
+			}
 		}
 
 		id, err := h.db.InsertAccountWithCredentials(ctx, name, h.newCodexAccountCredentials(seed), req.ProxyURL)
@@ -3465,9 +3511,12 @@ func (h *Handler) AddAccount(c *gin.Context) {
 	h.commitImportedRuntimeAccounts(pending, "manual_add", req.SkipRefresh)
 
 	// 记录安全审计日志
-	security.SecurityAuditLog("ACCOUNTS_ADDED", fmt.Sprintf("success=%d duplicate=%d failed=%d ip=%s", successCount, duplicateCount, failCount, c.ClientIP()))
+	security.SecurityAuditLog("ACCOUNTS_ADDED", fmt.Sprintf("success=%d updated=%d duplicate=%d failed=%d ip=%s", successCount, revivedCount, duplicateCount, failCount, c.ClientIP()))
 
 	msg := fmt.Sprintf("成功添加 %d 个账号", successCount)
+	if revivedCount > 0 {
+		msg += fmt.Sprintf("，%d 个已有账号已恢复", revivedCount)
+	}
 	if duplicateCount > 0 {
 		msg += fmt.Sprintf("，%d 个重复跳过", duplicateCount)
 	}
@@ -3487,6 +3536,7 @@ func (h *Handler) AddAccount(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{
 		"message":      msg,
 		"success":      successCount,
+		"updated":      revivedCount,
 		"duplicate":    duplicateCount,
 		"failed":       failCount,
 		"bound_groups": boundGroups,
@@ -3502,10 +3552,17 @@ func (h *Handler) streamAddAccounts(c *gin.Context, req addAccountReq, seeds []t
 	successCount := 0
 	failCount := 0
 	duplicateCount := 0
+	revivedCount := 0
 	sendImportEvent(c, importEvent{
 		Type: "progress", Current: 0, Total: total,
-		Success: 0, Duplicate: 0, Failed: 0,
+		Success: 0, Updated: 0, Duplicate: 0, Failed: 0,
 	})
+	progress := func(current int) {
+		sendImportEvent(c, importEvent{
+			Type: "progress", Current: current, Total: total,
+			Success: successCount, Updated: revivedCount, Duplicate: duplicateCount, Failed: failCount,
+		})
+	}
 
 	ctx, cancel := context.WithTimeout(c.Request.Context(), 30*time.Second)
 	defer cancel()
@@ -3525,23 +3582,24 @@ func (h *Handler) streamAddAccounts(c *gin.Context, req addAccountReq, seeds []t
 			name = fmt.Sprintf("%s-%d", req.Name, i+1)
 		}
 
-		if dedup != nil && dedup.checkAndMark(seed) {
-			duplicateCount++
-			sendImportEvent(c, importEvent{
-				Type: "progress", Current: i + 1, Total: total,
-				Success: successCount, Duplicate: duplicateCount, Failed: failCount,
-			})
-			continue
+		if dedup != nil {
+			if duplicate, ownerID := dedup.checkAndMarkOwner(seed); duplicate {
+				// 同一凭证再添加一次且旧账号正挂在 error / 401 态：视为要求复活。
+				if h.reviveDuplicateRouteOwner(ctx, ownerID, "manual_add") {
+					revivedCount++
+				} else {
+					duplicateCount++
+				}
+				progress(i + 1)
+				continue
+			}
 		}
 
 		id, err := h.db.InsertAccountWithCredentials(ctx, name, h.newCodexAccountCredentials(seed), req.ProxyURL)
 		if err != nil {
 			log.Printf("批量添加账号 %d 失败: %v", i+1, err)
 			failCount++
-			sendImportEvent(c, importEvent{
-				Type: "progress", Current: i + 1, Total: total,
-				Success: successCount, Duplicate: duplicateCount, Failed: failCount,
-			})
+			progress(i + 1)
 			continue
 		}
 
@@ -3549,20 +3607,17 @@ func (h *Handler) streamAddAccounts(c *gin.Context, req addAccountReq, seeds []t
 		createdIDs.add(id)
 		pending = append(pending, h.newCodexAccountFromSeed(id, req.ProxyURL, seed))
 
-		sendImportEvent(c, importEvent{
-			Type: "progress", Current: i + 1, Total: total,
-			Success: successCount, Duplicate: duplicateCount, Failed: failCount,
-		})
+		progress(i + 1)
 	}
 	h.db.BatchInsertAccountEventsAsync(createdIDs.snapshot(), "added", "manual")
 	h.commitImportedRuntimeAccounts(pending, "manual_add", req.SkipRefresh)
 
-	security.SecurityAuditLog("ACCOUNTS_ADDED", fmt.Sprintf("success=%d duplicate=%d failed=%d ip=%s", successCount, duplicateCount, failCount, c.ClientIP()))
+	security.SecurityAuditLog("ACCOUNTS_ADDED", fmt.Sprintf("success=%d updated=%d duplicate=%d failed=%d ip=%s", successCount, revivedCount, duplicateCount, failCount, c.ClientIP()))
 	// 绑定必须在 complete 事件之前完成：前端收到 complete 就会刷新列表。
 	if err := h.bindImportedAccountGroups(ctx, createdIDs.snapshot(), groupIDs); err != nil {
 		sendImportEvent(c, importEvent{
 			Type: "progress", Current: total, Total: total,
-			Success: successCount, Duplicate: duplicateCount, Failed: failCount,
+			Success: successCount, Updated: revivedCount, Duplicate: duplicateCount, Failed: failCount,
 			Warning: "账号已添加，但分组绑定失败: " + err.Error(),
 		})
 	}
@@ -3571,7 +3626,7 @@ func (h *Handler) streamAddAccounts(c *gin.Context, req addAccountReq, seeds []t
 
 	sendImportEvent(c, importEvent{
 		Type: "complete", Current: total, Total: total,
-		Success: successCount, Duplicate: duplicateCount, Failed: failCount,
+		Success: successCount, Updated: revivedCount, Duplicate: duplicateCount, Failed: failCount,
 		CreatedIDs: newAccountIDs,
 	})
 }
@@ -3671,11 +3726,11 @@ func (h *Handler) AddATAccount(c *gin.Context) {
 	// 按 access_token 原文去重；身份型 AT 由 upsertOAuthIdentityAccount 按 OAuth 身份
 	//（email + 有效工作区）去重/更新。显式 Chatgpt-Account-Id 可把同一 AT
 	// 拆成多个独立工作区路由；同一路由仍会更新已有账号。
-	existingATRoutes := make(map[string]bool)
+	existingATRoutes := make(map[string]int64)
 	seenATRoutes := make(map[string]bool)
 	workspaceOverrideKnown := openaiidentity.WorkspaceOverrideFromHeaders(customHeaders) != ""
 	if !req.AllowDuplicate || workspaceOverrideKnown {
-		if got, err := h.existingCredentialWorkspaceRouteKeys(ctx); err != nil {
+		if got, err := h.existingCredentialWorkspaceRouteOwners(ctx); err != nil {
 			log.Printf("查询已有凭证工作区路由失败: %v", err)
 		} else {
 			existingATRoutes = got
@@ -3717,7 +3772,12 @@ func (h *Handler) AddATAccount(c *gin.Context) {
 
 		if !req.AllowDuplicate || workspaceOverrideKnown {
 			routeKey := credentialWorkspaceRouteKey("at", at, seed.customHeaders)
-			if existingATRoutes[routeKey] || seenATRoutes[routeKey] {
+			if ownerID, exists := existingATRoutes[routeKey]; exists || seenATRoutes[routeKey] {
+				// 同一 AT 再添加一次且旧账号正挂在 error / 401 态：视为要求复活。
+				if exists && h.reviveDuplicateRouteOwner(ctx, ownerID, "manual_at") {
+					updatedCount++
+					continue
+				}
 				duplicateCount++
 				log.Printf("AT 账号 %d 已存在（access_token 与目标工作区重复），跳过", i+1)
 				continue
@@ -3790,11 +3850,11 @@ func (h *Handler) streamAddATAccounts(c *gin.Context, req addATAccountReq, token
 	ctx, cancel := context.WithTimeout(c.Request.Context(), 30*time.Second)
 	defer cancel()
 
-	existingATRoutes := make(map[string]bool)
+	existingATRoutes := make(map[string]int64)
 	seenATRoutes := make(map[string]bool)
 	workspaceOverrideKnown := openaiidentity.WorkspaceOverrideFromHeaders(req.CustomHeaders) != ""
 	if !req.AllowDuplicate || workspaceOverrideKnown {
-		if got, err := h.existingCredentialWorkspaceRouteKeys(ctx); err != nil {
+		if got, err := h.existingCredentialWorkspaceRouteOwners(ctx); err != nil {
 			log.Printf("查询已有凭证工作区路由失败: %v", err)
 		} else {
 			existingATRoutes = got
@@ -3840,8 +3900,13 @@ func (h *Handler) streamAddATAccounts(c *gin.Context, req addATAccountReq, token
 
 		if !req.AllowDuplicate || workspaceOverrideKnown {
 			routeKey := credentialWorkspaceRouteKey("at", at, seed.customHeaders)
-			if existingATRoutes[routeKey] || seenATRoutes[routeKey] {
-				duplicateCount++
+			if ownerID, exists := existingATRoutes[routeKey]; exists || seenATRoutes[routeKey] {
+				// 同一 AT 再添加一次且旧账号正挂在 error / 401 态：视为要求复活。
+				if exists && h.reviveDuplicateRouteOwner(ctx, ownerID, "manual_at") {
+					updatedCount++
+				} else {
+					duplicateCount++
+				}
 				progress(i + 1)
 				continue
 			}
@@ -5513,6 +5578,21 @@ func (h *Handler) importAccountsCommon(c *gin.Context, tokens []importToken, set
 	var newTokens []importToken
 	duplicateCount := ambiguousOAuthIdentityCount
 
+	// 命中「凭证一字不差的已有账号」时：账号状态正常计 duplicate 跳过；正挂在
+	// error / 401 unauthorized 态的进复活队列，稍后与新账号一起处理并计入
+	// "更新"——用户把同一份凭证再导一遍，就是在要求把这个号捞回来（issue #618）。
+	// 队列在去重阶段只读状态、不写库，复活动作放到后面的并发闸里执行。
+	var reviveRows []*database.AccountRow
+	queuedReviveIDs := make(map[int64]bool)
+	queueDuplicate := func(row *database.AccountRow) {
+		if row != nil && accountErrorStateNeedsReset(row) && !queuedReviveIDs[row.ID] {
+			queuedReviveIDs[row.ID] = true
+			reviveRows = append(reviveRows, row)
+			return
+		}
+		duplicateCount++
+	}
+
 	workspaceOverrideKnown := openaiidentity.WorkspaceOverrideFromHeaders(importCustomHeaders) != ""
 	if allowDuplicate && !workspaceOverrideKnown {
 		knownCount := 0
@@ -5536,7 +5616,7 @@ func (h *Handler) importAccountsCommon(c *gin.Context, tokens []importToken, set
 					if err != nil {
 						log.Printf("查询已有 OAuth 账号 %d 失败: %v", duplicateID, err)
 					} else if importAccountCredentialFingerprint(row) == importTokenCredentialFingerprint(t, conflictingChatGPTIDs) {
-						duplicateCount++
+						queueDuplicate(row)
 						continue
 					}
 				}
@@ -5545,10 +5625,11 @@ func (h *Handler) importAccountsCommon(c *gin.Context, tokens []importToken, set
 		}
 		duplicateCount += knownCount - knownUniqueCount - ambiguousOAuthIdentityCount
 	} else {
-		existingCredentialRoutes, err := h.existingCredentialWorkspaceRouteKeys(dedupeCtx)
+		// 路由键 → 持有者账号 ID；本批次新占的键记 0（无持有者，只用于批内去重）。
+		existingCredentialRoutes, err := h.existingCredentialWorkspaceRouteOwners(dedupeCtx)
 		if err != nil {
 			log.Printf("查询已有凭证工作区路由失败: %v", err)
-			existingCredentialRoutes = make(map[string]bool)
+			existingCredentialRoutes = make(map[string]int64)
 		}
 
 		for _, t := range unique {
@@ -5562,7 +5643,7 @@ func (h *Handler) importAccountsCommon(c *gin.Context, tokens []importToken, set
 					if err != nil {
 						log.Printf("查询已有 OAuth 账号 %d 失败: %v", duplicateID, err)
 					} else if importAccountCredentialFingerprint(row) == importTokenCredentialFingerprint(t, conflictingChatGPTIDs) {
-						duplicateCount++
+						queueDuplicate(row)
 						continue
 					}
 				}
@@ -5572,19 +5653,29 @@ func (h *Handler) importAccountsCommon(c *gin.Context, tokens []importToken, set
 
 			routeKeys := importTokenCredentialWorkspaceRouteKeys(t, conflictingChatGPTIDs, importCustomHeaders)
 			isDuplicate := false
+			var ownerID int64
 			for _, key := range routeKeys {
-				if existingCredentialRoutes[key] {
+				if id, exists := existingCredentialRoutes[key]; exists {
 					isDuplicate = true
+					ownerID = id
 					break
 				}
 			}
 			if isDuplicate {
-				duplicateCount++
+				var ownerRow *database.AccountRow
+				if ownerID > 0 {
+					if row, err := h.db.GetAccountByID(dedupeCtx, ownerID); err != nil {
+						log.Printf("查询已有凭证账号 %d 失败: %v", ownerID, err)
+					} else {
+						ownerRow = row
+					}
+				}
+				queueDuplicate(ownerRow)
 				continue
 			}
 			newTokens = append(newTokens, t)
 			for _, key := range routeKeys {
-				existingCredentialRoutes[key] = true
+				existingCredentialRoutes[key] = 0
 			}
 		}
 	}
@@ -5595,9 +5686,9 @@ func (h *Handler) importAccountsCommon(c *gin.Context, tokens []importToken, set
 	}
 	duplicateCount += agentDuplicate
 
-	log.Printf("导入去重: 总计 %d 条, 数据库已存在 %d 条, 待导入 %d 条", total, duplicateCount, len(newTokens))
+	log.Printf("导入去重: 总计 %d 条, 数据库已存在 %d 条, 待复活 %d 条, 待导入 %d 条", total, duplicateCount, len(reviveRows), len(newTokens))
 
-	if len(newTokens) == 0 {
+	if len(newTokens) == 0 && len(reviveRows) == 0 {
 		// 无常规 token 待导入（可能是纯 Agent Identity 文件）；反映 agent 计数。
 		if err := h.bindImportedAccountGroups(c.Request.Context(), agentCreatedIDs, importGroupIDsFromContext(c)); err != nil {
 			log.Printf("导入: Agent Identity 账号分组绑定失败: %v", err)
@@ -5667,6 +5758,29 @@ func (h *Handler) importAccountsCommon(c *gin.Context, tokens []importToken, set
 		},
 		func(e importEvent) bool { return sendImportEvent(c, e) },
 	)
+
+	// 复活队列：凭证一字不差、但旧账号正挂在 error / 401 态的重复条目。走同一个
+	// 写库并发闸，复活成功计入"更新"，状态已被别的流程清掉则退回"重复"。
+	// duplicateCount 被进度推送 goroutine 并发读取，这里只能改原子计数。
+	var revivedAsDuplicate int64
+	for _, row := range reviveRows {
+		if !dbLimiter.acquire(context.Background()) {
+			break
+		}
+		wg.Add(1)
+		go func(row *database.AccountRow) {
+			defer wg.Done()
+			defer dbLimiter.release()
+			reviveCtx, reviveCancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer reviveCancel()
+			if h.reviveReimportedAccount(reviveCtx, row, "import") {
+				atomic.AddInt64(&updatedCount, 1)
+			} else {
+				atomic.AddInt64(&revivedAsDuplicate, 1)
+			}
+			atomic.AddInt64(&current, 1)
+		}(row)
+	}
 
 	for i, t := range newTokens {
 		if !dbLimiter.acquire(context.Background()) {
@@ -5808,6 +5922,8 @@ func (h *Handler) importAccountsCommon(c *gin.Context, tokens []importToken, set
 	// 只 close(done) 不等待的话，收尾事件可能和最后一帧进度事件交错，
 	// 前端解析不到 complete，进度条永远停在最后一个百分比。
 	<-progressStopped
+	// 推送 goroutine 已退出，可以安全并入复活失败退回的重复计数。
+	duplicateCount += int(atomic.LoadInt64(&revivedAsDuplicate))
 
 	// 发送完成事件（并入 Agent Identity 计数）
 	suc := int(atomic.LoadInt64(&successCount)) + agentSuccess

--- a/admin/import_revive_test.go
+++ b/admin/import_revive_test.go
@@ -1,0 +1,382 @@
+package admin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/codex2api/auth"
+	"github.com/codex2api/cache"
+	"github.com/codex2api/database"
+	"github.com/gin-gonic/gin"
+)
+
+// issue #618：重授权后 RT 变化，裸 RT 导入在刷新后按身份合并进旧账号，但旧账号
+// 之前的 401 unauthorized / error 态没有一起清掉——用户看到新账号消失、旧账号
+// 继续挂"未授权"。合并时必须把旧账号的错误态清掉（库 + 跨实例冷却缓存）。
+func TestMergeRefreshedDuplicateClearsStaleUnauthorizedState(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	db := newTestAdminDB(t)
+	tokenCache := cache.NewMemory(4)
+	defer tokenCache.Close()
+	store := auth.NewStore(db, tokenCache, &database.SystemSettings{MaxConcurrency: 2, TestConcurrency: 1, TestModel: "gpt-5.4"})
+	handler := &Handler{
+		db:         db,
+		store:      store,
+		probeUsage: func(context.Context, *auth.Account) error { return nil },
+	}
+	ctx := context.Background()
+
+	oldID, err := db.InsertAccountWithCredentials(ctx, "stale", map[string]interface{}{
+		"refresh_token": "rt-dead",
+		"access_token":  "at-stale",
+		"email":         "revive@example.com",
+		"workspace_id":  "ws-revive",
+	}, "")
+	if err != nil {
+		t.Fatalf("Insert old: %v", err)
+	}
+	if err := store.LoadAccountByID(ctx, oldID); err != nil {
+		t.Fatalf("LoadAccountByID: %v", err)
+	}
+	old := store.FindByID(oldID)
+	if old == nil {
+		t.Fatal("old runtime account missing")
+	}
+	store.MarkCooldownWithError(old, time.Hour, "unauthorized", "401 unauthorized")
+	if got := old.RuntimeStatus(); got != "unauthorized" {
+		t.Fatalf("precondition: runtime status = %q, want unauthorized", got)
+	}
+	preRow, err := db.GetAccountByID(ctx, oldID)
+	if err != nil {
+		t.Fatalf("GetAccountByID pre: %v", err)
+	}
+	if !strings.EqualFold(preRow.CooldownReason, "unauthorized") {
+		t.Fatalf("precondition: db cooldown_reason = %q, want unauthorized", preRow.CooldownReason)
+	}
+
+	// 重授权后的新 RT 导入，刷新完成后身份与旧账号相同
+	newID, err := db.InsertAccountWithCredentials(ctx, "reauth", map[string]interface{}{
+		"refresh_token": "rt-fresh",
+		"access_token":  "at-fresh",
+		"email":         "revive@example.com",
+		"workspace_id":  "ws-revive",
+	}, "")
+	if err != nil {
+		t.Fatalf("Insert new: %v", err)
+	}
+	store.AddAccount(&auth.Account{DBID: newID, RefreshToken: "rt-fresh"})
+
+	if merged := handler.mergeRefreshedDuplicateIntoExisting(newID, "test"); !merged {
+		t.Fatal("expected re-authorized RT to merge into the stale account")
+	}
+
+	row, err := db.GetAccountByID(ctx, oldID)
+	if err != nil {
+		t.Fatalf("GetAccountByID: %v", err)
+	}
+	if got := row.GetCredential("refresh_token"); got != "rt-fresh" {
+		t.Fatalf("refresh_token = %q, want rt-fresh", got)
+	}
+	if strings.EqualFold(row.Status, "error") {
+		t.Fatalf("db status = %q, want cleared", row.Status)
+	}
+	if row.CooldownReason != "" || row.CooldownUntil.Valid {
+		t.Fatalf("db cooldown = (%q, valid=%v), want cleared", row.CooldownReason, row.CooldownUntil.Valid)
+	}
+	survivor := store.FindByID(oldID)
+	if survivor == nil {
+		t.Fatal("survivor missing from runtime store")
+	}
+	if got := survivor.RuntimeStatus(); got == "unauthorized" || got == "error" {
+		t.Fatalf("survivor runtime status = %q, want cleared", got)
+	}
+	survivor.Mu().RLock()
+	tier := survivor.HealthTier
+	survivor.Mu().RUnlock()
+	if tier == auth.HealthTierBanned {
+		t.Fatalf("survivor HealthTier = %q, want not banned", tier)
+	}
+	if store.FindByID(newID) != nil {
+		t.Fatal("merged duplicate should have left the runtime store")
+	}
+}
+
+// 限速冷却不是"过时的错误态"，合并时不能被顺手清掉。
+func TestMergeRefreshedDuplicateKeepsRateLimitCooldown(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	db := newTestAdminDB(t)
+	store := auth.NewStore(db, nil, &database.SystemSettings{MaxConcurrency: 2, TestConcurrency: 1, TestModel: "gpt-5.4"})
+	handler := &Handler{
+		db:         db,
+		store:      store,
+		probeUsage: func(context.Context, *auth.Account) error { return nil },
+	}
+	ctx := context.Background()
+
+	oldID, err := db.InsertAccountWithCredentials(ctx, "limited", map[string]interface{}{
+		"refresh_token": "rt-old",
+		"access_token":  "at-old",
+		"email":         "limited@example.com",
+		"workspace_id":  "ws-limited",
+	}, "")
+	if err != nil {
+		t.Fatalf("Insert old: %v", err)
+	}
+	if err := store.LoadAccountByID(ctx, oldID); err != nil {
+		t.Fatalf("LoadAccountByID: %v", err)
+	}
+	store.MarkCooldown(store.FindByID(oldID), time.Hour, "rate_limited")
+
+	newID, err := db.InsertAccountWithCredentials(ctx, "reauth", map[string]interface{}{
+		"refresh_token": "rt-new",
+		"access_token":  "at-new",
+		"email":         "limited@example.com",
+		"workspace_id":  "ws-limited",
+	}, "")
+	if err != nil {
+		t.Fatalf("Insert new: %v", err)
+	}
+	store.AddAccount(&auth.Account{DBID: newID, RefreshToken: "rt-new"})
+
+	if merged := handler.mergeRefreshedDuplicateIntoExisting(newID, "test"); !merged {
+		t.Fatal("expected merge")
+	}
+	row, err := db.GetAccountByID(ctx, oldID)
+	if err != nil {
+		t.Fatalf("GetAccountByID: %v", err)
+	}
+	if !strings.EqualFold(row.CooldownReason, "rate_limited") || !row.CooldownUntil.Valid {
+		t.Fatalf("rate-limit cooldown = (%q, valid=%v), want preserved", row.CooldownReason, row.CooldownUntil.Valid)
+	}
+}
+
+func newReviveTestHandler(t *testing.T) (*Handler, *database.DB, *auth.Store) {
+	t.Helper()
+	db := newTestAdminDB(t)
+	store := auth.NewStore(db, nil, &database.SystemSettings{MaxConcurrency: 2, TestConcurrency: 1, TestModel: "gpt-5.4"})
+	handler := &Handler{
+		db:    db,
+		store: store,
+		refreshAccount: func(_ context.Context, id int64) error {
+			acc := store.FindByID(id)
+			if acc == nil {
+				return fmt.Errorf("account %d not found", id)
+			}
+			acc.Mu().Lock()
+			acc.AccessToken = fmt.Sprintf("at-%d", id)
+			acc.Mu().Unlock()
+			return nil
+		},
+		probeUsage: func(context.Context, *auth.Account) error { return nil },
+	}
+	return handler, db, store
+}
+
+func waitForAccountStatusCleared(t *testing.T, db *database.DB, id int64) *database.AccountRow {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		row, err := db.GetAccountByID(context.Background(), id)
+		if err != nil {
+			t.Fatalf("GetAccountByID: %v", err)
+		}
+		if !accountErrorStateNeedsReset(row) {
+			return row
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("account %d still in error state: status=%q cooldown_reason=%q", id, row.Status, row.CooldownReason)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+// issue #618：凭证一字不差的重复导入，若旧账号正挂在 error 态，不该只计一次
+// duplicate 就完事——用户就是要把它捞回来。裸 RT 文件导入路径。
+func TestImportAccountsCommonRevivesErroredDuplicate(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	handler, db, store := newReviveTestHandler(t)
+	ctx := context.Background()
+
+	existingID, err := db.InsertAccountWithCredentials(ctx, "dead", map[string]interface{}{
+		"refresh_token": "rt-same",
+	}, "")
+	if err != nil {
+		t.Fatalf("InsertAccountWithCredentials: %v", err)
+	}
+	if err := store.LoadAccountByID(ctx, existingID); err != nil {
+		t.Fatalf("LoadAccountByID: %v", err)
+	}
+	store.MarkError(store.FindByID(existingID), "refresh failed")
+
+	recorder := httptest.NewRecorder()
+	ginCtx, _ := gin.CreateTestContext(recorder)
+	ginCtx.Request = httptest.NewRequest(http.MethodPost, "/api/admin/accounts/import", nil)
+
+	handler.importAccountsCommon(ginCtx, []importToken{{refreshToken: "rt-same"}}, importSettings{})
+
+	payload := recorder.Body.String()
+	if !strings.Contains(payload, `"type":"complete"`) {
+		t.Fatalf("payload = %q, want complete event", payload)
+	}
+	complete := lastImportEvent(t, payload)
+	if complete.Updated != 1 || complete.Duplicate != 0 || complete.Success != 0 || complete.Failed != 0 {
+		t.Fatalf("complete = %+v, want updated=1 duplicate=0 success=0 failed=0", complete)
+	}
+
+	row := waitForAccountStatusCleared(t, db, existingID)
+	if row.ErrorMessage != "" {
+		t.Fatalf("error_message = %q, want cleared", row.ErrorMessage)
+	}
+	rows, err := db.ListActive(ctx)
+	if err != nil {
+		t.Fatalf("ListActive: %v", err)
+	}
+	if len(rows) != 1 || rows[0].ID != existingID {
+		t.Fatalf("active rows = %d, want only existing id %d", len(rows), existingID)
+	}
+	acc := store.FindByID(existingID)
+	if acc == nil {
+		t.Fatal("revived account missing from runtime store")
+	}
+	if got := acc.RuntimeStatus(); got == "error" || got == "unauthorized" {
+		t.Fatalf("runtime status = %q, want cleared", got)
+	}
+}
+
+// 同一身份、同一凭证的 JSON 导入：旧账号处于 401 冷却时同样复活并计入更新。
+func TestImportAccountsCommonRevivesUnauthorizedOAuthIdentityDuplicate(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	handler, db, store := newReviveTestHandler(t)
+	ctx := context.Background()
+
+	existingID, err := db.InsertAccountWithCredentials(ctx, "existing", map[string]interface{}{
+		"refresh_token": "rt-same",
+		"access_token":  "at-same",
+		"email":         "same@example.com",
+		"account_id":    "acc-same",
+		"workspace_id":  "acc-same",
+	}, "")
+	if err != nil {
+		t.Fatalf("InsertAccountWithCredentials: %v", err)
+	}
+	if err := store.LoadAccountByID(ctx, existingID); err != nil {
+		t.Fatalf("LoadAccountByID: %v", err)
+	}
+	store.MarkCooldownWithError(store.FindByID(existingID), time.Hour, "unauthorized", "401 unauthorized")
+
+	recorder := httptest.NewRecorder()
+	ginCtx, _ := gin.CreateTestContext(recorder)
+	ginCtx.Request = httptest.NewRequest(http.MethodPost, "/api/admin/accounts/import", nil)
+
+	handler.importAccountsCommon(ginCtx, []importToken{{
+		refreshToken: "rt-same",
+		accessToken:  "at-same",
+		idToken:      makeOAuthTestIDToken("Same@Example.com", "acc-same", ""),
+		email:        "Same@Example.com",
+		accountID:    "acc-same",
+	}}, importSettings{})
+
+	complete := lastImportEvent(t, recorder.Body.String())
+	if complete.Updated != 1 || complete.Duplicate != 0 || complete.Success != 0 {
+		t.Fatalf("complete = %+v, want updated=1 duplicate=0 success=0", complete)
+	}
+	row := waitForAccountStatusCleared(t, db, existingID)
+	if row.CooldownReason != "" {
+		t.Fatalf("cooldown_reason = %q, want cleared", row.CooldownReason)
+	}
+	acc := store.FindByID(existingID)
+	if acc == nil {
+		t.Fatal("revived account missing from runtime store")
+	}
+	acc.Mu().RLock()
+	tier := acc.HealthTier
+	acc.Mu().RUnlock()
+	if tier == auth.HealthTierBanned {
+		t.Fatalf("HealthTier = %q, want not banned", tier)
+	}
+}
+
+// 手工批量添加同一 RT：旧账号处于 error 态时复活并计入 updated，正常态仍是 duplicate。
+func TestAddAccountRevivesErroredDuplicate(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	handler, db, store := newReviveTestHandler(t)
+	ctx := context.Background()
+
+	existingID, err := db.InsertAccountWithCredentials(ctx, "existing", map[string]interface{}{
+		"refresh_token": "rt-existing",
+	}, "")
+	if err != nil {
+		t.Fatalf("InsertAccountWithCredentials: %v", err)
+	}
+	if err := store.LoadAccountByID(ctx, existingID); err != nil {
+		t.Fatalf("LoadAccountByID: %v", err)
+	}
+
+	doAdd := func(body string) map[string]interface{} {
+		recorder := httptest.NewRecorder()
+		ginCtx, _ := gin.CreateTestContext(recorder)
+		ginCtx.Request = httptest.NewRequest(http.MethodPost, "/api/admin/accounts", strings.NewReader(body))
+		ginCtx.Request.Header.Set("Content-Type", "application/json")
+		handler.AddAccount(ginCtx)
+		if recorder.Code != http.StatusOK {
+			t.Fatalf("status = %d: %s", recorder.Code, recorder.Body.String())
+		}
+		var resp map[string]interface{}
+		if err := json.Unmarshal(recorder.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		return resp
+	}
+
+	// 正常态：仍按重复跳过，不产生副作用
+	resp := doAdd(`{"refresh_token":"rt-existing"}`)
+	if resp["duplicate"] != float64(1) || resp["updated"] != float64(0) {
+		t.Fatalf("healthy duplicate resp = %v, want duplicate=1 updated=0", resp)
+	}
+
+	store.MarkError(store.FindByID(existingID), "refresh failed")
+
+	resp = doAdd(`{"refresh_token":"rt-existing"}`)
+	if resp["updated"] != float64(1) || resp["duplicate"] != float64(0) || resp["success"] != float64(0) {
+		t.Fatalf("errored duplicate resp = %v, want updated=1 duplicate=0 success=0", resp)
+	}
+	waitForAccountStatusCleared(t, db, existingID)
+	if rows, _ := db.ListActive(ctx); len(rows) != 1 {
+		t.Fatalf("active rows = %d, want 1 (revived in place, no new row)", len(rows))
+	}
+}
+
+func lastImportEvent(t *testing.T, payload string) importEvent {
+	t.Helper()
+	var last importEvent
+	found := false
+	for _, line := range strings.Split(payload, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+		var event importEvent
+		if err := json.Unmarshal([]byte(strings.TrimSpace(strings.TrimPrefix(line, "data:"))), &event); err != nil {
+			t.Fatalf("decode SSE event %q: %v", line, err)
+		}
+		if event.Type == "complete" {
+			last = event
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("no complete event in payload: %q", payload)
+	}
+	return last
+}

--- a/admin/oauth.go
+++ b/admin/oauth.go
@@ -381,11 +381,7 @@ func (h *Handler) upsertOAuthIdentityAccountWithRuntime(ctx context.Context, nam
 		// 重新导入有效凭证时，若该账号此前处于错误/封禁（401）态，清除错误状态，
 		// 让重新加载后的运行时账号脱离 banned，并交由后续 probe 重新判定。
 		// 仅针对 error / unauthorized，避免误清合法的限速冷却（rate_limited）。
-		if accountErrorStateNeedsReset(row) {
-			if err := h.db.ClearError(ctx, duplicateID); err != nil {
-				log.Printf("重新导入清除账号 %d 错误状态失败: %v", duplicateID, err)
-			}
-		}
+		h.clearReimportedAccountErrorState(ctx, row, "重新导入")
 		if err := h.reloadTokenAccount(ctx, duplicateID, source); err != nil {
 			return 0, false, nil, err
 		}
@@ -416,6 +412,63 @@ func accountErrorStateNeedsReset(row *database.AccountRow) bool {
 		return true
 	}
 	return strings.EqualFold(strings.TrimSpace(row.CooldownReason), "unauthorized")
+}
+
+// clearReimportedAccountErrorState 在重新导入 / 重新授权 / 合并凭证拿到有效凭证后，
+// 就地清除已有账号的 error / unauthorized 状态。返回是否真的清过（账号不在
+// 该状态时什么都不做，限速冷却更不会被碰）。
+//
+// 库与跨实例冷却缓存必须一起清：调用方随后会 reloadTokenAccount 从库重建
+// 运行时账号，库里干净了内存才干净；而调度器挑号时还会回读缓存里的冷却
+// 记录并盖回账号，只清库会让账号继续被 unauthorized 缓存挡到 TTL 到期。
+// 内存里的 FailureStreak / PermanentRefreshFailures / Disabled 标志随重载
+// 一起归零，这里不需要单独处理。
+func (h *Handler) clearReimportedAccountErrorState(ctx context.Context, row *database.AccountRow, action string) bool {
+	if h == nil || h.db == nil || !accountErrorStateNeedsReset(row) {
+		return false
+	}
+	if err := h.db.ClearError(ctx, row.ID); err != nil {
+		log.Printf("%s清除账号 %d 错误状态失败: %v", action, row.ID, err)
+		return false
+	}
+	if h.store != nil {
+		h.store.ForgetCachedAccountCooldown(row.ID)
+	}
+	return true
+}
+
+// reviveReimportedAccount 处理「重复导入命中了一个处于 error / unauthorized 态的
+// 已有账号」：凭证一字不差，本来只会计一次 duplicate 跳过；但用户把同一份凭证
+// 再导一遍，就是在明确要求把这个号捞回来重新判定（issue #618）。这里清掉旧
+// 状态、重载运行时账号并重新探测，让它回到号池；探测若再次失败会照常重新
+// 落 unauthorized / error，代价只是一次上游探针。
+//
+// 账号本身状态正常（含限速冷却）时不做任何事、返回 false，调用方按普通重复
+// 计数——正常号重复导入不该产生任何副作用。
+func (h *Handler) reviveReimportedAccount(ctx context.Context, row *database.AccountRow, source string) bool {
+	if h == nil || h.db == nil || row == nil || !accountErrorStateNeedsReset(row) {
+		return false
+	}
+	if !h.clearReimportedAccountErrorState(ctx, row, "重复导入复活") {
+		return false
+	}
+	if h.store != nil {
+		if err := h.reloadTokenAccount(ctx, row.ID, source); err != nil {
+			log.Printf("重复导入复活账号 %d 后重载运行时失败: %v", row.ID, err)
+		} else if acc := h.store.FindByID(row.ID); acc != nil &&
+			acc.GetAccessToken() == "" && !acc.IsCodexAgentIdentity() &&
+			!h.store.GetLazyMode() && strings.HasPrefix(source, "import") {
+			// 导入来源的重载不会自动换票（reloadTokenAccount 把 import* 来源
+			// 留给导入流程自己排队），裸 RT 账号在这里补上，走导入并发闸。
+			id := row.ID
+			h.runImportProbeTask(func(ctx context.Context) {
+				h.refreshImportedAccountAndProbe(ctx, id, source+"_refresh")
+			})
+		}
+	}
+	h.db.InsertAccountEventAsync(row.ID, "updated", source+"_revive")
+	log.Printf("重复导入命中处于异常态的已有账号 %d，已清除错误/401 状态并重新探测 (source=%s)", row.ID, source)
+	return true
 }
 
 func (h *Handler) loadInsertedTokenAccount(id int64, proxyURL string, seed tokenCredentialSeed, source string) {
@@ -561,11 +614,7 @@ func (h *Handler) UpdateOAuthAccountCode(c *gin.Context) {
 	// 与重新导入合并路径(upsertOAuthIdentityAccount)对齐:拿到新凭证后,
 	// 错误/401 态就地清除、交由探针重新判定,而不是让账号一直挂在"异常"
 	// 等一次可能失败的异步探针(issue #493)。限流冷却不在清除范围内。
-	if accountErrorStateNeedsReset(row) {
-		if err := h.db.ClearError(ctx, id); err != nil {
-			log.Printf("重新授权清除账号 %d 错误状态失败: %v", id, err)
-		}
-	}
+	h.clearReimportedAccountErrorState(ctx, row, "重新授权")
 
 	if err := h.reloadTokenAccount(ctx, id, "oauth_reauth"); err != nil {
 		writeError(c, http.StatusInternalServerError, "重新加载运行时账号失败: "+err.Error())

--- a/admin/oauth.go
+++ b/admin/oauth.go
@@ -453,9 +453,18 @@ func (h *Handler) reviveReimportedAccount(ctx context.Context, row *database.Acc
 		return false
 	}
 	if h.store != nil {
+		// reloadTokenAccount 先移除再按库重建；重建失败时账号会从运行时池消失。
+		// 那样不能对外报"已复活"——把原来的运行时对象放回去（仍是异常态，与
+		// 未复活的结论一致），返回 false 让调用方按普通重复计数。
+		prev := h.store.FindByID(row.ID)
 		if err := h.reloadTokenAccount(ctx, row.ID, source); err != nil {
-			log.Printf("重复导入复活账号 %d 后重载运行时失败: %v", row.ID, err)
-		} else if acc := h.store.FindByID(row.ID); acc != nil &&
+			log.Printf("重复导入复活账号 %d 后重载运行时失败，保留原运行时状态: %v", row.ID, err)
+			if prev != nil && h.store.FindByID(row.ID) == nil {
+				h.store.AddAccount(prev)
+			}
+			return false
+		}
+		if acc := h.store.FindByID(row.ID); acc != nil &&
 			acc.GetAccessToken() == "" && !acc.IsCodexAgentIdentity() &&
 			!h.store.GetLazyMode() && strings.HasPrefix(source, "import") {
 			// 导入来源的重载不会自动换票（reloadTokenAccount 把 import* 来源

--- a/auth/cooldown_cache_test.go
+++ b/auth/cooldown_cache_test.go
@@ -258,3 +258,26 @@ func TestModelCooldownFixedModeDoesNotBackoff(t *testing.T) {
 		t.Fatal("model cooldown should be cleared")
 	}
 }
+
+// 管理端在库层清掉 unauthorized 后必须能把跨实例冷却缓存一起清掉，否则调度器
+// 每次挑号回读缓存又把冷却盖回来。
+func TestForgetCachedAccountCooldownDropsRecord(t *testing.T) {
+	tokenCache := cache.NewMemory(4)
+	defer tokenCache.Close()
+
+	account := newFastSchedulerTestAccount(11, HealthTierHealthy, 100, 1)
+	store := &Store{accounts: []*Account{account}, maxConcurrency: 1, tokenCache: tokenCache}
+	store.setCachedAccountCooldown(account.DBID, "unauthorized", time.Now().Add(time.Hour))
+	if _, ok := store.getCachedAccountCooldown(account.DBID); !ok {
+		t.Fatal("precondition: cached cooldown missing")
+	}
+
+	store.ForgetCachedAccountCooldown(account.DBID)
+
+	if _, ok := store.getCachedAccountCooldown(account.DBID); ok {
+		t.Fatal("cached cooldown should have been dropped")
+	}
+	if store.accountHasCachedCooldown(account) {
+		t.Fatal("accountHasCachedCooldown() = true after forget, want false")
+	}
+}

--- a/auth/store.go
+++ b/auth/store.go
@@ -3560,6 +3560,16 @@ func (s *Store) deleteCachedAccountCooldown(accountID int64) {
 	}
 }
 
+// ForgetCachedAccountCooldown 清除账号在跨实例冷却缓存里的记录。
+//
+// 管理端在数据库层直接清掉 error / unauthorized 状态（重新导入、重新授权、
+// 合并凭证）并重载运行时账号时必须一并调用：调度器每次挑号都会回读该缓存
+// 并把冷却重新盖回内存账号，只清库不清缓存会让刚复活的账号继续被挡到
+// 缓存 TTL（unauthorized 可达 24h）到期。
+func (s *Store) ForgetCachedAccountCooldown(accountID int64) {
+	s.deleteCachedAccountCooldown(accountID)
+}
+
 func (s *Store) applyCachedAccountCooldown(acc *Account, record runtimeCooldownRecord) {
 	if s == nil || acc == nil || !record.ResetAt.After(time.Now()) {
 		return


### PR DESCRIPTION
Fixes #618

## 问题
重授权后 RT 变化，裸 RT 导入会先当新号入库、刷新后按 email+工作区身份合并进旧账号。合并只更新凭证，旧账号的 `status=error` / unauthorized 冷却原样保留，新号被软删——用户看到新号消失、旧号继续挂"未授权"。

另外两处缺口：
- 凭证一字不差的重复导入（JSON 身份命中 / 裸 RT 路由命中 / 手工添加 / AT 添加）只计 duplicate，不复活处于异常态的旧账号。
- JWT 路径虽然 `db.ClearError`，但 PG+Redis 下调度器每次挑号回读跨实例冷却缓存，又把 unauthorized 盖回来（最长 24h）。

## 修复
- 新增 `clearReimportedAccountErrorState`：清库里 error/unauthorized + 清冷却缓存；限速冷却不碰。挂进刷新后合并、身份 upsert、重新授权三处。
- 新增 `reviveReimportedAccount`：重复命中且旧账号处于 error/unauthorized 时清状态、重载、重新探测，计入 `updated`（导入进度弹窗已有该列，前端零改动）。正常态重复仍直接跳过。
- 路由键去重改为返回持有账号 ID；`importAccountsCommon` 复活队列走现有 dbLimiter，退回重复的计数在进度 goroutine 退出后并入。
- 导出 `Store.ForgetCachedAccountCooldown`。

## 测试
新增 6 个测试（合并清 401、限速冷却保留、JSON 身份/裸 RT/手工添加复活、缓存清除），`admin` `auth` 全量通过。

## 发版说明
对处于 error / 未授权状态的账号重复导入相同凭证，现在会复活并计入"更新"，而非"重复跳过"。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Re-importing or re-adding accounts in an error or unauthorized state now revives the existing account instead of creating a duplicate.
  * Revived accounts clear stale error and unauthorized status while preserving rate-limit cooldowns.
  * Import and OAuth results now distinguish revived accounts from unchanged duplicates.
  * Removed unauthorized cooldowns are no longer restored from cache after being cleared.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->