### PR TITLE
fix(antigravity): support input_image in Responses adapter

### DIFF
--- a/proxy/antigravity_responses.go
+++ b/proxy/antigravity_responses.go
@@ -560,13 +560,19 @@ func responsesToGeminiInternal(raw []byte, project, model string) (map[string]an
 				if callID == "" || name == "" {
 					return nil, antigravityOAuthUnsupported("orphan function_call_output")
 				}
-				output, outputErr := antigravityFunctionOutputText(m["output"])
+				output, images, outputErr := antigravityFunctionOutput(m["output"])
 				if outputErr != nil {
 					return nil, outputErr
 				}
-				addParts("user", []any{map[string]any{"functionResponse": map[string]any{
-					"name": name, "response": map[string]any{"result": output}, "id": callID,
-				}}})
+				functionResponse := map[string]any{
+					"name":     name,
+					"response": map[string]any{"result": output},
+					"id":       callID,
+				}
+				if len(images) > 0 {
+					functionResponse["parts"] = images
+				}
+				addParts("user", []any{map[string]any{"functionResponse": functionResponse}})
 			case "reasoning":
 				// Codex and the Anthropic bridge echo previous reasoning items
 				// back as conversation history. Their payload is an opaque
@@ -776,35 +782,46 @@ func antigravityGeminiFunctionArguments(raw any) (any, error) {
 	return raw, nil
 }
 
-func antigravityFunctionOutputText(raw any) (string, error) {
+func antigravityFunctionOutput(raw any) (string, []any, error) {
 	if raw == nil {
-		return "", nil
+		return "", nil, nil
 	}
 	if text, ok := raw.(string); ok {
-		return text, nil
+		return text, nil, nil
 	}
 	if parts, ok := raw.([]any); ok {
 		texts := make([]string, 0, len(parts))
+		images := make([]any, 0)
 		for _, part := range parts {
 			partValue, ok := part.(map[string]any)
 			if !ok {
-				return "", antigravityOAuthUnsupported("non-text function_call_output parts")
+				return "", nil, antigravityOAuthUnsupported("non-map function_call_output parts")
 			}
 			partType := lowerStringField(partValue, "type")
-			if partType != "" && partType != "input_text" && partType != "output_text" && partType != "text" {
-				return "", antigravityOAuthUnsupported("function_call_output part type " + partType)
-			}
-			if text, ok := partValue["text"].(string); ok {
-				texts = append(texts, text)
+			switch partType {
+			case "", "input_text", "output_text", "text":
+				if text, ok := partValue["text"].(string); ok {
+					texts = append(texts, text)
+				} else if text, ok := partValue["content"].(string); ok {
+					texts = append(texts, text)
+				}
+			case "input_image", "image_url":
+				inlinePart, err := antigravityExtractInlineImagePart(partValue)
+				if err != nil {
+					return "", nil, err
+				}
+				images = append(images, inlinePart)
+			default:
+				return "", nil, antigravityOAuthUnsupported("function_call_output part type " + partType)
 			}
 		}
-		return strings.Join(texts, "\n"), nil
+		return strings.Join(texts, "\n"), images, nil
 	}
 	encoded, err := json.Marshal(raw)
 	if err != nil {
-		return "", fmt.Errorf("encode function_call_output: %w", err)
+		return "", nil, fmt.Errorf("encode function_call_output: %w", err)
 	}
-	return string(encoded), nil
+	return string(encoded), nil, nil
 }
 
 func antigravityGeminiNeedsToolSignature(model string) bool {

--- a/proxy/antigravity_responses.go
+++ b/proxy/antigravity_responses.go
@@ -516,19 +516,23 @@ func responsesToGeminiInternal(raw []byte, project, model string) (map[string]an
 				if role == "" {
 					role = "user"
 				}
-				text, textErr := responseItemText(m["content"])
-				if textErr != nil {
-					return nil, textErr
+				parts, partsErr := responseItemParts(m["content"], role == "user")
+				if partsErr != nil {
+					return nil, partsErr
 				}
 				switch role {
 				case "assistant":
-					add("model", text)
+					addParts("model", parts)
 				case "system", "developer":
-					if strings.TrimSpace(text) != "" {
-						systemParts = append(systemParts, text)
+					for _, p := range parts {
+						if pm, ok := p.(map[string]any); ok {
+							if t, ok := pm["text"].(string); ok && strings.TrimSpace(t) != "" {
+								systemParts = append(systemParts, t)
+							}
+						}
 					}
 				case "user":
-					add("user", text)
+					addParts("user", parts)
 				default:
 					return nil, antigravityOAuthUnsupported("message role " + role)
 				}
@@ -1258,6 +1262,85 @@ func antigravityOAuthUnsupported(feature string) error {
 		Type:       ErrorTypeInvalidRequest,
 		HTTPStatus: http.StatusBadRequest,
 	}
+}
+
+func responseItemParts(v any, allowImages bool) ([]any, error) {
+	if s, ok := v.(string); ok {
+		if strings.TrimSpace(s) == "" {
+			return nil, nil
+		}
+		return []any{map[string]any{"text": s}}, nil
+	}
+	arr, _ := v.([]any)
+	var parts []any
+	for _, x := range arr {
+		m, ok := x.(map[string]any)
+		if !ok {
+			return nil, antigravityOAuthUnsupported("non-map content parts")
+		}
+		partType := lowerStringField(m, "type")
+		switch partType {
+		case "", "input_text", "output_text", "text":
+			text := ""
+			if s, ok := m["text"].(string); ok {
+				text = s
+			} else if s, ok := m["content"].(string); ok {
+				text = s
+			}
+			if strings.TrimSpace(text) != "" {
+				parts = append(parts, map[string]any{"text": text})
+			}
+		case "input_image", "image_url":
+			if !allowImages {
+				return nil, antigravityOAuthUnsupported("images in non-user messages")
+			}
+			inlinePart, err := antigravityExtractInlineImagePart(m)
+			if err != nil {
+				return nil, err
+			}
+			parts = append(parts, inlinePart)
+		default:
+			return nil, antigravityOAuthUnsupported("content part type " + partType)
+		}
+	}
+	return parts, nil
+}
+
+func antigravityExtractInlineImagePart(m map[string]any) (map[string]any, error) {
+	var rawURL string
+	if u, ok := m["image_url"].(string); ok {
+		rawURL = strings.TrimSpace(u)
+	} else if obj, ok := m["image_url"].(map[string]any); ok {
+		if u, ok := obj["url"].(string); ok {
+			rawURL = strings.TrimSpace(u)
+		}
+	}
+	if rawURL == "" {
+		if u, ok := m["url"].(string); ok {
+			rawURL = strings.TrimSpace(u)
+		}
+	}
+	if rawURL == "" {
+		return nil, antigravityOAuthUnsupported("image part without image_url")
+	}
+	if strings.HasPrefix(rawURL, "data:") {
+		rest := strings.TrimPrefix(rawURL, "data:")
+		mediaType, data, ok := strings.Cut(rest, ";base64,")
+		if !ok || strings.TrimSpace(data) == "" {
+			return nil, antigravityOAuthUnsupported("invalid base64 image data URI")
+		}
+		mimeType := strings.TrimSpace(mediaType)
+		if mimeType == "" {
+			mimeType = "image/png"
+		}
+		return map[string]any{
+			"inlineData": map[string]any{
+				"mimeType": mimeType,
+				"data":     data,
+			},
+		}, nil
+	}
+	return nil, antigravityOAuthUnsupported("remote image URLs in Antigravity OAuth adapter; use data URI")
 }
 
 func responseItemText(v any) (string, error) {

--- a/proxy/antigravity_responses_test.go
+++ b/proxy/antigravity_responses_test.go
@@ -588,10 +588,88 @@ func TestResponsesToGeminiInternalSupportsInputImage(t *testing.T) {
 	}
 }
 
+func TestResponsesToGeminiInternalSupportsFunctionCallOutputInputImage(t *testing.T) {
+	body := []byte(`{
+		"input":[
+			{
+				"type":"function_call",
+				"call_id":"call_screenshot_1",
+				"name":"take_screenshot",
+				"arguments":"{}"
+			},
+			{
+				"type":"function_call_output",
+				"call_id":"call_screenshot_1",
+				"output":[
+					{"type":"input_text","text":"Screenshot captured"},
+					{"type":"input_image","image_url":"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="}
+				]
+			}
+		]
+	}`)
+	got, err := responsesToGeminiInternal(body, "project", "gemini-3.8-flash")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	req, ok := got["request"].(map[string]any)
+	if !ok {
+		t.Fatalf("request missing: %#v", got)
+	}
+	contents, ok := req["contents"].([]any)
+	if !ok || len(contents) != 2 {
+		t.Fatalf("contents length != 2: %#v", contents)
+	}
+	// turn 0: model functionCall
+	modelTurn, ok := contents[0].(map[string]any)
+	if !ok || modelTurn["role"] != "model" {
+		t.Fatalf("modelTurn role != model: %#v", modelTurn)
+	}
+	// turn 1: user functionResponse with parts
+	userTurn, ok := contents[1].(map[string]any)
+	if !ok || userTurn["role"] != "user" {
+		t.Fatalf("userTurn role != user: %#v", userTurn)
+	}
+	parts, ok := userTurn["parts"].([]any)
+	if !ok || len(parts) != 1 {
+		t.Fatalf("parts length != 1: %#v", parts)
+	}
+	fRespPart, ok := parts[0].(map[string]any)
+	if !ok {
+		t.Fatalf("parts[0] not a map: %#v", parts[0])
+	}
+	fResp, ok := fRespPart["functionResponse"].(map[string]any)
+	if !ok {
+		t.Fatalf("functionResponse missing: %#v", fRespPart)
+	}
+	if fResp["name"] != "take_screenshot" || fResp["id"] != "call_screenshot_1" {
+		t.Fatalf("functionResponse metadata mismatch: %#v", fResp)
+	}
+	respObj, ok := fResp["response"].(map[string]any)
+	if !ok || respObj["result"] != "Screenshot captured" {
+		t.Fatalf("functionResponse result mismatch: %#v", respObj)
+	}
+	imageParts, ok := fResp["parts"].([]any)
+	if !ok || len(imageParts) != 1 {
+		t.Fatalf("functionResponse parts length != 1: %#v", fResp["parts"])
+	}
+	imagePart, ok := imageParts[0].(map[string]any)
+	if !ok {
+		t.Fatalf("imagePart not map: %#v", imageParts[0])
+	}
+	inlineData, ok := imagePart["inlineData"].(map[string]any)
+	if !ok {
+		t.Fatalf("inlineData missing: %#v", imagePart)
+	}
+	if inlineData["mimeType"] != "image/png" || inlineData["data"] != "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==" {
+		t.Fatalf("inlineData mismatch: %#v", inlineData)
+	}
+}
+
 func TestResponsesToGeminiInternalRejectsUnsupportedInputs(t *testing.T) {
 	for _, body := range []string{
 		`{"input":[{"role":"assistant","content":[{"type":"input_image","image_url":"data:image/png;base64,AA=="}]}]}`,
 		`{"input":[{"role":"user","content":[{"type":"input_image","image_url":"https://example.com/test.png"}]}]}`,
+		`{"input":[{"type":"function_call_output","call_id":"call_1","output":[{"type":"input_image","image_url":"https://example.com/test.png"}]}]}`,
 		`{"input":[{"type":"function_call_output","call_id":"call_1","output":"ok"}]}`,
 	} {
 		if _, err := responsesToGeminiInternal([]byte(body), "project", "gemini"); err == nil {

--- a/proxy/antigravity_responses_test.go
+++ b/proxy/antigravity_responses_test.go
@@ -539,9 +539,59 @@ func TestResponsesToGeminiInternalAcceptsOrdinaryTextConfiguration(t *testing.T)
 	}
 }
 
-func TestResponsesToGeminiInternalRejectsImagesAndToolOutputs(t *testing.T) {
+func TestResponsesToGeminiInternalSupportsInputImage(t *testing.T) {
+	body := []byte(`{
+		"input":[
+			{
+				"role":"user",
+				"content":[
+					{"type":"input_text","text":"what is in this picture?"},
+					{"type":"input_image","image_url":"data:image/jpeg;base64,/9j/4AAQSkZJRg=="}
+				]
+			}
+		]
+	}`)
+	got, err := responsesToGeminiInternal(body, "project", "gemini-3.8-flash")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	req, ok := got["request"].(map[string]any)
+	if !ok {
+		t.Fatalf("request missing: %#v", got)
+	}
+	contents, ok := req["contents"].([]any)
+	if !ok || len(contents) != 1 {
+		t.Fatalf("contents length != 1: %#v", contents)
+	}
+	turn, ok := contents[0].(map[string]any)
+	if !ok || turn["role"] != "user" {
+		t.Fatalf("turn role != user: %#v", turn)
+	}
+	parts, ok := turn["parts"].([]any)
+	if !ok || len(parts) != 2 {
+		t.Fatalf("parts length != 2: %#v", parts)
+	}
+	textPart, ok := parts[0].(map[string]any)
+	if !ok || textPart["text"] != "what is in this picture?" {
+		t.Fatalf("first part != text: %#v", textPart)
+	}
+	imagePart, ok := parts[1].(map[string]any)
+	if !ok {
+		t.Fatalf("second part is not a map: %#v", parts[1])
+	}
+	inlineData, ok := imagePart["inlineData"].(map[string]any)
+	if !ok {
+		t.Fatalf("inlineData missing: %#v", imagePart)
+	}
+	if inlineData["mimeType"] != "image/jpeg" || inlineData["data"] != "/9j/4AAQSkZJRg==" {
+		t.Fatalf("inlineData mismatch: %#v", inlineData)
+	}
+}
+
+func TestResponsesToGeminiInternalRejectsUnsupportedInputs(t *testing.T) {
 	for _, body := range []string{
-		`{"input":[{"role":"user","content":[{"type":"input_image","image_url":"data:image/png;base64,AA=="}]}]}`,
+		`{"input":[{"role":"assistant","content":[{"type":"input_image","image_url":"data:image/png;base64,AA=="}]}]}`,
+		`{"input":[{"role":"user","content":[{"type":"input_image","image_url":"https://example.com/test.png"}]}]}`,
 		`{"input":[{"type":"function_call_output","call_id":"call_1","output":"ok"}]}`,
 	} {
 		if _, err := responsesToGeminiInternal([]byte(body), "project", "gemini"); err == nil {


### PR DESCRIPTION
### Summary
When using Codex CLI or Responses API with vision models on Antigravity channels:
1. User prompt image parts (`type: "input_image"` / `image_url`) were previously rejected by `responseItemText` with `Antigravity OAuth adapter does not safely support content part type input_image`.
2. Tool results (`type: "function_call_output"`) containing images (such as browser/computer-use screenshots returned by tools) were also rejected with `Antigravity OAuth adapter does not safely support function_call_output part type input_image`.

### Changes
- Added `responseItemParts` in `proxy/antigravity_responses.go` to parse user message text and image parts into Gemini native `inlineData`.
- Updated `function_call_output` handling with `antigravityFunctionOutput` to parse multimodal tool outputs and attach extracted `inlineData` image parts to `functionResponse.parts`.
- Supported `data:<mimeType>;base64,<data>` image data URIs across user prompts and tool outputs.
- Added comprehensive unit test coverage in `proxy/antigravity_responses_test.go`:
  - `TestResponsesToGeminiInternalSupportsInputImage`
  - `TestResponsesToGeminiInternalSupportsFunctionCallOutputInputImage`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * User messages can include inline images provided as base64 data URLs.
  * Function-call outputs can preserve inline images alongside text when converted for AI processing.
  * Text content is recognized from supported structured content fields.

* **Bug Fixes**
  * Improved handling and validation of structured message content.
  * Unsupported image placements and remote image URLs continue to be rejected with clearer validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->