### PR TITLE
fix(proxy): 零输出 incomplete 重试、工具 schema/工具名净化、Claude beta 门控、Gemini responseJsonSchema、messages thinking_tokens

### DIFF
--- a/proxy/anthropic.go
+++ b/proxy/anthropic.go
@@ -153,6 +153,28 @@ type anthropicUsage struct {
 	OutputTokens             int `json:"output_tokens"`
 	CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
 	CacheReadInputTokens     int `json:"cache_read_input_tokens"`
+	// OutputTokensDetails 回传 Codex 的 reasoning_tokens。开了 thinking-token-count
+	// beta 的 Claude Code 按 thinking_tokens 拼写读取;output_tokens 已含思考部分,
+	// 这里只是细分而非额外计费。缺失时整个字段省略,不能把"没报"说成 0。
+	OutputTokensDetails *anthropicOutputTokensDetails `json:"output_tokens_details,omitempty"`
+}
+
+type anthropicOutputTokensDetails struct {
+	ThinkingTokens int `json:"thinking_tokens"`
+}
+
+// anthropicThinkingTokensFromUsage 从 Responses usage 取 reasoning_tokens:只认非负
+// 数值,并钳到 output_tokens(思考是输出的子集,不能超过总输出)。
+func anthropicThinkingTokensFromUsage(usage gjson.Result) *anthropicOutputTokensDetails {
+	detail := usage.Get("output_tokens_details.reasoning_tokens")
+	if !detail.Exists() || detail.Type != gjson.Number || detail.Num < 0 {
+		return nil
+	}
+	tokens := int(detail.Int())
+	if output := int(usage.Get("output_tokens").Int()); tokens > output {
+		tokens = max(output, 0)
+	}
+	return &anthropicOutputTokensDetails{ThinkingTokens: tokens}
 }
 
 // ==================== Anthropic 流式事件类型 ====================
@@ -998,6 +1020,7 @@ type anthropicStreamTranslator struct {
 	inputTokens               int
 	outputTokens              int
 	cachedTokens              int
+	thinkingTokens            *anthropicOutputTokensDetails
 	pingAfterStartSent        bool
 	deltasSincePing           int
 }
@@ -1299,6 +1322,7 @@ func (t *anthropicStreamTranslator) handleCompleted(data []byte) []anthropicStre
 		t.cachedTokens = int(usage.Get("input_tokens_details.cached_tokens").Int())
 		t.inputTokens = max(int(usage.Get("input_tokens").Int())-t.cachedTokens, 0)
 		t.outputTokens = int(usage.Get("output_tokens").Int())
+		t.thinkingTokens = anthropicThinkingTokensFromUsage(usage)
 	}
 
 	// 确定 stop_reason
@@ -1325,6 +1349,7 @@ func (t *anthropicStreamTranslator) handleCompleted(data []byte) []anthropicStre
 			InputTokens:          t.inputTokens,
 			OutputTokens:         t.outputTokens,
 			CacheReadInputTokens: t.cachedTokens,
+			OutputTokensDetails:  t.thinkingTokens,
 		},
 	})
 
@@ -1621,6 +1646,7 @@ func buildAnthropicResponseFromCompleted(completedData []byte, model string) *an
 			InputTokens:          input,
 			OutputTokens:         int(usage.Get("output_tokens").Int()),
 			CacheReadInputTokens: cached,
+			OutputTokensDetails:  anthropicThinkingTokensFromUsage(usage),
 		}
 	}
 

--- a/proxy/anthropic.go
+++ b/proxy/anthropic.go
@@ -921,6 +921,9 @@ func convertAnthropicTools(tools []anthropicTool) []any {
 		item := map[string]any{
 			"type": "function",
 			"name": t.Name,
+			// Anthropic 工具没有 strict 概念，input_schema 常带可选属性；Responses
+			// 默认 strict=true 会按严格模式校验 schema 而 400，显式关掉。
+			"strict": false,
 		}
 		if t.Description != "" {
 			item["description"] = t.Description

--- a/proxy/anthropic_thinking_tokens_test.go
+++ b/proxy/anthropic_thinking_tokens_test.go
@@ -1,0 +1,78 @@
+package proxy
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestAnthropicThinkingTokensFromUsage(t *testing.T) {
+	cases := map[string]struct {
+		usage string
+		want  *anthropicOutputTokensDetails
+	}{
+		"present":          {`{"output_tokens":518,"output_tokens_details":{"reasoning_tokens":163}}`, &anthropicOutputTokensDetails{ThinkingTokens: 163}},
+		"explicit zero":    {`{"output_tokens":5,"output_tokens_details":{"reasoning_tokens":0}}`, &anthropicOutputTokensDetails{ThinkingTokens: 0}},
+		"clamped":          {`{"output_tokens":10,"output_tokens_details":{"reasoning_tokens":40}}`, &anthropicOutputTokensDetails{ThinkingTokens: 10}},
+		"absent":           {`{"output_tokens":5}`, nil},
+		"null":             {`{"output_tokens":5,"output_tokens_details":{"reasoning_tokens":null}}`, nil},
+		"negative ignored": {`{"output_tokens":5,"output_tokens_details":{"reasoning_tokens":-1}}`, nil},
+		"string ignored":   {`{"output_tokens":5,"output_tokens_details":{"reasoning_tokens":"7"}}`, nil},
+	}
+	for name, tc := range cases {
+		got := anthropicThinkingTokensFromUsage(gjson.Parse(tc.usage))
+		switch {
+		case tc.want == nil && got != nil:
+			t.Errorf("%s: want nil, got %+v", name, got)
+		case tc.want != nil && (got == nil || got.ThinkingTokens != tc.want.ThinkingTokens):
+			t.Errorf("%s: want %+v, got %+v", name, tc.want, got)
+		}
+	}
+}
+
+func TestAnthropicStreamTranslatorReportsThinkingTokens(t *testing.T) {
+	tr := newAnthropicStreamTranslator("claude-sonnet-4-5")
+	tr.translateEvent([]byte(`{"type":"response.created"}`))
+	completed := []byte(`{"type":"response.completed","response":{"status":"completed","usage":{"input_tokens":420,"output_tokens":518,"output_tokens_details":{"reasoning_tokens":163}}}}`)
+	var usage *anthropicUsage
+	for _, evt := range tr.translateEvent(completed) {
+		if evt.Type == "message_delta" && evt.Usage != nil {
+			usage = evt.Usage
+		}
+	}
+	if usage == nil || usage.OutputTokensDetails == nil || usage.OutputTokensDetails.ThinkingTokens != 163 {
+		t.Fatalf("message_delta usage = %+v, want thinking_tokens 163", usage)
+	}
+	if usage.OutputTokens != 518 {
+		t.Fatal("output_tokens must stay inclusive of thinking")
+	}
+	encoded, _ := json.Marshal(usage)
+	if gjson.GetBytes(encoded, "output_tokens_details.thinking_tokens").Int() != 163 {
+		t.Fatalf("wire spelling must be output_tokens_details.thinking_tokens: %s", encoded)
+	}
+
+	// 上游没报 reasoning_tokens 时整个字段省略,而不是写 0。
+	tr = newAnthropicStreamTranslator("claude-sonnet-4-5")
+	tr.translateEvent([]byte(`{"type":"response.created"}`))
+	for _, evt := range tr.translateEvent([]byte(`{"type":"response.completed","response":{"status":"completed","usage":{"input_tokens":1,"output_tokens":2}}}`)) {
+		if evt.Type == "message_delta" && evt.Usage != nil {
+			encoded, _ := json.Marshal(evt.Usage)
+			if gjson.GetBytes(encoded, "output_tokens_details").Exists() {
+				t.Fatalf("output_tokens_details must be omitted when upstream did not report it: %s", encoded)
+			}
+		}
+	}
+}
+
+func TestBuildAnthropicResponseFromCompletedReportsThinkingTokens(t *testing.T) {
+	completed := []byte(`{"type":"response.completed","response":{"status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"hi"}]}],"usage":{"input_tokens":7,"output_tokens":9,"output_tokens_details":{"reasoning_tokens":4}}}}`)
+	resp := buildAnthropicResponseFromCompleted(completed, "claude-sonnet-4-5")
+	if resp == nil || resp.Usage.OutputTokensDetails == nil || resp.Usage.OutputTokensDetails.ThinkingTokens != 4 {
+		t.Fatalf("non-stream usage = %+v, want thinking_tokens 4", resp.Usage)
+	}
+	encoded, _ := json.Marshal(resp)
+	if gjson.GetBytes(encoded, "usage.output_tokens_details.thinking_tokens").Int() != 4 || gjson.GetBytes(encoded, "usage.output_tokens").Int() != 9 {
+		t.Fatalf("unexpected usage wire shape: %s", gjson.GetBytes(encoded, "usage").Raw)
+	}
+}

--- a/proxy/antigravity_gemini.go
+++ b/proxy/antigravity_gemini.go
@@ -148,6 +148,7 @@ func geminiNativeToAntigravityEnvelope(rawBody []byte, project, model string) ([
 	antigravityRewriteNativeGeminiFunctionNames(request, nameMap)
 	wireModel := antigravityGeminiResolvedModel(model, nil)
 	antigravityApplyNativeGeminiThinkingConfig(request, model, wireModel)
+	antigravityNormalizeNativeGeminiResponseSchema(request)
 	antigravitySanitizeNativeGeminiThoughtSignatures(request, wireModel)
 	contents, _ := request["contents"].([]any)
 	request["sessionId"] = antigravitySessionID(nil, contents)
@@ -188,6 +189,52 @@ func antigravityApplyNativeGeminiThinkingConfig(request map[string]any, publicMo
 			"thinkingBudget":  budget,
 		}
 	}
+}
+
+// antigravityNormalizeNativeGeminiResponseSchema 把 generationConfig.responseJsonSchema
+// (及 snake_case 的 response_json_schema)归一成 responseSchema。Antigravity 后端不认
+// 前者,原样透传时结构化输出会静默不生效。responseJsonSchema 是标准 JSON Schema,
+// 可能带 $defs/$ref 与 responseSchema(OpenAPI 子集)不认的关键字,搬过去时套用与
+// Responses→Antigravity 相同的清洗;客户端已显式给了 responseSchema 则以它为准,
+// 只删掉过时键。
+func antigravityNormalizeNativeGeminiResponseSchema(request map[string]any) {
+	for _, container := range []string{"generationConfig", "generation_config"} {
+		genConfig, ok := request[container].(map[string]any)
+		if !ok {
+			continue
+		}
+		for _, key := range []string{"responseJsonSchema", "response_json_schema"} {
+			schema, exists := genConfig[key]
+			if !exists {
+				continue
+			}
+			delete(genConfig, key)
+			if _, has := genConfig["responseSchema"]; has || schema == nil {
+				continue
+			}
+			genConfig["responseSchema"] = antigravityResponseSchemaFromJSONSchema(schema)
+		}
+	}
+}
+
+func antigravityResponseSchemaFromJSONSchema(schema any) any {
+	root, ok := schema.(map[string]any)
+	if !ok {
+		return schema
+	}
+	definitions := map[string]any{}
+	for _, key := range []string{"$defs", "definitions"} {
+		if defs, defsOK := root[key].(map[string]any); defsOK {
+			for name, definition := range defs {
+				definitions[name] = definition
+			}
+		}
+	}
+	cleaned, cleanedOK := antigravityCleanGeminiSchema(root, definitions, map[string]bool{}, 0).(map[string]any)
+	if !cleanedOK || len(cleaned) == 0 {
+		return schema
+	}
+	return cleaned
 }
 
 const antigravityGeminiSkipThoughtSignature = "skip_thought_signature_validator"

--- a/proxy/antigravity_gemini_response_schema_test.go
+++ b/proxy/antigravity_gemini_response_schema_test.go
@@ -1,0 +1,108 @@
+package proxy
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestAntigravityNormalizeNativeGeminiResponseSchema_MovesJsonSchema(t *testing.T) {
+	request := map[string]any{
+		"generationConfig": map[string]any{
+			"responseMimeType": "application/json",
+			"responseJsonSchema": map[string]any{
+				"type":       "object",
+				"properties": map[string]any{"message": map[string]any{"type": "string"}},
+				"required":   []any{"message"},
+			},
+		},
+	}
+	antigravityNormalizeNativeGeminiResponseSchema(request)
+	encoded, _ := json.Marshal(request)
+	if gjson.GetBytes(encoded, "generationConfig.responseJsonSchema").Exists() {
+		t.Fatalf("responseJsonSchema must be removed: %s", encoded)
+	}
+	if got := gjson.GetBytes(encoded, "generationConfig.responseSchema.properties.message.type").String(); got == "" {
+		t.Fatalf("responseSchema not populated: %s", encoded)
+	}
+	if gjson.GetBytes(encoded, "generationConfig.responseMimeType").String() != "application/json" {
+		t.Fatal("sibling generationConfig keys must be preserved")
+	}
+}
+
+func TestAntigravityNormalizeNativeGeminiResponseSchema_SnakeCaseAndExistingWins(t *testing.T) {
+	request := map[string]any{
+		"generation_config": map[string]any{
+			"response_json_schema": map[string]any{"type": "object", "properties": map[string]any{"a": map[string]any{"type": "string"}}},
+			"responseSchema":       map[string]any{"type": "OBJECT", "properties": map[string]any{"keep": map[string]any{"type": "STRING"}}},
+		},
+	}
+	antigravityNormalizeNativeGeminiResponseSchema(request)
+	encoded, _ := json.Marshal(request)
+	if gjson.GetBytes(encoded, "generation_config.response_json_schema").Exists() {
+		t.Fatalf("snake_case key must be removed: %s", encoded)
+	}
+	if !gjson.GetBytes(encoded, "generation_config.responseSchema.properties.keep").Exists() {
+		t.Fatalf("explicit responseSchema must win: %s", encoded)
+	}
+}
+
+func TestAntigravityNormalizeNativeGeminiResponseSchema_ResolvesDefsLikeResponsesPath(t *testing.T) {
+	request := map[string]any{
+		"generationConfig": map[string]any{
+			"responseJsonSchema": map[string]any{
+				"type": "object",
+				"$defs": map[string]any{
+					"Item": map[string]any{"type": "object", "properties": map[string]any{"id": map[string]any{"type": "integer"}}},
+				},
+				"properties": map[string]any{
+					"items": map[string]any{"type": "array", "items": map[string]any{"$ref": "#/$defs/Item"}},
+				},
+			},
+		},
+	}
+	antigravityNormalizeNativeGeminiResponseSchema(request)
+	encoded, _ := json.Marshal(request)
+	schema := gjson.GetBytes(encoded, "generationConfig.responseSchema")
+	if !schema.Exists() {
+		t.Fatalf("responseSchema missing: %s", encoded)
+	}
+	if schema.Get("$defs").Exists() || schema.Get("properties.items.items.$ref").Exists() {
+		t.Fatalf("$defs/$ref must be resolved for responseSchema: %s", schema.Raw)
+	}
+	if !schema.Get("properties.items.items.properties.id").Exists() {
+		t.Fatalf("referenced definition must be inlined: %s", schema.Raw)
+	}
+}
+
+func TestAntigravityNormalizeNativeGeminiResponseSchema_NoConfigNoop(t *testing.T) {
+	request := map[string]any{"contents": []any{}}
+	antigravityNormalizeNativeGeminiResponseSchema(request)
+	if _, ok := request["generationConfig"]; ok {
+		t.Fatal("must not invent generationConfig")
+	}
+	request = map[string]any{"generationConfig": map[string]any{"responseJsonSchema": nil}}
+	antigravityNormalizeNativeGeminiResponseSchema(request)
+	genConfig := request["generationConfig"].(map[string]any)
+	if _, has := genConfig["responseSchema"]; has {
+		t.Fatal("null responseJsonSchema must not produce a responseSchema")
+	}
+	if _, has := genConfig["responseJsonSchema"]; has {
+		t.Fatal("null responseJsonSchema must still be dropped")
+	}
+}
+
+func TestGeminiNativeToAntigravityEnvelope_NormalizesResponseJsonSchema(t *testing.T) {
+	raw := []byte(`{"contents":[{"role":"user","parts":[{"text":"hi"}]}],"generationConfig":{"responseMimeType":"application/json","responseJsonSchema":{"type":"object","properties":{"message":{"type":"string"}},"required":["message"]}}}`)
+	payload, _, _, err := geminiNativeToAntigravityEnvelope(raw, "proj", "gemini-3.7-flash-high")
+	if err != nil {
+		t.Fatalf("envelope: %v", err)
+	}
+	if gjson.GetBytes(payload, "request.generationConfig.responseJsonSchema").Exists() {
+		t.Fatalf("responseJsonSchema leaked to Antigravity: %s", payload)
+	}
+	if !gjson.GetBytes(payload, "request.generationConfig.responseSchema.properties.message").Exists() {
+		t.Fatalf("responseSchema missing in envelope: %s", payload)
+	}
+}

--- a/proxy/antigravity_gemini_response_schema_test.go
+++ b/proxy/antigravity_gemini_response_schema_test.go
@@ -106,3 +106,36 @@ func TestGeminiNativeToAntigravityEnvelope_NormalizesResponseJsonSchema(t *testi
 		t.Fatalf("responseSchema missing in envelope: %s", payload)
 	}
 }
+
+// $ref 里的 JSON Pointer 转义(~1 → /、~0 → ~、百分号编码)要解码后再查定义键,
+// 否则 "A/B" 这类键永远命中不了,引用会被清成 {} 丢约束。
+func TestAntigravityNormalizeNativeGeminiResponseSchema_DecodesJSONPointerRefs(t *testing.T) {
+	request := map[string]any{
+		"generationConfig": map[string]any{
+			"responseJsonSchema": map[string]any{
+				"type": "object",
+				"$defs": map[string]any{
+					"A/B":    map[string]any{"type": "object", "properties": map[string]any{"slash": map[string]any{"type": "string"}}},
+					"T~X":    map[string]any{"type": "object", "properties": map[string]any{"tilde": map[string]any{"type": "integer"}}},
+					"Sp ace": map[string]any{"type": "object", "properties": map[string]any{"space": map[string]any{"type": "boolean"}}},
+				},
+				"properties": map[string]any{
+					"a": map[string]any{"$ref": "#/$defs/A~1B"},
+					"b": map[string]any{"$ref": "#/$defs/T~0X"},
+					"c": map[string]any{"$ref": "#/$defs/Sp%20ace"},
+				},
+			},
+		},
+	}
+	antigravityNormalizeNativeGeminiResponseSchema(request)
+	encoded, _ := json.Marshal(request)
+	schema := gjson.GetBytes(encoded, "generationConfig.responseSchema")
+	for prop, leaf := range map[string]string{"a": "slash", "b": "tilde", "c": "space"} {
+		if !schema.Get("properties." + prop + ".properties." + leaf).Exists() {
+			t.Fatalf("$ref for %q not resolved through pointer decoding: %s", prop, schema.Raw)
+		}
+	}
+	if schema.Get("properties.a.$ref").Exists() || schema.Get("$defs").Exists() {
+		t.Fatalf("unresolved $ref/$defs leaked: %s", schema.Raw)
+	}
+}

--- a/proxy/antigravity_responses.go
+++ b/proxy/antigravity_responses.go
@@ -14,6 +14,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"regexp"
 	"sort"
@@ -1147,6 +1148,17 @@ func antigravityRequiredFieldNames(raw any) []string {
 	}
 }
 
