### PR TITLE
feat(proxy): 原生 Gemini /v1beta 接受 x-goog-api-key 鉴权(#639)

### DIFF
--- a/auth/upstream_trace.go
+++ b/auth/upstream_trace.go
@@ -18,7 +18,8 @@ func ValidateUpstreamRequestIDHeader(value string) error {
 		return fmt.Errorf("upstream_request_id_header must be a valid HTTP header name of at most 64 bytes")
 	}
 	switch strings.ToLower(value) {
-	case "authorization", "proxy-authorization", "cookie", "set-cookie", "x-api-key":
+	case "authorization", "proxy-authorization", "cookie", "set-cookie",
+		"x-api-key", "anthropic-auth-token", "x-goog-api-key":
 		return fmt.Errorf("upstream_request_id_header cannot name a credential header")
 	}
 	return nil

--- a/auth/upstream_trace_test.go
+++ b/auth/upstream_trace_test.go
@@ -33,3 +33,16 @@ func TestUpstreamTraceConfigAndProxySnapshots(t *testing.T) {
 		t.Fatal("outbox snapshot dropped trace configuration")
 	}
 }
+
+func TestValidateUpstreamRequestIDHeaderRejectsCredentialHeaders(t *testing.T) {
+	for _, name := range []string{"Authorization", "x-api-key", "anthropic-auth-token", "X-Goog-Api-Key", "cookie"} {
+		if err := ValidateUpstreamRequestIDHeader(name); err == nil {
+			t.Errorf("%s must be rejected as a credential header", name)
+		}
+	}
+	for _, name := range []string{"", "x-request-id", "cf-ray"} {
+		if err := ValidateUpstreamRequestIDHeader(name); err != nil {
+			t.Errorf("%q must be accepted: %v", name, err)
+		}
+	}
+}

--- a/docs/ANTIGRAVITY.md
+++ b/docs/ANTIGRAVITY.md
@@ -84,6 +84,7 @@ Antigravity OAuth accounts also support the native Gemini REST shape for clients
 Requirements and behavior:
 
 - **OAuth only.** API Key / Interactions accounts are rejected; bind a downstream key to the `antigravity` upstream channel (or use an `auto` key whose scoped catalog includes Antigravity models).
+- **Authentication.** Send the Codex2API downstream key as `Authorization: Bearer <key>`, `x-api-key: <key>`, or `x-goog-api-key: <key>`. The last form is what the `google-genai` SDK, ADK, and the Gemini channel of aggregator gateways send by default, so pointing their base URL at Codex2API works without a custom header. The `?key=` query-string form is not accepted (the key would land in URLs and access logs).
 - **Model IDs** match the published Antigravity catalog (`gemini-3.7-flash-high`, `gemini-3.8-flash-low`, Claude tiers exposed by the channel, and so on), not raw Google wire IDs.
 - **Tool schemas** are normalized before upstream dispatch: orphan `required` entries are dropped, `anyOf` / `oneOf` / `allOf` unions are flattened, invalid function names are sanitized with response-name restore, and schemas are sent as `parametersJsonSchema` (Cloud Code expectation).
 - **Multi-turn tools:** `functionResponse` turns are regrouped for the adapter; leading `inlineData` parts in the same user turn are attached under the matching `functionResponse.parts`.
@@ -99,6 +100,14 @@ curl -s http://127.0.0.1:2004/v1beta/models/gemini-3.7-flash-high:generateConten
   -H "Authorization: Bearer $CODEX2API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"contents":[{"role":"user","parts":[{"text":"Say hello"}]}]}'
+```
+
+Gemini-native clients authenticate with the same key through `x-goog-api-key`; for example with the `google-genai` Python SDK:
+
+```python
+from google import genai
+client = genai.Client(api_key=CODEX2API_KEY, http_options={"base_url": "http://127.0.0.1:2004"})
+client.models.generate_content(model="gemini-3.7-flash-high", contents="Say hello")
 ```
 
 Not yet implemented on this surface: batch/embed APIs, Imagen `predict`, and full parity with every `generativelanguage` metadata field on model list responses.

--- a/docs/ANTIGRAVITY.md
+++ b/docs/ANTIGRAVITY.md
@@ -105,8 +105,10 @@ curl -s http://127.0.0.1:2004/v1beta/models/gemini-3.7-flash-high:generateConten
 Gemini-native clients authenticate with the same key through `x-goog-api-key`; for example with the `google-genai` Python SDK:
 
 ```python
+import os
 from google import genai
