### PR TITLE
更新 Antigravity 模型目录并支持 Gemini 3.8 Flash

### DIFF
--- a/admin/antigravity_accounts.go
+++ b/admin/antigravity_accounts.go
@@ -129,6 +129,8 @@ func antigravityPublishedModelForObservation(model string, publishedModels []str
 // wire models, but the admin response exposes exactly one quota entry for it.
 func antigravityPublishedQuota(raw auth.AntigravityQuotaSnapshot) auth.AntigravityQuotaSnapshot {
 	projected := raw
+	projected.CatalogModelIDs = antigravityPublishedModels(auth.AntigravityDiscoveredModels(raw))
+	projected.InternalModelIDs = nil
 	projected.Models = []auth.AntigravityModelQuota{}
 	// Forwarding rules are provider-wire implementation details and are not an
 	// admin-facing model contract.
@@ -1696,10 +1698,7 @@ func antigravityCredentialUpdates(result auth.AntigravitySyncResult, previous *d
 	if err != nil {
 		return nil, err
 	}
-	models := make([]string, 0, len(quotaSnapshot.Models))
-	for _, model := range quotaSnapshot.Models {
-		models = append(models, model.ModelID)
-	}
+	models := auth.AntigravityDiscoveredModels(quotaSnapshot)
 	updates := map[string]any{
 		"upstream_type": auth.UpstreamAntigravity,
 		"access_token":  result.Credential.AccessToken, "refresh_token": result.Credential.RefreshToken,

--- a/api/responses.go
+++ b/api/responses.go
@@ -93,12 +93,19 @@ func SendAccepted(c *gin.Context, data interface{}) {
 
 // Model represents an OpenAI-style model object
 type Model struct {
-	ID         string `json:"id"`
-	Object     string `json:"object"`
-	Created    int64  `json:"created"`
-	OwnedBy    string `json:"owned_by"`
-	Root       string `json:"root,omitempty"`
-	Parent     string `json:"parent,omitempty"`
+	ID                       string                `json:"id"`
+	Object                   string                `json:"object"`
+	Created                  int64                 `json:"created"`
+	OwnedBy                  string                `json:"owned_by"`
+	Root                     string                `json:"root,omitempty"`
+	Parent                   string                `json:"parent,omitempty"`
+	SupportedReasoningLevels []ModelReasoningLevel `json:"supported_reasoning_levels,omitempty"`
+	DefaultReasoningLevel    string                `json:"default_reasoning_level,omitempty"`
+}
+
+type ModelReasoningLevel struct {
+	Effort      string `json:"effort"`
+	Description string `json:"description"`
 }
 
 // ModelList represents a list of models

--- a/auth/antigravity_catalog.go
+++ b/auth/antigravity_catalog.go
@@ -1,0 +1,129 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+const antigravityCatalogRefreshInterval = 30 * time.Minute
+
+// RefreshAntigravityCatalog only reads the model/quota control plane. Token
+// refresh and identity changes remain owned by the existing OAuth scheduler.
+func (s *Store) RefreshAntigravityCatalog(ctx context.Context, account *Account) error {
+	if s == nil || s.db == nil || account == nil || account.AntigravityAuthKind() != AntigravityAuthKindOAuth {
+		return errors.New("Antigravity catalog requires a database-backed OAuth account")
+	}
+	row, err := s.db.GetAccountByID(ctx, account.ID())
+	if err != nil {
+		return err
+	}
+	if reason, _ := antigravityPersistedHardFence(row); reason != "" {
+		return errors.New("Antigravity account needs authentication or administrative recovery")
+	}
+	proxyURL, usable := s.ResolveUsableProxyForAccount(account)
+	if !usable {
+		return errors.New("Antigravity catalog has no usable proxy")
+	}
+	client, err := NewAntigravityClient(proxyURL)
+	if err != nil {
+		return err
+	}
+	quota, err := client.fetchQuota(ctx, row.GetCredential("access_token"), row.GetCredential("project_id"))
+	if err != nil {
+		return err
+	}
+	if quota.Forbidden {
+		return errors.New("Antigravity catalog access denied")
+	}
+	models := antigravityRefreshModels(AntigravitySyncResult{Quota: quota})
+	// An empty/malformed result is not evidence that every model was withdrawn.
+	if len(models) == 0 {
+		return errors.New("Antigravity catalog is empty; retaining last successful catalog")
+	}
+	// Preserve quota groups and credits, which this list-only endpoint cannot see.
+	var previous AntigravityQuotaSnapshot
+	_ = json.Unmarshal([]byte(row.GetCredential("antigravity_quota")), &previous)
+	quota.Groups, quota.AICredits = previous.Groups, previous.AICredits
+	raw, err := json.Marshal(quota)
+	if err != nil {
+		return err
+	}
+	applied, err := s.db.MergeAccountCredentialsForGeneration(ctx, row.ID, row.CredentialGeneration, map[string]any{
+		"models": models, "antigravity_quota": string(raw),
+		"antigravity_catalog_source": "upstream", "antigravity_catalog_verified": true,
+		"antigravity_catalog_updated_at": time.Now().UTC().Format(time.RFC3339),
+	})
+	if err != nil {
+		return err
+	}
+	if !applied {
+		return errors.New("Antigravity credential changed during catalog fetch; discarded stale response")
+	}
+	current, err := s.db.GetAccountByID(ctx, row.ID)
+	if err != nil {
+		return err
+	}
+	// Publish only the catalog, not an older credential/status snapshot.
+	account.mu.Lock()
+	if account.CredentialGeneration == current.CredentialGeneration {
+		account.Models = normalizeModelList(current.GetCredentialStringSlice("models"))
+	}
+	account.mu.Unlock()
+	return nil
+}
+
+func (s *Store) triggerAntigravityCatalogRefresh() {
+	if s == nil || s.db == nil || !s.antigravityCatalogBatch.CompareAndSwap(false, true) {
+		return
+	}
+	started := s.startDBBackgroundTask(func(parent context.Context) {
+		defer s.antigravityCatalogBatch.Store(false)
+		ctx, cancel := context.WithTimeout(parent, 5*time.Minute)
+		defer cancel()
+		jobs := make(chan *Account)
+		var workers sync.WaitGroup
+		for i := 0; i < 4; i++ {
+			workers.Add(1)
+			go func() {
+				defer workers.Done()
+				for account := range jobs {
+					callCtx, stop := context.WithTimeout(ctx, 30*time.Second)
+					err := s.RefreshAntigravityCatalog(callCtx, account)
+					stop()
+					if err != nil && ctx.Err() == nil {
+						// Do not log upstream error bodies or credentials.
+						log.Printf("[Antigravity catalog] account %d refresh failed; retaining cached catalog", account.ID())
+					}
+				}
+			}()
+		}
+		for _, account := range s.Accounts() {
+			if account == nil || account.AntigravityAuthKind() != AntigravityAuthKindOAuth || atomic.LoadInt32(&account.Disabled) != 0 {
+				continue
+			}
+			select {
+			case jobs <- account:
+			case <-ctx.Done():
+				close(jobs)
+				workers.Wait()
+				return
+			}
+		}
+		close(jobs)
+		workers.Wait()
+	})
+	if !started {
+		s.antigravityCatalogBatch.Store(false)
+	}
+}
+
+// Keep credential-independent model IDs bounded and suitable for API names.
+func validAntigravityDiscoveredModelID(id string) bool {
+	return len(id) > 0 && len(id) <= 200 && !strings.ContainsAny(id, "\r\n\t ")
+}

--- a/auth/antigravity_catalog_test.go
+++ b/auth/antigravity_catalog_test.go
@@ -1,0 +1,96 @@
+package auth
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestAntigravityCatalogRefreshKeepsAllIDsAndLastSuccess(t *testing.T) {
+	var status atomic.Int32
+	var empty atomic.Bool
+	status.Store(http.StatusOK)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/quota" {
+			t.Errorf("catalog refresh called non-catalog endpoint %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(int(status.Load()))
+		if empty.Load() {
+			_, _ = io.WriteString(w, `{"models":{}}`)
+			return
+		}
+		_, _ = io.WriteString(w, `{"models":{"gemini-3.8-flash-tiered":{"quotaInfo":{"remainingFraction":0.9}},"future-model-v4":{"displayName":"Future model"},"gemini-private-future":{"isInternal":true,"quotaInfo":{"remainingFraction":1}}}}`)
+	}))
+	defer server.Close()
+	useAntigravityTestEndpoints(t, server.URL)
+	store, db, account, id := newAntigravityRefreshTestAccount(t, nil)
+	if err := store.RefreshAntigravityCatalog(context.Background(), account); err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"future-model-v4", "gemini-3.8-flash-tiered"}
+	if got := account.AntigravityModels(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("full catalog = %v", got)
+	}
+	before, err := db.GetAccountByID(context.Background(), id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if before.GetCredential("antigravity_catalog_updated_at") == "" || !strings.Contains(before.GetCredential("antigravity_quota"), "future-model-v4") {
+		t.Fatal("successful catalog metadata was not persisted")
+	}
+	if !strings.Contains(before.GetCredential("antigravity_quota"), "gemini-private-future") {
+		t.Fatal("raw internal catalog evidence was discarded")
+	}
+	for _, failedStatus := range []int{http.StatusUnauthorized, http.StatusForbidden, http.StatusOK} {
+		status.Store(int32(failedStatus))
+		empty.Store(failedStatus == http.StatusOK)
+		if err := store.RefreshAntigravityCatalog(context.Background(), account); err == nil {
+			t.Fatalf("failed or empty catalog falsely succeeded: %d", failedStatus)
+		}
+		after, err := db.GetAccountByID(context.Background(), id)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(after.GetCredentialStringSlice("models"), want) || after.GetCredential("antigravity_quota") != before.GetCredential("antigravity_quota") {
+			t.Fatal("failed fetch destroyed last successful catalog")
+		}
+		if after.GetCredential("access_token") != before.GetCredential("access_token") {
+			t.Fatal("catalog poll changed OAuth credentials")
+		}
+	}
+}
+
+func TestAntigravityCatalogRefreshDiscardsOldCredentialGeneration(t *testing.T) {
+	entered, release := make(chan struct{}), make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(entered)
+		<-release
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"models":{"gemini-stale":{"quotaInfo":{"remainingFraction":1}}}}`)
+	}))
+	defer server.Close()
+	useAntigravityTestEndpoints(t, server.URL)
+	store, db, account, id := newAntigravityRefreshTestAccount(t, nil)
+	row, _ := db.GetAccountByID(context.Background(), id)
+	done := make(chan error, 1)
+	go func() { done <- store.RefreshAntigravityCatalog(context.Background(), account) }()
+	<-entered
+	_, applied, err := db.UpdateAccountCredentialsCAS(context.Background(), id, row.CredentialGeneration, map[string]any{"models": []string{"gemini-new-principal"}})
+	close(release)
+	if err != nil || !applied {
+		t.Fatalf("fixture credential change failed: %v", err)
+	}
+	if err := <-done; err == nil {
+		t.Fatal("stale generation accepted")
+	}
+	current, _ := db.GetAccountByID(context.Background(), id)
+	if got := current.GetCredentialStringSlice("models"); !reflect.DeepEqual(got, []string{"gemini-new-principal"}) {
+		t.Fatalf("stale response overwrote newer catalog: %v", got)
+	}
+}

--- a/auth/antigravity_client.go
+++ b/auth/antigravity_client.go
@@ -184,6 +184,7 @@ type antigravityQuotaResponse struct {
 			ResetTime         string   `json:"resetTime"`
 		} `json:"quotaInfo"`
 		DisplayName        string          `json:"displayName"`
+		IsInternal         bool            `json:"isInternal"`
 		SupportsImages     *bool           `json:"supportsImages"`
 		SupportsThinking   *bool           `json:"supportsThinking"`
 		ThinkingBudget     *int            `json:"thinkingBudget"`
@@ -954,6 +955,12 @@ func normalizeAntigravityQuota(payload antigravityQuotaResponse, now time.Time) 
 		Models: []AntigravityModelQuota{}, ModelForwardingRules: map[string]string{}, UpdatedAt: now.UTC(),
 	}
 	for modelID, model := range payload.Models {
+		if validAntigravityDiscoveredModelID(strings.TrimSpace(modelID)) {
+			result.CatalogModelIDs = append(result.CatalogModelIDs, strings.TrimSpace(modelID))
+			if model.IsInternal {
+				result.InternalModelIDs = append(result.InternalModelIDs, strings.TrimSpace(modelID))
+			}
+		}
 		if model.QuotaInfo == nil || !isTrackedAntigravityModel(modelID) {
 			continue
 		}
@@ -977,6 +984,8 @@ func normalizeAntigravityQuota(payload antigravityQuotaResponse, now time.Time) 
 		})
 	}
 	sort.Slice(result.Models, func(i, j int) bool { return result.Models[i].ModelID < result.Models[j].ModelID })
+	sort.Strings(result.CatalogModelIDs)
+	sort.Strings(result.InternalModelIDs)
 	for oldID, rule := range payload.DeprecatedModelIDs {
 		if strings.TrimSpace(oldID) != "" && strings.TrimSpace(rule.NewModelID) != "" {
 			result.ModelForwardingRules[oldID] = strings.TrimSpace(rule.NewModelID)

--- a/auth/antigravity_types.go
+++ b/auth/antigravity_types.go
@@ -89,7 +89,7 @@ func (a *Account) AntigravityAPIKey() string {
 
 // AntigravityDefaultModelIDs is the conservative raw/wire fallback catalog.
 // Public model discovery expands these backing IDs through the proxy's native
-// 14-model projection; keeping wire IDs here preserves request admission and
+// model projection; keeping wire IDs here preserves request admission and
 // capability checks when an account has not completed its first sync yet.
 func AntigravityDefaultModelIDs() []string {
 	return []string{
@@ -100,6 +100,7 @@ func AntigravityDefaultModelIDs() []string {
 		"gemini-3.6-flash-medium",
 		"gemini-3.6-flash-high",
 		"gemini-3.7-flash-tiered",
+		"gemini-3.8-flash-tiered",
 		"gemini-3.1-pro-low",
 		"gemini-pro-agent",
 		"claude-opus-4-6-thinking",
@@ -294,6 +295,9 @@ type AntigravityAICredits struct {
 }
 
 type AntigravityQuotaSnapshot struct {
+	// Includes models with no quotaInfo; absence of quota is not zero capacity.
+	CatalogModelIDs      []string                `json:"catalog_model_ids,omitempty"`
+	InternalModelIDs     []string                `json:"internal_model_ids,omitempty"`
 	Models               []AntigravityModelQuota `json:"models"`
 	Groups               []AntigravityQuotaGroup `json:"quota_groups,omitempty"`
 	ModelForwardingRules map[string]string       `json:"model_forwarding_rules,omitempty"`

--- a/auth/store.go
+++ b/auth/store.go
@@ -3225,6 +3225,7 @@ type Store struct {
 	usageProbe                         func(context.Context, *Account) error
 	usageProbeCompletion               func()
 	usageProbeBatch                    atomic.Bool
+	antigravityCatalogBatch            atomic.Bool
 	recoveryProbeBatch                 atomic.Bool
 	autoCleanUnauthorized              atomic.Bool
 	autoCleanRateLimited               atomic.Bool
@@ -5745,6 +5746,8 @@ func (s *Store) StartBackgroundRefresh() {
 	go func() {
 		defer s.wg.Done()
 		refreshTimer := time.NewTimer(s.GetBackgroundRefreshInterval())
+		catalogTimer := time.NewTimer(10 * time.Second)
+		defer catalogTimer.Stop()
 		autoCleanupTicker := time.NewTicker(30 * time.Second)
 		fullUsageCleanupTicker := time.NewTicker(5 * time.Minute)
 		expiredCleanupTicker := time.NewTicker(15 * time.Minute)
@@ -5780,6 +5783,9 @@ func (s *Store) StartBackgroundRefresh() {
 
 		for {
 			select {
+			case <-catalogTimer.C:
+				s.triggerAntigravityCatalogRefresh()
+				catalogTimer.Reset(antigravityCatalogRefreshInterval)
 			case <-refreshTimer.C:
 				if s.GetLazyMode() {
 					s.TriggerUsageProbeAsync()
@@ -11412,13 +11418,29 @@ func antigravityCredentialFromStoreRow(row *database.AccountRow) AntigravityCred
 }
 
 func antigravityRefreshModels(result AntigravitySyncResult) []string {
-	models := make([]string, 0, len(result.Quota.Models))
-	for _, model := range result.Quota.Models {
+	return AntigravityDiscoveredModels(result.Quota)
+}
+
+// Keep the complete raw catalog in the quota snapshot, but never publish IDs
+// explicitly marked internal by the provider into the dispatch model list.
+func AntigravityDiscoveredModels(quota AntigravityQuotaSnapshot) []string {
+	internal := make(map[string]bool)
+	for _, id := range quota.InternalModelIDs {
+		internal[strings.ToLower(id)] = true
+	}
+	models := append([]string(nil), quota.CatalogModelIDs...)
+	for _, model := range quota.Models {
 		if id := strings.TrimSpace(model.ModelID); id != "" {
 			models = append(models, id)
 		}
 	}
-	return normalizeModelList(models)
+	visible := models[:0]
+	for _, id := range models {
+		if !internal[strings.ToLower(id)] {
+			visible = append(visible, id)
+		}
+	}
+	return normalizeModelList(visible)
 }
 
 func antigravityCredentialRotated(row *database.AccountRow, credential AntigravityCredential) bool {

--- a/database/grok_state.go
+++ b/database/grok_state.go
@@ -976,6 +976,7 @@ func (db *DB) MergeAccountCredentialsForGeneration(ctx context.Context, accountI
 		"antigravity_sync_error": {}, "antigravity_sync_warning": {}, "antigravity_last_sync_attempt_at": {},
 		"antigravity_permanent_refresh_error": {},
 		"antigravity_catalog_source":          {}, "antigravity_catalog_verified": {},
+		"antigravity_catalog_updated_at": {}, "antigravity_quota": {},
 		"antigravity_capabilities": {}, "antigravity_capability_last_probe_at": {},
 	}
 	filtered := make(map[string]any, len(updates))

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next'
 import { api, resetAdminAuthState } from '../api'
 import { DEFAULT_SITE_LOGO, isBrandingVideo, useBranding } from '../branding'
 import { useVersionCheck } from '../hooks/useVersionCheck'
+import { buildVersionLabel } from '../lib/buildVersion'
 import { useTheme } from '../hooks/useTheme'
 import { useToast } from '../hooks/useToast'
 import { getErrorMessage } from '../utils/error'
@@ -380,7 +381,7 @@ export default function Layout({ children }: PropsWithChildren) {
                         tabIndex={sidebarCollapsed ? -1 : 0}
                         onClick={() => setShowVersionPopover((current) => !current)}
                       >
-                        {__APP_VERSION__}
+                        {buildVersionLabel(__APP_VERSION__)}
                         {hasUpdate && (
                           <span className="absolute -top-1.5 left-1/2 size-2.5 -translate-x-1/2 rounded-full bg-red-500 shadow-sm ring-2 ring-[hsl(var(--sidebar-background))] animate-pulse" />
                         )}
@@ -619,7 +620,7 @@ export default function Layout({ children }: PropsWithChildren) {
                 title={hasUpdate && latestVersion ? t('common.newVersionAvailable', { version: latestVersion }) : undefined}
                 onClick={() => setShowVersionPopover((current) => !current)}
               >
-                {__APP_VERSION__}
+                {buildVersionLabel(__APP_VERSION__)}
                 {hasUpdate && (
                   <span className="absolute -top-1 -right-1 size-2 rounded-full bg-red-500 shadow-sm ring-2 ring-card animate-pulse" />
                 )}
@@ -764,7 +765,7 @@ export default function Layout({ children }: PropsWithChildren) {
                     {t('common.online')}
                   </span>
                   <span className="font-mono text-[11px] font-semibold">
-                    v{__APP_VERSION__}
+                    {buildVersionLabel(__APP_VERSION__)}
                   </span>
                 </div>
               </div>

--- a/frontend/src/lib/accountStateOverlay.test.mjs
+++ b/frontend/src/lib/accountStateOverlay.test.mjs
@@ -201,7 +201,7 @@ test("pull request CI runs frontend regression tests", () => {
     "utf8",
   );
   const frontendJob = sourceSlice(
-    workflowSource,
+    workflowSource.replace(/\r\n/g, "\n"),
     "  frontend:\n",
     "  golangci-lint:\n",
   );

--- a/frontend/src/lib/antigravityModels.test.mjs
+++ b/frontend/src/lib/antigravityModels.test.mjs
@@ -1,0 +1,12 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import { ANTIGRAVITY_DEFAULT_MODELS } from './antigravityModels.ts'
+
+test('frontend fallbacks match public backend IDs including Flash 3.8', () => {
+  const source = readFileSync(new URL('../../../proxy/antigravity_models.go', import.meta.url), 'utf8')
+  const catalog = source.split('var antigravityPublicModelCatalog =')[1].split('var antigravityLogicalCompatibilityCatalog')[0]
+  const ids = Array.from(catalog.matchAll(/id: "([^"]+)"/g), match => match[1])
+  assert.deepEqual([...ANTIGRAVITY_DEFAULT_MODELS].sort(), ids.sort())
+  assert.equal(ANTIGRAVITY_DEFAULT_MODELS[0], 'gemini-3.8-flash-low')
+})

--- a/frontend/src/lib/antigravityModels.ts
+++ b/frontend/src/lib/antigravityModels.ts
@@ -1,0 +1,10 @@
+// Fallback only: account-synchronized model discovery takes precedence.
+// These are public gateway IDs, never Cloud Code's private backing IDs.
+export const ANTIGRAVITY_DEFAULT_MODELS = [
+  'gemini-3.8-flash-low', 'gemini-3.8-flash-medium', 'gemini-3.8-flash-high',
+  'gemini-3.7-flash-low', 'gemini-3.7-flash-medium', 'gemini-3.7-flash-high',
+  'gemini-3.6-flash-low', 'gemini-3.6-flash-medium', 'gemini-3.6-flash-high',
+  'gemini-3.5-flash-low', 'gemini-3.5-flash-medium', 'gemini-3.5-flash-high',
+  'gemini-3.1-pro-low', 'gemini-3.1-pro-high',
+  'claude-opus-4-6-thinking', 'claude-sonnet-4-6', 'gpt-oss-120b-medium',
+]

--- a/frontend/src/lib/buildVersion.test.mjs
+++ b/frontend/src/lib/buildVersion.test.mjs
@@ -1,0 +1,9 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { buildVersionLabel } from './buildVersion.ts'
+
+test('local version uses its build date and preserves normal releases', () => {
+  assert.equal(buildVersionLabel('local-20260906-0310-fb4426b2'), '本地版本 2026-09-06 03:10')
+  assert.equal(buildVersionLabel('v2.9.0'), 'v2.9.0')
+  assert.equal(buildVersionLabel('dev'), 'dev')
+})

--- a/frontend/src/lib/buildVersion.ts
+++ b/frontend/src/lib/buildVersion.ts
@@ -1,0 +1,7 @@
+// The date comes from the injected build ID, never from the browser clock.
+export function buildVersionLabel(version: string): string {
+  const match = /^local-(\d{4})(\d{2})(\d{2})-(\d{2})(\d{2})(?:-|$)/.exec(version)
+  return match
+    ? `本地版本 ${match[1]}-${match[2]}-${match[3]} ${match[4]}:${match[5]}`
+    : version
+}

--- a/frontend/src/pages/APIKeys.tsx
+++ b/frontend/src/pages/APIKeys.tsx
@@ -1,3 +1,4 @@
+import { ANTIGRAVITY_DEFAULT_MODELS as DEFAULT_ANTIGRAVITY_MODEL_OPTIONS } from "../lib/antigravityModels";
 import type { ChangeEvent, FormEvent, ReactNode } from "react";
 import {
   useCallback,
@@ -196,11 +197,6 @@ const DEFAULT_GROK_MODEL_OPTIONS = [
   "grok-2",
 ];
 
-const DEFAULT_ANTIGRAVITY_MODEL_OPTIONS = [
-  "gemini-3-pro-preview",
-  "gemini-2.5-pro",
-  "gemini-2.5-flash",
-];
 // Keep this fallback in lockstep with proxy.defaultClaudeModelIDs. The
 // server catalog normally wins; these aliases are only used when no
 // Claude account has populated a catalog yet.

--- a/frontend/src/pages/AntigravityAccounts.tsx
+++ b/frontend/src/pages/AntigravityAccounts.tsx
@@ -1,3 +1,4 @@
+import { ANTIGRAVITY_DEFAULT_MODELS } from "../lib/antigravityModels";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { ChangeEvent, ReactNode } from "react";
 import { useTranslation } from "react-i18next";
@@ -97,12 +98,6 @@ type OAuthModalStatus = "idle" | "starting" | "waiting" | "processing" | "comple
 const ANTIGRAVITY_TABLE_COLUMNS = [
   "project", "permission", "quota", "proxy", "status", "updatedAt",
 ] as const;
-
-const ANTIGRAVITY_DEFAULT_MODELS = [
-  "gemini-3-pro-preview",
-  "gemini-2.5-pro",
-  "gemini-2.5-flash",
-];
 
 function parseModelList(value: string): string[] {
   return Array.from(

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/codex2api/config"
 	"github.com/codex2api/database"
 	"github.com/codex2api/internal/imagestore"
+	"github.com/codex2api/internal/version"
 	"github.com/codex2api/proxy"
 	"github.com/codex2api/proxy/wsrelay"
 	"github.com/codex2api/security"
@@ -562,6 +563,7 @@ func main() {
 		}
 		c.JSON(200, gin.H{
 			"status":          "ok",
+			"build_version":   version.Current(),
 			"available":       available,
 			"total":           total,
 			"counts_complete": countsComplete,

--- a/proxy/antigravity_flash38_test.go
+++ b/proxy/antigravity_flash38_test.go
@@ -1,0 +1,135 @@
+package proxy
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/codex2api/auth"
+	"github.com/codex2api/database"
+)
+
+func TestAntigravityFlash38DiscoveryAndAccountIsolation(t *testing.T) {
+	want := []string{"gemini-3.8-flash-low", "gemini-3.8-flash-medium", "gemini-3.8-flash-high"}
+	account := &auth.Account{DBID: 3801, UpstreamType: auth.UpstreamAntigravity, AccessToken: "test-token", Models: []string{"gemini-3.8-flash-tiered"}}
+	if got := antigravityPublicModelsForAccount(account); !reflect.DeepEqual(got, want) {
+		t.Fatalf("3.8 catalog = %v, want %v", got, want)
+	}
+	store := auth.NewStore(nil, nil, &database.SystemSettings{MaxConcurrency: 2})
+	store.AddAccount(account)
+	handler := &Handler{store: store}
+	listed := handler.supportedModelIDs(context.Background())
+	old := &auth.Account{UpstreamType: auth.UpstreamAntigravity, AccessToken: "old-token", Models: []string{"gemini-3.7-flash-tiered"}}
+	for _, model := range want {
+		if !strings.Contains("|"+strings.Join(listed, "|")+"|", "|"+model+"|") {
+			t.Fatalf("model discovery omitted %q: %v", model, listed)
+		}
+		if !antigravityChannelAccountFilter(model)(account) || antigravityChannelAccountFilter(model)(old) {
+			t.Fatalf("account-specific admission lost for %s", model)
+		}
+	}
+	if antigravityChannelAccountFilter("gemini-3.8-flash-tiered")(account) {
+		t.Fatal("raw wire ID leaked into the public route")
+	}
+	if got := antigravityGeminiResolvedModel("gemini-3.7-flash-medium", nil); got != "gemini-3.7-flash-tiered" {
+		t.Fatalf("old model silently upgraded: %s", got)
+	}
+	if antigravityChannelAccountFilter("gemini-3.8-flash-medium")(&auth.Account{AccessToken: "codex-token"}) {
+		t.Fatal("Antigravity request admitted a Codex account")
+	}
+	t.Setenv(auth.AntigravityExperimentalInteractionsEnv, "")
+	if antigravityChannelAccountFilter("gemini-3.8-flash-medium")(&auth.Account{UpstreamType: auth.UpstreamAntigravity, APIKey: "test-key", Models: account.Models}) {
+		t.Fatal("model upgrade enabled experimental Interactions")
+	}
+}
+
+func TestAntigravityFlash38WireAndThinkingLevels(t *testing.T) {
+	for _, tc := range []struct{ model, effort, level string }{
+		{"gemini-3.8-flash-low", "high", "LOW"},
+		{"gemini-3.8-flash-medium", "low", "MEDIUM"},
+		{"gemini-3.8-flash-high", "low", "HIGH"},
+		{"gemini-3.8-flash", "", "LOW"},
+		{"gemini-3.8-flash", "low", "LOW"},
+		{"gemini-3.8-flash", "high", "HIGH"},
+		{"gemini-3.8-flash", "minimal", "LOW"},
+		{"gemini-3.8-flash-tiered", "high", "HIGH"},
+	} {
+		t.Run(tc.model+"/"+tc.effort, func(t *testing.T) {
+			body := `{"input":"hello"}`
+			if tc.effort != "" {
+				body = `{"input":"hello","reasoning":{"effort":"` + tc.effort + `"}}`
+			}
+			payload, err := responsesToGeminiInternal([]byte(body), "project", tc.model)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if payload["model"] != "gemini-3.8-flash-tiered" {
+				t.Fatalf("wrong wire model: %v", payload["model"])
+			}
+			cfg, ok := payload["request"].(map[string]any)["generationConfig"].(map[string]any)
+			if !ok {
+				t.Fatal("missing generationConfig")
+			}
+			thinking, ok := cfg["thinkingConfig"].(map[string]any)
+			if !ok || thinking["thinkingLevel"] != tc.level {
+				t.Fatalf("thinking = %v, want %s", thinking, tc.level)
+			}
+			if _, exists := thinking["thinkingBudget"]; exists {
+				t.Fatal("3.8 inherited an unverified numeric thinking budget")
+			}
+			if antigravityGeminiMaxOutputTokens(payload["model"].(string)) != 65536 {
+				t.Fatal("3.8 output capacity is stale")
+			}
+		})
+	}
+}
+
+func TestAntigravityFlash38ExecutorJSONAndSSE(t *testing.T) {
+	for _, stream := range []bool{false, true} {
+		var received map[string]any
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if err := json.NewDecoder(r.Body).Decode(&received); err != nil {
+				t.Error(err)
+			}
+			if stream {
+				if r.URL.Path != "/v1internal:streamGenerateContent" || r.URL.Query().Get("alt") != "sse" {
+					t.Errorf("wrong SSE route: %v", r.URL)
+				}
+				w.Header().Set("Content-Type", "text/event-stream")
+				_, _ = io.WriteString(w, "data: {\"response\":{\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"ok\"}]},\"finishReason\":\"STOP\"}],\"usageMetadata\":{\"promptTokenCount\":5,\"candidatesTokenCount\":2,\"totalTokenCount\":7}}}\n\n")
+			} else {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, `{"response":{"candidates":[{"content":{"parts":[{"text":"ok"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":5,"candidatesTokenCount":2,"totalTokenCount":7}}}`)
+			}
+		}))
+		previous := antigravityOAuthEndpointBases
+		antigravityOAuthEndpointBases = []string{server.URL}
+		account := &auth.Account{DBID: 3802, UpstreamType: auth.UpstreamAntigravity, AccessToken: "test-token", AntigravityProjectID: "test-project", Models: []string{"gemini-3.8-flash-tiered"}}
+		resp, err := ExecuteAntigravityResponsesRequest(context.Background(), account, "gemini-3.8-flash-high", []byte(`{"input":"hello"}`), stream, "")
+		antigravityOAuthEndpointBases = previous
+		if err != nil {
+			server.Close()
+			t.Fatal(err)
+		}
+		body, err := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		server.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if received["model"] != "gemini-3.8-flash-tiered" {
+			t.Fatalf("actual HTTP wire = %v", received["model"])
+		}
+		if !strings.Contains(string(body), "gemini-3.8-flash-high") || !strings.Contains(string(body), "ok") {
+			t.Fatalf("downstream response lost public identity or content: %s", body)
+		}
+		if stream && !strings.Contains(string(body), "response.completed") {
+			t.Fatalf("stream did not complete: %s", body)
+		}
+	}
+}

--- a/proxy/antigravity_model_choices.go
+++ b/proxy/antigravity_model_choices.go
@@ -1,0 +1,52 @@
+package proxy
+
+import (
+	"strings"
+
+	"github.com/codex2api/api"
+)
+
+// Group only the choices already admitted by account and key permissions.
+// Both public list formats use this projection; routing retains fixed aliases.
+func antigravityModelChoiceGroups(models []api.Model) (map[string]string, map[string][]string) {
+	visible := make(map[string]bool, len(models))
+	for _, model := range models {
+		visible[strings.ToLower(strings.TrimSpace(model.ID))] = true
+	}
+	fold := make(map[string]string)
+	levels := make(map[string][]string)
+	for _, logical := range antigravityLogicalCompatibilityCatalog {
+		for _, variant := range logical.variants {
+			alias := logical.id + "-" + variant.level
+			if visible[alias] {
+				fold[alias] = logical.id
+				levels[logical.id] = append(levels[logical.id], variant.level)
+			}
+		}
+	}
+	return fold, levels
+}
+
+func collapseAntigravityModelChoices(models []api.Model) []api.Model {
+	fold, levels := antigravityModelChoiceGroups(models)
+	result := make([]api.Model, 0, len(models))
+	seen := make(map[string]bool, len(models))
+	for _, model := range models {
+		if base, ok := fold[strings.ToLower(model.ID)]; ok {
+			model.ID = base
+		}
+		key := strings.ToLower(model.ID)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		if available := levels[key]; len(available) > 0 {
+			model.DefaultReasoningLevel = available[0]
+			for _, effort := range available {
+				model.SupportedReasoningLevels = append(model.SupportedReasoningLevels, api.ModelReasoningLevel{Effort: effort, Description: "Antigravity " + effort + " reasoning"})
+			}
+		}
+		result = append(result, model)
+	}
+	return result
+}

--- a/proxy/antigravity_model_choices_test.go
+++ b/proxy/antigravity_model_choices_test.go
@@ -1,0 +1,101 @@
+package proxy
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/codex2api/api"
+	"github.com/codex2api/auth"
+	"github.com/codex2api/config"
+	"github.com/codex2api/database"
+	"github.com/gin-gonic/gin"
+)
+
+func TestAntigravityBothModelListFormatsExposeOneChoice(t *testing.T) {
+	store := auth.NewStore(nil, nil, &database.SystemSettings{MaxConcurrency: 4})
+	store.AddAccount(&auth.Account{DBID: 3800, UpstreamType: auth.UpstreamAntigravity, AccessToken: "test-token", AntigravityProjectID: "test-project", Models: []string{"gemini-3.8-flash-tiered"}, HealthTier: auth.HealthTierHealthy, Status: auth.StatusReady})
+	handler := NewHandler(store, nil, &config.Config{AllowAnonymousV1: true}, nil)
+	for _, channel := range []string{database.UpstreamChannelAntigravity, database.UpstreamChannelAuto} {
+		for _, scope := range []struct {
+			allow []string
+			want  []string
+		}{
+			{nil, []string{"low", "medium", "high"}},
+			{[]string{"gemini-3.8-flash-low"}, []string{"low"}},
+			{[]string{"gemini-3.8-flash-high"}, []string{"high"}},
+		} {
+			row := &database.APIKeyRow{ID: 3800, Limits: database.APIKeyLimits{UpstreamChannel: channel, ModelAllow: scope.allow}}
+			for _, url := range []string{"/v1/models", "/v1/models?client_version=0.153.0"} {
+				recorder := httptest.NewRecorder()
+				c, _ := gin.CreateTestContext(recorder)
+				c.Request = httptest.NewRequest(http.MethodGet, url, nil)
+				c.Set(contextAPIKeyRow, row)
+				handler.listModelsOrManifest(c)
+				if recorder.Code != 200 {
+					t.Fatalf("%s: %d %s", url, recorder.Code, recorder.Body.String())
+				}
+				var payload struct {
+					Data   []api.Model               `json:"data"`
+					Models []scopedCodexManifestItem `json:"models"`
+				}
+				if err := json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
+					t.Fatal(err)
+				}
+				var id, defaultLevel string
+				var levels []api.ModelReasoningLevel
+				if url == "/v1/models" {
+					if len(payload.Data) != 1 {
+						t.Fatalf("duplicate ordinary choices: %s", recorder.Body.String())
+					}
+					id, defaultLevel, levels = payload.Data[0].ID, payload.Data[0].DefaultReasoningLevel, payload.Data[0].SupportedReasoningLevels
+				} else {
+					if len(payload.Models) != 1 {
+						t.Fatalf("duplicate native choices: %s", recorder.Body.String())
+					}
+					id, defaultLevel, levels = payload.Models[0].Slug, payload.Models[0].DefaultReasoningLevel, payload.Models[0].SupportedReasoningLevels
+				}
+				var actual []string
+				for _, level := range levels {
+					actual = append(actual, level.Effort)
+				}
+				if id != "gemini-3.8-flash" || defaultLevel != scope.want[0] || !reflect.DeepEqual(actual, scope.want) {
+					t.Fatalf("%s: id=%s default=%s efforts=%v", url, id, defaultLevel, actual)
+				}
+			}
+		}
+	}
+}
+
+func TestAntigravityModelChoicesKeepUnrelatedModels(t *testing.T) {
+	models := []api.Model{{ID: "gemini-3.8-flash-high"}, {ID: "gemini-3.8-flash-low"}, {ID: "gemini-3.8-flash-medium"}, {ID: "gemini-3.8-flash-lite"}, {ID: "gemini-Future-high"}, {ID: "gpt-oss-120b-medium"}}
+	choices := collapseAntigravityModelChoices(models)
+	var ids []string
+	for _, choice := range choices {
+		ids = append(ids, choice.ID)
+	}
+	if !reflect.DeepEqual(ids, []string{"gemini-3.8-flash", "gemini-3.8-flash-lite", "gemini-Future-high", "gpt-oss-120b-medium"}) {
+		t.Fatalf("incorrect grouping: %v", ids)
+	}
+	if models[0].ID != "gemini-3.8-flash-high" {
+		t.Fatal("advertising changed routing catalog")
+	}
+}
+
+func TestAntigravityPublishedChoicesExcludeInternalAndDuplicateBackings(t *testing.T) {
+	raw := []string{"chat_20706", "chat_23310", "tab_flash_lite_preview", "tab_jump_flash_lite_preview", "gemini-3.6-flash-tiered", "gemini-3.6-flash-low", "gemini-3.6-flash-medium", "gemini-3.6-flash-high", "gemini-3.8-flash-tiered", "gemini-3.1-flash-lite", "gemini-2.5-flash", "gemini-2.5-flash-lite", "gemini-2.5-flash-thinking", "gemini-Future-V4", "gemini-2.5-pro"}
+	var records []api.Model
+	for _, id := range AntigravityPublishedModelIDs(raw) {
+		records = append(records, api.Model{ID: id})
+	}
+	got := map[string]bool{}
+	for _, model := range collapseAntigravityModelChoices(records) {
+		got[model.ID] = true
+	}
+	want := map[string]bool{"gemini-3.6-flash": true, "gemini-3.8-flash": true, "gemini-3.1-flash-lite": true, "gemini-Future-V4": true, "gemini-2.5-pro": true}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("chat catalog = %v, want %v", got, want)
+	}
+}

--- a/proxy/antigravity_models.go
+++ b/proxy/antigravity_models.go
@@ -1,10 +1,23 @@
 package proxy
 
 import (
+	"sort"
 	"strings"
 
 	"github.com/codex2api/auth"
 )
+
+func (h *Handler) antigravityAcceptedModels() []string {
+	ids := antigravityAcceptedModelIDs()
+	if h != nil && h.store != nil {
+		for _, account := range h.store.Accounts() {
+			if account.IsAntigravityAPI() && account.AntigravityDispatchEnabled() {
+				ids = append(ids, antigravityPublicModelsForAccount(account)...)
+			}
+		}
+	}
+	return ids
+}
 
 type antigravityReasoningVariant struct {
 	level          string
@@ -21,9 +34,8 @@ type antigravityPublicModelDefinition struct {
 }
 
 // antigravityPublicModelCatalog is the exact fixed-tier surface advertised to
-// downstream clients. Codex clients do not consistently render provider-local
-// supported_reasoning_levels metadata, so every real Antigravity tier is a
-// separate public model ID.
+// downstream clients. The native Codex manifest folds known variants into one
+// base model with separate reasoning controls; these IDs remain callable.
 var antigravityPublicModelCatalog = []antigravityPublicModelDefinition{
 	{
 		id: "gemini-3.5-flash-low", wireModel: "gemini-3.5-flash-extra-low",
@@ -46,6 +58,9 @@ var antigravityPublicModelCatalog = []antigravityPublicModelDefinition{
 	{id: "gemini-3.7-flash-low", wireModel: "gemini-3.7-flash-tiered", variants: []antigravityReasoningVariant{{level: "low", wireModel: "gemini-3.7-flash-tiered", thinkingBudget: 4096}}},
 	{id: "gemini-3.7-flash-medium", wireModel: "gemini-3.7-flash-tiered", variants: []antigravityReasoningVariant{{level: "medium", wireModel: "gemini-3.7-flash-tiered", thinkingBudget: 8192}}},
 	{id: "gemini-3.7-flash-high", wireModel: "gemini-3.7-flash-tiered", variants: []antigravityReasoningVariant{{level: "high", wireModel: "gemini-3.7-flash-tiered", thinkingBudget: 24576}}},
+	{id: "gemini-3.8-flash-low", wireModel: "gemini-3.8-flash-tiered", variants: []antigravityReasoningVariant{{level: "low", wireModel: "gemini-3.8-flash-tiered"}}},
+	{id: "gemini-3.8-flash-medium", wireModel: "gemini-3.8-flash-tiered", variants: []antigravityReasoningVariant{{level: "medium", wireModel: "gemini-3.8-flash-tiered"}}},
+	{id: "gemini-3.8-flash-high", wireModel: "gemini-3.8-flash-tiered", variants: []antigravityReasoningVariant{{level: "high", wireModel: "gemini-3.8-flash-tiered"}}},
 	{id: "gemini-3.1-pro-low", wireModel: "gemini-3.1-pro-low", variants: []antigravityReasoningVariant{{level: "low", wireModel: "gemini-3.1-pro-low", thinkingBudget: 1001}}},
 	{id: "gemini-3.1-pro-high", wireModel: "gemini-pro-agent", variants: []antigravityReasoningVariant{{level: "high", wireModel: "gemini-pro-agent", thinkingBudget: 10001}}},
 	{id: "claude-opus-4-6-thinking", wireModel: "claude-opus-4-6-thinking"},
@@ -54,7 +69,7 @@ var antigravityPublicModelCatalog = []antigravityPublicModelDefinition{
 }
 
 // antigravityLogicalCompatibilityCatalog keeps the former logical model names
-// callable for existing clients. They are deliberately not advertised.
+// callable for existing clients and supplies the native Codex base model names.
 var antigravityLogicalCompatibilityCatalog = []antigravityPublicModelDefinition{
 	{id: "gemini-3.5-flash", defaultReasoningLevel: "medium", variants: []antigravityReasoningVariant{
 		{level: "low", wireModel: "gemini-3.5-flash-extra-low", thinkingBudget: 1000},
@@ -70,6 +85,11 @@ var antigravityLogicalCompatibilityCatalog = []antigravityPublicModelDefinition{
 		{level: "low", wireModel: "gemini-3.7-flash-tiered", thinkingBudget: 4096},
 		{level: "medium", wireModel: "gemini-3.7-flash-tiered", thinkingBudget: 8192},
 		{level: "high", wireModel: "gemini-3.7-flash-tiered", thinkingBudget: 24576},
+	}},
+	{id: "gemini-3.8-flash", defaultReasoningLevel: "low", variants: []antigravityReasoningVariant{
+		{level: "low", wireModel: "gemini-3.8-flash-tiered"},
+		{level: "medium", wireModel: "gemini-3.8-flash-tiered"},
+		{level: "high", wireModel: "gemini-3.8-flash-tiered"},
 	}},
 	{id: "gemini-3.1-pro", defaultReasoningLevel: "high", variants: []antigravityReasoningVariant{
 		{level: "low", wireModel: "gemini-3.1-pro-low", thinkingBudget: 1001},
@@ -203,7 +223,50 @@ func AntigravityPublishedModelIDs(rawModels []string) []string {
 			models = append(models, definition.id)
 		}
 	}
+	// Unrecognized models keep their actual upstream ID. Do not infer thinking
+	// tiers, aliases, or modality support from a future version number.
+	var discovered []string
+	seenDiscovered := make(map[string]bool)
+	for _, rawModel := range rawModels {
+		model := strings.TrimSpace(rawModel)
+		name := strings.ToLower(model)
+		// Provider-internal chat placeholders, IDE tab completions, and an
+		// alternate physical backing of a known base are not extra chat models.
+		if name == "chat_20706" || name == "chat_23310" || strings.HasPrefix(name, "tab_") {
+			continue
+		}
+		if strings.HasSuffix(name, "-tiered") {
+			if _, known := antigravityLogicalCompatibilityModel(strings.TrimSuffix(name, "-tiered")); known {
+				continue
+			}
+		}
+		// These old IDs currently identify Gemini 3.1 Flash Lite in the upstream
+		// catalog. Hide redundant menu entries when its actual public ID exists;
+		// this does not rewrite callers' existing model requests.
+		if _, hasLite := available["gemini-3.1-flash-lite"]; hasLite && (name == "gemini-2.5-flash" || name == "gemini-2.5-flash-lite" || name == "gemini-2.5-flash-thinking") {
+			continue
+		}
+		if !antigravityKnownWireModel(model) && antigravityResponsesTextModel(model) {
+			if _, known := antigravityPublicModel(model); !known && !seenDiscovered[model] {
+				discovered = append(discovered, model)
+				seenDiscovered[model] = true
+			}
+		}
+	}
+	sort.Strings(discovered)
+	models = append(models, discovered...)
 	return models
+}
+
+func antigravityKnownWireModel(model string) bool {
+	for _, definition := range antigravityPublicModelCatalog {
+		for _, wire := range AntigravityWireModelIDs(definition.id) {
+			if strings.EqualFold(model, wire) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func antigravityPublicModelsForAccount(account *auth.Account) []string {
@@ -226,6 +289,13 @@ func antigravityResolvePublicModelForAccount(account *auth.Account, model string
 	}
 	wires := AntigravityWireModelIDs(model)
 	if len(wires) == 0 {
+		if !antigravityKnownWireModel(model) && antigravityResponsesTextModel(model) {
+			for _, actual := range account.AntigravityModels() {
+				if strings.EqualFold(strings.TrimSpace(actual), strings.TrimSpace(model)) {
+					return strings.TrimSpace(actual), true
+				}
+			}
+		}
 		return "", false
 	}
 	available := make(map[string]struct{}, len(account.AntigravityModels()))

--- a/proxy/antigravity_models_test.go
+++ b/proxy/antigravity_models_test.go
@@ -12,6 +12,7 @@ func TestAntigravityPublicModelCatalogIsExact(t *testing.T) {
 		"gemini-3.5-flash-low", "gemini-3.5-flash-medium", "gemini-3.5-flash-high",
 		"gemini-3.6-flash-low", "gemini-3.6-flash-medium", "gemini-3.6-flash-high",
 		"gemini-3.7-flash-low", "gemini-3.7-flash-medium", "gemini-3.7-flash-high",
+		"gemini-3.8-flash-low", "gemini-3.8-flash-medium", "gemini-3.8-flash-high",
 		"gemini-3.1-pro-low", "gemini-3.1-pro-high",
 		"claude-opus-4-6-thinking",
 		"claude-sonnet-4-6",
@@ -79,7 +80,7 @@ func TestAntigravityPublishedModelsProjectCompleteRawCatalog(t *testing.T) {
 	raw := []string{
 		"gemini-3.5-flash-extra-low", "gemini-3.5-flash-low", "gemini-3-flash-agent",
 		"gemini-3.6-flash-low", "gemini-3.6-flash-medium", "gemini-3.6-flash-high",
-		"gemini-3.7-flash-tiered", "gemini-3.1-pro-low", "gemini-pro-agent",
+		"gemini-3.7-flash-tiered", "gemini-3.8-flash-tiered", "gemini-3.1-pro-low", "gemini-pro-agent",
 		"claude-opus-4-6-thinking", "claude-sonnet-4-6", "gpt-oss-120b-medium",
 	}
 	want := antigravityPublicModelIDs()

--- a/proxy/antigravity_native_manifest_test.go
+++ b/proxy/antigravity_native_manifest_test.go
@@ -1,0 +1,174 @@
+package proxy
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/codex2api/api"
+	"github.com/codex2api/auth"
+	"github.com/codex2api/config"
+	"github.com/codex2api/database"
+	"github.com/gin-gonic/gin"
+)
+
+func TestMergedAntigravityManifestReplacesStaleCapabilities(t *testing.T) {
+	// A mixed upstream catalog can retain an old base model and effort aliases.
+	// The gateway's allowed variants must win, without changing Grok metadata.
+	body := []byte(`{"future":true,"models":[{"slug":"gemini-3.8-flash","default_reasoning_level":"xhigh","supported_reasoning_levels":[{"effort":"xhigh"}]},{"slug":"gemini-3.8-flash-low"},{"slug":"gemini-3.8-flash-high"},{"slug":"grok-4.5","supported_reasoning_levels":[{"effort":"low"},{"effort":"medium"},{"effort":"high"}]},{"slug":"grok-4.6","supported_reasoning_levels":[{"effort":"low"},{"effort":"medium"},{"effort":"high"},{"effort":"xhigh"}]}]}`)
+	for _, allowed := range [][]string{{"low", "medium", "high"}, {"high"}} {
+		var extras []api.Model
+		for _, effort := range allowed {
+			extras = append(extras, api.Model{ID: "gemini-3.8-flash-" + effort})
+		}
+		merged, err := mergeCodexManifestModels(body, extras)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var root struct {
+			Future bool                      `json:"future"`
+			Models []scopedCodexManifestItem `json:"models"`
+		}
+		if err := json.Unmarshal(merged, &root); err != nil {
+			t.Fatal(err)
+		}
+		if !root.Future || len(root.Models) != 3 {
+			t.Fatalf("stale aliases or root metadata lost: %s", merged)
+		}
+		for _, model := range root.Models {
+			var got []string
+			for _, option := range model.SupportedReasoningLevels {
+				got = append(got, option.Effort)
+			}
+			switch model.Slug {
+			case "gemini-3.8-flash":
+				if !reflect.DeepEqual(got, allowed) || model.DefaultReasoningLevel != allowed[0] {
+					t.Fatalf("stale or unauthorized capabilities retained: %s", merged)
+				}
+			case "grok-4.5":
+				if !reflect.DeepEqual(got, []string{"low", "medium", "high"}) {
+					t.Fatal("changed Grok 4.5")
+				}
+			case "grok-4.6":
+				if !reflect.DeepEqual(got, []string{"low", "medium", "high", "xhigh"}) {
+					t.Fatal("changed Grok 4.6")
+				}
+			default:
+				t.Fatalf("unexpected model: %s", model.Slug)
+			}
+		}
+		if scopedCodexManifestETag(body) == scopedCodexManifestETag(merged) {
+			t.Fatal("stale manifest validator retained")
+		}
+	}
+}
+
+func TestAntigravityNativeManifestContract(t *testing.T) {
+	var models []api.Model
+	for _, id := range AntigravityPublishedModelIDs([]string{"gemini-3.8-flash-tiered", "gemini-3.7-flash-tiered", "gemini-4-future", "claude-opus-4-6-thinking"}) {
+		models = append(models, api.Model{ID: id, OwnedBy: "google"})
+	}
+	body, err := buildScopedCodexManifest(models)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var payload struct {
+		Models []scopedCodexManifestItem `json:"models"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatal(err)
+	}
+	if len(payload.Models) != 4 {
+		t.Fatalf("duplicate effort models: %s", body)
+	}
+	for _, model := range payload.Models {
+		if model.Slug == "gemini-3.8-flash" && (len(model.InputModalities) != 1 || model.InputModalities[0] != "text") {
+			t.Fatal("manifest advertises unsupported image inputs")
+		}
+		if model.Slug == "gemini-3.8-flash" || model.Slug == "gemini-3.7-flash" {
+			if len(model.SupportedReasoningLevels) != 3 || model.DefaultReasoningLevel != "low" {
+				t.Fatalf("invalid native reasoning contract: %+v", model)
+			}
+		} else if len(model.SupportedReasoningLevels) != 0 {
+			t.Fatalf("invented future/non-Gemini controls: %+v", model)
+		}
+	}
+	if path := os.Getenv("CODEX_MODEL_MANIFEST_FIXTURE_PATH"); path != "" {
+		if err := os.WriteFile(path, body, 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestAntigravityDiscoveredModelPreservesActualWireID(t *testing.T) {
+	account := &auth.Account{UpstreamType: auth.UpstreamAntigravity, AccessToken: "test-token", AntigravityProjectID: "test-project", Models: []string{"Future-Model-V4"}}
+	models := AntigravityPublishedModelIDs(account.AntigravityModels())
+	if len(models) != 1 || models[0] != "Future-Model-V4" {
+		t.Fatalf("discovery changed actual model ID: %v", models)
+	}
+	wire, ok := antigravityResolvePublicModelForAccount(account, "future-model-v4")
+	if !ok || wire != "Future-Model-V4" {
+		t.Fatalf("wire ID = %q, supported = %v", wire, ok)
+	}
+	if _, ok := antigravityResolvePublicModelForAccount(account, "future-model-v5"); ok {
+		t.Fatal("undiscovered model accepted")
+	}
+}
+
+func TestAntigravityNativeEffortReachesWireAndHonorsKeyScope(t *testing.T) {
+	requests := make(chan map[string]any, 8)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Error(err)
+		}
+		requests <- payload
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"response":{"candidates":[{"content":{"parts":[{"text":"ok"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":5,"candidatesTokenCount":2,"totalTokenCount":7}}}`)
+	}))
+	defer server.Close()
+	previous := antigravityOAuthEndpointBases
+	antigravityOAuthEndpointBases = []string{server.URL}
+	t.Cleanup(func() { antigravityOAuthEndpointBases = previous })
+	store := auth.NewStore(nil, nil, &database.SystemSettings{MaxConcurrency: 4})
+	store.AddAccount(&auth.Account{DBID: 3810, UpstreamType: auth.UpstreamAntigravity, AccessToken: "test-token", AntigravityProjectID: "test-project", Models: []string{"gemini-3.8-flash-tiered"}, HealthTier: auth.HealthTierHealthy, Status: auth.StatusReady})
+	handler := NewHandler(store, nil, &config.Config{AllowAnonymousV1: true}, nil)
+	for _, channel := range []string{database.UpstreamChannelAntigravity, database.UpstreamChannelAuto} {
+		for _, tc := range []struct {
+			model, effort, want string
+			allow               []string
+			status              int
+		}{
+			{"gemini-3.8-flash", "", "LOW", nil, 200},
+			{"gemini-3.8-flash", "medium", "MEDIUM", nil, 200},
+			{"gemini-3.8-flash", "high", "HIGH", nil, 200},
+			{"gemini-3.8-flash", "xhigh", "", nil, 400},
+			{"gemini-3.8-flash-high", "low", "HIGH", nil, 200},
+			{"gemini-3.8-flash", "high", "", []string{"gemini-3.8-flash-low"}, 403},
+			{"gemini-3.8-flash", "low", "LOW", []string{"gemini-3.8-flash-low"}, 200},
+		} {
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+			c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"`+tc.model+`","input":"hi","stream":false,"reasoning":{"effort":"`+tc.effort+`"}}`))
+			c.Set(contextAPIKeyRow, &database.APIKeyRow{ID: 3810, Limits: database.APIKeyLimits{UpstreamChannel: channel, ModelAllow: tc.allow}})
+			handler.Responses(c)
+			if rec.Code != tc.status {
+				t.Fatalf("%s/%s status=%d body=%s", tc.model, tc.effort, rec.Code, rec.Body.String())
+			}
+			if tc.status == 200 {
+				payload := <-requests
+				thinking := payload["request"].(map[string]any)["generationConfig"].(map[string]any)["thinkingConfig"].(map[string]any)
+				if payload["model"] != "gemini-3.8-flash-tiered" || thinking["thinkingLevel"] != tc.want {
+					t.Fatalf("actual upstream payload = %v", payload)
+				}
+			} else if len(requests) != 0 {
+				t.Fatal("denied effort reached upstream")
+			}
+		}
+	}
+}

--- a/proxy/antigravity_responses.go
+++ b/proxy/antigravity_responses.go
@@ -588,7 +588,9 @@ func responsesToGeminiInternal(raw []byte, project, model string) (map[string]an
 	if t, ok := in["temperature"].(float64); ok {
 		generationConfig["temperature"] = t
 	}
-	if thinkingBudget, enabled := antigravityGeminiThinkingBudget(model, wireModel, reasoning); enabled {
+	if level, enabled := antigravityGeminiThinkingLevel(model, wireModel, reasoning); enabled {
+		generationConfig["thinkingConfig"] = map[string]any{"thinkingLevel": level}
+	} else if thinkingBudget, enabled := antigravityGeminiThinkingBudget(model, wireModel, reasoning); enabled {
 		generationConfig["thinkingConfig"] = map[string]any{
 			"includeThoughts": true,
 			"thinkingBudget":  thinkingBudget,
@@ -828,6 +830,21 @@ func antigravityGeminiResolvedModel(model string, reasoning map[string]any) stri
 	return strings.TrimSpace(model)
 }
 
+// New tiered Flash uses a named level, not the older numeric budget ladder.
+// Fixed suffixes win over conflicting effort; bare models default to low.
+func antigravityGeminiThinkingLevel(requestedModel, wireModel string, reasoning map[string]any) (string, bool) {
+	if wireModel != "gemini-3.8-flash-tiered" {
+		return "", false
+	}
+	if variant, ok := antigravityResolvedVariant(requestedModel, reasoning); ok {
+		return strings.ToUpper(variant.level), true
+	}
+	if len(reasoning) == 0 {
+		return "LOW", true
+	}
+	return strings.ToUpper(antigravityGeminiReasoningTier(reasoning)), true
+}
+
 func antigravityGeminiThinkingBudget(requestedModel, wireModel string, reasoning map[string]any) (int, bool) {
 	var budget int
 	if _, ok := antigravityPublicModel(requestedModel); ok {
@@ -917,6 +934,8 @@ func antigravityGeminiThinkingBudgetCap(model string) int {
 func antigravityGeminiMaxOutputTokens(model string) int {
 	name := strings.ToLower(strings.TrimSpace(model))
 	switch {
+	case name == "gemini-3.8-flash-tiered":
+		return 65536
 	case strings.Contains(name, "claude"):
 		return 64000
 	case strings.Contains(name, "gpt-oss"):

--- a/proxy/apikey_limits.go
+++ b/proxy/apikey_limits.go
@@ -303,16 +303,26 @@ func (h *Handler) enforceAPIKeyLimitsAndReply(c *gin.Context, model string) bool
 // 大小写不敏感比较。
 func checkAPIKeyModel(model string, limits database.APIKeyLimits) string {
 	model = strings.ToLower(strings.TrimSpace(model))
+	base := ""
+	for _, logical := range antigravityLogicalCompatibilityCatalog {
+		for _, variant := range logical.variants {
+			if model == logical.id+"-"+variant.level {
+				base = logical.id
+			}
+		}
+	}
 	if len(limits.ModelAllow) > 0 {
 		for _, m := range limits.ModelAllow {
-			if strings.ToLower(strings.TrimSpace(m)) == model {
+			allowed := strings.ToLower(strings.TrimSpace(m))
+			if allowed == model || (base != "" && allowed == base) {
 				return ""
 			}
 		}
 		return fmt.Sprintf("Model %q is not allowed for this API key", model)
 	}
 	for _, m := range limits.ModelDeny {
-		if strings.ToLower(strings.TrimSpace(m)) == model {
+		denied := strings.ToLower(strings.TrimSpace(m))
+		if denied == model || (base != "" && denied == base) {
 			return fmt.Sprintf("Model %q is denied for this API key", model)
 		}
 	}

--- a/proxy/codex_models_manifest.go
+++ b/proxy/codex_models_manifest.go
@@ -175,24 +175,42 @@ func (h *Handler) writeCodexManifest(c *gin.Context, body []byte, etag string) {
 	c.Data(http.StatusOK, "application/json", body)
 }
 
+type codexReasoningLevel = api.ModelReasoningLevel
+
 type scopedCodexManifestItem struct {
-	ServiceTiers             []map[string]string `json:"service_tiers,omitempty"`
-	Slug                     string              `json:"slug"`
-	DisplayName              string              `json:"display_name"`
-	Hidden                   bool                `json:"hidden"`
-	Availability             string              `json:"availability"`
-	SupportedInAPI           bool                `json:"supported_in_api"`
-	PreferWebsockets         bool                `json:"prefer_websockets"`
-	UseResponsesLite         bool                `json:"use_responses_lite"`
-	InputModalities          []string            `json:"input_modalities,omitempty"`
-	SupportedReasoningLevels []string            `json:"supported_reasoning_levels,omitempty"`
+	ServiceTiers               []map[string]string   `json:"service_tiers,omitempty"`
+	Slug                       string                `json:"slug"`
+	DisplayName                string                `json:"display_name"`
+	Hidden                     bool                  `json:"hidden"`
+	Availability               string                `json:"availability"`
+	SupportedInAPI             bool                  `json:"supported_in_api"`
+	PreferWebsockets           bool                  `json:"prefer_websockets"`
+	UseResponsesLite           bool                  `json:"use_responses_lite"`
+	InputModalities            []string              `json:"input_modalities,omitempty"`
+	SupportedReasoningLevels   []codexReasoningLevel `json:"supported_reasoning_levels"`
+	DefaultReasoningLevel      string                `json:"default_reasoning_level"`
+	Description                string                `json:"description"`
+	ShellType                  string                `json:"shell_type"`
+	Visibility                 string                `json:"visibility"`
+	Priority                   int                   `json:"priority"`
+	BaseInstructions           string                `json:"base_instructions"`
+	SupportsReasoningSummaries bool                  `json:"supports_reasoning_summaries"`
+	SupportVerbosity           bool                  `json:"support_verbosity"`
+	SupportsParallelToolCalls  bool                  `json:"supports_parallel_tool_calls"`
+	ExperimentalSupportedTools []string              `json:"experimental_supported_tools"`
+	TruncationPolicy           map[string]any        `json:"truncation_policy"`
+	ContextWindow              int                   `json:"context_window,omitempty"`
 }
 
 func buildScopedCodexManifest(models []api.Model) ([]byte, error) {
+	fold, levels := antigravityModelChoiceGroups(models)
 	items := make([]scopedCodexManifestItem, 0, len(models))
 	seen := make(map[string]struct{}, len(models))
 	for _, model := range models {
 		slug := strings.TrimSpace(model.ID)
+		if base, ok := fold[strings.ToLower(slug)]; ok {
+			slug = base
+		}
 		if slug == "" {
 			continue
 		}
@@ -202,13 +220,20 @@ func buildScopedCodexManifest(models []api.Model) ([]byte, error) {
 		}
 		seen[key] = struct{}{}
 		item := scopedCodexManifestItem{
-			Slug:             slug,
-			DisplayName:      slug,
-			Availability:     "available",
-			SupportedInAPI:   true,
-			PreferWebsockets: false,
-			UseResponsesLite: false,
-			InputModalities:  []string{"text"},
+			Slug:                     slug,
+			DisplayName:              slug,
+			Availability:             "available",
+			SupportedInAPI:           true,
+			PreferWebsockets:         false,
+			UseResponsesLite:         false,
+			InputModalities:          []string{"text"},
+			SupportedReasoningLevels: []codexReasoningLevel{},
+			DefaultReasoningLevel:    "none",
+			Description:              "Gateway model: " + slug,
+			ShellType:                "shell_command", Visibility: "list",
+			BaseInstructions:           "You are a helpful coding assistant.",
+			ExperimentalSupportedTools: []string{},
+			TruncationPolicy:           map[string]any{"mode": "tokens", "limit": 10000},
 		}
 		if key == "gpt-5.6-sol" && strings.EqualFold(model.OwnedBy, "openai") {
 			item.ServiceTiers = []map[string]string{{"id": "priority", "name": "Fast"}, {"id": "ultrafast", "name": "Ultrafast"}}
@@ -219,10 +244,18 @@ func buildScopedCodexManifest(models []api.Model) ([]byte, error) {
 		// Antigravity's reasoning metadata is provider-specific. Never infer
 		// levels from names such as "thinking" or "reason": Claude Opus
 		// `*-thinking` is not a Gemini reasoning-control model.
-		if _, isAntigravityModel := antigravityPublicModel(slug); isAntigravityModel {
-			item.SupportedReasoningLevels = antigravityCodexReasoningLevels(slug)
-		} else if !strings.EqualFold(strings.TrimSpace(model.OwnedBy), "google") && (strings.Contains(key, "thinking") || strings.Contains(key, "reason")) {
-			item.SupportedReasoningLevels = []string{"low", "medium", "high"}
+		if available := levels[slug]; len(available) > 0 {
+			for _, level := range available {
+				item.SupportedReasoningLevels = append(item.SupportedReasoningLevels, codexReasoningLevel{Effort: level, Description: "Antigravity " + level + " reasoning"})
+			}
+			item.DefaultReasoningLevel = available[0]
+			item.SupportsReasoningSummaries = true
+		}
+		if slug == "gemini-3.8-flash" {
+			item.ContextWindow = 1048576
+			// The current OAuth adapter accepts text parts only, even though the
+			// upstream model itself has vision. Advertise the gateway contract.
+			item.InputModalities = []string{"text"}
 		}
 		items = append(items, item)
 	}
@@ -263,6 +296,32 @@ func mergeCodexManifestModels(body []byte, extras []api.Model) ([]byte, error) {
 	if err := json.Unmarshal(rawModels, &models); err != nil {
 		return nil, err
 	}
+	// Locally routed Antigravity variants are authoritative for their base
+	// model. An upstream manifest can contain stale capabilities or fixed
+	// effort aliases; keeping those by slug would discard the current scoped
+	// contract (including a key restricted to a single effort).
+	_, localLevels := antigravityModelChoiceGroups(extras)
+	replacedSlugs := make(map[string]bool)
+	for _, definition := range antigravityLogicalCompatibilityCatalog {
+		if len(localLevels[definition.id]) == 0 {
+			continue
+		}
+		replacedSlugs[definition.id] = true
+		for _, variant := range definition.variants {
+			replacedSlugs[definition.id+"-"+variant.level] = true
+		}
+	}
+	retained := models[:0]
+	for _, raw := range models {
+		var item struct {
+			Slug string `json:"slug"`
+		}
+		if json.Unmarshal(raw, &item) == nil && replacedSlugs[strings.ToLower(strings.TrimSpace(item.Slug))] {
+			continue
+		}
+		retained = append(retained, raw)
+	}
+	models = retained
 	seen := make(map[string]struct{}, len(models)+len(extraRoot.Models))
 	for _, raw := range models {
 		var item struct {

--- a/proxy/codex_models_manifest_test.go
+++ b/proxy/codex_models_manifest_test.go
@@ -85,7 +85,7 @@ func TestListModelsOrManifestServesAntigravityAsCodexManifest(t *testing.T) {
 			t.Fatalf("slug %s prefer_websockets=true, Antigravity must stay on HTTP", model.Slug)
 		}
 	}
-	if !got["gemini-3.6-flash-low"] || !got["gemini-3.6-flash-medium"] || !got["gemini-3.6-flash-high"] || !got["claude-sonnet-4-6"] || len(got) != 4 {
+	if !got["gemini-3.6-flash"] || !got["claude-sonnet-4-6"] || len(got) != 2 {
 		t.Fatalf("manifest slugs = %v, want cockpit Antigravity models", got)
 	}
 
@@ -95,7 +95,7 @@ func TestListModelsOrManifestServesAntigravityAsCodexManifest(t *testing.T) {
 	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), `"object":"list"`) {
 		t.Fatalf("cockpit list status=%d body=%s", rec.Code, rec.Body.String())
 	}
-	if !strings.Contains(rec.Body.String(), "gemini-3.6-flash-low") || strings.Contains(rec.Body.String(), `"id":"gemini-3.6-flash"`) {
+	if strings.Contains(rec.Body.String(), "gemini-3.6-flash-low") || !strings.Contains(rec.Body.String(), `"id":"gemini-3.6-flash"`) {
 		t.Fatalf("cockpit list has wrong Antigravity surface: %s", rec.Body.String())
 	}
 }
@@ -122,7 +122,7 @@ func TestMergeCodexManifestModelsAppendsMissingRelaySlugs(t *testing.T) {
 	}
 }
 
-func TestScopedAntigravityManifestPublishesFixedTierModelsWithoutReasoningLevels(t *testing.T) {
+func TestScopedAntigravityManifestKeepsOnlyAvailableEfforts(t *testing.T) {
 	body, err := buildScopedCodexManifest([]api.Model{
 		{ID: "gemini-3.7-flash-high", OwnedBy: "google"},
 		{ID: "gemini-3.6-flash-medium", OwnedBy: "google"},
@@ -140,8 +140,8 @@ func TestScopedAntigravityManifestPublishesFixedTierModelsWithoutReasoningLevels
 		t.Fatal(err)
 	}
 	for _, item := range payload.Models {
-		if len(item.SupportedReasoningLevels) != 0 {
-			t.Fatalf("%s unexpectedly advertises reasoning levels: %v", item.Slug, item.SupportedReasoningLevels)
+		if strings.HasPrefix(item.Slug, "gemini-") && len(item.SupportedReasoningLevels) != 1 {
+			t.Fatalf("%s must expose only its scoped effort: %v", item.Slug, item.SupportedReasoningLevels)
 		}
 	}
 }

--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -3665,13 +3665,49 @@ func (h *Handler) Responses(c *gin.Context) {
 	upstreamChannel := requestUpstreamChannel(c)
 	var requestModel, mappedModel string
 	var mappingApplied bool
-	if upstreamChannel == database.UpstreamChannelAntigravity {
+	nativeAntigravityModel := false
+	if upstreamChannel == database.UpstreamChannelAuto {
+		if logical, known := antigravityLogicalCompatibilityModel(gjson.GetBytes(rawBody, "model").String()); known {
+			for _, account := range h.store.Accounts() {
+				if !account.IsAntigravityAPI() || !account.AntigravityDispatchEnabled() {
+					continue
+				}
+				for _, variant := range logical.variants {
+					if antigravityAccountSupportsPublicModel(account, logical.id+"-"+variant.level) {
+						nativeAntigravityModel = true
+					}
+				}
+			}
+		}
+	}
+	if upstreamChannel == database.UpstreamChannelAntigravity || nativeAntigravityModel {
 		// Antigravity is a native, fixed public surface. Do not let global Codex
 		// aliases or synthesized reasoning aliases rewrite an Antigravity-only
 		// request before validation; the adapter performs the sole public->wire
 		// translation after an account proves it owns the required backing model.
 		requestModel = strings.TrimSpace(gjson.GetBytes(rawBody, "model").String())
 		mappedModel = requestModel
+		if logical, known := antigravityLogicalCompatibilityModel(requestModel); known {
+			effort := strings.ToLower(strings.TrimSpace(gjson.GetBytes(rawBody, "reasoning.effort").String()))
+			if effort == "" {
+				effort = "low"
+			}
+			allowedEfforts := make([]string, 0, len(logical.variants))
+			validEffort := false
+			for _, option := range logical.variants {
+				allowedEfforts = append(allowedEfforts, option.level)
+				validEffort = validEffort || effort == option.level
+			}
+			if !validEffort {
+				api.SendError(c, api.NewAPIError(api.ErrCodeInvalidParameter, "Model "+logical.id+" supports reasoning.effort: "+strings.Join(allowedEfforts, ", "), api.ErrorTypeInvalidRequest))
+				return
+			}
+			variant, ok := antigravityVariantForDefinition(logical, map[string]any{"effort": effort})
+			if ok {
+				mappedModel = logical.id + "-" + variant.level
+				rawBody, _ = sjson.SetBytes(rawBody, "model", mappedModel)
+			}
+		}
 	} else if nativeRemoteCompactionV2 {
 		rawBody, requestModel, mappedModel, mappingApplied = h.applyConfiguredCompactModelMappingToBody(rawBody, supportedModels)
 	} else {
@@ -3689,7 +3725,7 @@ func (h *Handler) Responses(c *gin.Context) {
 	case database.UpstreamChannelAntigravity:
 		// Antigravity 专用 Key 公开稳定的逻辑模型，同时继续接受旧的固定
 		// effort 别名；raw backing 与 account model_mapping 不是下游模型名。
-		rules["model"] = append(rules["model"], api.ModelValidator(antigravityAcceptedModelIDs()))
+		rules["model"] = append(rules["model"], api.ModelValidator(h.antigravityAcceptedModels()))
 	default:
 		rules["model"] = append(rules["model"], h.modelValidator(supportedModels))
 	}
@@ -8583,7 +8619,7 @@ func (h *Handler) ListModels(c *gin.Context) {
 	// middleware (including older embedders); a real key always gets an
 	// isolated, read-only account snapshot.
 	if row := apiKeyRowFromContext(c); row != nil {
-		api.SendList(c, "list", h.scopedModels(ctx, row))
+		api.SendList(c, "list", collapseAntigravityModelChoices(h.scopedModels(ctx, row)))
 		return
 	}
 	modelIDs := h.supportedModelIDs(ctx)
@@ -8596,7 +8632,7 @@ func (h *Handler) ListModels(c *gin.Context) {
 			OwnedBy: "openai",
 		})
 	}
-	api.SendList(c, "list", models)
+	api.SendList(c, "list", collapseAntigravityModelChoices(models))
 }
 
 func (h *Handler) supportedModelIDs(ctx context.Context) []string {

--- a/proxy/scoped_models_test.go
+++ b/proxy/scoped_models_test.go
@@ -224,7 +224,7 @@ func TestScopedModelsIncludeAntigravityAccounts(t *testing.T) {
 	for _, model := range models {
 		found[model.ID] = true
 	}
-	if !found["gemini-3.7-flash-low"] || !found["gemini-3.7-flash-medium"] || !found["gemini-3.7-flash-high"] {
+	if !found["gemini-3.7-flash"] || len(found) != 1 {
 		t.Fatal("projected Antigravity public model missing from /v1/models")
 	}
 }


### PR DESCRIPTION
- 支持 Gemini 3.8 Flash，自动刷新并清理 Antigravity 模型目录。
- 合并基础模型条目，按模型校验、转发推理档位，修复旧能力残留。

验证：相关 Go 测试、全量 vet、前端 255 项测试、类型检查及构建通过；Windows 全量 Go 测试仍有 6 项既有失败。

已知限制：旧版 Codex 菜单仍可能显示多余档位，服务端会拒绝不支持的值。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Gemini 3.8 Flash models with low, medium, and high reasoning levels.
  * Model listings now present a single model with available reasoning options.
  * Antigravity accounts periodically refresh their available model catalogs.
  * Added support for discovered account-specific models and improved model routing.
  * Health checks now include the current build version.
* **Bug Fixes**
  * Improved API-key model matching for compatibility variants.
  * Prevented internal or duplicate provider models from appearing in public listings.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->