+// decodeJSONPointerToken 把 $ref 里的 JSON Pointer 引用 token 还原成定义键:
+// 片段里先做百分号解码,再按 RFC 6901 把 ~1 还原成 /、~0 还原成 ~(顺序不能反)。
+// 不解码时 "#/$defs/A~1B" 会按字面量找不到 "A/B",引用被清成 {} 丢掉约束。
+func decodeJSONPointerToken(token string) string {
+	if unescaped, err := url.PathUnescape(token); err == nil {
+		token = unescaped
+	}
+	token = strings.ReplaceAll(token, "~1", "/")
+	return strings.ReplaceAll(token, "~0", "~")
+}
+
 func antigravityCleanGeminiSchema(value any, definitions map[string]any, resolving map[string]bool, depth int) any {
 	if depth > 32 {
 		return nil
@@ -1164,6 +1176,7 @@ func antigravityCleanGeminiSchema(value any, definitions map[string]any, resolvi
 			case strings.HasPrefix(ref, definitionsPrefix):
 				name = strings.TrimPrefix(ref, definitionsPrefix)
 			}
+			name = decodeJSONPointerToken(name)
 			if definition, ok := definitions[name]; ok && name != "" && !resolving[name] {
 				resolving[name] = true
 				if expanded, ok := antigravityCleanGeminiSchema(definition, definitions, resolving, depth+1).(map[string]any); ok {

--- a/proxy/claude_upstream.go
+++ b/proxy/claude_upstream.go
@@ -837,7 +837,7 @@ func mergeAnthropicBetaWithConfig(incoming http.Header, cfg auth.ClaudeSecurityC
 //  2. body 驱动(按 body 实际携带的功能补声明,保证字段与 beta 成对,
 //     缺失会被上游 400 "required beta"):thinking→interleaved-thinking /
 //     thinking-token-count / redact-thinking;context_management→
-//     context-management;tools→advanced-tool-use;effort→effort;
+//     context-management;工具搜索/高级工具特性→advanced-tool-use;effort→effort;
 //     1h 缓存→extended-cache-ttl;cache scope→prompt-caching-scope;
 //  3. 下游透传:入站 anthropic-beta 按白名单过滤(白名单缺省时用真实 CLI
 //     注册表 DefaultClaudeAllowedBetaHeaders,避免任意第三方 beta 混入)。
@@ -892,7 +892,11 @@ func buildClaudeBetaHeader(incoming http.Header, cfg auth.ClaudeSecurityConfig, 
 		if gjson.GetBytes(body, "context_management").Exists() {
 			add("context-management-2025-06-27", false)
 		}
-		if gjson.GetBytes(body, "tools").Exists() {
+		// Claude Code 2.1.258 实测:普通工具声明不再带 advanced-tool-use,只有工具
+		// 搜索(tool_search_tool_* 服务端工具、defer_loading)、工具用例(input_examples)
+		// 或程序化调用(allowed_callers)上线时才发。客户端自己带了该 beta 时仍按
+		// 白名单从入站头透传(见下方)。
+		if claudeBodyUsesAdvancedToolUse(body) {
 			add("advanced-tool-use-2025-11-20", false)
 		}
 		if gjson.GetBytes(body, "output_config.effort").Exists() || gjson.GetBytes(body, "reasoning_effort").Exists() || gjson.GetBytes(body, "effort").Exists() {
@@ -919,6 +923,27 @@ func buildClaudeBetaHeader(incoming http.Header, cfg auth.ClaudeSecurityConfig, 
 		}
 	}
 	return strings.Join(ordered, ",")
+}
+
+// claudeBodyUsesAdvancedToolUse 报告请求是否用到了 advanced-tool-use beta 背后的
+// 功能:工具搜索服务端工具(type 以 tool_search_tool_ 开头)、延迟加载的工具
+// (defer_loading)、工具用例(input_examples)、程序化调用(allowed_callers)。
+// 这些都能从 body 直接看出,用到了就必须成对带上 beta,否则上游 400。
+func claudeBodyUsesAdvancedToolUse(body []byte) bool {
+	tools := gjson.GetBytes(body, "tools")
+	if !tools.IsArray() {
+		return false
+	}
+	for _, tool := range tools.Array() {
+		toolType := strings.ToLower(strings.TrimSpace(tool.Get("type").String()))
+		if strings.HasPrefix(toolType, "tool_search_tool_") {
+			return true
+		}
+		if tool.Get("defer_loading").Bool() || tool.Get("input_examples").Exists() || tool.Get("allowed_callers").Exists() {
+			return true
+		}
+	}
+	return false
 }
 
 // claudeCacheControlHasExtendedTTL 报告请求中是否存在 ttl=1h 的 cache_control 块

--- a/proxy/claude_upstream_test.go
+++ b/proxy/claude_upstream_test.go
@@ -142,7 +142,7 @@ func TestBuildClaudeBetaHeader_HaikuOmitsClaudeCode(t *testing.T) {
 }
 
 func TestBuildClaudeBetaHeader_BodyDriven(t *testing.T) {
-	body := []byte(`{"model":"claude-opus-5","thinking":{"type":"enabled","budget_tokens":1000},"tools":[{"name":"a"}],"context_management":{"edits":[]},"output_config":{"effort":"high"},"system":[{"type":"text","text":"x","cache_control":{"type":"ephemeral","ttl":"1h"}}],"messages":[]}`)
+	body := []byte(`{"model":"claude-opus-5","thinking":{"type":"enabled","budget_tokens":1000},"tools":[{"name":"a"},{"type":"tool_search_tool_regex_20251119","name":"tool_search"}],"context_management":{"edits":[]},"output_config":{"effort":"high"},"system":[{"type":"text","text":"x","cache_control":{"type":"ephemeral","ttl":"1h"}}],"messages":[]}`)
 	got := buildClaudeBetaHeader(nil, auth.DefaultClaudeSecurityConfig(), body)
 	for _, want := range []string{
 		auth.ClaudeCodeBeta, auth.ClaudeOAuthBeta,
@@ -153,6 +153,34 @@ func TestBuildClaudeBetaHeader_BodyDriven(t *testing.T) {
 		if !strings.Contains(got, want) {
 			t.Fatalf("缺 body 驱动 beta %s: %s", want, got)
 		}
+	}
+}
+
+// Claude Code 2.1.258 实测:普通工具声明不带 advanced-tool-use,只有工具搜索/
+// 延迟加载/工具用例/程序化调用上线时才带;客户端显式带的仍按白名单透传。
+func TestBuildClaudeBetaHeader_AdvancedToolUseOnlyForAdvancedFeatures(t *testing.T) {
+	const beta = "advanced-tool-use-2025-11-20"
+	plain := []byte(`{"model":"claude-opus-5","tools":[{"name":"Read","input_schema":{"type":"object"}},{"name":"Bash","input_schema":{"type":"object"}}],"messages":[]}`)
+	if got := buildClaudeBetaHeader(nil, auth.DefaultClaudeSecurityConfig(), plain); strings.Contains(got, beta) {
+		t.Fatalf("普通工具声明不应带 %s: %s", beta, got)
+	}
+	for name, body := range map[string]string{
+		"tool_search_tool": `{"model":"claude-opus-5","tools":[{"type":"tool_search_tool_bm25_20251119","name":"tool_search"},{"name":"Read","input_schema":{"type":"object"}}],"messages":[]}`,
+		"defer_loading":    `{"model":"claude-opus-5","tools":[{"name":"Read","input_schema":{"type":"object"},"defer_loading":true}],"messages":[]}`,
+		"input_examples":   `{"model":"claude-opus-5","tools":[{"name":"Read","input_schema":{"type":"object"},"input_examples":[{"path":"a"}]}],"messages":[]}`,
+		"allowed_callers":  `{"model":"claude-opus-5","tools":[{"name":"Read","input_schema":{"type":"object"},"allowed_callers":["code_execution_20250825"]}],"messages":[]}`,
+	} {
+		if got := buildClaudeBetaHeader(nil, auth.DefaultClaudeSecurityConfig(), []byte(body)); !strings.Contains(got, beta) {
+			t.Fatalf("%s 上线时必须带 %s: %s", name, beta, got)
+		}
+	}
+	h := http.Header{}
+	h.Set("anthropic-beta", beta)
+	if got := buildClaudeBetaHeader(h, auth.DefaultClaudeSecurityConfig(), plain); strings.Count(got, beta) != 1 {
+		t.Fatalf("客户端显式带的 %s 应按白名单透传且只出现一次: %s", beta, got)
+	}
+	if claudeBodyUsesAdvancedToolUse([]byte(`{"tools":"not-an-array"}`)) || claudeBodyUsesAdvancedToolUse(nil) {
+		t.Fatal("非法 tools 形态不应判定为高级工具特性")
 	}
 }
 

--- a/proxy/codex_empty_incomplete.go
+++ b/proxy/codex_empty_incomplete.go
@@ -1,0 +1,129 @@
+package proxy
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// 上游偶发以 HTTP 200 + response.incomplete 结束一次"什么都没生成"的响应：
+// usage.output_tokens 精确为 0、response.output 为空、此前也没有任何非空 delta
+// 或 output_item.done。这不是 max_output_tokens 截断，而是上游静默中止（已知触发
+// 之一是工具 schema 里的大 oneOf/const 联合）。原样转发会让 Chat 下游拿到
+// finish_reason=length 的空回复且不会重试，看起来像"模型死了"。
+//
+// 这里把它就地改写成 response.failed，复用既有的首包前透明重试/换号路径。判定
+// 条件刻意收紧（数值精确 0、无 output 项、无非空 delta），避免把正常截断重新
+// 误判成断流（v2.8.3 修过的那类回归）。故障按请求维度计：不进账号健康度。
+const (
+	codexEmptyIncompleteErrorCode    = "empty_incomplete_response"
+	codexEmptyIncompleteErrorMessage = "upstream terminated with an incomplete empty response (0 output tokens)"
+	codexEmptyIncompleteFailureKind  = "empty_incomplete"
+)
+
+// emptyIncompleteTracker 记录一次上游尝试内是否出现过真实输出。每个 attempt 一份。
+type emptyIncompleteTracker struct {
+	sawOutputDelta bool
+	outputItems    int
+}
+
+// Observe 记录事件。只有非空的文本/思考/工具参数 delta 与 output_item.done 计入。
+func (t *emptyIncompleteTracker) Observe(eventType string, parsed gjson.Result) {
+	if t == nil {
+		return
+	}
+	switch eventType {
+	case "response.output_text.delta",
+		"response.reasoning_text.delta",
+		"response.reasoning_summary_text.delta",
+		"response.function_call_arguments.delta",
+		"response.custom_tool_call_input.delta":
+		if strings.TrimSpace(parsed.Get("delta").String()) != "" {
+			t.sawOutputDelta = true
+		}
+	case "response.output_item.done":
+		t.outputItems++
+	}
+}
+
+// IsEmptyIncomplete 判断该终态事件是否为"零输出"的 response.incomplete。
+func (t *emptyIncompleteTracker) IsEmptyIncomplete(eventType string, parsed gjson.Result) bool {
+	if eventType != "response.incomplete" {
+		return false
+	}
+	if t != nil && (t.sawOutputDelta || t.outputItems > 0) {
+		return false
+	}
+	return isEmptyIncompleteResponse(parsed.Get("response"))
+}
+
+// isEmptyIncompleteResponse 要求 output 为空且 usage.output_tokens 是字面量整数 0。
+// 缺失/null/浮点/非数字一律不算，宁可漏判也不误判。
+func isEmptyIncompleteResponse(response gjson.Result) bool {
+	if !response.Exists() || !response.IsObject() {
+		return false
+	}
+	if output := response.Get("output"); output.IsArray() && len(output.Array()) > 0 {
+		return false
+	}
+	tokens := response.Get("usage.output_tokens")
+	if !tokens.Exists() || tokens.Type != gjson.Number {
+		return false
+	}
+	return strings.TrimSpace(tokens.Raw) == "0"
+}
+
+// isEmptyIncompleteResponseBody 是非流式 Responses 对象的同款判定。
+func isEmptyIncompleteResponseBody(body []byte) bool {
+	root := gjson.ParseBytes(body)
+	if strings.ToLower(strings.TrimSpace(root.Get("status").String())) != "incomplete" {
+		return false
+	}
+	return isEmptyIncompleteResponse(root)
+}
+
+// synthesizeEmptyIncompleteFailureEvent 把 response.incomplete 事件改写成
+// response.failed，保留 response.id/model/usage 等字段供日志与计费使用。
+func synthesizeEmptyIncompleteFailureEvent(data []byte) []byte {
+	out := append([]byte(nil), data...)
+	out, _ = sjson.SetBytes(out, "type", "response.failed")
+	out, _ = sjson.DeleteBytes(out, "response.incomplete_details")
+	return setEmptyIncompleteFailure(out, "response.")
+}
+
+// synthesizeEmptyIncompleteFailureBody 是非流式 Responses 对象的同款改写。
+func synthesizeEmptyIncompleteFailureBody(body []byte) []byte {
+	out := append([]byte(nil), body...)
+	out, _ = sjson.DeleteBytes(out, "incomplete_details")
+	return setEmptyIncompleteFailure(out, "")
+}
+
+func setEmptyIncompleteFailure(payload []byte, prefix string) []byte {
+	payload, _ = sjson.SetBytes(payload, prefix+"status", "failed")
+	payload, _ = sjson.SetBytes(payload, prefix+"error.type", "server_error")
+	payload, _ = sjson.SetBytes(payload, prefix+"error.code", codexEmptyIncompleteErrorCode)
+	payload, _ = sjson.SetBytes(payload, prefix+"error.status_code", http.StatusBadGateway)
+	payload, _ = sjson.SetBytes(payload, prefix+"error.message", codexEmptyIncompleteErrorMessage)
+	return payload
+}
+
+// isEmptyIncompleteFailurePayload 识别本文件合成的失败载荷（流式事件或非流式对象）。
+func isEmptyIncompleteFailurePayload(payload []byte) bool {
+	if len(payload) == 0 {
+		return false
+	}
+	return gjson.GetBytes(responseFailedErrorBody(payload), "error.code").String() == codexEmptyIncompleteErrorCode
+}
+
+// rewriteEmptyIncompleteTerminal 是各条 SSE 读取循环共用的入口：命中时返回改写后的
+// 事件与 response.failed 类型，未命中时原样返回。调用方把返回值赋回本地变量即可。
+func rewriteEmptyIncompleteTerminal(tracker *emptyIncompleteTracker, eventType string, data []byte, parsed gjson.Result) (string, []byte, gjson.Result) {
+	tracker.Observe(eventType, parsed)
+	if !tracker.IsEmptyIncomplete(eventType, parsed) {
+		return eventType, data, parsed
+	}
+	data = synthesizeEmptyIncompleteFailureEvent(data)
+	return "response.failed", data, gjson.ParseBytes(data)
+}

--- a/proxy/codex_empty_incomplete_test.go
+++ b/proxy/codex_empty_incomplete_test.go
@@ -5,6 +5,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/codex2api/auth"
+	"github.com/codex2api/config"
+	"github.com/codex2api/database"
 	"github.com/tidwall/gjson"
 )
 
@@ -186,13 +189,33 @@ func TestEmptyIncompleteNonStreamBody(t *testing.T) {
 }
 
 func TestReportStreamOutcomeFailure_SkipsRequestScoped(t *testing.T) {
-	// 空 incomplete 与容量降载一样不进账号健康度；这里只验证判定入口。
-	outcome := streamOutcome{logStatusCode: http.StatusBadGateway, failureKind: codexEmptyIncompleteFailureKind, penalize: true, requestScoped: true}
-	if !outcome.penalize || !outcome.requestScoped {
-		t.Fatal("fixture must be retryable and request scoped")
+	// 空 incomplete 与容量降载一样不进账号健康度:用真实 store 与账号断言
+	// 连击与健康档位不变,并以同样的非请求维度故障做对照。
+	store := auth.NewStore(nil, nil, &database.SystemSettings{MaxConcurrency: 1, TestConcurrency: 1, TestModel: "gpt-5.4"})
+	t.Cleanup(store.Stop)
+	account := &auth.Account{DBID: 1, AccessToken: "at-1", PlanType: "pro", AccountID: "acct-1"}
+	store.AddAccount(account)
+	h := NewHandler(store, nil, &config.Config{AllowAnonymousV1: true}, nil)
+
+	failureStreak := func() int {
+		account.Mu().RLock()
+		defer account.Mu().RUnlock()
+		return account.FailureStreak
 	}
-	var h *Handler
-	// h.store 为 nil；若 requestScoped 未被跳过，这里会解引用空指针而 panic。
-	h = &Handler{}
-	h.reportStreamOutcomeFailure(nil, outcome, 0)
+	tierBefore := account.GetHealthTier()
+
+	scoped := streamOutcome{logStatusCode: http.StatusBadGateway, failureKind: codexEmptyIncompleteFailureKind, penalize: true, requestScoped: true}
+	h.reportStreamOutcomeFailure(account, scoped, 0)
+	if got := failureStreak(); got != 0 {
+		t.Fatalf("request-scoped failure must not touch FailureStreak, got %d", got)
+	}
+	if got := account.GetHealthTier(); got != tierBefore {
+		t.Fatalf("request-scoped failure must not change health tier: %s -> %s", tierBefore, got)
+	}
+
+	plain := streamOutcome{logStatusCode: http.StatusBadGateway, failureKind: "server", penalize: true}
+	h.reportStreamOutcomeFailure(account, plain, 0)
+	if got := failureStreak(); got != 1 {
+		t.Fatalf("control: ordinary 5xx must be reported, FailureStreak = %d", got)
+	}
 }

--- a/proxy/codex_empty_incomplete_test.go
+++ b/proxy/codex_empty_incomplete_test.go
@@ -1,0 +1,198 @@
+package proxy
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestEmptyIncompleteTracker_Detection(t *testing.T) {
+	trueEmpty := []byte(`{"type":"response.incomplete","response":{"id":"r1","output":[],"usage":{"output_tokens":0}}}`)
+	parsedEmpty := gjson.ParseBytes(trueEmpty)
+
+	t.Run("true empty incomplete", func(t *testing.T) {
+		tracker := &emptyIncompleteTracker{}
+		if !tracker.IsEmptyIncomplete("response.incomplete", parsedEmpty) {
+			t.Fatal("expected empty incomplete to be detected")
+		}
+	})
+	t.Run("non-empty delta observed", func(t *testing.T) {
+		tracker := &emptyIncompleteTracker{}
+		tracker.Observe("response.output_text.delta", gjson.Parse(`{"type":"response.output_text.delta","delta":"Hi"}`))
+		if tracker.IsEmptyIncomplete("response.incomplete", parsedEmpty) {
+			t.Fatal("text delta must suppress detection")
+		}
+	})
+	t.Run("whitespace delta does not count", func(t *testing.T) {
+		tracker := &emptyIncompleteTracker{}
+		tracker.Observe("response.output_text.delta", gjson.Parse(`{"type":"response.output_text.delta","delta":"   "}`))
+		tracker.Observe("response.reasoning_summary_text.delta", gjson.Parse(`{"delta":""}`))
+		if !tracker.IsEmptyIncomplete("response.incomplete", parsedEmpty) {
+			t.Fatal("empty/whitespace deltas must not count as output")
+		}
+	})
+	t.Run("function call arguments delta counts", func(t *testing.T) {
+		tracker := &emptyIncompleteTracker{}
+		tracker.Observe("response.function_call_arguments.delta", gjson.Parse(`{"delta":"{\"a\":1}"}`))
+		if tracker.IsEmptyIncomplete("response.incomplete", parsedEmpty) {
+			t.Fatal("tool argument delta must suppress detection")
+		}
+	})
+	t.Run("output item done counts", func(t *testing.T) {
+		tracker := &emptyIncompleteTracker{}
+		tracker.Observe("response.output_item.done", gjson.Parse(`{"item":{"type":"reasoning"}}`))
+		if tracker.IsEmptyIncomplete("response.incomplete", parsedEmpty) {
+			t.Fatal("completed output item must suppress detection")
+		}
+	})
+	t.Run("positive output tokens", func(t *testing.T) {
+		tracker := &emptyIncompleteTracker{}
+		parsed := gjson.Parse(`{"type":"response.incomplete","response":{"output":[],"usage":{"output_tokens":5}}}`)
+		if tracker.IsEmptyIncomplete("response.incomplete", parsed) {
+			t.Fatal("output_tokens > 0 must not be treated as empty")
+		}
+	})
+	t.Run("float zero-ish tokens rejected", func(t *testing.T) {
+		tracker := &emptyIncompleteTracker{}
+		parsed := gjson.Parse(`{"type":"response.incomplete","response":{"output":[],"usage":{"output_tokens":0.5}}}`)
+		if tracker.IsEmptyIncomplete("response.incomplete", parsed) {
+			t.Fatal("0.5 must not be treated as zero")
+		}
+	})
+	t.Run("missing or null tokens rejected", func(t *testing.T) {
+		tracker := &emptyIncompleteTracker{}
+		for _, raw := range []string{
+			`{"type":"response.incomplete","response":{"output":[],"usage":{}}}`,
+			`{"type":"response.incomplete","response":{"output":[],"usage":{"output_tokens":null}}}`,
+			`{"type":"response.incomplete","response":{"output":[]}}`,
+		} {
+			if tracker.IsEmptyIncomplete("response.incomplete", gjson.Parse(raw)) {
+				t.Fatalf("payload without explicit numeric zero must not match: %s", raw)
+			}
+		}
+	})
+	t.Run("non-empty response.output rejected", func(t *testing.T) {
+		tracker := &emptyIncompleteTracker{}
+		parsed := gjson.Parse(`{"type":"response.incomplete","response":{"output":[{"type":"message"}],"usage":{"output_tokens":0}}}`)
+		if tracker.IsEmptyIncomplete("response.incomplete", parsed) {
+			t.Fatal("non-empty output must not be treated as empty")
+		}
+	})
+	t.Run("response.completed never matches", func(t *testing.T) {
+		tracker := &emptyIncompleteTracker{}
+		parsed := gjson.Parse(`{"type":"response.completed","response":{"output":[],"usage":{"output_tokens":0}}}`)
+		if tracker.IsEmptyIncomplete("response.completed", parsed) {
+			t.Fatal("only response.incomplete is eligible")
+		}
+	})
+}
+
+func TestRewriteEmptyIncompleteTerminal_SynthesizesRetryableFailure(t *testing.T) {
+	tracker := &emptyIncompleteTracker{}
+	original := []byte(`{"type":"response.incomplete","sequence_number":7,"response":{"id":"resp_1","model":"gpt-5.5","service_tier":"default","status":"incomplete","incomplete_details":{"reason":"max_output_tokens"},"output":[],"usage":{"input_tokens":12,"output_tokens":0,"total_tokens":12}}}`)
+	eventType, data, parsed := rewriteEmptyIncompleteTerminal(tracker, "response.incomplete", original, gjson.ParseBytes(original))
+	if eventType != "response.failed" {
+		t.Fatalf("event type = %q, want response.failed", eventType)
+	}
+	if got := parsed.Get("type").String(); got != "response.failed" {
+		t.Fatalf("payload type = %q", got)
+	}
+	if got := parsed.Get("response.status").String(); got != "failed" {
+		t.Fatalf("response.status = %q", got)
+	}
+	if parsed.Get("response.incomplete_details").Exists() {
+		t.Fatal("incomplete_details must be dropped from the synthesized failure")
+	}
+	if got := parsed.Get("response.error.code").String(); got != codexEmptyIncompleteErrorCode {
+		t.Fatalf("error.code = %q", got)
+	}
+	if got := parsed.Get("response.id").String(); got != "resp_1" {
+		t.Fatal("response.id must be preserved for logging")
+	}
+	if got := parsed.Get("response.usage.input_tokens").Int(); got != 12 {
+		t.Fatal("usage must be preserved for billing")
+	}
+	if !isResponsesTerminalEvent(eventType) || isResponsesSuccessTerminalEvent(eventType) {
+		t.Fatal("rewritten event must be a failure terminal")
+	}
+
+	outcome := classifyResponseFailedOutcome(data)
+	if outcome.logStatusCode != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502", outcome.logStatusCode)
+	}
+	if !outcome.penalize {
+		t.Fatal("outcome must remain retryable (penalize drives transparent retry)")
+	}
+	if !outcome.requestScoped {
+		t.Fatal("outcome must be request scoped so the account is not penalized")
+	}
+	if outcome.capacityShed {
+		t.Fatal("must not be classified as capacity shed")
+	}
+	if outcome.failureKind != codexEmptyIncompleteFailureKind {
+		t.Fatalf("failureKind = %q", outcome.failureKind)
+	}
+	if !strings.Contains(outcome.failureMessage, "0 output tokens") {
+		t.Fatalf("failureMessage = %q", outcome.failureMessage)
+	}
+	if !responseFailedRetryable(data) {
+		t.Fatal("WS ingress relies on responseFailedRetryable for pre-content rotation")
+	}
+}
+
+func TestRewriteEmptyIncompleteTerminal_PassThroughWhenNotEmpty(t *testing.T) {
+	tracker := &emptyIncompleteTracker{}
+	tracker.Observe("response.output_text.delta", gjson.Parse(`{"delta":"partial"}`))
+	original := []byte(`{"type":"response.incomplete","response":{"id":"resp_1","status":"incomplete","incomplete_details":{"reason":"max_output_tokens"},"output":[],"usage":{"output_tokens":0}}}`)
+	eventType, data, _ := rewriteEmptyIncompleteTerminal(tracker, "response.incomplete", original, gjson.ParseBytes(original))
+	if eventType != "response.incomplete" {
+		t.Fatalf("event type = %q, want untouched response.incomplete", eventType)
+	}
+	if string(data) != string(original) {
+		t.Fatal("payload must be returned untouched")
+	}
+}
+
+func TestEmptyIncompleteNonStreamBody(t *testing.T) {
+	body := []byte(`{"id":"resp_2","object":"response","status":"incomplete","incomplete_details":{"reason":"max_output_tokens"},"output":[],"usage":{"input_tokens":3,"output_tokens":0}}`)
+	if !isEmptyIncompleteResponseBody(body) {
+		t.Fatal("expected non-stream empty incomplete to be detected")
+	}
+	rewritten := synthesizeEmptyIncompleteFailureBody(body)
+	if got := gjson.GetBytes(rewritten, "status").String(); got != "failed" {
+		t.Fatalf("status = %q", got)
+	}
+	if gjson.GetBytes(rewritten, "incomplete_details").Exists() {
+		t.Fatal("incomplete_details must be dropped")
+	}
+	failure, failed := protocolNonStreamFailure(GrokProtocolResponses, rewritten)
+	if !failed {
+		t.Fatal("rewritten body must be recognized as a non-stream failure")
+	}
+	if failure.logStatusCode != http.StatusBadGateway || !failure.requestScoped {
+		t.Fatalf("unexpected outcome: status=%d requestScoped=%v", failure.logStatusCode, failure.requestScoped)
+	}
+
+	completed := []byte(`{"id":"resp_3","object":"response","status":"completed","output":[],"usage":{"output_tokens":0}}`)
+	if isEmptyIncompleteResponseBody(completed) {
+		t.Fatal("completed responses are never rewritten")
+	}
+	truncated := []byte(`{"id":"resp_4","object":"response","status":"incomplete","output":[{"type":"message"}],"usage":{"output_tokens":0}}`)
+	if isEmptyIncompleteResponseBody(truncated) {
+		t.Fatal("incomplete with output must stay a normal truncation")
+	}
+}
+
+func TestReportStreamOutcomeFailure_SkipsRequestScoped(t *testing.T) {
+	// 空 incomplete 与容量降载一样不进账号健康度；这里只验证判定入口。
+	outcome := streamOutcome{logStatusCode: http.StatusBadGateway, failureKind: codexEmptyIncompleteFailureKind, penalize: true, requestScoped: true}
+	if !outcome.penalize || !outcome.requestScoped {
+		t.Fatal("fixture must be retryable and request scoped")
+	}
+	var h *Handler
+	// h.store 为 nil；若 requestScoped 未被跳过，这里会解引用空指针而 panic。
+	h = &Handler{}
+	h.reportStreamOutcomeFailure(nil, outcome, 0)
+}

--- a/proxy/codex_tool_names.go
+++ b/proxy/codex_tool_names.go
@@ -1,0 +1,244 @@
+package proxy
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/tidwall/gjson"
+)
+
+// Codex 上游要求函数/自定义工具名匹配 ^[a-zA-Z0-9_-]{1,64}$。Chat Completions
+// 客户端（尤其是把 MCP 工具原名透传的 agent 框架）常带 `.`、`:`、空格或非 ASCII，
+// 原样转发必 400 "Invalid tools[N].name"。这里在 Chat→Responses 转换时把非法
+// 字符替换成 `_`、超长截断并去重，响应侧再按同一张映射把名字还原，客户端看到
+// 的仍是原名。合法名字不进映射，常规请求零开销。
+//
+// 只作用于 /v1/chat/completions 路由：原生 Responses 请求视为已按上游规范构造，
+// Grok 路由有自己的命名空间映射。
+const codexToolNameLimit = 64
+
+func isCodexToolNameRune(r rune) bool {
+	return (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' || r == '-'
+}
+
+// sanitizeCodexToolName 把 [a-zA-Z0-9_-] 之外的字符替换成下划线。
+func sanitizeCodexToolName(name string) string {
+	changed := false
+	var sb strings.Builder
+	for _, r := range name {
+		if isCodexToolNameRune(r) {
+			sb.WriteRune(r)
+			continue
+		}
+		sb.WriteByte('_')
+		changed = true
+	}
+	if !changed {
+		return name
+	}
+	return sb.String()
+}
+
+// shortenCodexToolName 净化后再按 64 字节截断；mcp__ 前缀的名字优先保留前缀与
+// 最后一段（服务器名段最长也最没有区分度）。净化后全是 ASCII，按字节切安全。
+func shortenCodexToolName(name string) string {
+	sanitized := sanitizeCodexToolName(name)
+	if len(sanitized) <= codexToolNameLimit {
+		return sanitized
+	}
+	if strings.HasPrefix(sanitized, "mcp__") {
+		if idx := strings.LastIndex(sanitized, "__"); idx > 0 {
+			candidate := "mcp__" + sanitized[idx+2:]
+			if len(candidate) > codexToolNameLimit {
+				candidate = candidate[:codexToolNameLimit]
+			}
+			return candidate
+		}
+	}
+	return sanitized[:codexToolNameLimit]
+}
+
+// collectChatToolNames 按确定顺序收集请求里出现的全部工具名：tools 声明、
+// tool_choice、历史 assistant tool_calls。请求侧改名与响应侧还原都从同一份
+// 列表推导，保证两边的去重后缀一致。
+func collectChatToolNames(req openAIRequest) []string {
+	var names []string
+	seen := map[string]struct{}{}
+	add := func(name string) {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			return
+		}
+		if _, ok := seen[name]; ok {
+			return
+		}
+		seen[name] = struct{}{}
+		names = append(names, name)
+	}
+	for _, raw := range req.Tools {
+		tool := gjson.ParseBytes(raw)
+		switch tool.Get("type").String() {
+		case "function", "":
+			name := tool.Get("function.name").String()
+			if name == "" {
+				name = tool.Get("name").String()
+			}
+			add(name)
+		case "custom":
+			name := tool.Get("custom.name").String()
+			if name == "" {
+				name = tool.Get("name").String()
+			}
+			add(name)
+		}
+	}
+	if choice := gjson.ParseBytes(req.ToolChoice); choice.IsObject() {
+		switch choice.Get("type").String() {
+		case "function":
+			name := choice.Get("function.name").String()
+			if name == "" {
+				name = choice.Get("name").String()
+			}
+			add(name)
+		case "custom":
+			name := choice.Get("custom.name").String()
+			if name == "" {
+				name = choice.Get("name").String()
+			}
+			add(name)
+		}
+	}
+	for _, msg := range req.Messages {
+		if msg.Role != "assistant" {
+			continue
+		}
+		for _, tc := range msg.ToolCalls {
+			if tc.Type == "custom" && tc.Custom != nil {
+				add(tc.Custom.Name)
+				continue
+			}
+			add(tc.Function.Name)
+		}
+	}
+	return names
+}
+
+// buildCodexToolNameMap 生成 原名 → 上游名 的映射，只收录需要改写的名字。
+// 先把本来就合法的名字占位，再给非法名字分配去重后缀，避免把合法名字挤走。
+func buildCodexToolNameMap(names []string) map[string]string {
+	used := make(map[string]struct{}, len(names))
+	var pending []string
+	for _, name := range names {
+		if shortenCodexToolName(name) == name {
+			used[name] = struct{}{}
+			continue
+		}
+		pending = append(pending, name)
+	}
+	if len(pending) == 0 {
+		return nil
+	}
+	mapped := make(map[string]string, len(pending))
+	for _, name := range pending {
+		short := uniqueCodexToolName(shortenCodexToolName(name), used)
+		used[short] = struct{}{}
+		mapped[name] = short
+	}
+	return mapped
+}
+
+func uniqueCodexToolName(base string, used map[string]struct{}) string {
+	if _, taken := used[base]; !taken {
+		return base
+	}
+	for i := 1; ; i++ {
+		suffix := "_" + strconv.Itoa(i)
+		candidate := base
+		if len(candidate)+len(suffix) > codexToolNameLimit {
+			candidate = candidate[:codexToolNameLimit-len(suffix)]
+		}
+		candidate += suffix
+		if _, taken := used[candidate]; !taken {
+			return candidate
+		}
+	}
+}
+
+// applyCodexToolNameMap 把映射套到已转换好的 Responses 请求体：tools 声明、
+// tool_choice、input 里的 function_call / custom_tool_call 历史项。
+func applyCodexToolNameMap(out map[string]any, nameMap map[string]string) {
+	if len(nameMap) == 0 || out == nil {
+		return
+	}
+	rename := func(item map[string]any) {
+		name, ok := item["name"].(string)
+		if !ok {
+			return
+		}
+		if short, ok := nameMap[name]; ok {
+			item["name"] = short
+		}
+	}
+	if tools, ok := out["tools"].([]any); ok {
+		for _, raw := range tools {
+			tool, ok := raw.(map[string]any)
+			if !ok || isReservedCodexTool(tool) {
+				continue
+			}
+			switch strings.TrimSpace(firstNonEmptyAnyString(tool["type"])) {
+			case "function", "custom":
+				rename(tool)
+			}
+		}
+	}
+	if choice, ok := out["tool_choice"].(map[string]any); ok {
+		rename(choice)
+	}
+	if input, ok := out["input"].([]any); ok {
+		for _, raw := range input {
+			item, ok := raw.(map[string]any)
+			if !ok {
+				continue
+			}
+			switch strings.TrimSpace(firstNonEmptyAnyString(item["type"])) {
+			case "function_call", "custom_tool_call":
+				rename(item)
+			}
+		}
+	}
+}
+
+// ChatToolNameRestoreMap 返回 上游名 → 原名 的还原映射；请求里没有需要改写的
+// 名字时返回 nil。与 TranslateRequest 从同一份解析结果推导。
+func ChatToolNameRestoreMap(rawJSON []byte) map[string]string {
+	nameMap := buildCodexToolNameMap(collectChatToolNames(cachedOrParse(rawJSON)))
+	if len(nameMap) == 0 {
+		return nil
+	}
+	restore := make(map[string]string, len(nameMap))
+	for original, short := range nameMap {
+		restore[short] = original
+	}
+	return restore
+}
+
+func restoreCodexToolName(restore map[string]string, name string) string {
+	if len(restore) == 0 {
+		return name
+	}
+	if original, ok := restore[name]; ok {
+		return original
+	}
+	return name
+}
+
+// restoreToolCallNames 把非流式 Chat 响应里的工具调用名还原成客户端原名。
+func restoreToolCallNames(toolCalls []ToolCallResult, restore map[string]string) []ToolCallResult {
+	if len(restore) == 0 {
+		return toolCalls
+	}
+	for i := range toolCalls {
+		toolCalls[i].Name = restoreCodexToolName(restore, toolCalls[i].Name)
+	}
+	return toolCalls
+}

--- a/proxy/codex_tool_names_test.go
+++ b/proxy/codex_tool_names_test.go
@@ -1,0 +1,179 @@
+package proxy
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestShortenCodexToolName(t *testing.T) {
+	cases := map[string]string{
+		"read_file":       "read_file",
+		"mcp.server.tool": "mcp_server_tool",
+		"my tool:run":     "my_tool_run",
+		"查询天气":            "____",
+		"a-b_C9":          "a-b_C9",
+		"mcp__" + strings.Repeat("s", 70) + "__last": "mcp__last",
+		strings.Repeat("x", 70):                      strings.Repeat("x", 64),
+	}
+	for in, want := range cases {
+		if got := shortenCodexToolName(in); got != want {
+			t.Errorf("shortenCodexToolName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestBuildCodexToolNameMap_ValidNamesUntouchedAndCollisionsSuffixed(t *testing.T) {
+	// "a_b" 是合法原名，必须保住；"a.b" 与 "a:b" 都会净化成 "a_b"，得让位。
+	names := []string{"a.b", "a_b", "a:b", "plain"}
+	m := buildCodexToolNameMap(names)
+	if _, ok := m["a_b"]; ok {
+		t.Fatal("valid original name must not be renamed")
+	}
+	if _, ok := m["plain"]; ok {
+		t.Fatal("valid original name must not enter the map")
+	}
+	if m["a.b"] != "a_b_1" {
+		t.Fatalf(`m["a.b"] = %q, want a_b_1`, m["a.b"])
+	}
+	if m["a:b"] != "a_b_2" {
+		t.Fatalf(`m["a:b"] = %q, want a_b_2`, m["a:b"])
+	}
+	if buildCodexToolNameMap([]string{"ok", "fine"}) != nil {
+		t.Fatal("all-valid input must yield nil map (zero-cost fast path)")
+	}
+}
+
+func TestTranslateRequest_SanitizesToolNamesAndRestoreMapRoundTrips(t *testing.T) {
+	raw := []byte(`{
+		"model": "gpt-5.5",
+		"messages": [
+			{"role": "user", "content": "hi"},
+			{"role": "assistant", "content": null, "tool_calls": [
+				{"id": "call_1", "type": "function", "function": {"name": "mcp.fs.read", "arguments": "{}"}},
+				{"id": "call_2", "type": "custom", "custom": {"name": "shell:exec", "input": "ls"}}
+			]},
+			{"role": "tool", "tool_call_id": "call_1", "content": "ok"},
+			{"role": "tool", "tool_call_id": "call_2", "content": "ok"}
+		],
+		"tools": [
+			{"type": "function", "function": {"name": "mcp.fs.read", "parameters": {"type":"object","properties":{}}}},
+			{"type": "function", "function": {"name": "mcp_fs_read", "parameters": {"type":"object","properties":{}}}},
+			{"type": "custom", "custom": {"name": "shell:exec"}}
+		],
+		"tool_choice": {"type": "custom", "custom": {"name": "shell:exec"}}
+	}`)
+	out, err := TranslateRequest(raw)
+	if err != nil {
+		t.Fatalf("TranslateRequest: %v", err)
+	}
+	tools := gjson.GetBytes(out, "tools").Array()
+	var names []string
+	for _, tool := range tools {
+		names = append(names, tool.Get("name").String())
+	}
+	joined := strings.Join(names, ",")
+	if strings.Contains(joined, ".") || strings.Contains(joined, ":") {
+		t.Fatalf("tool names must be sanitized, got %s", joined)
+	}
+	if !strings.Contains(joined, "mcp_fs_read_1") {
+		t.Fatalf("collision with the valid name mcp_fs_read must be suffixed, got %s", joined)
+	}
+	if !strings.Contains(joined, "shell_exec") {
+		t.Fatalf("custom tool name must be sanitized, got %s", joined)
+	}
+	if got := gjson.GetBytes(out, "tool_choice.name").String(); got != "shell_exec" {
+		t.Fatalf("tool_choice.name = %q", got)
+	}
+	var historyNames []string
+	for _, item := range gjson.GetBytes(out, "input").Array() {
+		switch item.Get("type").String() {
+		case "function_call", "custom_tool_call":
+			historyNames = append(historyNames, item.Get("name").String())
+		}
+	}
+	if strings.Join(historyNames, ",") != "mcp_fs_read_1,shell_exec" {
+		t.Fatalf("history call names = %v", historyNames)
+	}
+
+	restore := ChatToolNameRestoreMap(raw)
+	if restore["mcp_fs_read_1"] != "mcp.fs.read" || restore["shell_exec"] != "shell:exec" {
+		t.Fatalf("restore map = %v", restore)
+	}
+	if _, ok := restore["mcp_fs_read"]; ok {
+		t.Fatal("valid name must not be in restore map")
+	}
+
+	st := NewStreamTranslator("chatcmpl-x", "gpt-5.5", 1)
+	st.SetToolNameRestore(restore)
+	chunk, _ := st.TranslateParsed(gjson.Parse(`{"type":"response.output_item.added","output_index":0,"item":{"type":"function_call","id":"fc_1","call_id":"call_9","name":"mcp_fs_read_1","arguments":""}}`))
+	if got := gjson.GetBytes(chunk, "choices.0.delta.tool_calls.0.function.name").String(); got != "mcp.fs.read" {
+		t.Fatalf("stream tool name not restored: %s", chunk)
+	}
+	calls := restoreToolCallNames([]ToolCallResult{{ID: "call_9", Type: "function_call", Name: "mcp_fs_read_1"}, {ID: "c2", Type: "custom_tool_call", Name: "shell_exec"}}, restore)
+	if calls[0].Name != "mcp.fs.read" || calls[1].Name != "shell:exec" {
+		t.Fatalf("non-stream tool names not restored: %+v", calls)
+	}
+}
+
+func TestTranslateRequest_ValidToolNamesLeaveNoRestoreMap(t *testing.T) {
+	raw := []byte(`{"model":"gpt-5.5","messages":[{"role":"user","content":"hi"}],"tools":[{"type":"function","function":{"name":"read_file","parameters":{"type":"object","properties":{}}}}]}`)
+	if restore := ChatToolNameRestoreMap(raw); restore != nil {
+		t.Fatalf("expected nil restore map, got %v", restore)
+	}
+	out, err := TranslateRequest(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := gjson.GetBytes(out, "tools.0.name").String(); got != "read_file" {
+		t.Fatalf("tools.0.name = %q", got)
+	}
+}
+
+func TestTranslateRequest_FunctionToolStrictDefaultsFalse(t *testing.T) {
+	raw := []byte(`{"model":"gpt-5.5","messages":[{"role":"user","content":"hi"}],"tools":[
+		{"type":"function","function":{"name":"omitted","parameters":{"type":"object","properties":{"a":{"type":"string"}}}}},
+		{"type":"function","function":{"name":"explicit_true","strict":true,"parameters":{"type":"object","properties":{}}}},
+		{"type":"function","function":{"name":"explicit_false","strict":false,"parameters":{"type":"object","properties":{}}}}
+	]}`)
+	out, err := TranslateRequest(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i, want := range []string{"false", "true", "false"} {
+		strict := gjson.GetBytes(out, "tools."+strconv.Itoa(i)+".strict")
+		if !strict.Exists() || strict.Raw != want {
+			t.Fatalf("tools[%d].strict = %q, want %s", i, strict.Raw, want)
+		}
+	}
+}
+
+func TestNormalizeFunctionToolsInArray_ChatShapedStrictDefaultsFalse(t *testing.T) {
+	tools := []any{
+		map[string]any{"type": "function", "function": map[string]any{"name": "a", "parameters": map[string]any{"type": "object"}}},
+		map[string]any{"type": "function", "name": "native", "parameters": map[string]any{"type": "object"}},
+	}
+	kept, _ := normalizeFunctionToolsInArray(tools)
+	chatShaped := kept[0].(map[string]any)
+	if strict, ok := chatShaped["strict"].(bool); !ok || strict {
+		t.Fatalf("chat-shaped tool strict = %v, want explicit false", chatShaped["strict"])
+	}
+	native := kept[1].(map[string]any)
+	if _, ok := native["strict"]; ok {
+		t.Fatal("native Responses tool must keep the upstream default (no strict key)")
+	}
+}
+
+func TestConvertAnthropicTools_StrictFalse(t *testing.T) {
+	tools := convertAnthropicTools([]anthropicTool{{Name: "Read", InputSchema: json.RawMessage(`{"type":"object","properties":{"path":{"type":"string"}}}`)}})
+	if len(tools) != 1 {
+		t.Fatalf("tools = %d", len(tools))
+	}
+	item := tools[0].(map[string]any)
+	if strict, ok := item["strict"].(bool); !ok || strict {
+		t.Fatalf("strict = %v, want false", item["strict"])
+	}
+}

--- a/proxy/codex_tool_schema_unions.go
+++ b/proxy/codex_tool_schema_unions.go
@@ -1,0 +1,124 @@
+package proxy
+
+import (
+	"encoding/json"
+	"math/big"
+	"strconv"
+)
+
+// MCP 服务器常把枚举写成带说明的常量联合：
+//
+//	"action": {"type":"string","oneOf":[{"const":"a","description":"..."}, ...]}
+//
+// 分支一多（实测 13 支）Codex 上游会静默中止：HTTP 200 + response.incomplete、
+// 0 输出 token、无任何内容，且任意去掉一支就恢复。这种联合与 enum 语义完全等价，
+// 这里把它折成 enum 后再发上游。只有能证明等价的形态才动：每一支只含
+// const（可带 description/title）、常量互不重复、oneOf/anyOf 不同时出现；已有
+// enum 时必须与常量集合一致才删掉联合，否则原样保留。
+const codexConstUnionFoldThreshold = 8
+
+// simplifyConstUnionSchemas 递归折叠 schema 及其全部子 schema 里的纯常量联合。
+func simplifyConstUnionSchemas(schema map[string]any) bool {
+	if schema == nil {
+		return false
+	}
+	changed := foldPureConstUnion(schema)
+	forEachSubSchema(schema, func(child map[string]any) {
+		if simplifyConstUnionSchemas(child) {
+			changed = true
+		}
+	})
+	return changed
+}
+
+func foldPureConstUnion(schema map[string]any) bool {
+	_, hasOneOf := schema["oneOf"]
+	_, hasAnyOf := schema["anyOf"]
+	if hasOneOf == hasAnyOf {
+		// 两者都没有，或同时出现（复合约束，语义不再是单纯的枚举）。
+		return false
+	}
+	unionKey := "oneOf"
+	if hasAnyOf {
+		unionKey = "anyOf"
+	}
+	branches, ok := schema[unionKey].([]any)
+	if !ok || len(branches) < codexConstUnionFoldThreshold {
+		return false
+	}
+	values := make([]any, 0, len(branches))
+	seen := make(map[string]struct{}, len(branches))
+	for _, raw := range branches {
+		branch, ok := raw.(map[string]any)
+		if !ok {
+			return false
+		}
+		constValue, ok := branch["const"]
+		if !ok {
+			return false
+		}
+		for key := range branch {
+			if key != "const" && key != "description" && key != "title" {
+				return false
+			}
+		}
+		canonical, ok := canonicalSchemaConstKey(constValue)
+		if !ok {
+			return false
+		}
+		if _, dup := seen[canonical]; dup {
+			return false
+		}
+		seen[canonical] = struct{}{}
+		values = append(values, constValue)
+	}
+	if rawEnum, exists := schema["enum"]; exists {
+		enum, ok := rawEnum.([]any)
+		if !ok || len(enum) != len(values) {
+			return false
+		}
+		enumSeen := make(map[string]struct{}, len(enum))
+		for _, value := range enum {
+			canonical, ok := canonicalSchemaConstKey(value)
+			if !ok {
+				return false
+			}
+			if _, dup := enumSeen[canonical]; dup {
+				return false
+			}
+			if _, matched := seen[canonical]; !matched {
+				return false
+			}
+			enumSeen[canonical] = struct{}{}
+		}
+		delete(schema, unionKey)
+		return true
+	}
+	schema["enum"] = values
+	delete(schema, unionKey)
+	return true
+}
+
+// canonicalSchemaConstKey 给标量常量一个类型限定的比较键；对象/数组常量不折。
+func canonicalSchemaConstKey(value any) (string, bool) {
+	switch typed := value.(type) {
+	case string:
+		return "s:" + typed, true
+	case float64:
+		return "n:" + strconv.FormatFloat(typed, 'g', -1, 64), true
+	case json.Number:
+		var ratio big.Rat
+		if _, ok := ratio.SetString(typed.String()); ok {
+			return "n:" + ratio.RatString(), true
+		}
+		return "n:" + typed.String(), true
+	case bool:
+		if typed {
+			return "b:true", true
+		}
+		return "b:false", true
+	case nil:
+		return "null", true
+	}
+	return "", false
+}

--- a/proxy/codex_tool_schema_unions_test.go
+++ b/proxy/codex_tool_schema_unions_test.go
@@ -1,0 +1,158 @@
+package proxy
+
+import (
+	"encoding/json"
+	"strconv"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func constUnion(n int, key string) string {
+	branches := ""
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			branches += ","
+		}
+		branches += `{"const":"v` + strconv.Itoa(i) + `","description":"d` + strconv.Itoa(i) + `"}`
+	}
+	return `"` + key + `":[` + branches + `]`
+}
+
+func TestSimplifyConstUnionSchemas_FoldsLargeOneOfIntoEnum(t *testing.T) {
+	// issue-shaped repro: 8+ pure const branches inside a property schema.
+	raw := `{"type":"object","properties":{"action":{"type":"string",` + constUnion(9, "oneOf") + `,"description":"Action"},"target":{"type":"string"}},"required":["action"]}`
+	var schema map[string]any
+	if err := json.Unmarshal([]byte(raw), &schema); err != nil {
+		t.Fatal(err)
+	}
+	if !simplifyConstUnionSchemas(schema) {
+		t.Fatal("expected schema to change")
+	}
+	encoded, _ := json.Marshal(schema)
+	action := gjson.GetBytes(encoded, "properties.action")
+	if action.Get("oneOf").Exists() {
+		t.Fatalf("oneOf must be removed: %s", action.Raw)
+	}
+	enum := action.Get("enum").Array()
+	if len(enum) != 9 || enum[0].String() != "v0" || enum[8].String() != "v8" {
+		t.Fatalf("enum must carry all constants in order: %s", action.Get("enum").Raw)
+	}
+	if action.Get("type").String() != "string" || action.Get("description").String() != "Action" {
+		t.Fatal("sibling keywords on the property must be preserved")
+	}
+	if gjson.GetBytes(encoded, "properties.target.type").String() != "string" || gjson.GetBytes(encoded, "required.0").String() != "action" {
+		t.Fatal("unrelated properties/required must be preserved")
+	}
+}
+
+func TestSimplifyConstUnionSchemas_ExistingEqualEnumDropsUnion(t *testing.T) {
+	raw := `{"type":"object","properties":{"a":{"type":"string","enum":["v7","v0","v1","v2","v3","v4","v5","v6"],` + constUnion(8, "anyOf") + `}}}`
+	var schema map[string]any
+	_ = json.Unmarshal([]byte(raw), &schema)
+	if !simplifyConstUnionSchemas(schema) {
+		t.Fatal("expected union to be dropped")
+	}
+	encoded, _ := json.Marshal(schema)
+	if gjson.GetBytes(encoded, "properties.a.anyOf").Exists() {
+		t.Fatal("anyOf must be removed when enum is semantically identical")
+	}
+	if got := len(gjson.GetBytes(encoded, "properties.a.enum").Array()); got != 8 {
+		t.Fatalf("existing enum must be kept as-is, got %d entries", got)
+	}
+}
+
+func TestSimplifyConstUnionSchemas_LeavesNonEquivalentShapesAlone(t *testing.T) {
+	cases := map[string]string{
+		"below threshold":           `{"properties":{"a":{` + constUnion(7, "oneOf") + `}}}`,
+		"branch with extra keyword": `{"properties":{"a":{"oneOf":[{"const":"1","type":"string"},{"const":"2"},{"const":"3"},{"const":"4"},{"const":"5"},{"const":"6"},{"const":"7"},{"const":"8"}]}}}`,
+		"duplicate const":           `{"properties":{"a":{"oneOf":[{"const":"1"},{"const":"1"},{"const":"3"},{"const":"4"},{"const":"5"},{"const":"6"},{"const":"7"},{"const":"8"}]}}}`,
+		"object const":              `{"properties":{"a":{"oneOf":[{"const":{"k":1}},{"const":"2"},{"const":"3"},{"const":"4"},{"const":"5"},{"const":"6"},{"const":"7"},{"const":"8"}]}}}`,
+		"oneOf and anyOf together":  `{"properties":{"a":{` + constUnion(8, "oneOf") + `,` + constUnion(8, "anyOf") + `}}}`,
+		"enum differs":              `{"properties":{"a":{"enum":["x"],` + constUnion(8, "oneOf") + `}}}`,
+	}
+	for name, raw := range cases {
+		var schema map[string]any
+		if err := json.Unmarshal([]byte(raw), &schema); err != nil {
+			t.Fatalf("%s: %v", name, err)
+		}
+		before, _ := json.Marshal(schema)
+		if simplifyConstUnionSchemas(schema) {
+			t.Errorf("%s: schema must not change", name)
+		}
+		after, _ := json.Marshal(schema)
+		if string(before) != string(after) {
+			t.Errorf("%s: schema mutated: %s", name, after)
+		}
+	}
+}
+
+func TestSimplifyConstUnionSchemas_RecursesIntoNestedSchemas(t *testing.T) {
+	raw := `{"type":"object","properties":{"outer":{"type":"object","properties":{"inner":{` + constUnion(8, "oneOf") + `}}},"list":{"type":"array","items":{` + constUnion(8, "anyOf") + `}}}}`
+	var schema map[string]any
+	_ = json.Unmarshal([]byte(raw), &schema)
+	simplifyConstUnionSchemas(schema)
+	encoded, _ := json.Marshal(schema)
+	if gjson.GetBytes(encoded, "properties.outer.properties.inner.oneOf").Exists() || len(gjson.GetBytes(encoded, "properties.outer.properties.inner.enum").Array()) != 8 {
+		t.Fatalf("nested property union not folded: %s", encoded)
+	}
+	if gjson.GetBytes(encoded, "properties.list.items.anyOf").Exists() || len(gjson.GetBytes(encoded, "properties.list.items.enum").Array()) != 8 {
+		t.Fatalf("array items union not folded: %s", encoded)
+	}
+}
+
+func TestSimplifyConstUnionSchemas_NumericAndMixedConstants(t *testing.T) {
+	raw := `{"properties":{"n":{"oneOf":[{"const":1},{"const":2.5},{"const":true},{"const":null},{"const":"s"},{"const":-3},{"const":7},{"const":8}]}}}`
+	var schema map[string]any
+	_ = json.Unmarshal([]byte(raw), &schema)
+	if !simplifyConstUnionSchemas(schema) {
+		t.Fatal("mixed scalar constants are still a pure const union")
+	}
+	encoded, _ := json.Marshal(schema)
+	if got := gjson.GetBytes(encoded, "properties.n.enum").Raw; got != `[1,2.5,true,null,"s",-3,7,8]` {
+		t.Fatalf("enum = %s", got)
+	}
+	// 1 与 1.0 语义相同，视为重复。
+	dup := `{"properties":{"n":{"oneOf":[{"const":1},{"const":1.0},{"const":3},{"const":4},{"const":5},{"const":6},{"const":7},{"const":8}]}}}`
+	var dupSchema map[string]any
+	_ = json.Unmarshal([]byte(dup), &dupSchema)
+	if simplifyConstUnionSchemas(dupSchema) {
+		t.Fatal("numerically equal constants must be treated as duplicates")
+	}
+}
+
+func TestSanitizeSchemaForUpstream_FoldsUnionsBeforeStripping(t *testing.T) {
+	raw := `{"type":"object","properties":{"action":{"type":"string","maxLength":10,` + constUnion(13, "oneOf") + `}}}`
+	var schema map[string]any
+	_ = json.Unmarshal([]byte(raw), &schema)
+	sanitizeSchemaForUpstream(schema)
+	encoded, _ := json.Marshal(schema)
+	if gjson.GetBytes(encoded, "properties.action.oneOf").Exists() {
+		t.Fatal("tool parameter union must be folded by the shared sanitizer")
+	}
+	if len(gjson.GetBytes(encoded, "properties.action.enum").Array()) != 13 {
+		t.Fatalf("enum missing after sanitize: %s", encoded)
+	}
+	if gjson.GetBytes(encoded, "properties.action.maxLength").Exists() {
+		t.Fatal("existing keyword stripping must still run")
+	}
+}
+
+func TestChatCompactResponse_CarriesServiceTier(t *testing.T) {
+	out := BuildCompactChatResponse("id", "m", 1, "hi", "", nil, nil, "", "priority")
+	if got := gjson.GetBytes(out, "service_tier").String(); got != "priority" {
+		t.Fatalf("service_tier = %q", got)
+	}
+	plain := BuildCompactResponseWithFinishReason("id", "m", 1, "hi", "", nil, nil, "")
+	if gjson.GetBytes(plain, "service_tier").Exists() {
+		t.Fatal("service_tier must be omitted when unknown")
+	}
+	st := NewStreamTranslator("id", "m", 1)
+	chunk, done := st.TranslateParsed(gjson.Parse(`{"type":"response.completed","response":{"service_tier":"default","usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}}`))
+	if !done {
+		t.Fatal("completed must terminate")
+	}
+	if got := gjson.GetBytes(chunk, "service_tier").String(); got != "default" {
+		t.Fatalf("final chunk service_tier = %q (%s)", got, chunk)
+	}
+}

--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -2038,6 +2038,9 @@ type streamOutcome struct {
 	// WS 通道下 token 失效表现为上游主动关闭而非 401，需异步跑一次探针确认账号鉴权状态，
 	// 命中 401 才按 unauthorized 冷却，避免失效账号不被封、反复被调度。
 	verifyAccountAuth bool
+	// requestScoped 标记故障由本次请求内容触发（如零输出的 response.incomplete）：
+	// penalize 保持 true 以复用首包前透明重试/换号，但不计入账号健康度。
+	requestScoped bool
 	// terminalLocal marks proxy replay/storage failures; they never affect
 	// upstream retry or account health and must exit as protocol terminal errors.
 	// terminalLocal 标记代理自身的回放/存储失败；它们不参与上游重试或账号健康度，
@@ -2194,6 +2197,12 @@ func classifyResponseFailedOutcome(payload []byte) streamOutcome {
 			kind = "client"
 		}
 	}
+	// 零输出的 response.incomplete 由网关改写成 response.failed（见
+	// codex_empty_incomplete.go）：按 502 走透明重试，但不惩罚账号。
+	emptyIncomplete := isEmptyIncompleteFailurePayload(payload)
+	if emptyIncomplete {
+		kind = codexEmptyIncompleteFailureKind
+	}
 	// 400 中"账号不支持该模型"属账号权益问题，冷却后换号重试有意义，视同可重试故障。
 	modelUnsupported := statusCode == http.StatusBadRequest && isCodexModelUnsupportedError(errorBody)
 	return streamOutcome{
@@ -2203,6 +2212,7 @@ func classifyResponseFailedOutcome(payload []byte) streamOutcome {
 		failurePayload: append([]byte(nil), payload...),
 		penalize:       !safetyPolicy && (statusCode == http.StatusUnauthorized || statusCode == http.StatusTooManyRequests || statusCode >= 500 || modelUnsupported),
 		capacityShed:   !capacityShedHandlingDisabled() && isCapacityShedPayload(payload),
+		requestScoped:  emptyIncomplete,
 	}
 }
 
@@ -2210,7 +2220,7 @@ func classifyResponseFailedOutcome(payload []byte) streamOutcome {
 // 例外：它是按模型/身份容量分桶的请求级瞬时信号，换号不改变被降载因素，计入连击只会
 // 在高峰期把整池账号逐个调度降权。跳过上报即"软信号保留、硬惩罚移除"。
 func (h *Handler) reportStreamOutcomeFailure(account *auth.Account, outcome streamOutcome, d time.Duration) {
-	if outcome.capacityShed {
+	if outcome.capacityShed || outcome.requestScoped {
 		return
 	}
 	h.store.ReportRequestFailure(account, outcome.failureKind, d)
@@ -4408,6 +4418,7 @@ func (h *Handler) Responses(c *gin.Context) {
 				streamWriter.diag = streamDiag
 				clientGone := false
 				var pendingFirstTokenEvents bytes.Buffer
+				emptyIncomplete := &emptyIncompleteTracker{}
 				readErr = readSSEStreamWithContinuousRetryKeepalive(c.Request.Context(), resp.Body, func(sseEvent string, data []byte) bool {
 					streamDiag.markUpstreamFrame()
 					if continuousRetryBuffersAttempts(continuousRetryPolicy) {
@@ -4432,6 +4443,7 @@ func (h *Handler) Responses(c *gin.Context) {
 					if eventType == "response.output_text.delta" {
 						deltaCharCount += len(parsed.Get("delta").String())
 					}
+					eventType, data, parsed = rewriteEmptyIncompleteTerminal(emptyIncomplete, eventType, data, parsed)
 					if isResponsesSuccessTerminalEvent(eventType) {
 						usage = extractUsageFromResult(parsed.Get("response.usage"))
 						if tier := parsed.Get("response.service_tier").String(); tier != "" {
@@ -4520,6 +4532,9 @@ func (h *Handler) Responses(c *gin.Context) {
 				var respBody []byte
 				respBody, readErr = io.ReadAll(resp.Body)
 				if readErr == nil {
+					if isEmptyIncompleteResponseBody(respBody) {
+						respBody = synthesizeEmptyIncompleteFailureBody(respBody)
+					}
 					nonStreamResponseBody = append([]byte(nil), respBody...)
 					usage = extractUsageFromResult(gjson.GetBytes(respBody, "usage"))
 					actualServiceTier = gjson.GetBytes(respBody, "service_tier").String()
@@ -5064,6 +5079,7 @@ func (h *Handler) Responses(c *gin.Context) {
 			preflightSettings := CurrentRuntimeSettings()
 			preflightSettings.ContinuousRetryPolicy = continuousRetryPolicy
 			preflightPassthrough := continuousRetryPreflightPassthrough(preflightSettings)
+			emptyIncomplete := &emptyIncompleteTracker{}
 			forwardWithEvent := func(sseEvent string, data []byte) bool {
 				streamDiag.markUpstreamFrame()
 				if continuousRetryBuffersAttempts(continuousRetryPolicy) {
@@ -5107,6 +5123,7 @@ func (h *Handler) Responses(c *gin.Context) {
 					imageLogInfo = mergeImageUsageLogInfo(imageLogInfo, imageUsageLogInfoFromImage(image))
 				}
 				outputCollector.Add(data)
+				eventType, data, parsed = rewriteEmptyIncompleteTerminal(emptyIncomplete, eventType, data, parsed)
 
 				// 提取 usage + service_tier
 				if isResponsesSuccessTerminalEvent(eventType) {
@@ -5352,6 +5369,7 @@ func (h *Handler) Responses(c *gin.Context) {
 			var lastResponseData []byte
 			imageOutputs := make([]json.RawMessage, 0, 1)
 			seenImageOutputs := make(map[string]struct{})
+			emptyIncomplete := &emptyIncompleteTracker{}
 			readErr = readSSEStreamWithContinuousRetryKeepalive(c.Request.Context(), resp.Body, func(sseEvent string, data []byte) bool {
 				if continuousRetryBuffersAttempts(continuousRetryPolicy) {
 					compactionProvenancePayloads = append(compactionProvenancePayloads, bytes.Clone(data))
@@ -5383,6 +5401,7 @@ func (h *Handler) Responses(c *gin.Context) {
 				if eventType == "response.output_text.delta" {
 					deltaCharCount += len(parsed.Get("delta").String())
 				}
+				eventType, data, parsed = rewriteEmptyIncompleteTerminal(emptyIncomplete, eventType, data, parsed)
 				if isResponsesSuccessTerminalEvent(eventType) {
 					usage = extractUsageFromResult(parsed.Get("response.usage"))
 					if tier := parsed.Get("response.service_tier").String(); tier != "" {
@@ -6588,6 +6607,8 @@ func (h *Handler) ChatCompletions(c *gin.Context) {
 		api.SendError(c, api.NewAPIError(api.ErrCodeInvalidRequest, "Request translation failed: "+err.Error(), api.ErrorTypeInvalidRequest))
 		return
 	}
+	// 工具名在转换时可能被净化改写（codex_tool_names.go），响应侧按此表还原。
+	toolNameRestore := ChatToolNameRestoreMap(rawBody)
 	effectiveModel := effectiveRequestModel(codexBody, model)
 	logEffectiveModel := usageEffectiveModelForMapping(logModel, effectiveModel, mappingApplied)
 	if h.enforceAPIKeyLimitsAndReply(c, effectiveModel) {
@@ -7087,10 +7108,12 @@ func (h *Handler) ChatCompletions(c *gin.Context) {
 		var streamAttempt *continuousRetryStreamAttempt
 
 		chunkID := "chatcmpl-" + uuid.New().String()[:8]
+		emptyIncomplete := &emptyIncompleteTracker{}
 		created := time.Now().Unix()
 
 		if isStream {
 			streamTranslator := NewStreamTranslator(chunkID, responseModel, created)
+			streamTranslator.SetToolNameRestore(toolNameRestore)
 			setSSEStreamHeaders(c, "text/event-stream")
 
 			flusher, ok := c.Writer.(http.Flusher)
@@ -7183,6 +7206,7 @@ func (h *Handler) ChatCompletions(c *gin.Context) {
 				if eventType == "response.output_text.delta" || isCodexToolInputDeltaEvent(eventType) {
 					deltaCharCount += len(parsed.Get("delta").String())
 				}
+				eventType, data, parsed = rewriteEmptyIncompleteTerminal(emptyIncomplete, eventType, data, parsed)
 				if isResponsesSuccessTerminalEvent(eventType) {
 					usage = extractUsageFromResult(parsed.Get("response.usage"))
 					if tier := parsed.Get("response.service_tier").String(); tier != "" {
@@ -7326,6 +7350,7 @@ func (h *Handler) ChatCompletions(c *gin.Context) {
 					firstTokenMs = int(time.Since(start).Milliseconds())
 					ttftRecorded = true
 				}
+				eventType, data, parsed = rewriteEmptyIncompleteTerminal(emptyIncomplete, eventType, data, parsed)
 				switch eventType {
 				case "response.output_text.delta":
 					delta := parsed.Get("delta").String()
@@ -7350,6 +7375,7 @@ func (h *Handler) ChatCompletions(c *gin.Context) {
 					if toolErr != nil {
 						terminalFailurePayload = malformedToolArgumentsFailurePayload(toolErr)
 					}
+					toolCalls = restoreToolCallNames(toolCalls, toolNameRestore)
 					gotTerminal = true
 					preContentErrorCandidate = nil
 					return false
@@ -7367,7 +7393,7 @@ func (h *Handler) ChatCompletions(c *gin.Context) {
 				return true
 			})
 
-			compactResult = BuildCompactResponseWithFinishReason(chunkID, responseModel, created, fullContent.String(), fullReasoning.String(), toolCalls, usage, finishReasonOverride)
+			compactResult = BuildCompactChatResponse(chunkID, responseModel, created, fullContent.String(), fullReasoning.String(), toolCalls, usage, finishReasonOverride, actualServiceTier)
 		}
 
 		// 断流检测 + token 估算

--- a/proxy/handler_empty_incomplete_test.go
+++ b/proxy/handler_empty_incomplete_test.go
@@ -1,0 +1,208 @@
+package proxy
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+const emptyIncompleteTerminalEvent = `{"type":"response.incomplete","response":{"id":"resp_empty","status":"incomplete","incomplete_details":{"reason":"max_output_tokens"},"output":[],"usage":{"input_tokens":111,"output_tokens":0,"total_tokens":111}}}`
+
+func writeEmptyIncompleteAttempt(w http.ResponseWriter) {
+	for _, event := range []string{
+		`{"type":"response.created","response":{"id":"resp_empty","status":"in_progress"}}`,
+		`{"type":"response.in_progress","response":{"id":"resp_empty","status":"in_progress"}}`,
+		emptyIncompleteTerminalEvent,
+	} {
+		_, _ = io.WriteString(w, "data: "+event+"\n\n")
+	}
+}
+
+func writeSuccessfulAttempt(w http.ResponseWriter) {
+	for _, event := range []string{
+		`{"type":"response.created","response":{"id":"resp_ok","status":"in_progress"}}`,
+		`{"type":"response.output_text.delta","delta":"OK"}`,
+		`{"type":"response.output_item.done","output_index":0,"item":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"OK"}]}}`,
+		`{"type":"response.completed","response":{"id":"resp_ok","status":"completed","service_tier":"default","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"OK"}]}],"usage":{"input_tokens":111,"output_tokens":5,"total_tokens":116}}}`,
+	} {
+		_, _ = io.WriteString(w, "data: "+event+"\n\n")
+	}
+}
+
+func invokeChatCompletionsWithBody(t *testing.T, handler *Handler, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+	ctx.Request.Header.Set("Content-Type", "application/json")
+	handler.ChatCompletions(ctx)
+	return recorder
+}
+
+// 上游第一轮以 0 输出的 response.incomplete 静默中止，第二轮正常：网关必须把第一轮
+// 当失败透明重试，下游只看到成功结果。
+func TestChatCompletionsEmptyIncompleteRetriesThenSucceeds(t *testing.T) {
+	for _, stream := range []bool{true, false} {
+		name := "non-stream"
+		if stream {
+			name = "stream"
+		}
+		t.Run(name, func(t *testing.T) {
+			var attempts atomic.Int32
+			handler, calls := newChatStreamServeTestHandler(t, func(w http.ResponseWriter) {
+				if attempts.Add(1) == 1 {
+					writeEmptyIncompleteAttempt(w)
+					return
+				}
+				writeSuccessfulAttempt(w)
+			})
+			body := `{"model":"gpt-5.4","stream":` + boolString(stream) + `,"messages":[{"role":"user","content":"Reply with exactly: OK"}]}`
+			recorder := invokeChatCompletionsWithBody(t, handler, body)
+			got := recorder.Body.String()
+			if recorder.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200; body=%q", recorder.Code, got)
+			}
+			if !strings.Contains(got, `"OK"`) {
+				t.Fatalf("successful retry content missing: %q", got)
+			}
+			if strings.Contains(got, `"finish_reason":"length"`) {
+				t.Fatalf("empty incomplete must not leak as a length finish: %q", got)
+			}
+			if !strings.Contains(got, `"service_tier":"default"`) {
+				t.Fatalf("upstream service_tier must be echoed: %q", got)
+			}
+			if stream && !strings.Contains(got, "data: [DONE]") {
+				t.Fatalf("successful stream must end with [DONE]: %q", got)
+			}
+			if n := calls.Load(); n != 2 {
+				t.Fatalf("upstream calls = %d, want 2 (empty attempt + retry)", n)
+			}
+		})
+	}
+}
+
+// 每一轮都静默中止：重试预算耗尽后按 502 + 稳定错误码返回，而不是 200 + 空内容。
+func TestChatCompletionsEmptyIncompleteExhaustedReturns502(t *testing.T) {
+	for _, stream := range []bool{true, false} {
+		name := "non-stream"
+		if stream {
+			name = "stream"
+		}
+		t.Run(name, func(t *testing.T) {
+			handler, calls := newChatStreamServeTestHandler(t, writeEmptyIncompleteAttempt)
+			body := `{"model":"gpt-5.4","stream":` + boolString(stream) + `,"messages":[{"role":"user","content":"Reply with exactly: OK"}]}`
+			recorder := invokeChatCompletionsWithBody(t, handler, body)
+			got := recorder.Body.String()
+			if recorder.Code != http.StatusBadGateway {
+				t.Fatalf("status = %d, want 502; body=%q", recorder.Code, got)
+			}
+			if !strings.Contains(got, "0 output tokens") {
+				t.Fatalf("error message must name the empty incomplete failure: %q", got)
+			}
+			if strings.Contains(got, "[DONE]") || strings.Contains(got, `"finish_reason":"length"`) {
+				t.Fatalf("exhausted empty incomplete must not look like a successful completion: %q", got)
+			}
+			if n := calls.Load(); n != 2 {
+				t.Fatalf("upstream calls = %d, want 2 (initial + MaxRetries=1)", n)
+			}
+		})
+	}
+}
+
+// 真正的 max_output_tokens 截断（有输出、有 token）必须维持 v2.8.3 的正常终态语义。
+func TestChatCompletionsRealTruncationStillReportsLength(t *testing.T) {
+	handler, calls := newChatStreamTerminalTestHandler(t, []string{
+		`{"type":"response.created","response":{"id":"resp_trunc"}}`,
+		`{"type":"response.output_text.delta","delta":"half"}`,
+		`{"type":"response.incomplete","response":{"id":"resp_trunc","status":"incomplete","incomplete_details":{"reason":"max_output_tokens"},"output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"half"}]}],"usage":{"input_tokens":3,"output_tokens":1,"total_tokens":4}}}`,
+	})
+	recorder := invokeChatCompletionsStream(t, handler)
+	got := recorder.Body.String()
+	if recorder.Code != http.StatusOK || !strings.Contains(got, `"finish_reason":"length"`) || !strings.Contains(got, "data: [DONE]") {
+		t.Fatalf("real truncation must stay a normal length terminal: status=%d body=%q", recorder.Code, got)
+	}
+	if n := calls.Load(); n != 1 {
+		t.Fatalf("upstream calls = %d, want 1 (no retry for real truncation)", n)
+	}
+}
+
+func boolString(v bool) string {
+	if v {
+		return "true"
+	}
+	return "false"
+}
+
+func invokeResponsesWithBody(t *testing.T, handler *Handler, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(body))
+	ctx.Request.Header.Set("Content-Type", "application/json")
+	handler.Responses(ctx)
+	return recorder
+}
+
+// 原生 /v1/responses 路径同样要把零输出的 incomplete 当失败重试。
+func TestResponsesEmptyIncompleteRetriesThenSucceeds(t *testing.T) {
+	for _, stream := range []bool{true, false} {
+		name := "non-stream"
+		if stream {
+			name = "stream"
+		}
+		t.Run(name, func(t *testing.T) {
+			var attempts atomic.Int32
+			handler, calls := newChatStreamServeTestHandler(t, func(w http.ResponseWriter) {
+				if attempts.Add(1) == 1 {
+					writeEmptyIncompleteAttempt(w)
+					return
+				}
+				writeSuccessfulAttempt(w)
+			})
+			body := `{"model":"gpt-5.4","stream":` + boolString(stream) + `,"input":"Reply with exactly: OK"}`
+			recorder := invokeResponsesWithBody(t, handler, body)
+			got := recorder.Body.String()
+			if recorder.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200; body=%q", recorder.Code, got)
+			}
+			if !strings.Contains(got, `"OK"`) || !strings.Contains(got, `"completed"`) {
+				t.Fatalf("successful retry payload missing: %q", got)
+			}
+			if strings.Contains(got, `response.incomplete`) || strings.Contains(got, `"status":"incomplete"`) {
+				t.Fatalf("empty incomplete must not leak downstream: %q", got)
+			}
+			if n := calls.Load(); n != 2 {
+				t.Fatalf("upstream calls = %d, want 2", n)
+			}
+		})
+	}
+}
+
+func TestResponsesEmptyIncompleteExhaustedReturns502(t *testing.T) {
+	for _, stream := range []bool{true, false} {
+		name := "non-stream"
+		if stream {
+			name = "stream"
+		}
+		t.Run(name, func(t *testing.T) {
+			handler, calls := newChatStreamServeTestHandler(t, writeEmptyIncompleteAttempt)
+			body := `{"model":"gpt-5.4","stream":` + boolString(stream) + `,"input":"Reply with exactly: OK"}`
+			recorder := invokeResponsesWithBody(t, handler, body)
+			got := recorder.Body.String()
+			if recorder.Code != http.StatusBadGateway {
+				t.Fatalf("status = %d, want 502; body=%q", recorder.Code, got)
+			}
+			if !strings.Contains(got, "0 output tokens") {
+				t.Fatalf("error message must name the empty incomplete failure: %q", got)
+			}
+			if n := calls.Load(); n != 2 {
+				t.Fatalf("upstream calls = %d, want 2", n)
+			}
+		})
+	}
+}

--- a/proxy/responses_ws.go
+++ b/proxy/responses_ws.go
@@ -1089,6 +1089,7 @@ func (h *Handler) streamResponsesWSUpstream(
 	var preContentErrorCandidate []byte
 	var completedResponsePayload []byte
 	outputCollector := newResponseOutputCollector()
+	emptyIncomplete := &emptyIncompleteTracker{}
 	terminalFailureEventType := ""
 	wroteAnyBody := false
 	var wsReplay *continuousRetryWSReplay
@@ -1138,6 +1139,7 @@ func (h *Handler) streamResponsesWSUpstream(
 		outputCollector.Add(data)
 		parsed := gjson.ParseBytes(data)
 		eventType := normalizedUpstreamSSEEventType(sseEvent, data)
+		eventType, data, parsed = rewriteEmptyIncompleteTerminal(emptyIncomplete, eventType, data, parsed)
 		clientData := data
 		if options != nil && options.transformClientEvent != nil {
 			if transformed := options.transformClientEvent(data); len(transformed) > 0 {

--- a/proxy/translator.go
+++ b/proxy/translator.go
@@ -99,6 +99,8 @@ type openAIStreamChunk struct {
 	Model   string         `json:"model"`
 	Choices []streamChoice `json:"choices"`
 	Usage   *UsageInfo     `json:"usage,omitempty"`
+	// ServiceTier 回传上游实际处理档位（response.service_tier），只在终结块携带。
+	ServiceTier string `json:"service_tier,omitempty"`
 }
 
 // streamChoice 流式块中的选项
@@ -145,6 +147,8 @@ type openAICompactResponse struct {
 	Model   string          `json:"model"`
 	Choices []compactChoice `json:"choices"`
 	Usage   *UsageInfo      `json:"usage,omitempty"`
+	// ServiceTier 回传上游实际处理档位（response.service_tier）。
+	ServiceTier string `json:"service_tier,omitempty"`
 }
 
 // compactChoice 非流式响应中的选项
@@ -1695,11 +1699,15 @@ func cachedOrParse(rawJSON []byte) openAIRequest {
 // TranslateRequest 将 OpenAI Chat Completions 请求转换为 Codex Responses 格式
 // 采用 Unmarshal→构造 map→Marshal 模式，只做一次 JSON 序列化
 func TranslateRequest(rawJSON []byte) ([]byte, error) {
-	req := sanitizeChatCompletionToolHistory(cachedOrParse(rawJSON))
+	parsed := cachedOrParse(rawJSON)
+	req := sanitizeChatCompletionToolHistory(parsed)
 	if err := validateChatCompletionFunctionNames(req); err != nil {
 		return nil, err
 	}
 	out := buildChatResponsesRequest(req)
+	// 工具名净化映射从净化历史前的解析结果推导，与响应侧 ChatToolNameRestoreMap
+	// 使用同一份输入，保证去重后缀两边一致。
+	applyCodexToolNameMap(out, buildCodexToolNameMap(collectChatToolNames(parsed)))
 	return json.Marshal(out)
 }
 
@@ -2156,8 +2164,11 @@ func normalizeFunctionToolsInArray(tools []any) ([]any, bool) {
 		if _, ok := tool["strict"]; !ok {
 			if strict, ok := function["strict"]; ok {
 				tool["strict"] = strict
-				modified = true
+			} else {
+				// Chat 形态（带 function 子对象）的工具按 Chat 默认：strict=false。
+				tool["strict"] = false
 			}
+			modified = true
 		}
 		delete(tool, "function")
 		modified = true
@@ -2940,6 +2951,11 @@ func convertToolsToCodexFormat(rawTools []json.RawMessage) []any {
 		normalizeFunctionToolParameters(item)
 		if parsed.Function.Strict != nil {
 			item["strict"] = *parsed.Function.Strict
+		} else {
+			// Chat Completions 的 strict 默认 false，Responses 默认 true。省略时
+			// 必须显式带 false，否则上游按 strict 校验 schema（可选属性、缺
+			// additionalProperties:false 等）直接 400。Codex CLI 自身的工具也全发 false。
+			item["strict"] = false
 		}
 		tools = append(tools, item)
 	}
@@ -3182,6 +3198,7 @@ func stripUnsupportedSchemaKeysWithPolicy(schema map[string]interface{}, policy 
 }
 
 func sanitizeSchemaForUpstream(schema map[string]interface{}) {
+	simplifyConstUnionSchemas(schema)
 	stripUnsupportedSchemaKeys(schema)
 	normalizeSchemaRequiredFields(schema)
 	ensureArrayItems(schema)
@@ -3744,6 +3761,11 @@ func newToolCallDeltaChunk(id, model string, created int64, tcIndex int, argsDel
 // (Rust/serde 系)把 delta 当必填字段,缺失会直接报
 // "missing field `delta`" 并让整轮对话失败。
 func newFinalChunk(id, model string, created int64, finishReason string, usage *UsageInfo) []byte {
+	return newFinalChunkWithTier(id, model, created, finishReason, usage, "")
+}
+
+// newFinalChunkWithTier 在终结块上附带上游实际 service_tier（空则省略）。
+func newFinalChunkWithTier(id, model string, created int64, finishReason string, usage *UsageInfo, serviceTier string) []byte {
 	chunk := openAIStreamChunk{
 		ID: id, Object: "chat.completion.chunk", Created: created, Model: model,
 		Choices: []streamChoice{{
@@ -3751,7 +3773,8 @@ func newFinalChunk(id, model string, created int64, finishReason string, usage *
 			Delta:        &streamDelta{},
 			FinishReason: &finishReason,
 		}},
-		Usage: usage,
+		Usage:       usage,
+		ServiceTier: strings.TrimSpace(serviceTier),
 	}
 	b, _ := json.Marshal(chunk)
 	return b
@@ -3815,13 +3838,13 @@ func TranslateStreamChunk(eventData []byte, model string, chunkID string, create
 
 	case "response.completed":
 		usage := extractUsage(eventData)
-		return newFinalChunk(chunkID, model, created, "stop", usage), true
+		return newFinalChunkWithTier(chunkID, model, created, "stop", usage, gjson.GetBytes(eventData, "response.service_tier").String()), true
 
 	// max_output_tokens 截断的正常终态：Chat 侧对应 finish_reason=length。
 	case "response.incomplete":
 		usage := extractUsage(eventData)
 		reason := gjson.GetBytes(eventData, "response.incomplete_details.reason").String()
-		return newFinalChunk(chunkID, model, created, responsesIncompleteFinishReason(eventType, reason), usage), true
+		return newFinalChunkWithTier(chunkID, model, created, responsesIncompleteFinishReason(eventType, reason), usage, gjson.GetBytes(eventData, "response.service_tier").String()), true
 
 	case "response.failed":
 		errMsg := gjson.GetBytes(eventData, "response.error.message").String()
@@ -3876,6 +3899,16 @@ type StreamTranslator struct {
 	toolCallFinalized     map[int]bool
 	invalidToolArguments  error
 	nextIdx               int
+	// toolNameRestore 上游名 → 客户端原名（codex_tool_names.go），nil 表示无改写。
+	toolNameRestore map[string]string
+}
+
+// SetToolNameRestore 注册工具名还原映射；请求侧未改写任何名字时可传 nil。
+func (st *StreamTranslator) SetToolNameRestore(restore map[string]string) {
+	if st == nil {
+		return
+	}
+	st.toolNameRestore = restore
 }
 
 // NewStreamTranslator 创建流式翻译器实例
@@ -4042,7 +4075,7 @@ func (st *StreamTranslator) TranslateParsed(parsed gjson.Result) ([]byte, bool) 
 		if callID == "" {
 			callID = parsed.Get("item.id").String()
 		}
-		name := parsed.Get("item.name").String()
+		name := restoreCodexToolName(st.toolNameRestore, parsed.Get("item.name").String())
 		itemID := parsed.Get("item.id").String()
 		if itemID == "" {
 			itemID = callID
@@ -4126,7 +4159,7 @@ func (st *StreamTranslator) TranslateParsed(parsed gjson.Result) ([]byte, bool) 
 		if override := responsesIncompleteFinishReason(eventType, parsed.Get("response.incomplete_details.reason").String()); override != "" {
 			finishReason = override
 		}
-		return newFinalChunk(st.ChunkID, st.Model, st.Created, finishReason, usage), true
+		return newFinalChunkWithTier(st.ChunkID, st.Model, st.Created, finishReason, usage, parsed.Get("response.service_tier").String()), true
 
 	case "response.failed":
 		errMsg := parsed.Get("response.error.message").String()
@@ -4234,6 +4267,12 @@ func BuildCompactResponse(id, model string, created int64, content, reasoning st
 // 上游按 max_output_tokens 截断时终态是 response.incomplete，推导值 stop /
 // tool_calls 会把截断响应说成正常收尾，需要覆盖成 length。空串表示不覆盖。
 func BuildCompactResponseWithFinishReason(id, model string, created int64, content, reasoning string, toolCalls []ToolCallResult, usage *UsageInfo, finishReasonOverride string) []byte {
+	return BuildCompactChatResponse(id, model, created, content, reasoning, toolCalls, usage, finishReasonOverride, "")
+}
+
+// BuildCompactChatResponse 在 BuildCompactResponseWithFinishReason 基础上附带上游
+// 实际 service_tier（空则省略）。
+func BuildCompactChatResponse(id, model string, created int64, content, reasoning string, toolCalls []ToolCallResult, usage *UsageInfo, finishReasonOverride string, serviceTier string) []byte {
 	finishReason := "stop"
 	msg := compactMessage{
 		Role:    "assistant",
@@ -4279,7 +4318,8 @@ func BuildCompactResponseWithFinishReason(id, model string, created int64, conte
 			Message:      msg,
 			FinishReason: finishReason,
 		}},
-		Usage: usage,
+		Usage:       usage,
+		ServiceTier: strings.TrimSpace(serviceTier),
 	}
 	b, _ := json.Marshal(resp)
 	return b


### PR DESCRIPTION
## 概述

两批修复,分两个提交。第一批围绕 Codex 上游在工具 schema / 工具名 / 空回复上的三类真实故障;第二批修正 Claude OAuth 渠道指纹、原生 Gemini 入口的结构化输出与 `/v1/messages` 的思考 token 统计。

**第一批(b08430fc)**

- **零输出的 `response.incomplete` 判失败并透明重试**(`proxy/codex_empty_incomplete.go`)。上游偶发以 HTTP 200 + `response.incomplete` 结束一次什么都没生成的响应:`output_tokens` 字面量 0、`output` 为空、此前没有任何非空 delta 或 `output_item.done`。原样转发时 Chat 下游拿到 `finish_reason=length` 的空回复且不会重试。现在就地改写成 `response.failed`(502,错误码 `empty_incomplete_response`),复用首包前透明重试/换号;故障按请求维度计,不进账号健康度(`streamOutcome.requestScoped`)。接入全部六条上游读流:Responses 中转流式/非流式、原生 Responses 流式/非流式客户端分支、Chat 流式/非流式、WS 原生入口。判定条件刻意收紧,真截断(有输出、有 token)仍按 v2.8.3 的正常终态处理。
- **纯常量 oneOf/anyOf 联合折成 enum**(`proxy/codex_tool_schema_unions.go`)。MCP 服务器常把枚举写成带说明的 `{"const":...,"description":...}` 联合,分支一多(实测 13 支)上游就静默中止成上面那种空回复,任意去掉一支就恢复。至少 8 支、每支只含 const/description/title、常量互不重复、已有 enum 时须与常量集一致才折;挂在共享的 `sanitizeSchemaForUpstream` 第一步,递归下钻嵌套 schema,chat / 原生 / Anthropic / Lite additional_tools 全覆盖。
- **Chat 路由工具名净化**(`proxy/codex_tool_names.go`)。上游要求 `^[a-zA-Z0-9_-]{1,64}$`,含 `.`、`:`、空格或非 ASCII 的名字原样转发必 400。非法字符替换成 `_`、64 字节截断(`mcp__` 前缀保尾段),合法名字先占位、只给非法名字加 `_1`/`_2` 后缀;请求侧覆盖 tools、tool_choice、历史 tool_calls,响应侧流式与非流式都还原原名。合法名字零开销,不建映射。
- **省略的 `strict` 显式补 `false`**。Chat Completions 的 `strict` 默认 false、Responses 默认 true;Chat 转换、原生路由上 Chat 形态(带 `function` 子对象)的工具、Anthropic 路由三处补齐,Codex CLI 自身的工具也全发 false。
- **Chat 输出回传上游 `service_tier`**(终结块与非流式响应)。

**第二批(766aadbe)**

- **`advanced-tool-use-2025-11-20` 按功能门控**(`proxy/claude_upstream.go`)。本仓库仿真的 Claude Code 2.1.258 只在工具搜索(`tool_search_tool_*` 服务端工具)、`defer_loading`、`input_examples`、`allowed_callers` 上线时才发这个 beta,普通工具声明不带;此前对所有带 tools 的请求都加,每个带工具的请求都和真 CLI 不一致。客户端显式带的仍按白名单透传。
- **原生 Gemini `/v1beta` 入口 `responseJsonSchema` 归一**(`proxy/antigravity_gemini.go`)。`generationConfig.responseJsonSchema` 与 snake_case 的 `response_json_schema` 搬到 `responseSchema`(Antigravity 后端只认它),搬运时复用 Responses 路径的 `antigravityCleanGeminiSchema` 解掉 `$defs`/`$ref`;客户端已显式给 `responseSchema` 则以它为准,只删过时键。
- **`/v1/messages` 回传 `thinking_tokens`**(`proxy/anthropic.go`)。Codex 的 `reasoning_tokens` 映成 `usage.output_tokens_details.thinking_tokens`,流式 `message_delta` 与非流式都有;只认非负数值、钳到 `output_tokens`,上游没报就整个省略而不是写 0。

## 验证

- Go:`proxy`、`proxy/wsrelay`、`api` 全量 `go test` 通过。新增用例:空 incomplete 判定矩阵(精确 0 / 浮点 / 缺失 / null / 有 output / 有 delta)、合成失败载荷的分类(502、可重试、请求维度、非降载)、非流式对象同款改写;假上游端到端(chat 与 responses 两个 handler、流式与非流式):第一轮空回第二轮成功、全部空回耗尽后 502、真截断不误判仍报 length;const 联合折叠(折/不折的各种形态、递归、数值常量去重、与既有清洗顺序);工具名净化(合法名保位、冲突后缀、请求侧三处改写、还原表往返到流式与非流式);strict 三处默认;service_tier 输出;Claude beta 四种触发条件 / 普通工具不带 / 入站透传;Gemini 两种拼写、显式 responseSchema 优先、$defs 解引用、envelope 端到端;thinking_tokens 取值矩阵、流式与非流式线上拼写。
- `admin` 包 `TestWhamDailyBackfillFailureCooldownSkipsRetry` 在干净的 main 上同样失败,与本 PR 无关:该测试只桩了 counts 端点没桩拆分端点,拆分那条 goroutine 会真打 chatgpt.com,本机耗时 3~4 秒超过断言的 2 秒;把出站网络切断后 0.8 秒通过,CI 上网络快所以一直是绿的。
- 2004 真上游实测(Codex plus/pro 账号、Claude OAuth 账号、Antigravity 账号各有):

| 场景 | 改前 | 改后 |
|---|---|---|
| 13 支 oneOf 最小复现,流式 / 非流式 | 200、`finish_reason=length`、0 token 空内容 | 返回 "OK" |
| 工具名 `mcp.fs.read`,流式 / 非流式 / 历史回放 | 上游 400 pattern 错误 | 200,三种形态都还原原名 |
| strict 省略 + 可选嵌套对象(gpt-5.5 / 5.6-sol / 6-astra) | 200 | 200(未复现故障,防御性对齐) |
| `/v1beta` generateContent,`responseJsonSchema` 与 `response_json_schema` | — | 输出严格含全部 required 键的 JSON |
| `/v1/messages`→Codex 流式 / 非流式 | usage 无思考细分 | `output_tokens_details.thinking_tokens` 23 / 24 |
| Claude OAuth 普通工具 / `defer_loading`+tool_search | — | 都 200;延迟加载后 input_tokens 从 1178 降到 329,说明 beta 已带上 |

空 incomplete 检测器无法在真上游触发(折叠后已知触发条件消失,两个绕过折叠的变体上游都正常回复),靠假上游端到端用例覆盖。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reasoning-token usage is now reported in Anthropic-compatible responses.
  * Chat Completions responses now include service-tier metadata when available.
  * Tool names are normalized for compatibility and restored in returned tool calls.

* **Bug Fixes**
  * Empty, incomplete upstream responses are automatically retried and return a clear error if retries are exhausted.
  * Improved JSON Schema compatibility, including references, optional fields, constant choices, and native Gemini response schemas.
  * Advanced tool-use indicators are now sent only when applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->