### PR TITLE
fix(proxy): recognize Codex Desktop client versions

### DIFF
--- a/proxy/device_profile.go
+++ b/proxy/device_profile.go
@@ -26,7 +26,7 @@ const (
 
 var (
 	codexClientVersionPatterns = []*regexp.Regexp{
-		regexp.MustCompile(`(?i)(?:^|[\s(;])(?:codex-tui|codex_cli_rs|codex_vscode|codex_app|codex_chatgpt_desktop|codex_atlas|codex_exec|codex_sdk_ts|opencode)/v?(\d+\.\d+\.\d+(?:-[A-Za-z0-9][A-Za-z0-9.-]*)?)(?:$|[\s;)])`),
+		regexp.MustCompile(`(?i)(?:^|[\s(;])(?:codex-tui|codex_cli_rs|codex_vscode|codex_app|codex_chatgpt_desktop|codex_atlas|codex_exec|codex_sdk_ts|codex desktop|opencode)/v?(\d+\.\d+\.\d+(?:-[A-Za-z0-9][A-Za-z0-9.-]*)?)(?:$|[\s;)])`),
 		regexp.MustCompile(`(?i)(?:^|[\s(;])codex\s+v?(\d+\.\d+\.\d+(?:-[A-Za-z0-9][A-Za-z0-9.-]*)?)(?:$|[\s;)])`),
 	}
 

--- a/proxy/executor_test.go
+++ b/proxy/executor_test.go
@@ -929,6 +929,67 @@ func TestApplyCodexRequestHeadersPreservesOfficialClientHeaders(t *testing.T) {
 	}
 }
 
+func TestApplyCodexRequestHeadersAutoDerivesVersionFromDesktopUserAgent(t *testing.T) {
+	prev := CurrentRuntimeSettings()
+	ApplyRuntimeSettings(RuntimeSettings{
+		ClientCompatMode:   ClientCompatModeAuto,
+		CodexMinCLIVersion: "0.153.3",
+	})
+	t.Cleanup(func() { ApplyRuntimeSettings(prev) })
+
+	req, err := http.NewRequest(http.MethodPost, "https://example.com/v1/responses", nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest() error = %v", err)
+	}
+	desktopUserAgent := "Codex Desktop/0.153.3 (Mac OS 26.4.0; arm64) dumb (codex_exec; 0.153.3)"
+	downstreamHeaders := http.Header{
+		"User-Agent": []string{desktopUserAgent},
+		"Originator": []string{"Codex Desktop"},
+	}
+
+	applyCodexRequestHeaders(req, &auth.Account{DBID: 42}, "token-123", "", "api-key-1", nil, downstreamHeaders)
+
+	if got := req.Header.Get("User-Agent"); got != desktopUserAgent {
+		t.Fatalf("User-Agent = %q, want %q", got, desktopUserAgent)
+	}
+	if got := req.Header.Get("Originator"); got != "Codex Desktop" {
+		t.Fatalf("Originator = %q, want Codex Desktop", got)
+	}
+	if got := req.Header.Get("Version"); got != "0.153.3" {
+		t.Fatalf("Version = %q, want 0.153.3 derived from desktop User-Agent", got)
+	}
+}
+
+func TestApplyCodexRequestHeadersAutoUpgradesOldDesktopClient(t *testing.T) {
+	prev := CurrentRuntimeSettings()
+	ApplyRuntimeSettings(RuntimeSettings{
+		ClientCompatMode:   ClientCompatModeAuto,
+		CodexMinCLIVersion: "0.153.3",
+	})
+	t.Cleanup(func() { ApplyRuntimeSettings(prev) })
+
+	req, err := http.NewRequest(http.MethodPost, "https://example.com/v1/responses", nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest() error = %v", err)
+	}
+	downstreamHeaders := http.Header{
+		"User-Agent": []string{"Codex Desktop/0.152.0 (Mac OS 26.4.0; arm64) dumb (codex_exec; 0.152.0)"},
+		"Originator": []string{"Codex Desktop"},
+	}
+
+	applyCodexRequestHeaders(req, &auth.Account{DBID: 42}, "token-123", "", "api-key-1", nil, downstreamHeaders)
+
+	if got := req.Header.Get("User-Agent"); got == downstreamHeaders.Get("User-Agent") {
+		t.Fatalf("User-Agent preserved old desktop UA %q", got)
+	}
+	if got := req.Header.Get("Originator"); got != Originator {
+		t.Fatalf("Originator = %q, want generated client originator %q", got, Originator)
+	}
+	if got := req.Header.Get("Version"); got != "0.153.3" {
+		t.Fatalf("Version = %q, want auto minimum 0.153.3", got)
+	}
+}
+
 func TestApplyCodexRequestHeadersAutoUpgradesOldCodexCLI(t *testing.T) {
 	prev := CurrentRuntimeSettings()
 	ApplyRuntimeSettings(RuntimeSettings{


### PR DESCRIPTION
## Summary

- recognize the official `Codex Desktop/<version>` User-Agent format
- derive the outbound `Version` header from the desktop User-Agent in auto compatibility mode
- cover both current and below-minimum desktop client versions with regression tests

## Root cause

Codex Desktop sends headers such as:

```text
User-Agent: Codex Desktop/0.153.3 (...)
Originator: Codex Desktop
```

but may omit the `Version` header. The client-version parser did not recognize the spaced `Codex Desktop/` token, so CodexProxy fell back to its built-in `0.144.1` version. Version-gated models such as `gpt-6-astra` then rejected the request as coming from an outdated Codex client.

## Validation

- based directly on release `v2.9.0` (`c3a2b9ffd96b365ac3bb891607b3ffccd4155405`)
- regression test fails on the unmodified release with `Version = "0.144.1"`
- removing the parser change makes both desktop tests fail; restoring it makes both pass
- `go test ./... -count=1`
- `go vet ./...`
- `npm test` (225 tests)
- `npm run typecheck`
- `npm run build`
- live upstream-backed request using the desktop headers above, with no explicit `Version`, completed successfully

Related to #634.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recognition of Codex Desktop clients from their User-Agent strings.
  - Current Codex Desktop clients now retain their original User-Agent while reporting the correct version.
  - Older Codex Desktop clients are automatically upgraded to the minimum supported version and receive compatible request headers.

- **Tests**
  - Added coverage for current and outdated Codex Desktop client compatibility behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->