### PR TITLE
fix(billing): disable GPT-6 Astra long-context pricing

### DIFF
--- a/database/billing.go
+++ b/database/billing.go
@@ -56,16 +56,12 @@ var (
 	defaultModelPricing = &ModelPricing{InputPricePerMToken: 1.0, OutputPricePerMToken: 2.0}
 
 	modelPricingRules = []modelPricingRule{
-		// gpt-6-astra：官方定价页 standard $10/$50、缓存 $1；≥272K 长上下文
-		// $20/$75、缓存 $2。fast（priority）档恒为 standard 的 2×，由
-		// serviceTierCostMultiplier 兜底自动得出，无需显式配置。
+		// gpt-6-astra：Codex 长上下文例外，超过 272K 仍按 $10/$50、缓存 $1。
+		// 保留现有 fast（priority）2× 倍率，由 serviceTierCostMultiplier 兜底。
 		{model: "gpt-6-astra", pricing: ModelPricing{
-			InputPricePerMToken:         10.0,
-			OutputPricePerMToken:        50.0,
-			CacheReadPricePerMToken:     1.0,
-			LongInputPricePerMToken:     20.0,
-			LongOutputPricePerMToken:    75.0,
-			LongCacheReadPricePerMToken: 2.0,
+			InputPricePerMToken:     10.0,
+			OutputPricePerMToken:    50.0,
+			CacheReadPricePerMToken: 1.0,
 		}},
 		{model: "gpt-5.5", pricing: ModelPricing{
 			InputPricePerMToken:                 5.0,

--- a/database/billing_test.go
+++ b/database/billing_test.go
@@ -208,8 +208,8 @@ func TestGPT56VariantPricing(t *testing.T) {
 	}
 }
 
-// gpt-6-astra 官方定价（developers.openai.com/api/docs/pricing，2026-09）：
-// standard $10/$50、缓存 $1；≥272K 长上下文 $20/$75、缓存 $2；fast 恒 2×。
+// gpt-6-astra 在 Codex 中不收长上下文溢价：跨过 272K 后仍使用同一组单价。
+// standard $10/$50、缓存 $1；保留现有 fast 2× 倍率。
 // 变体后缀 / 思考强度别名同价；未知 gpt-6 变体按 astra 兜底，绝不能掉进默认价。
 func TestGPT6AstraPricing(t *testing.T) {
 	for _, model := range []string{"gpt-6-astra", "gpt-6-astra-high", "gpt-6-astra(xhigh)", "GPT-6-Astra", "gpt-6", "gpt-6-nova"} {
@@ -220,17 +220,28 @@ func TestGPT6AstraPricing(t *testing.T) {
 		assertFloatEqual(t, p.InputPricePerMToken, 10.0)
 		assertFloatEqual(t, p.OutputPricePerMToken, 50.0)
 		assertFloatEqual(t, p.CacheReadPricePerMToken, 1.0)
-		assertFloatEqual(t, p.LongInputPricePerMToken, 20.0)
-		assertFloatEqual(t, p.LongOutputPricePerMToken, 75.0)
-		assertFloatEqual(t, p.LongCacheReadPricePerMToken, 2.0)
+		assertFloatEqual(t, p.LongInputPricePerMToken, 0)
+		assertFloatEqual(t, p.LongOutputPricePerMToken, 0)
+		assertFloatEqual(t, p.LongCacheReadPricePerMToken, 0)
 	}
 
-	// 短上下文 fast 档：2× standard。
-	const n = 100_000
-	assertFloatEqual(t, CalculateCost(n, n, 0, "gpt-6-astra", "fast"), (20.0+100.0)*float64(n)/1_000_000.0)
-	// 长上下文（≥272K）standard 档走 long 价。
-	const long = 300_000
-	assertFloatEqual(t, CalculateCost(long, 1_000, 0, "gpt-6-astra", ""), 20.0*float64(long)/1_000_000.0+75.0*1_000/1_000_000.0)
+	for _, input := range []int{100_000, 271_999, 272_000, 272_001, 1_000_000} {
+		for _, tier := range []struct {
+			name       string
+			multiplier float64
+		}{{"", 1}, {"fast", 2}, {"priority", 2}, {"flex", 0.5}} {
+			const cached, output = 100_000, 1_000
+			got := CalculateCostBreakdown(input, output, cached, "gpt-6-astra", tier.name)
+			if got.LongContext {
+				t.Fatalf("Astra applied long-context pricing at input=%d tier=%q: %+v", input, tier.name, got)
+			}
+			assertFloatEqual(t, got.InputPricePerMToken, 10*tier.multiplier)
+			assertFloatEqual(t, got.CacheReadPricePerMToken, tier.multiplier)
+			assertFloatEqual(t, got.OutputPricePerMToken, 50*tier.multiplier)
+			want := (float64(input-cached)*10 + cached + output*50) / 1_000_000 * tier.multiplier
+			assertFloatEqual(t, got.TotalCost, want)
+		}
+	}
 
 	// gpt-5.6 家族不得被 gpt-6 前缀误伤。
 	if got := CanonicalBillingModelKey("gpt-5.6-sol"); got != "gpt-5.6-sol" {

--- a/database/model_pricing_mutation_test.go
+++ b/database/model_pricing_mutation_test.go
@@ -2,10 +2,80 @@ package database
 
 import (
 	"context"
+	"encoding/json"
 	"path/filepath"
 	"testing"
 	"time"
 )
+
+func TestAstraPricingStaysFlatAcrossSettingsLoadAndMutation(t *testing.T) {
+	t.Cleanup(func() { SetModelPricingOverrides(nil) })
+	db, err := New("sqlite", filepath.Join(t.TempDir(), "astra-pricing.db"))
+	if err != nil {
+		t.Fatalf("New sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	ctx := context.Background()
+	const legacy = `{
+		"gpt-6-astra": {"source":"custom","input":10,"cached_input":1,"output":50,
+			"input_priority":20,"cached_input_priority":2,"output_priority":100,
+			"input_long":20,"cached_input_long":2,"output_long":75,
+			"input_long_priority":40,"cached_input_long_priority":4,"output_long_priority":150,
+			"long_context_threshold_tokens":272000},
+		"gpt-5.4": {"source":"custom","input_long":7,"output_long":30}
+	}`
+	if err := db.UpdateModelPricingSettings(ctx, legacy, ""); err != nil {
+		t.Fatalf("seed legacy settings: %v", err)
+	}
+	settings, err := db.GetSystemSettings(ctx)
+	if err != nil {
+		t.Fatalf("read legacy settings: %v", err)
+	}
+	loaded, err := ParseModelPricingOverridesJSON(settings.ModelPricingOverrides)
+	if err != nil {
+		t.Fatalf("load pricing: %v", err)
+	}
+	want := ModelPricingOverride{
+		Source: ModelPricingSourceCustom, Input: 10, CachedInput: 1, Output: 50,
+		InputPriority: 20, CachedInputPriority: 2, OutputPriority: 100,
+	}
+	if loaded["gpt-6-astra"] != want {
+		t.Fatalf("loaded Astra pricing retained legacy tiers: %+v", loaded["gpt-6-astra"])
+	}
+	SetModelPricingOverrides(loaded)
+	assertFloatEqual(t, CalculateCost(300000, 1000, 100000, "gpt-6-astra", "fast"), 4.3)
+
+	// 所有手工/官方/JSON 同步共用此写入路径；旧 API 长档不能再次落入生效配置。
+	var incoming map[string]ModelPricingOverride
+	if err := json.Unmarshal([]byte(legacy), &incoming); err != nil {
+		t.Fatalf("decode incoming pricing: %v", err)
+	}
+	updated, err := db.MutateModelPricingSettings(ctx, nil, func(current map[string]ModelPricingOverride) error {
+		current["gpt-6-astra"] = incoming["gpt-6-astra"]
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("mutate pricing: %v", err)
+	}
+	settings, err = db.GetSystemSettings(ctx)
+	if err != nil {
+		t.Fatalf("read persisted pricing: %v", err)
+	}
+	// 直接解码存储值，避免读取时的归一化掩盖持久化遗漏。
+	var stored map[string]ModelPricingOverride
+	if err := json.Unmarshal([]byte(settings.ModelPricingOverrides), &stored); err != nil {
+		t.Fatalf("decode stored pricing: %v", err)
+	}
+	if stored["gpt-6-astra"] != want || updated["gpt-6-astra"] != want {
+		t.Fatalf("Astra tiers survived mutation: stored=%+v returned=%+v", stored["gpt-6-astra"], updated["gpt-6-astra"])
+	}
+	if stored["gpt-5.4"] != incoming["gpt-5.4"] {
+		t.Fatalf("other model pricing changed: %+v", stored["gpt-5.4"])
+	}
+	SetModelPricingOverrides(nil)
+	SetModelPricingOverrides(stored)
+	assertFloatEqual(t, CalculateCost(300000, 1000, 100000, "gpt-6-astra", "fast"), 4.3)
+}
 
 func TestMutateModelPricingSettingsSerializesReadMergeWrite(t *testing.T) {
 	db, err := New("sqlite", filepath.Join(t.TempDir(), "pricing.db"))

--- a/database/model_pricing_override.go
+++ b/database/model_pricing_override.go
@@ -51,6 +51,23 @@ type ModelPricingOverride struct {
 	LongContextThresholdTokens int `json:"long_context_threshold_tokens,omitempty"`
 }
 
+// normalizeModelPricingOverride 应用 Codex Astra 的长上下文计费例外。
+// 旧覆盖、手工编辑和官方 API 定价同步都不能重新启用 Astra 的长档；
+// 标准价、priority 价及其他模型的覆盖保持原样。
+func normalizeModelPricingOverride(model string, o ModelPricingOverride) ModelPricingOverride {
+	if CanonicalBillingModelKey(model) != "gpt-6-astra" {
+		return o
+	}
+	o.InputLong = 0
+	o.CachedInputLong = 0
+	o.OutputLong = 0
+	o.InputLongPriority = 0
+	o.CachedInputLongPriority = 0
+	o.OutputLongPriority = 0
+	o.LongContextThresholdTokens = 0
+	return o
+}
+
 // IsEmpty 判断覆盖是否不含任何价格（全 0）。
 func (o ModelPricingOverride) IsEmpty() bool {
 	return o.Input == 0 && o.CachedInput == 0 && o.CacheWrite5m == 0 && o.CacheWrite1h == 0 && o.Output == 0 &&
@@ -174,6 +191,9 @@ func (db *DB) MutateModelPricingSettings(ctx context.Context, syncURL *string, m
 			return nil, err
 		}
 	}
+	for model, override := range overrides {
+		overrides[model] = normalizeModelPricingOverride(model, override)
+	}
 	blob, err := MarshalModelPricingOverridesJSON(overrides)
 	if err != nil {
 		return nil, err
@@ -194,6 +214,7 @@ func SetModelPricingOverrides(m map[string]ModelPricingOverride) {
 	norm := make(map[string]ModelPricingOverride, len(m))
 	for k, v := range m {
 		key := strings.ToLower(strings.TrimSpace(k))
+		v = normalizeModelPricingOverride(key, v)
 		if key == "" || v.IsEmpty() {
 			continue
 		}
@@ -277,6 +298,7 @@ func ParseModelPricingOverridesJSON(s string) (map[string]ModelPricingOverride, 
 	out := make(map[string]ModelPricingOverride, len(raw))
 	for k, v := range raw {
 		key := strings.ToLower(strings.TrimSpace(k))
+		v = normalizeModelPricingOverride(key, v)
 		if key == "" || v.IsEmpty() {
 			continue
 		}

--- a/database/model_pricing_override_test.go
+++ b/database/model_pricing_override_test.go
@@ -181,6 +181,58 @@ func TestModelPricingOverride_LongPriorityFieldsRoundTripAndApply(t *testing.T) 
 	}
 }
 
+func TestModelPricingOverride_AstraIgnoresLongContextPrices(t *testing.T) {
+	t.Cleanup(func() { SetModelPricingOverrides(nil) })
+
+	for _, source := range []string{ModelPricingSourceCustom, ModelPricingSourceSynced} {
+		t.Run(source, func(t *testing.T) {
+			// 旧手工价和官方 API 同步价都可能包含长档；标准价和 Fast 价仍须保留。
+			override := ModelPricingOverride{
+				Source: source, Input: 12, CachedInput: 2, Output: 60,
+				InputPriority: 24, CachedInputPriority: 4, OutputPriority: 120,
+				InputLong: 30, CachedInputLong: 4, OutputLong: 90,
+				InputLongPriority: 60, CachedInputLongPriority: 8, OutputLongPriority: 180,
+				LongContextThresholdTokens: 200000,
+			}
+			SetModelPricingOverrides(map[string]ModelPricingOverride{
+				"gpt-6-astra": override,
+				"gpt-5.6-sol": override,
+			})
+			want := ModelPricingOverride{
+				Source: source, Input: 12, CachedInput: 2, Output: 60,
+				InputPriority: 24, CachedInputPriority: 4, OutputPriority: 120,
+			}
+			for _, model := range []string{"gpt-6-astra", "GPT-6-Astra", "gpt-6-astra-high", "gpt-6-astra(xhigh)"} {
+				projected := ModelPricingOverrideFromPricing(GetModelPricing(model), ModelPricingSourceFor("gpt-6-astra"))
+				if projected != want {
+					t.Fatalf("%s effective pricing = %+v, want %+v", model, projected, want)
+				}
+				for _, tier := range []string{"", "fast", "priority"} {
+					got := CalculateCostBreakdown(300000, 1000, 100000, model, tier)
+					if got.LongContext {
+						t.Fatalf("%s tier=%q restored long-context pricing: %+v", model, tier, got)
+					}
+					cost := 2.66 // 200K uncached * $12 + 100K cached * $2 + 1K output * $60.
+					if tier != "" {
+						cost *= 2
+					}
+					assertFloatEqual(t, got.TotalCost, cost)
+				}
+			}
+
+			// 相同的覆盖用于其他模型时，长档价和阈值全部继续生效。
+			if got := ModelPricingOverrideFromPricing(GetModelPricing("gpt-5.6-sol"), source); got != override {
+				t.Fatalf("other model override changed: %+v, want %+v", got, override)
+			}
+			other := CalculateCostBreakdown(300000, 1000, 100000, "gpt-5.6-sol", "fast")
+			if !other.LongContext || other.LongContextThreshold != 200000 {
+				t.Fatalf("other model lost long-context pricing: %+v", other)
+			}
+			assertFloatEqual(t, other.TotalCost, 12.98)
+		})
+	}
+}
+
 func TestModelPricingOverride_CacheWriteFieldsRoundTripAndApply(t *testing.T) {
 	override := ModelPricingOverride{Input: 10, CachedInput: 1, CacheWrite5m: 12.5, CacheWrite1h: 20, Output: 50}
 	raw, err := MarshalModelPricingOverridesJSON(map[string]ModelPricingOverride{"claude-fable-5": override})

--- a/frontend/src/pages/ModelPricing.tsx
+++ b/frontend/src/pages/ModelPricing.tsx
@@ -1390,14 +1390,17 @@ export default function ModelPricing() {
                 const inputVal = normalizePrice(draft.input)
                 const outputVal = normalizePrice(draft.output)
                 const multiplier = getOutputMultiplier(inputVal, outputVal)
-                const advancedFields = r.model === 'gpt-6-astra'
-                  ? ADVANCED_FIELDS.filter((field) => !field.key.includes('_long'))
-                  : ADVANCED_FIELDS
-                const hasLongContextPricing =
+                const pricingModel = (r.canonical_model?.trim() || r.model.trim()).toLowerCase()
+                const supportsLongContextPricing = pricingModel !== 'gpt-6-astra'
+                const advancedFields = supportsLongContextPricing
+                  ? ADVANCED_FIELDS
+                  : ADVANCED_FIELDS.filter((field) => !field.key.includes('_long'))
+                const hasLongContextPricing = supportsLongContextPricing && (
                   normalizePrice(draft.long_context_threshold_tokens) > 0 ||
                   normalizePrice(draft.input_long) > 0 ||
                   normalizePrice(draft.cached_input_long) > 0 ||
                   normalizePrice(draft.output_long) > 0
+                )
 
                 return (
                   <article

--- a/frontend/src/pages/ModelPricing.tsx
+++ b/frontend/src/pages/ModelPricing.tsx
@@ -1390,6 +1390,9 @@ export default function ModelPricing() {
                 const inputVal = normalizePrice(draft.input)
                 const outputVal = normalizePrice(draft.output)
                 const multiplier = getOutputMultiplier(inputVal, outputVal)
+                const advancedFields = r.model === 'gpt-6-astra'
+                  ? ADVANCED_FIELDS.filter((field) => !field.key.includes('_long'))
+                  : ADVANCED_FIELDS
                 const hasLongContextPricing =
                   normalizePrice(draft.long_context_threshold_tokens) > 0 ||
                   normalizePrice(draft.input_long) > 0 ||
@@ -1559,7 +1562,7 @@ export default function ModelPricing() {
                         >
                           <div className="min-h-0 overflow-hidden">
                             <div className="grid grid-cols-1 gap-2.5 pt-2 min-[480px]:grid-cols-2 xl:grid-cols-4">
-                              {ADVANCED_FIELDS.map((field) => (
+                              {advancedFields.map((field) => (
                                 <PriceField
                                   key={field.key}
                                   field={field}

--- a/pricing.json
+++ b/pricing.json
@@ -99,9 +99,6 @@
     "output": 50,
     "input_priority": 20,
     "cached_input_priority": 2,
-    "output_priority": 100,
-    "input_long": 20,
-    "cached_input_long": 2,
-    "output_long": 75
+    "output_priority": 100
   }
 }

--- a/proxy/model_pricing_sync_test.go
+++ b/proxy/model_pricing_sync_test.go
@@ -1,8 +1,72 @@
 package proxy
 
 import (
+	"math"
 	"testing"
+
+	"github.com/codex2api/database"
 )
+
+func TestAstraPricingSourcesCannotRestoreLongContext(t *testing.T) {
+	t.Cleanup(func() { database.SetModelPricingOverrides(nil) })
+	for _, tt := range []struct {
+		name  string
+		body  string
+		parse func([]byte) (map[string]database.ModelPricingOverride, error)
+	}{
+		{
+			name: "flat JSON",
+			body: `{"gpt-6-astra":{"input":10,"cached_input":1,"output":50,
+				"input_priority":20,"cached_input_priority":2,"output_priority":100,
+				"input_long":20,"cached_input_long":2,"output_long":75,
+				"input_long_priority":40,"cached_input_long_priority":4,"output_long_priority":150}}`,
+			parse: parseModelPricingPayload,
+		},
+		{
+			name: "models.dev",
+			body: `{"openai":{"models":{"gpt-6-astra":{"cost":{
+				"input":10,"cache_read":1,"output":50,
+				"tiers":[{"input":20,"cache_read":2,"output":75,"tier":{"type":"context","size":272000}}]
+			}}}}}`,
+			parse: parseModelPricingPayload,
+		},
+		{
+			name: "official API Markdown",
+			body: `
+### Standard pricing data
+| Model | Short context input | Short context cached input | Short context cache writes | Short context output | Long context input | Long context cached input | Long context cache writes | Long context output |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| gpt-6-astra | $10.00 | $1.00 | $12.50 | $50.00 | $20.00 | $2.00 | $25.00 | $75.00 |
+### Fast pricing data
+| Model | Short context input | Short context cached input | Short context cache writes | Short context output | Long context input | Long context cached input | Long context cache writes | Long context output |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| gpt-6-astra | $20.00 | $2.00 | $25.00 | $100.00 | $40.00 | $4.00 | $50.00 | $150.00 |
+`,
+			parse: ParseOpenAIOfficialPricingMarkdown,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			parsed, err := tt.parse([]byte(tt.body))
+			if err != nil {
+				t.Fatalf("parse source: %v", err)
+			}
+			if parsed["gpt-6-astra"].InputLong != 20 {
+				t.Fatalf("fixture must supply API long-context rates: %+v", parsed)
+			}
+			database.SetModelPricingOverrides(parsed)
+			for _, tier := range []string{"", "fast", "priority"} {
+				got := database.CalculateCostBreakdown(300000, 1000, 100000, "gpt-6-astra", tier)
+				want := 2.15
+				if tier != "" {
+					want = 4.3
+				}
+				if got.LongContext || math.Abs(got.TotalCost-want) > 1e-9 {
+					t.Fatalf("tier=%q restored API long-context rates: %+v, want total %v", tier, got, want)
+				}
+			}
+		})
+	}
+}
 
 func TestParseModelPricingPayloadFlat(t *testing.T) {
 	body := []byte(`{


### PR DESCRIPTION
GPT-6 Astra requests in Codex were charged higher per-token rates once input reached 272K tokens. Apply the Codex long-context exception so Astra uses the same rates at every context length: the built-in Standard rates remain $10 input, $1 cached input, and $50 output per million tokens.

Remove Astra's long-context rates from the built-in table and pricing.json, and strip its long-context fields when loading or updating pricing overrides. This prevents legacy custom prices and subsequent official, flat JSON, or models.dev syncs from restoring the surcharge. The pricing page also hides Astra's long-context fields. Standard custom prices, existing service-tier multipliers, and other models' billing are preserved.

Validation passed:

- `go test -count=1 -timeout 8m ./...`
- `npm --prefix frontend test` (248 tests)
- `npm --prefix frontend run typecheck`
- `npm --prefix frontend run build`

Regression coverage includes the 272K boundary and 1M-token inputs, cached input, Fast/Priority/Flex tiers, legacy settings load and persistence, all three pricing-source formats, and preservation of other models' long-context pricing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Billing**
  - Updated gpt-6-astra pricing so long-context requests use standard rates instead of separate long-context rates.
  - Long-context pricing no longer applies to gpt-6-astra or its aliases, including requests at or above the long-context threshold.

- **Model Pricing**
  - Advanced pricing screens no longer show long-context fields or thresholds for gpt-6-astra.
  - Pricing settings consistently preserve standard and priority-tier rates while ignoring unsupported long-context overrides from custom or synchronized sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->