-client = genai.Client(api_key=CODEX2API_KEY, http_options={"base_url": "http://127.0.0.1:2004"})
+
+client = genai.Client(api_key=os.environ["CODEX2API_KEY"], http_options={"base_url": "http://127.0.0.1:2004"})
 client.models.generate_content(model="gemini-3.7-flash-high", contents="Say hello")
 ```
 

--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -8729,6 +8729,10 @@ func (h *Handler) supportedModelIDs(ctx context.Context) []string {
 
 // downstreamAuthorizationHeader is shared by authentication and per-key memory
 // namespaces so supported header forms cannot collapse into an anonymous key.
+//
+// 接受的凭据形态:Authorization: Bearer、x-api-key / anthropic-auth-token
+// (Anthropic 系客户端)、x-goog-api-key(google-genai SDK、ADK 与聚合网关的
+// Gemini 渠道打 /v1beta 时的默认头)。不接受 ?key= 查询串:密钥会进 URL 与访问日志。
 func downstreamAuthorizationHeader(req *http.Request) string {
 	if req == nil {
 		return ""
@@ -8741,7 +8745,7 @@ func downstreamAuthorizationHeader(req *http.Request) string {
 			return "Bearer " + key
 		}
 	}
-	for _, name := range []string{"x-api-key", "anthropic-auth-token"} {
+	for _, name := range []string{"x-api-key", "anthropic-auth-token", "x-goog-api-key"} {
 		if value := strings.TrimSpace(req.Header.Get(name)); value != "" {
 			return "Bearer " + value
 		}

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -5139,6 +5139,75 @@ func TestAuthMiddlewareSetsAPIKeyContext(t *testing.T) {
 	}
 }
 
+// Gemini 原生客户端(google-genai SDK、ADK、聚合网关的 Gemini 渠道)默认用
+// x-goog-api-key 传密钥,/v1beta 必须认它;?key= 查询串不认。
+func TestAuthMiddlewareAcceptsGoogleAPIKeyHeader(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	dbPath := filepath.Join(t.TempDir(), "codex2api.db")
+	db, err := database.New("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("database.New 返回错误: %v", err)
+	}
+	defer db.Close()
+
+	key := "sk-test-goog-1234567890"
+	id, err := db.InsertAPIKey(context.Background(), "Gemini client", key)
+	if err != nil {
+		t.Fatalf("InsertAPIKey 返回错误: %v", err)
+	}
+
+	handler := NewHandler(nil, db, nil, nil)
+	router := gin.New()
+	router.Use(handler.authMiddleware())
+	router.GET("/v1beta/models", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"id": c.MustGet(contextAPIKeyID), "raw": c.MustGet("apiKey")})
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1beta/models", nil)
+	req.Header.Set("x-goog-api-key", key)
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("x-goog-api-key status = %d, want 200; body=%s", recorder.Code, recorder.Body.String())
+	}
+	var payload struct {
+		ID  int64  `json:"id"`
+		Raw string `json:"raw"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("json.Unmarshal 返回错误: %v", err)
+	}
+	if payload.ID != id || payload.Raw != key {
+		t.Fatalf("api key context = %+v, want id %d / raw %q", payload, id, key)
+	}
+
+	// 查询串形态不接受:密钥会进 URL 与访问日志。
+	req = httptest.NewRequest(http.MethodGet, "/v1beta/models?key="+key, nil)
+	recorder = httptest.NewRecorder()
+	router.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusUnauthorized {
+		t.Fatalf("?key= status = %d, want 401", recorder.Code)
+	}
+}
+
+func TestDownstreamAuthorizationHeaderPrecedence(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/v1beta/models", nil)
+	req.Header.Set("x-goog-api-key", "goog-key")
+	if got := downstreamAuthorizationHeader(req); got != "Bearer goog-key" {
+		t.Fatalf("x-goog-api-key alone = %q, want Bearer goog-key", got)
+	}
+	req.Header.Set("Authorization", "Bearer auth-key")
+	if got := downstreamAuthorizationHeader(req); got != "Bearer auth-key" {
+		t.Fatalf("Authorization must win over x-goog-api-key, got %q", got)
+	}
+	req.Header.Del("Authorization")
+	req.Header.Set("x-api-key", "anthropic-key")
+	if got := downstreamAuthorizationHeader(req); got != "Bearer anthropic-key" {
+		t.Fatalf("x-api-key must win over x-goog-api-key, got %q", got)
+	}
+}
+
 func TestAuthMiddlewareAcceptsOpenAIWebSocketSubprotocolAPIKey(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 


### PR DESCRIPTION
## 概述

跟进 #639:原生 Gemini `/v1beta` 入口(b18a4024)已经能跑,但只认 `Authorization: Bearer` 与 `x-api-key`。提 issue 的场景是把它和其他 Gemini 供应商并列接进聚合网关"统一设置",而 google-genai SDK、ADK 以及聚合网关的 Gemini 渠道默认用 `x-goog-api-key` 传密钥,现在会 401,只有能自定义 Authorization 头的客户端才接得上。

- **接受 `x-goog-api-key`**:加进共享的下游凭据读取 `downstreamAuthorizationHeader`,鉴权与按 key 的记忆命名空间同时生效;优先级仍是 `Authorization` > `x-api-key` / `anthropic-auth-token` > `x-goog-api-key`。`?key=` 查询串不接受,密钥会进 URL 与访问日志。
- **凭据头黑名单补齐**:`upstream_request_id_header` 设置项原本只拒 `authorization` / `x-api-key` 等,补上 `anthropic-auth-token` 与 `x-goog-api-key`。
- **文档**:`docs/ANTIGRAVITY.md` 的 `/v1beta` 一节写明三种鉴权形态与 `?key=` 不支持,补 google-genai SDK 直连示例。

上游侧不会泄露:Antigravity 与 Claude 的出站请求头都是逐字段构造,不克隆入站头;Grok 目录的头黑名单过滤的是管理端自定义头,与下游凭据无关。

## 验证

- Go:`proxy`、`auth`、`api` 全量测试通过。新增:鉴权中间件接受 `x-goog-api-key` 并解析出同一把 key 的上下文、`?key=` 返回 401;`downstreamAuthorizationHeader` 优先级;`ValidateUpstreamRequestIDHeader` 拒绝三种凭据头名。
- 2004 真上游:`/v1beta/models` 与 `generateContent` 用 `x-goog-api-key` 鉴权 200(改前 401);`Authorization: Bearer` 与 `x-api-key` 不变;`?key=` 仍 401。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for authenticating native Gemini API requests with the `x-goog-api-key` header.
  * Added documentation and an SDK example for configuring Gemini clients.
  * Preserved credential precedence when multiple supported authentication headers are provided.

* **Bug Fixes**
  * Credential headers are now excluded from upstream tracing identifiers.
  * Query-string API keys remain rejected for authentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->