### PR TITLE
feat(proxy): add downstream HTTP and WebSocket keepalives

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,13 @@ CODEX_PORT=8080
 # Codex HTTP TLS 指纹：默认 standard；如需回滚旧行为可设 utls_chrome
 # CODEX_TRANSPORT_MODE=standard
 
+# 下游 HTTP/SSE 保活周期；Go duration，0 关闭。Responses/Chat/Images 使用 SSE 注释，
+# Messages 使用原生 ping，响应提交前及非流式端点使用 HTTP 102 Processing。
+# DOWNSTREAM_HTTP_KEEPALIVE_INTERVAL=30s
+
+# 下游 WebSocket Ping 周期；Go duration，0 关闭。覆盖 Responses、Realtime 和 Live Sideband。
+# DOWNSTREAM_WS_KEEPALIVE_INTERVAL=45s
+
 # WS 握手默认发送 Codex User-Agent/Version；如需关闭可设 false
 # CODEX_WS_SEND_USER_AGENT=true
 

--- a/.env.example
+++ b/.env.example
@@ -49,8 +49,8 @@ CODEX_PORT=8080
 # Codex HTTP TLS 指纹：默认 standard；如需回滚旧行为可设 utls_chrome
 # CODEX_TRANSPORT_MODE=standard
 
-# 下游 HTTP/SSE 保活周期；Go duration，0 关闭。Responses/Chat/Images 使用 SSE 注释，
-# Messages 使用原生 ping，响应提交前及非流式端点使用 HTTP 102 Processing。
+# 下游 HTTP/SSE 保活周期；Go duration，0 关闭。流式端点从首个心跳起提交 SSE：
+# Responses/Chat/Images 使用注释，Messages 使用原生 ping；非流式端点使用 HTTP 102。
 # DOWNSTREAM_HTTP_KEEPALIVE_INTERVAL=30s
 
 # 下游 WebSocket Ping 周期；Go duration，0 关闭。覆盖 Responses、Realtime 和 Live Sideband。

--- a/.env.sqlite.example
+++ b/.env.sqlite.example
@@ -53,6 +53,13 @@ DATABASE_PATH=/data/codex2api.db
 # Codex HTTP TLS 指纹：默认 standard；如需回滚旧行为可设 utls_chrome
 # CODEX_TRANSPORT_MODE=standard
 
+# 下游 HTTP/SSE 保活周期；Go duration，0 关闭。Responses/Chat/Images 使用 SSE 注释，
+# Messages 使用原生 ping，响应提交前及非流式端点使用 HTTP 102 Processing。
+# DOWNSTREAM_HTTP_KEEPALIVE_INTERVAL=30s
+
+# 下游 WebSocket Ping 周期；Go duration，0 关闭。覆盖 Responses、Realtime 和 Live Sideband。
+# DOWNSTREAM_WS_KEEPALIVE_INTERVAL=45s
+
 # WS 握手默认不发送 User-Agent/Version；如需回滚旧行为可设 true
 # CODEX_WS_SEND_USER_AGENT=false
 

--- a/.env.sqlite.example
+++ b/.env.sqlite.example
@@ -53,8 +53,8 @@ DATABASE_PATH=/data/codex2api.db
 # Codex HTTP TLS 指纹：默认 standard；如需回滚旧行为可设 utls_chrome
 # CODEX_TRANSPORT_MODE=standard
 
-# 下游 HTTP/SSE 保活周期；Go duration，0 关闭。Responses/Chat/Images 使用 SSE 注释，
-# Messages 使用原生 ping，响应提交前及非流式端点使用 HTTP 102 Processing。
+# 下游 HTTP/SSE 保活周期；Go duration，0 关闭。流式端点从首个心跳起提交 SSE：
+# Responses/Chat/Images 使用注释，Messages 使用原生 ping；非流式端点使用 HTTP 102。
 # DOWNSTREAM_HTTP_KEEPALIVE_INTERVAL=30s
 
 # 下游 WebSocket Ping 周期；Go duration，0 关闭。覆盖 Responses、Realtime 和 Live Sideband。

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -81,7 +81,7 @@ Codex2API 采用三层配置架构：
 | `CODEX_STATSIG_API_KEY` | 否 | 内置公开 key | 覆盖 Codex Desktop/CLI 共用的公开 Statsig SDK key，仅遥测开启时使用 |
 | `CODEX_SESSION_HEADER_MODE` | 否 | `native` | 出站会话头形态。`native` 发真实客户端的 `session-id` / `thread-id` / `x-client-request-id`；`legacy` 回退到旧的 `Session_id`（WS 另带 `Conversation_id`） |
 | `CODEX_SESSION_HEADER_ALIGN_CONVERGED` | 否 | `false` | 开启后 `session-id` 头改用指纹收敛后的会话身份，与 turn metadata 的 `session_id` 对齐。默认关：请求体 `prompt_cache_key` 始终独立隔离，但上游是否也拿该头参与缓存分组无法从客户端源码确认 |
-| `DOWNSTREAM_HTTP_KEEPALIVE_INTERVAL` | 否 | `30s` | 下游 HTTP/SSE 保活周期，使用 Go duration；`0` 关闭。响应提交前及非流式端点发送 HTTP 102，已提交流按协议发送 SSE 注释或 Messages ping |
+| `DOWNSTREAM_HTTP_KEEPALIVE_INTERVAL` | 否 | `30s` | 下游 HTTP/SSE 保活周期，使用 Go duration；`0` 关闭。流式端点从首个心跳起建立 SSE 200，发送注释或 Messages ping；非流式端点发送 HTTP 102 |
 | `DOWNSTREAM_WS_KEEPALIVE_INTERVAL` | 否 | `45s` | 下游 WebSocket Ping 周期，使用 Go duration；`0` 关闭。覆盖 Responses、Realtime 与 Live Sideband |
 
 > `CODEX_UPSTREAM_TRANSPORT` 只控制 HTTP 入站请求转发到 Codex 上游时使用 `http` 还是 `ws`。客户端侧 WebSocket 入口独立可用：使用 `GET ws://<host>/v1/responses` 建连，首帧发送 `response.create` JSON，服务端会通过 Codex 上游 WS 返回 Responses 事件帧。
@@ -282,7 +282,7 @@ Codex 瞬时账号限流按 `15s → 30s → 60s → 120s → 240s → 300s` 退
 
 `catch_all` 是默认关闭的超级模式。开启后不再依赖已知类别或错误码清单；除明确的上游 `cyber_policy` 外，任何真实上游 HTTP、传输、流读取、`error`、`response.failed` 或未知失败都会进入持续重试，包括永久额度、余额、鉴权、无效请求和其他结构化安全策略错误。明确的上游 `cyber_policy` 始终终止当前请求，不换号、不重放。文本推理只接受上游 HTTP `200` 及协议正常终态；其他状态、失败终态及无终态 EOF 都会丢弃整次尝试并继续。管理界面的超级开关会在一次保存中同时设置 `enabled=true` 和 `catch_all=true`；关闭总开关会同步清除 `catch_all`，避免隐藏启用。
 
-持续重试会把每次流式上游尝试完整暂存；失败整次丢弃，正常终态才一次性回放。目标端点等待上游响应头、读取响应体或流数据时保持下游连接：Responses、Chat Completions 和 Images 在 SSE 正式提交后发送 `: keepalive` 注释，Messages 发送 Anthropic 原生 `event: ping`；Responses、Realtime 与 Live Sideband WebSocket 使用 Ping 控制帧。原生 Grok SSE 仍保留上游帧格式并允许插入保活帧。SSE 正式提交前以及非流式 JSON（包括 relay/native Responses、compact、Images、Grok 图片和 Alpha Search）使用标准 HTTP `102 Processing` 信息响应，不提交最终状态或 JSON；中间代理可能丢弃 1xx，仍需依赖墙钟上限和客户端超时。`max_duration_seconds` 设置无限预算的墙钟时间上限（默认 600 秒，范围 1 到 900 秒），从请求第一次进入无限重试时开始，后续尝试不会重置。期限到达会立即取消上游并返回最近一次真实上游失败；仅在尚无失败可返回时使用 `504 upstream_timeout`。普通自选模式不会无限重试未选中的结构化安全策略拒绝；`catch_all` 可覆盖其他拒绝，但不能覆盖明确的上游 `cyber_policy` 或本地重试期限。
+持续重试会把每次流式上游尝试完整暂存；失败整次丢弃，正常终态才一次性回放。目标端点等待上游响应头、读取响应体或流数据时保持下游连接：Responses、Chat Completions 和 Images 在首个保活周期到达时建立 SSE 200 并发送 `: keepalive` 注释，Messages 发送 Anthropic 原生 `event: ping`；Responses、Realtime 与 Live Sideband WebSocket 使用 Ping 控制帧。原生 Grok SSE 仍保留上游帧格式并允许插入保活帧。心跳提交 SSE 后，随后的上游错误会使用协议错误事件，不再改变 HTTP 200。非流式 JSON（包括 relay/native Responses、compact、Images、Grok 图片和 Alpha Search）使用标准 HTTP `102 Processing` 信息响应，不提交最终状态或 JSON；Cloudflare 收到 102 后仍要求在 125 秒内收到最终响应，因此它只能延长等待，不是无限期保活。`max_duration_seconds` 设置无限预算的墙钟时间上限（默认 600 秒，范围 1 到 900 秒），从请求第一次进入无限重试时开始，后续尝试不会重置。期限到达会立即取消上游并返回最近一次真实上游失败；仅在尚无失败可返回时使用 `504 upstream_timeout`。普通自选模式不会无限重试未选中的结构化安全策略拒绝；`catch_all` 可覆盖其他拒绝，但不能覆盖明确的上游 `cyber_policy` 或本地重试期限。
 
 上述 HTTP/SSE 保活覆盖 `/v1/responses`（含 relay/native、stream 与 non-stream）、`/v1/chat/completions`、`/v1/messages`、`/v1/responses/compact`、`/v1/alpha/search`、`/v1/images/generations` 和 `/v1/images/edits`；视频、image jobs 与 `POST /v1/live` 不启用这套保活。Claude 原生 Messages 的首字前及已提交流保活继续由 `stream_keepalive_enabled` 共同控制，缺省为开启。
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -81,6 +81,8 @@ Codex2API 采用三层配置架构：
 | `CODEX_STATSIG_API_KEY` | 否 | 内置公开 key | 覆盖 Codex Desktop/CLI 共用的公开 Statsig SDK key，仅遥测开启时使用 |
 | `CODEX_SESSION_HEADER_MODE` | 否 | `native` | 出站会话头形态。`native` 发真实客户端的 `session-id` / `thread-id` / `x-client-request-id`；`legacy` 回退到旧的 `Session_id`（WS 另带 `Conversation_id`） |
 | `CODEX_SESSION_HEADER_ALIGN_CONVERGED` | 否 | `false` | 开启后 `session-id` 头改用指纹收敛后的会话身份，与 turn metadata 的 `session_id` 对齐。默认关：请求体 `prompt_cache_key` 始终独立隔离，但上游是否也拿该头参与缓存分组无法从客户端源码确认 |
+| `DOWNSTREAM_HTTP_KEEPALIVE_INTERVAL` | 否 | `30s` | 下游 HTTP/SSE 保活周期，使用 Go duration；`0` 关闭。响应提交前及非流式端点发送 HTTP 102，已提交流按协议发送 SSE 注释或 Messages ping |
+| `DOWNSTREAM_WS_KEEPALIVE_INTERVAL` | 否 | `45s` | 下游 WebSocket Ping 周期，使用 Go duration；`0` 关闭。覆盖 Responses、Realtime 与 Live Sideband |
 
 > `CODEX_UPSTREAM_TRANSPORT` 只控制 HTTP 入站请求转发到 Codex 上游时使用 `http` 还是 `ws`。客户端侧 WebSocket 入口独立可用：使用 `GET ws://<host>/v1/responses` 建连，首帧发送 `response.create` JSON，服务端会通过 Codex 上游 WS 返回 Responses 事件帧。
 
@@ -280,7 +282,9 @@ Codex 瞬时账号限流按 `15s → 30s → 60s → 120s → 240s → 300s` 退
 
 `catch_all` 是默认关闭的超级模式。开启后不再依赖已知类别或错误码清单；除明确的上游 `cyber_policy` 外，任何真实上游 HTTP、传输、流读取、`error`、`response.failed` 或未知失败都会进入持续重试，包括永久额度、余额、鉴权、无效请求和其他结构化安全策略错误。明确的上游 `cyber_policy` 始终终止当前请求，不换号、不重放。文本推理只接受上游 HTTP `200` 及协议正常终态；其他状态、失败终态及无终态 EOF 都会丢弃整次尝试并继续。管理界面的超级开关会在一次保存中同时设置 `enabled=true` 和 `catch_all=true`；关闭总开关会同步清除 `catch_all`，避免隐藏启用。
 
-持续重试会把每次流式上游尝试完整暂存；失败整次丢弃，正常终态才一次性回放。因此客户端等待时由 SSE 注释或 Responses WebSocket Ping 保活，但不再实时逐 token 收到生成结果。非流式 JSON（包括 Grok media）在进入无限重试后，会在退避、等待账号、等待响应头和读取响应体时发送标准 HTTP `102 Processing` 信息响应；它不会提交最终 JSON 状态，但中间代理可能丢弃 1xx，仍需依赖墙钟上限和客户端超时。`max_duration_seconds` 设置无限预算的墙钟时间上限（默认 600 秒，范围 1 到 900 秒），从请求第一次进入无限重试时开始，后续尝试不会重置。期限到达会立即取消上游并返回最近一次真实上游失败；仅在尚无失败可返回时使用 `504 upstream_timeout`。普通自选模式不会无限重试未选中的结构化安全策略拒绝；`catch_all` 可覆盖其他拒绝，但不能覆盖明确的上游 `cyber_policy` 或本地重试期限。
+持续重试会把每次流式上游尝试完整暂存；失败整次丢弃，正常终态才一次性回放。目标端点等待上游响应头、读取响应体或流数据时保持下游连接：Responses、Chat Completions 和 Images 在 SSE 正式提交后发送 `: keepalive` 注释，Messages 发送 Anthropic 原生 `event: ping`；Responses、Realtime 与 Live Sideband WebSocket 使用 Ping 控制帧。原生 Grok SSE 仍保留上游帧格式并允许插入保活帧。SSE 正式提交前以及非流式 JSON（包括 relay/native Responses、compact、Images、Grok 图片和 Alpha Search）使用标准 HTTP `102 Processing` 信息响应，不提交最终状态或 JSON；中间代理可能丢弃 1xx，仍需依赖墙钟上限和客户端超时。`max_duration_seconds` 设置无限预算的墙钟时间上限（默认 600 秒，范围 1 到 900 秒），从请求第一次进入无限重试时开始，后续尝试不会重置。期限到达会立即取消上游并返回最近一次真实上游失败；仅在尚无失败可返回时使用 `504 upstream_timeout`。普通自选模式不会无限重试未选中的结构化安全策略拒绝；`catch_all` 可覆盖其他拒绝，但不能覆盖明确的上游 `cyber_policy` 或本地重试期限。
+
+上述 HTTP/SSE 保活覆盖 `/v1/responses`（含 relay/native、stream 与 non-stream）、`/v1/chat/completions`、`/v1/messages`、`/v1/responses/compact`、`/v1/alpha/search`、`/v1/images/generations` 和 `/v1/images/edits`；视频、image jobs 与 `POST /v1/live` 不启用这套保活。Claude 原生 Messages 的首字前及已提交流保活继续由 `stream_keepalive_enabled` 共同控制，缺省为开启。
 
 单次流式尝试的暂存上限为 64 MiB，前 8 MiB 使用内存，之后写入立即 unlink 的 mode-0600 临时文件；暂存超限或存储失败会作为本地错误立即停止。当前没有跨请求的进程级暂存总预算，高并发环境需要另行限制并发并监控内存与临时磁盘。Responses HTTP 等待期间若 SSE 心跳已提交响应头，最终成功账号的 `X-Codex-Turn-State` 无法再补发，因此实现会省略该头而不会转发失败账号的状态；无法安全展开为自包含请求的账号绑定 continuation 也不会强行换号。
 

--- a/main.go
+++ b/main.go
@@ -40,6 +40,7 @@ func migrateOnlyEnabled() bool {
 	return value == "1" || strings.EqualFold(value, "true")
 }
 
+// main 加载配置、初始化存储与路由，并启动 Codex2API HTTP 服务。
 func main() {
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
 	log.Println("Codex2API v2 启动中...")

--- a/main.go
+++ b/main.go
@@ -49,6 +49,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("加载核心环境配置失败 (请检查 .env 文件): %v", err)
 	}
+	proxy.ConfigureDownstreamKeepaliveFromEnv()
 	log.Printf("物理层配置加载成功: port=%d, database=%s, cache=%s, tz=%s", cfg.Port, cfg.Database.Label(), cfg.Cache.Label(), time.Local)
 
 	// 2. 初始化数据库

--- a/proxy/apikey_model_requests.go
+++ b/proxy/apikey_model_requests.go
@@ -119,6 +119,11 @@ func ConsumeAPIKeyModelRequestQuota(ctx context.Context, model string) error {
 				api.ErrorTypeRateLimit, hit.APIKeyModelRequestUsage)}
 	}
 	state.admitted = true
+	// 入站保活在额度准入前不能提交 SSE 200；准入成功后
+	// 立即激活，覆盖随后可能长时间无响应头的上游请求。
+	if keepalive := continuousRetryKeepaliveForContext(ctx); keepalive != nil {
+		keepalive.Activate()
+	}
 	return nil
 }
 

--- a/proxy/apikey_model_requests_test.go
+++ b/proxy/apikey_model_requests_test.go
@@ -133,6 +133,8 @@ func TestModelRequestQuotaHTTPMappedModelAndProtocolErrors(t *testing.T) {
 	}
 }
 
+// TestModelRequestQuotaExecutorRetriesAndFreshRequest 验证同一逻辑请求的重试共享一次额度扣减，
+// 且重新进入处理器时仍使用新的请求身份。
 func TestModelRequestQuotaExecutorRetriesAndFreshRequest(t *testing.T) {
 	var calls atomic.Int32
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -171,6 +173,8 @@ func TestModelRequestQuotaExecutorRetriesAndFreshRequest(t *testing.T) {
 	}
 }
 
+// TestModelRequestQuotaActivatesSSEKeepaliveAfterAdmission 验证额度准入成功后，
+// 上游尚未返回响应头时也会激活下游 SSE 保活。
 func TestModelRequestQuotaActivatesSSEKeepaliveAfterAdmission(t *testing.T) {
 	previousInterval := continuousRetryKeepaliveInterval
 	continuousRetryKeepaliveInterval = 5 * time.Millisecond

--- a/proxy/apikey_model_requests_test.go
+++ b/proxy/apikey_model_requests_test.go
@@ -171,6 +171,28 @@ func TestModelRequestQuotaExecutorRetriesAndFreshRequest(t *testing.T) {
 	}
 }
 
+func TestModelRequestQuotaActivatesSSEKeepaliveAfterAdmission(t *testing.T) {
+	previousInterval := continuousRetryKeepaliveInterval
+	continuousRetryKeepaliveInterval = 5 * time.Millisecond
+	t.Cleanup(func() { continuousRetryKeepaliveInterval = previousInterval })
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(30 * time.Millisecond)
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, modelQuotaSSE)
+	}))
+	t.Cleanup(upstream.Close)
+	_, _, router := newModelQuotaTestHandler(t, 2, upstream.URL, false)
+
+	response := performModelQuotaRequest(router, "/v1/responses", `{"model":"gpt-6-astra","input":"hi","stream":true}`)
+	body := response.Body.String()
+	keepaliveAt := strings.Index(body, downstreamSSEKeepaliveComment)
+	completedAt := strings.Index(body, `"type":"response.completed"`)
+	if response.Code != http.StatusOK || keepaliveAt < 0 || completedAt < 0 || keepaliveAt > completedAt {
+		t.Fatalf("status=%d keepalive=%d completed=%d body=%q", response.Code, keepaliveAt, completedAt, body)
+	}
+}
+
 func TestModelRequestQuotaWebsocketFramesAndOtherModel(t *testing.T) {
 	previousExecute := WebsocketExecuteFunc
 	t.Cleanup(func() { WebsocketExecuteFunc = previousExecute })

--- a/proxy/codex_alpha_search.go
+++ b/proxy/codex_alpha_search.go
@@ -65,6 +65,13 @@ func (h *Handler) CodexAlphaSearchHandler(c *gin.Context) {
 	if h.inspectPromptFilterOpenAI(c, rawBody, "/v1/alpha/search", model) {
 		return
 	}
+	continuousRetryPolicy := continuousRetryPolicyForCall(nil)
+	rememberContinuousRetryPolicyForRequest(c, continuousRetryPolicy)
+	stopRetryDeadline := installContinuousRetryHTTPDeadline(c, continuousRetryPolicy, continuousRetryProtocolResponses)
+	defer stopRetryDeadline()
+	stopRetryKeepalive := installContinuousRetryHTTPInformationalKeepalive(c)
+	defer stopRetryKeepalive()
+	activateContinuousRetryKeepalive(c.Request.Context())
 
 	apiKeyID := requestAPIKeyID(c)
 	// 搜索端点只存在于 ChatGPT 后端，relay/Grok 账号无从代答。
@@ -159,13 +166,15 @@ func ForwardCodexAlphaSearch(ctx context.Context, account *auth.Account, proxyUR
 	// 复用网关同款 transport（支持 uTLS Chrome 指纹），与 /responses、清单透传一致。
 	// 池化而非每次新建，避免一次性 uTLS transport 泄漏连接（issue #446）。
 	client := getCodexMaintenanceClient(account, proxyURL)
-	resp, err := client.Do(req)
+	resp, err := executeHTTPWithContinuousRetryKeepalive(reqCtx, func() (*http.Response, error) {
+		return client.Do(req)
+	})
 	if err != nil {
 		return nil, fmt.Errorf("codex search request: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	body, err := io.ReadAll(io.LimitReader(resp.Body, codexAlphaSearchBodyLimit))
+	body, err := readAllLimitedWithContinuousRetryKeepalive(reqCtx, resp.Body, codexAlphaSearchBodyLimit)
 	if err != nil {
 		return nil, fmt.Errorf("read codex search response: %w", err)
 	}

--- a/proxy/codex_alpha_search_test.go
+++ b/proxy/codex_alpha_search_test.go
@@ -2,10 +2,14 @@ package proxy
 
 import (
 	"bytes"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/http/httptrace"
+	"net/textproto"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/codex2api/auth"
 	"github.com/codex2api/database"
@@ -163,5 +167,65 @@ func TestCodexAlphaSearchHandler_RelayOnlyPoolFastFails(t *testing.T) {
 
 	if rec.Code != http.StatusServiceUnavailable {
 		t.Fatalf("status = %d, want 503; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestCodexAlphaSearchHandler_KeepsJSONResponseAliveWhileReadingBody(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	previousInterval := continuousRetryKeepaliveInterval
+	continuousRetryKeepaliveInterval = 5 * time.Millisecond
+	t.Cleanup(func() { continuousRetryKeepaliveInterval = previousInterval })
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.(http.Flusher).Flush()
+		time.Sleep(30 * time.Millisecond)
+		_, _ = w.Write([]byte(`{"output":[]}`))
+	}))
+	defer upstream.Close()
+	codexAlphaSearchURLForTest = upstream.URL
+	defer func() { codexAlphaSearchURLForTest = "" }()
+
+	store := auth.NewStore(nil, nil, &database.SystemSettings{MaxConcurrency: 2})
+	store.AddAccount(&auth.Account{DBID: 1, AccessToken: "at-search", PlanType: "plus"})
+	handler := NewHandler(store, nil, nil, nil)
+	engine := gin.New()
+	engine.POST("/v1/alpha/search", handler.CodexAlphaSearchHandler)
+	server := httptest.NewServer(engine)
+	defer server.Close()
+
+	request, err := http.NewRequest(http.MethodPost, server.URL+"/v1/alpha/search", strings.NewReader(`{"model":"gpt-5.6-sol"}`))
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	informational := make(chan int, 1)
+	trace := &httptrace.ClientTrace{Got1xxResponse: func(code int, _ textproto.MIMEHeader) error {
+		select {
+		case informational <- code:
+		default:
+		}
+		return nil
+	}}
+	request = request.WithContext(httptrace.WithClientTrace(request.Context(), trace))
+	response, err := server.Client().Do(request)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer response.Body.Close()
+	select {
+	case code := <-informational:
+		if code != http.StatusProcessing {
+			t.Fatalf("informational status = %d, want %d", code, http.StatusProcessing)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("alpha search did not emit HTTP 102 while reading response body")
+	}
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	if response.StatusCode != http.StatusOK || string(body) != `{"output":[]}` {
+		t.Fatalf("response = %d %q, want 200 JSON", response.StatusCode, body)
 	}
 }

--- a/proxy/codex_alpha_search_test.go
+++ b/proxy/codex_alpha_search_test.go
@@ -170,6 +170,8 @@ func TestCodexAlphaSearchHandler_RelayOnlyPoolFastFails(t *testing.T) {
 	}
 }
 
+// TestCodexAlphaSearchHandler_KeepsJSONResponseAliveWhileReadingBody 验证读取静默的
+// 非流式 JSON 响应体时会发送 HTTP 102，同时保留最终 JSON 响应。
 func TestCodexAlphaSearchHandler_KeepsJSONResponseAliveWhileReadingBody(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	previousInterval := continuousRetryKeepaliveInterval

--- a/proxy/compact_via_responses.go
+++ b/proxy/compact_via_responses.go
@@ -146,6 +146,8 @@ func collectCompactResponsesSSE(body io.Reader) (responseJSON []byte, failedPayl
 	return collectCompactResponsesSSEWithContinuousRetryKeepalive(context.Background(), body)
 }
 
+// collectCompactResponsesSSEWithContinuousRetryKeepalive 聚合上游 compact SSE，
+// 并在读取期间通过请求级保活刷新下游连接。
 func collectCompactResponsesSSEWithContinuousRetryKeepalive(ctx context.Context, body io.Reader) (responseJSON []byte, failedPayload []byte, err error) {
 	outputItems := make([]json.RawMessage, 0, 2)
 	seenOutputItems := make(map[string]struct{})

--- a/proxy/compact_via_responses.go
+++ b/proxy/compact_via_responses.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -142,10 +143,14 @@ func isCanonicalCompactionTrigger(item gjson.Result) bool {
 // response.output_item.done（含 compaction 项）补齐 output。上游以 response.failed
 // 终止时原样返回该事件负载，由调用方按上游错误处理；流在终止事件前结束视为读错误。
 func collectCompactResponsesSSE(body io.Reader) (responseJSON []byte, failedPayload []byte, err error) {
+	return collectCompactResponsesSSEWithContinuousRetryKeepalive(context.Background(), body)
+}
+
+func collectCompactResponsesSSEWithContinuousRetryKeepalive(ctx context.Context, body io.Reader) (responseJSON []byte, failedPayload []byte, err error) {
 	outputItems := make([]json.RawMessage, 0, 2)
 	seenOutputItems := make(map[string]struct{})
 	var completed []byte
-	readErr := ReadSSEStream(body, func(data []byte) bool {
+	readErr := readSSEStreamWithContinuousRetryKeepalive(ctx, body, func(_ string, data []byte) bool {
 		if item, ok := extractResponseOutputItemDone(data, seenOutputItems); ok {
 			outputItems = append(outputItems, item)
 		}

--- a/proxy/continue_thinking.go
+++ b/proxy/continue_thinking.go
@@ -27,12 +27,7 @@ const (
 	reasoningTruncationStep    = 518
 	continueThinkingMarkerText = "Continue thinking..."
 
-	// 隐藏续想轮的下游保活间隔与内容。隐藏轮期间(开轮握手、续想轮无可转发
-	// reasoning)下游可能长时间收不到任何字节,反代的空闲读超时(常见 60~125s)
-	// 会拦腰掐断连接并诱发客户端整轮重试循环(issue #458)。SSE 注释行是标准
-	// 协议内容,客户端解析器一律忽略,但能刷新链路上每一跳的空闲计时器。
-	continueKeepaliveInterval = 15 * time.Second
-	continueKeepaliveComment  = ": keepalive\n\n"
+	continueKeepaliveComment = ": keepalive\n\n"
 )
 
 // isReasoningTruncationTokens 判断 reasoning token 数是否命中截断指纹（518*n - 2）。
@@ -112,12 +107,12 @@ type continueFold struct {
 	openRound  func(body []byte) (*http.Response, error) // 用同一账号/通道开续想轮
 	clientGone func() bool                               // 客户端是否已断开
 
-	// keepalive 隐藏轮期间向下游写 SSE 注释保活,返回 false 表示下游已死、停止
+	// keepalive 折叠期间向下游写 SSE 注释保活,返回 false 表示下游已死、停止
 	// 保活(折叠本身继续,由 clientGone 语义收尾)。nil 关闭保活。回调运行在独立
 	// goroutine,与 forward 并发,由调用方负责写路径互斥;首个真实字节写出前
 	// 是否跳过也由回调自行判断(提前写会提交 200 header)。
 	keepalive func() bool
-	// keepaliveInterval 保活间隔;<=0 用 continueKeepaliveInterval。测试用。
+	// keepaliveInterval 保活间隔;<=0 禁用。测试用。
 	keepaliveInterval time.Duration
 }
 
@@ -484,23 +479,18 @@ func runContinueThinkingFold(firstResp *http.Response, f *continueFold) continue
 	st := &foldState{}
 	var result continueFoldResult
 
-	// 保活循环只在确认进入隐藏续想后启动(首轮命中指纹、决定续想的那一刻),
-	// 单纯透传的首轮不启动——正常路径零变化。停止时同步等 goroutine 退出,
+	// 保活覆盖整个折叠周期，包括可能长时间无输出的首轮。停止时同步等 goroutine 退出,
 	// 保证 fold 返回后不会再有保活回调与收尾 flush 并发。
 	var keepaliveStop, keepaliveDone chan struct{}
 	startKeepalive := func() {
-		if f.keepalive == nil || keepaliveStop != nil {
+		if f.keepalive == nil || f.keepaliveInterval <= 0 || keepaliveStop != nil {
 			return
-		}
-		interval := f.keepaliveInterval
-		if interval <= 0 {
-			interval = continueKeepaliveInterval
 		}
 		keepaliveStop = make(chan struct{})
 		keepaliveDone = make(chan struct{})
 		go func() {
 			defer close(keepaliveDone)
-			ticker := time.NewTicker(interval)
+			ticker := time.NewTicker(f.keepaliveInterval)
 			defer ticker.Stop()
 			for {
 				select {
@@ -514,6 +504,7 @@ func runContinueThinkingFold(firstResp *http.Response, f *continueFold) continue
 			}
 		}()
 	}
+	startKeepalive()
 	defer func() {
 		if keepaliveStop != nil {
 			close(keepaliveStop)
@@ -603,9 +594,6 @@ func runContinueThinkingFold(firstResp *http.Response, f *continueFold) continue
 			result.StopReason = stopReason
 			return result
 		}
-
-		// 续想确认:从现在起进入隐藏轮,启动下游保活(幂等,多轮只启一次)。
-		startKeepalive()
 
 		// 续想：本轮 reasoning 剥 id 后连同 marker 追加到回放尾巴。
 		for _, ritem := range outcome.roundReasoning {

--- a/proxy/continue_thinking_test.go
+++ b/proxy/continue_thinking_test.go
@@ -28,6 +28,18 @@ func sseResponse(events ...string) *http.Response {
 	return &http.Response{StatusCode: http.StatusOK, Body: sseBody(events...)}
 }
 
+func delayedSSEResponse(delay time.Duration, events ...string) *http.Response {
+	reader, writer := io.Pipe()
+	payload := sseBody(events...)
+	go func() {
+		defer writer.Close()
+		defer payload.Close()
+		time.Sleep(delay)
+		_, _ = io.Copy(writer, payload)
+	}()
+	return &http.Response{StatusCode: http.StatusOK, Body: reader}
+}
+
 func evCreated() string {
 	return `{"type":"response.created","sequence_number":0,"response":{"id":"resp_r1","created_at":1700000000,"status":"in_progress"}}`
 }
@@ -704,26 +716,47 @@ func TestFoldKeepaliveFiresDuringHiddenRoundAndStopsAfterFold(t *testing.T) {
 	}
 }
 
-func TestFoldKeepaliveNotStartedOnCleanSingleRound(t *testing.T) {
+func TestFoldKeepaliveFiresDuringCleanFirstRoundAndStops(t *testing.T) {
 	var counter atomic.Int32
 	f := keepaliveFold(t, &counter, func() bool { return true }, 0, nil)
 	f.openRound = func([]byte) (*http.Response, error) {
 		t.Fatal("未命中指纹不应开续想轮")
 		return nil, nil
 	}
-
-	res := runContinueThinkingFold(sseResponse(
+	resp := delayedSSEResponse(30*time.Millisecond,
 		evCreated(),
 		evReasoningAdded(1, 0),
 		evReasoningDone(2, 0, "enc-a"),
 		evCompleted(3, 100, 600, 400), // 400 不命中指纹
+	)
+
+	res := runContinueThinkingFold(resp, f)
+	if res.StopReason != continueStopClean || res.RoundsRun != 1 {
+		t.Fatalf("unexpected result: %+v", res)
+	}
+	after := counter.Load()
+	if after < 1 {
+		t.Fatalf("首轮延迟 30ms、间隔 10ms，保活至少应触发 1 次, got %d", after)
+	}
+	time.Sleep(20 * time.Millisecond)
+	if got := counter.Load(); got != after {
+		t.Fatalf("fold 返回后保活仍在触发: %d -> %d", after, got)
+	}
+}
+
+func TestFoldKeepaliveDisabledAtZeroInterval(t *testing.T) {
+	var counter atomic.Int32
+	f := keepaliveFold(t, &counter, func() bool { return true }, 0, nil)
+	f.keepaliveInterval = 0
+	res := runContinueThinkingFold(delayedSSEResponse(30*time.Millisecond,
+		evCreated(),
+		evCompleted(1, 100, 600, 400),
 	), f)
 	if res.StopReason != continueStopClean || res.RoundsRun != 1 {
 		t.Fatalf("unexpected result: %+v", res)
 	}
-	time.Sleep(30 * time.Millisecond)
 	if got := counter.Load(); got != 0 {
-		t.Fatalf("单轮干净结束不进隐藏轮,保活不应触发, got %d", got)
+		t.Fatalf("间隔为 0 时不应触发保活, got %d", got)
 	}
 }
 

--- a/proxy/continue_thinking_test.go
+++ b/proxy/continue_thinking_test.go
@@ -24,10 +24,12 @@ func sseBody(events ...string) io.ReadCloser {
 	return io.NopCloser(strings.NewReader(b.String()))
 }
 
+// sseResponse 构造包含给定事件的成功测试 SSE 响应。
 func sseResponse(events ...string) *http.Response {
 	return &http.Response{StatusCode: http.StatusOK, Body: sseBody(events...)}
 }
 
+// delayedSSEResponse 返回在指定延迟后写入事件的测试 SSE 响应。
 func delayedSSEResponse(delay time.Duration, events ...string) *http.Response {
 	reader, writer := io.Pipe()
 	payload := sseBody(events...)
@@ -696,6 +698,8 @@ func cleanSecondRound() *http.Response {
 	)
 }
 
+// TestFoldKeepaliveFiresDuringHiddenRoundAndStopsAfterFold 验证隐藏续想轮等待期间会保活，
+// 且整个折叠结束后停止回调。
 func TestFoldKeepaliveFiresDuringHiddenRoundAndStopsAfterFold(t *testing.T) {
 	var counter atomic.Int32
 	f := keepaliveFold(t, &counter, func() bool { return true }, 80*time.Millisecond, cleanSecondRound())
@@ -716,6 +720,8 @@ func TestFoldKeepaliveFiresDuringHiddenRoundAndStopsAfterFold(t *testing.T) {
 	}
 }
 
+// TestFoldKeepaliveFiresDuringCleanFirstRoundAndStops 验证首轮静默期间会发送保活，
+// 且折叠结束后保活协程会停止。
 func TestFoldKeepaliveFiresDuringCleanFirstRoundAndStops(t *testing.T) {
 	var counter atomic.Int32
 	f := keepaliveFold(t, &counter, func() bool { return true }, 0, nil)
@@ -744,6 +750,7 @@ func TestFoldKeepaliveFiresDuringCleanFirstRoundAndStops(t *testing.T) {
 	}
 }
 
+// TestFoldKeepaliveDisabledAtZeroInterval 验证保活间隔为零时不会启动心跳。
 func TestFoldKeepaliveDisabledAtZeroInterval(t *testing.T) {
 	var counter atomic.Int32
 	f := keepaliveFold(t, &counter, func() bool { return true }, 0, nil)

--- a/proxy/continuous_retry_keepalive.go
+++ b/proxy/continuous_retry_keepalive.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/codex2api/auth"
@@ -26,6 +27,7 @@ type continuousRetryKeepalive interface {
 type continuousRetryKeepaliveContextKey struct{}
 
 type requestContinuousRetryKeepalive struct {
+	mu     sync.Mutex
 	active bool
 	last   time.Time
 	write  func() error
@@ -33,17 +35,23 @@ type requestContinuousRetryKeepalive struct {
 }
 
 func (k *requestContinuousRetryKeepalive) Activate() {
-	if k != nil && !k.active {
+	if k == nil {
+		return
+	}
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	if !k.active {
 		k.active = true
-		// Start the heartbeat window when unlimited retry actually begins.
-		// Short backoff calls then accumulate toward the same deadline instead
-		// of restarting a fresh interval on every retry.
+		// 从请求具备下游保活资格时开始计时；后续短等待共用同一时间窗，
+		// 不在每次重试时重新开始一个完整周期。
 		k.last = time.Now()
 	}
 }
 
 func (k *requestContinuousRetryKeepalive) Deactivate() {
 	if k != nil {
+		k.mu.Lock()
+		defer k.mu.Unlock()
 		k.active = false
 	}
 }
@@ -57,11 +65,21 @@ func (k *requestContinuousRetryKeepalive) SetActive(active bool) {
 }
 
 func (k *requestContinuousRetryKeepalive) Active() bool {
-	return k != nil && k.active
+	if k == nil {
+		return false
+	}
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	return k.active
 }
 
 func (k *requestContinuousRetryKeepalive) Keepalive() error {
-	if k == nil || !k.active || k.write == nil {
+	if k == nil {
+		return nil
+	}
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	if !k.active || k.write == nil {
 		return nil
 	}
 	if continuousRetryKeepaliveInterval <= 0 {
@@ -120,16 +138,14 @@ func installContinuousRetrySSEKeepaliveWithOptions(c *gin.Context, stream bool, 
 	if options.payload == "" {
 		options.payload = continuousRetryKeepaliveComment
 	}
-	informationalWriter, supportsInformational := unwrapHTTPResponseWriter(responseWriter)
 	original := c.Request
 	requestCtx, cancel := context.WithCancelCause(original.Context())
 	keepalive := &requestContinuousRetryKeepalive{write: func() error {
 		setSSEStreamHeaders(c, options.contentType)
 		if !c.Writer.Written() {
-			if supportsInformational {
-				informationalWriter.WriteHeader(http.StatusProcessing)
-			}
-			return nil
+			// Cloudflare 对 102 之后的最终响应仍有 125s 限制；长期保活
+			// 必须建立 SSE 200，再持续写入协议内心跳帧。
+			c.Writer.WriteHeaderNow()
 		}
 		if _, err := io.WriteString(responseWriter, options.payload); err != nil {
 			return err
@@ -248,7 +264,12 @@ func continuousRetryKeepaliveDelay(keepalive continuousRetryKeepalive) time.Dura
 		return 0
 	}
 	requestKeepalive, ok := keepalive.(*requestContinuousRetryKeepalive)
-	if !ok || requestKeepalive.last.IsZero() {
+	if !ok {
+		return continuousRetryKeepaliveInterval
+	}
+	requestKeepalive.mu.Lock()
+	defer requestKeepalive.mu.Unlock()
+	if requestKeepalive.last.IsZero() {
 		return continuousRetryKeepaliveInterval
 	}
 	delay := continuousRetryKeepaliveInterval - time.Since(requestKeepalive.last)
@@ -291,7 +312,7 @@ func executeHTTPWithContinuousRetryKeepalive(ctx context.Context, execute func()
 	if execute == nil {
 		return nil, errors.New("nil upstream executor")
 	}
-	if keepalive == nil || !keepalive.Active() || continuousRetryKeepaliveInterval <= 0 {
+	if keepalive == nil || continuousRetryKeepaliveInterval <= 0 {
 		return execute()
 	}
 
@@ -316,8 +337,10 @@ func executeHTTPWithContinuousRetryKeepalive(ctx context.Context, execute func()
 			stopContinuousRetryTimer(timer)
 			return callResult.response, callResult.err
 		case <-timer.C:
-			if err := keepalive.Keepalive(); err != nil {
-				return nil, err
+			if keepalive.Active() {
+				if err := keepalive.Keepalive(); err != nil {
+					return nil, err
+				}
 			}
 		case <-ctx.Done():
 			stopContinuousRetryTimer(timer)

--- a/proxy/continuous_retry_keepalive.go
+++ b/proxy/continuous_retry_keepalive.go
@@ -360,6 +360,49 @@ func executeHTTPWithContinuousRetryKeepalive(ctx context.Context, execute func()
 	}
 }
 
+// runWithContinuousRetryKeepalive 在阻塞操作运行期间继续写入请求级保活。
+// 操作结果仍由调用方线程消费，心跳写入失败或请求取消会作为错误返回。
+func runWithContinuousRetryKeepalive[T any](ctx context.Context, operation func() T) (T, error) {
+	var zero T
+	if operation == nil {
+		return zero, errors.New("nil keepalive operation")
+	}
+	keepalive := continuousRetryKeepaliveForContext(ctx)
+	if keepalive == nil || !keepalive.Active() || continuousRetryKeepaliveInterval <= 0 {
+		return operation(), nil
+	}
+	result := make(chan T, 1)
+	go func() { result <- operation() }()
+	for {
+		delay := continuousRetryKeepaliveDelay(keepalive)
+		if delay <= 0 {
+			if err := keepalive.Keepalive(); err != nil {
+				return <-result, err
+			}
+			delay = continuousRetryKeepaliveDelay(keepalive)
+			if delay <= 0 {
+				delay = continuousRetryKeepaliveInterval
+			}
+		}
+		timer := time.NewTimer(delay)
+		select {
+		case value := <-result:
+			stopContinuousRetryTimer(timer)
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return value, continuousRetryContextError(ctx)
+			}
+			return value, nil
+		case <-timer.C:
+			if err := keepalive.Keepalive(); err != nil {
+				return <-result, err
+			}
+		case <-ctx.Done():
+			stopContinuousRetryTimer(timer)
+			return <-result, continuousRetryContextError(ctx)
+		}
+	}
+}
+
 type continuousRetryReadResult struct {
 	data []byte
 	err  error

--- a/proxy/continuous_retry_keepalive.go
+++ b/proxy/continuous_retry_keepalive.go
@@ -11,12 +11,11 @@ import (
 
 	"github.com/codex2api/auth"
 	"github.com/gin-gonic/gin"
-	"github.com/gorilla/websocket"
 )
 
-const continuousRetryKeepaliveComment = ": keepalive\n\n"
+const continuousRetryKeepaliveComment = downstreamSSEKeepaliveComment
 
-var continuousRetryKeepaliveInterval = 15 * time.Second
+var continuousRetryKeepaliveInterval = downstreamSSEKeepaliveInterval
 
 type continuousRetryKeepalive interface {
 	Activate()
@@ -43,12 +42,29 @@ func (k *requestContinuousRetryKeepalive) Activate() {
 	}
 }
 
+func (k *requestContinuousRetryKeepalive) Deactivate() {
+	if k != nil {
+		k.active = false
+	}
+}
+
+func (k *requestContinuousRetryKeepalive) SetActive(active bool) {
+	if active {
+		k.Activate()
+		return
+	}
+	k.Deactivate()
+}
+
 func (k *requestContinuousRetryKeepalive) Active() bool {
 	return k != nil && k.active
 }
 
 func (k *requestContinuousRetryKeepalive) Keepalive() error {
 	if k == nil || !k.active || k.write == nil {
+		return nil
+	}
+	if continuousRetryKeepaliveInterval <= 0 {
 		return nil
 	}
 	if !k.last.IsZero() && time.Since(k.last) < continuousRetryKeepaliveInterval {
@@ -65,23 +81,60 @@ func (k *requestContinuousRetryKeepalive) Keepalive() error {
 }
 
 func installContinuousRetrySSEKeepalive(c *gin.Context, stream bool, contentType string) func() {
-	if c == nil || c.Request == nil || c.Writer == nil || !stream {
+	return installContinuousRetrySSEKeepaliveWithOptions(c, stream, continuousRetrySSEKeepaliveOptions{
+		contentType: contentType,
+		payload:     continuousRetryKeepaliveComment,
+	})
+}
+
+// installContinuousRetryMessagesKeepalive 使用 Messages 协议要求的 ping 事件。
+func installContinuousRetryMessagesKeepalive(c *gin.Context, stream bool) func() {
+	return installContinuousRetrySSEKeepaliveWithOptions(c, stream, continuousRetrySSEKeepaliveOptions{
+		contentType: "text/event-stream; charset=utf-8",
+		payload:     downstreamMessagesKeepaliveEvent,
+	})
+}
+
+type continuousRetrySSEKeepaliveOptions struct {
+	contentType string
+	payload     string
+}
+
+func installContinuousRetrySSEKeepaliveWithOptions(c *gin.Context, stream bool, options continuousRetrySSEKeepaliveOptions) func() {
+	if !stream {
+		return installContinuousRetryHTTPInformationalKeepalive(c)
+	}
+	if c == nil || c.Request == nil || c.Writer == nil {
 		return func() {}
 	}
-	if _, ok := c.Writer.(http.Flusher); !ok {
+	responseWriter, ok := c.Writer.(http.ResponseWriter)
+	if !ok {
 		return func() {}
 	}
-	if contentType == "" {
-		contentType = "text/event-stream"
+	if _, ok := responseWriter.(http.Flusher); !ok {
+		return func() {}
 	}
+	if options.contentType == "" {
+		options.contentType = "text/event-stream"
+	}
+	if options.payload == "" {
+		options.payload = continuousRetryKeepaliveComment
+	}
+	informationalWriter, supportsInformational := unwrapHTTPResponseWriter(responseWriter)
 	original := c.Request
 	requestCtx, cancel := context.WithCancelCause(original.Context())
 	keepalive := &requestContinuousRetryKeepalive{write: func() error {
-		setSSEStreamHeaders(c, contentType)
-		if _, err := c.Writer.WriteString(continuousRetryKeepaliveComment); err != nil {
+		setSSEStreamHeaders(c, options.contentType)
+		if !c.Writer.Written() {
+			if supportsInformational {
+				informationalWriter.WriteHeader(http.StatusProcessing)
+			}
+			return nil
+		}
+		if _, err := io.WriteString(responseWriter, options.payload); err != nil {
 			return err
 		}
-		if flusher, ok := c.Writer.(http.Flusher); ok {
+		if flusher, ok := responseWriter.(http.Flusher); ok {
 			flusher.Flush()
 		}
 		return nil
@@ -91,6 +144,24 @@ func installContinuousRetrySSEKeepalive(c *gin.Context, stream bool, contentType
 		cancel(nil)
 		c.Request = original
 	}
+}
+
+func unwrapHTTPResponseWriter(writer http.ResponseWriter) (http.ResponseWriter, bool) {
+	if writer == nil {
+		return nil, false
+	}
+	for depth := 0; depth < 8; depth++ {
+		unwrapper, ok := writer.(interface{ Unwrap() http.ResponseWriter })
+		if !ok {
+			return writer, depth > 0
+		}
+		next := unwrapper.Unwrap()
+		if next == nil {
+			return nil, false
+		}
+		writer = next
+	}
+	return nil, false
 }
 
 // installContinuousRetryHTTPInformationalKeepalive installs a non-committing
@@ -107,25 +178,8 @@ func installContinuousRetryHTTPInformationalKeepalive(c *gin.Context) func() {
 	if !ok {
 		return func() {}
 	}
-	// Gin exposes one Unwrap layer, but middleware may add another. Resolve a
-	// short chain while refusing to guess when the final writer is unknown.
-	unwrapped := false
-	for depth := 0; depth < 8; depth++ {
-		unwrapper, canUnwrap := writer.(interface{ Unwrap() http.ResponseWriter })
-		if !canUnwrap {
-			break
-		}
-		next := unwrapper.Unwrap()
-		if next == nil {
-			return func() {}
-		}
-		writer = next
-		unwrapped = true
-	}
+	writer, unwrapped := unwrapHTTPResponseWriter(writer)
 	if !unwrapped {
-		return func() {}
-	}
-	if _, stillWrapped := writer.(interface{ Unwrap() http.ResponseWriter }); stillWrapped {
 		return func() {}
 	}
 	original := c.Request
@@ -139,22 +193,6 @@ func installContinuousRetryHTTPInformationalKeepalive(c *gin.Context) func() {
 		},
 		cancel: cancel,
 	}
-	c.Request = original.WithContext(context.WithValue(requestCtx, continuousRetryKeepaliveContextKey{}, continuousRetryKeepalive(keepalive)))
-	return func() {
-		cancel(nil)
-		c.Request = original
-	}
-}
-
-func installContinuousRetryWSKeepalive(c *gin.Context, conn *websocket.Conn) func() {
-	if c == nil || c.Request == nil || conn == nil {
-		return func() {}
-	}
-	original := c.Request
-	requestCtx, cancel := context.WithCancelCause(original.Context())
-	keepalive := &requestContinuousRetryKeepalive{write: func() error {
-		return conn.WriteControl(websocket.PingMessage, []byte("continuous-retry"), time.Now().Add(responsesWSWriteTimeout))
-	}, cancel: cancel}
 	c.Request = original.WithContext(context.WithValue(requestCtx, continuousRetryKeepaliveContextKey{}, continuousRetryKeepalive(keepalive)))
 	return func() {
 		cancel(nil)

--- a/proxy/continuous_retry_keepalive.go
+++ b/proxy/continuous_retry_keepalive.go
@@ -34,6 +34,7 @@ type requestContinuousRetryKeepalive struct {
 	cancel context.CancelCauseFunc
 }
 
+// Activate 开始请求级保活时间窗；重复激活不会重置已有时间窗。
 func (k *requestContinuousRetryKeepalive) Activate() {
 	if k == nil {
 		return
@@ -48,6 +49,7 @@ func (k *requestContinuousRetryKeepalive) Activate() {
 	}
 }
 
+// Deactivate 停止请求级保活，但保留请求上下文供调用方收尾。
 func (k *requestContinuousRetryKeepalive) Deactivate() {
 	if k != nil {
 		k.mu.Lock()
@@ -56,6 +58,7 @@ func (k *requestContinuousRetryKeepalive) Deactivate() {
 	}
 }
 
+// SetActive 根据端点协议开关启用或停用请求级保活。
 func (k *requestContinuousRetryKeepalive) SetActive(active bool) {
 	if active {
 		k.Activate()
@@ -64,6 +67,7 @@ func (k *requestContinuousRetryKeepalive) SetActive(active bool) {
 	k.Deactivate()
 }
 
+// Active 报告请求级保活当前是否处于激活状态。
 func (k *requestContinuousRetryKeepalive) Active() bool {
 	if k == nil {
 		return false
@@ -73,6 +77,7 @@ func (k *requestContinuousRetryKeepalive) Active() bool {
 	return k.active
 }
 
+// Keepalive 在心跳到期时写入一次协议保活，并在写失败时取消请求。
 func (k *requestContinuousRetryKeepalive) Keepalive() error {
 	if k == nil {
 		return nil
@@ -98,6 +103,7 @@ func (k *requestContinuousRetryKeepalive) Keepalive() error {
 	return nil
 }
 
+// installContinuousRetrySSEKeepalive 为流式端点安装 SSE 注释保活，非流式端点转用 102。
 func installContinuousRetrySSEKeepalive(c *gin.Context, stream bool, contentType string) func() {
 	return installContinuousRetrySSEKeepaliveWithOptions(c, stream, continuousRetrySSEKeepaliveOptions{
 		contentType: contentType,
@@ -118,6 +124,7 @@ type continuousRetrySSEKeepaliveOptions struct {
 	payload     string
 }
 
+// installContinuousRetrySSEKeepaliveWithOptions 安装带指定内容类型和心跳载荷的请求保活。
 func installContinuousRetrySSEKeepaliveWithOptions(c *gin.Context, stream bool, options continuousRetrySSEKeepaliveOptions) func() {
 	if !stream {
 		return installContinuousRetryHTTPInformationalKeepalive(c)
@@ -162,6 +169,7 @@ func installContinuousRetrySSEKeepaliveWithOptions(c *gin.Context, stream bool, 
 	}
 }
 
+// unwrapHTTPResponseWriter 解开中间件包装的 ResponseWriter，并报告是否发生了解包。
 func unwrapHTTPResponseWriter(writer http.ResponseWriter) (http.ResponseWriter, bool) {
 	if writer == nil {
 		return nil, false
@@ -252,6 +260,7 @@ func activateContinuousRetryKeepaliveForLimit(ctx context.Context, retryLimit in
 	}
 }
 
+// continuousRetryKeepaliveActive 报告上下文中的请求级保活是否已激活。
 func continuousRetryKeepaliveActive(ctx context.Context) bool {
 	if keepalive := continuousRetryKeepaliveForContext(ctx); keepalive != nil {
 		return keepalive.Active()
@@ -259,6 +268,7 @@ func continuousRetryKeepaliveActive(ctx context.Context) bool {
 	return false
 }
 
+// continuousRetryKeepaliveDelay 计算距离下一次请求级心跳的剩余等待时间。
 func continuousRetryKeepaliveDelay(keepalive continuousRetryKeepalive) time.Duration {
 	if continuousRetryKeepaliveInterval <= 0 {
 		return 0
@@ -289,6 +299,7 @@ func continuousRetryContextError(ctx context.Context) error {
 	return ctx.Err()
 }
 
+// stopContinuousRetryTimer 停止计时器并清空可能已排队的计时事件。
 func stopContinuousRetryTimer(timer *time.Timer) {
 	if timer == nil || timer.Stop() {
 		return

--- a/proxy/continuous_retry_keepalive_test.go
+++ b/proxy/continuous_retry_keepalive_test.go
@@ -21,6 +21,19 @@ type recordingContinuousRetryKeepalive struct {
 	err    error
 }
 
+type informationalRecordingWriter struct {
+	*httptest.ResponseRecorder
+	informational []int
+}
+
+func (w *informationalRecordingWriter) WriteHeader(code int) {
+	if code >= http.StatusContinue && code < http.StatusOK {
+		w.informational = append(w.informational, code)
+		return
+	}
+	w.ResponseRecorder.WriteHeader(code)
+}
+
 func (k *recordingContinuousRetryKeepalive) Activate() { k.active = true }
 func (k *recordingContinuousRetryKeepalive) Active() bool {
 	return k.active
@@ -61,6 +74,18 @@ func TestRequestContinuousRetryKeepaliveAccumulatesShortWaits(t *testing.T) {
 	}
 	if writes != 1 {
 		t.Fatalf("due heartbeat writes = %d, want 1", writes)
+	}
+}
+
+func TestSetContinuousRetryKeepaliveActive(t *testing.T) {
+	keepalive := &requestContinuousRetryKeepalive{}
+	keepalive.SetActive(true)
+	if !keepalive.Active() {
+		t.Fatal("keepalive was not activated")
+	}
+	keepalive.SetActive(false)
+	if keepalive.Active() {
+		t.Fatal("keepalive was not deactivated")
 	}
 }
 
@@ -267,6 +292,8 @@ func TestContinuousRetrySSEKeepaliveAndCommittedErrors(t *testing.T) {
 	}
 	keepalive.Activate()
 	keepalive.last = time.Time{}
+	setSSEStreamHeaders(c, "text/event-stream")
+	c.Writer.WriteHeaderNow()
 	if err := keepalive.Keepalive(); err != nil {
 		t.Fatalf("write SSE heartbeat: %v", err)
 	}
@@ -282,6 +309,64 @@ func TestContinuousRetrySSEKeepaliveAndCommittedErrors(t *testing.T) {
 	}
 	if body := recorder.Body.String(); !strings.Contains(body, `"type":"response.failed"`) || !strings.Contains(body, "upstream failed") {
 		t.Fatalf("committed Responses SSE error = %q", body)
+	}
+}
+
+func TestContinuousRetryMessagesKeepaliveWritesPingAfterCommit(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+	stop := installContinuousRetryMessagesKeepalive(c, true)
+	defer stop()
+
+	keepalive, ok := continuousRetryKeepaliveForContext(c.Request.Context()).(*requestContinuousRetryKeepalive)
+	if !ok {
+		t.Fatal("Messages heartbeat was not installed")
+	}
+	keepalive.Activate()
+	keepalive.last = time.Time{}
+	setSSEStreamHeaders(c, "text/event-stream; charset=utf-8")
+	c.Writer.WriteHeaderNow()
+	if err := keepalive.Keepalive(); err != nil {
+		t.Fatalf("write Messages heartbeat: %v", err)
+	}
+	if got := recorder.Body.String(); got != downstreamMessagesKeepaliveEvent {
+		t.Fatalf("Messages heartbeat body = %q, want %q", got, downstreamMessagesKeepaliveEvent)
+	}
+}
+
+func TestContinuousRetrySSEKeepaliveUsesHTTP102BeforeCommit(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := &informationalRecordingWriter{ResponseRecorder: httptest.NewRecorder()}
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	stop := installContinuousRetrySSEKeepalive(c, true, "text/event-stream")
+	defer stop()
+	keepalive, ok := continuousRetryKeepaliveForContext(c.Request.Context()).(*requestContinuousRetryKeepalive)
+	if !ok {
+		t.Fatal("SSE heartbeat was not installed")
+	}
+	keepalive.Activate()
+	keepalive.last = time.Time{}
+	if err := keepalive.Keepalive(); err != nil {
+		t.Fatalf("write informational heartbeat: %v", err)
+	}
+	if len(recorder.informational) != 1 || recorder.informational[0] != http.StatusProcessing {
+		t.Fatalf("informational statuses = %v, want [%d]", recorder.informational, http.StatusProcessing)
+	}
+	if recorder.Body.Len() != 0 {
+		t.Fatalf("pre-commit SSE body = %q, want empty", recorder.Body.String())
+	}
+
+	setSSEStreamHeaders(c, "text/event-stream")
+	c.Writer.WriteHeaderNow()
+	keepalive.last = time.Time{}
+	if err := keepalive.Keepalive(); err != nil {
+		t.Fatalf("write committed heartbeat: %v", err)
+	}
+	if got := recorder.Body.String(); got != continuousRetryKeepaliveComment {
+		t.Fatalf("committed SSE body = %q, want %q", got, continuousRetryKeepaliveComment)
 	}
 }
 

--- a/proxy/continuous_retry_keepalive_test.go
+++ b/proxy/continuous_retry_keepalive_test.go
@@ -242,6 +242,30 @@ func TestExecuteHTTPWithContinuousRetryKeepaliveWhileWaitingForHeaders(t *testin
 	}
 }
 
+// TestRunWithContinuousRetryKeepaliveDuringBlockingOperation 验证阻塞操作期间保活仍持续触发。
+func TestRunWithContinuousRetryKeepaliveDuringBlockingOperation(t *testing.T) {
+	previousInterval := continuousRetryKeepaliveInterval
+	continuousRetryKeepaliveInterval = 5 * time.Millisecond
+	t.Cleanup(func() { continuousRetryKeepaliveInterval = previousInterval })
+
+	keepalive := &recordingContinuousRetryKeepalive{}
+	keepalive.Activate()
+	ctx := contextWithContinuousRetryKeepalive(keepalive)
+	value, err := runWithContinuousRetryKeepalive(ctx, func() string {
+		time.Sleep(35 * time.Millisecond)
+		return "done"
+	})
+	if err != nil {
+		t.Fatalf("run blocking operation: %v", err)
+	}
+	if value != "done" {
+		t.Fatalf("operation result = %q, want done", value)
+	}
+	if keepalive.writes < 2 {
+		t.Fatalf("heartbeat writes = %d, want at least 2", keepalive.writes)
+	}
+}
+
 func TestReadSSEStreamWithContinuousRetryKeepaliveWhileWaitingForFrame(t *testing.T) {
 	previousInterval := continuousRetryKeepaliveInterval
 	continuousRetryKeepaliveInterval = time.Millisecond

--- a/proxy/continuous_retry_keepalive_test.go
+++ b/proxy/continuous_retry_keepalive_test.go
@@ -26,6 +26,7 @@ type informationalRecordingWriter struct {
 	informational []int
 }
 
+// WriteHeader 记录信息响应，其他状态码交给 ResponseRecorder 处理。
 func (w *informationalRecordingWriter) WriteHeader(code int) {
 	if code >= http.StatusContinue && code < http.StatusOK {
 		w.informational = append(w.informational, code)
@@ -47,6 +48,7 @@ func contextWithContinuousRetryKeepalive(keepalive continuousRetryKeepalive) con
 	return context.WithValue(context.Background(), continuousRetryKeepaliveContextKey{}, keepalive)
 }
 
+// TestRequestContinuousRetryKeepaliveAccumulatesShortWaits 验证短等待共用同一心跳时间窗。
 func TestRequestContinuousRetryKeepaliveAccumulatesShortWaits(t *testing.T) {
 	previousInterval := continuousRetryKeepaliveInterval
 	continuousRetryKeepaliveInterval = time.Minute
@@ -77,6 +79,7 @@ func TestRequestContinuousRetryKeepaliveAccumulatesShortWaits(t *testing.T) {
 	}
 }
 
+// TestSetContinuousRetryKeepaliveActive 验证请求级保活可以切换激活状态。
 func TestSetContinuousRetryKeepaliveActive(t *testing.T) {
 	keepalive := &requestContinuousRetryKeepalive{}
 	keepalive.SetActive(true)
@@ -278,6 +281,7 @@ func TestReadSSEStreamWithContinuousRetryKeepaliveWhileWaitingForFrame(t *testin
 	}
 }
 
+// TestContinuousRetrySSEKeepaliveAndCommittedErrors 验证已提交 SSE 可同时承载心跳和错误事件。
 func TestContinuousRetrySSEKeepaliveAndCommittedErrors(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	recorder := httptest.NewRecorder()
@@ -312,6 +316,7 @@ func TestContinuousRetrySSEKeepaliveAndCommittedErrors(t *testing.T) {
 	}
 }
 
+// TestContinuousRetryMessagesKeepaliveWritesPingAfterCommit 验证 Messages 使用原生 ping 事件保活。
 func TestContinuousRetryMessagesKeepaliveWritesPingAfterCommit(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	recorder := httptest.NewRecorder()
@@ -336,6 +341,7 @@ func TestContinuousRetryMessagesKeepaliveWritesPingAfterCommit(t *testing.T) {
 	}
 }
 
+// TestContinuousRetrySSEKeepaliveCommitsHeartbeatBeforeFirstEvent 验证首个心跳会先提交 SSE 200。
 func TestContinuousRetrySSEKeepaliveCommitsHeartbeatBeforeFirstEvent(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	recorder := httptest.NewRecorder()

--- a/proxy/continuous_retry_keepalive_test.go
+++ b/proxy/continuous_retry_keepalive_test.go
@@ -336,9 +336,9 @@ func TestContinuousRetryMessagesKeepaliveWritesPingAfterCommit(t *testing.T) {
 	}
 }
 
-func TestContinuousRetrySSEKeepaliveUsesHTTP102BeforeCommit(t *testing.T) {
+func TestContinuousRetrySSEKeepaliveCommitsHeartbeatBeforeFirstEvent(t *testing.T) {
 	gin.SetMode(gin.TestMode)
-	recorder := &informationalRecordingWriter{ResponseRecorder: httptest.NewRecorder()}
+	recorder := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(recorder)
 	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
 	stop := installContinuousRetrySSEKeepalive(c, true, "text/event-stream")
@@ -350,23 +350,21 @@ func TestContinuousRetrySSEKeepaliveUsesHTTP102BeforeCommit(t *testing.T) {
 	keepalive.Activate()
 	keepalive.last = time.Time{}
 	if err := keepalive.Keepalive(); err != nil {
-		t.Fatalf("write informational heartbeat: %v", err)
+		t.Fatalf("write initial heartbeat: %v", err)
 	}
-	if len(recorder.informational) != 1 || recorder.informational[0] != http.StatusProcessing {
-		t.Fatalf("informational statuses = %v, want [%d]", recorder.informational, http.StatusProcessing)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", recorder.Code)
 	}
-	if recorder.Body.Len() != 0 {
-		t.Fatalf("pre-commit SSE body = %q, want empty", recorder.Body.String())
+	if got := recorder.Body.String(); got != continuousRetryKeepaliveComment {
+		t.Fatalf("initial SSE heartbeat = %q, want %q", got, continuousRetryKeepaliveComment)
 	}
 
-	setSSEStreamHeaders(c, "text/event-stream")
-	c.Writer.WriteHeaderNow()
 	keepalive.last = time.Time{}
 	if err := keepalive.Keepalive(); err != nil {
 		t.Fatalf("write committed heartbeat: %v", err)
 	}
-	if got := recorder.Body.String(); got != continuousRetryKeepaliveComment {
-		t.Fatalf("committed SSE body = %q, want %q", got, continuousRetryKeepaliveComment)
+	if got := recorder.Body.String(); got != continuousRetryKeepaliveComment+continuousRetryKeepaliveComment {
+		t.Fatalf("SSE heartbeat body = %q", got)
 	}
 }
 

--- a/proxy/downstream_keepalive.go
+++ b/proxy/downstream_keepalive.go
@@ -18,6 +18,7 @@ const (
 // 变量形式只为处理器级测试缩短等待；生产运行从环境变量读取。
 var downstreamSSEKeepaliveInterval = downstreamSSEKeepaliveIntervalFromEnv()
 
+// downstreamSSEKeepaliveIntervalFromEnv 读取下游 HTTP/SSE 保活周期配置。
 func downstreamSSEKeepaliveIntervalFromEnv() time.Duration {
 	return durationFromEnv("DOWNSTREAM_HTTP_KEEPALIVE_INTERVAL", defaultDownstreamSSEKeepaliveInterval)
 }

--- a/proxy/downstream_keepalive.go
+++ b/proxy/downstream_keepalive.go
@@ -7,15 +7,28 @@ import (
 )
 
 const (
-	// 普通 Responses SSE 在上游长时间只思考、不产出可转发事件时，也要持续
-	// 刷新下游链路的 idle timer。10 秒低于常见的 30/60 秒反代超时，同时
-	// 每分钟仅增加几十字节；SSE 注释不会被 Codex 客户端当作模型输出。
-	defaultDownstreamSSEKeepaliveInterval = 10 * time.Second
-	downstreamSSEKeepaliveComment         = ": keepalive\n\n"
+	// 普通 SSE 在上游长时间只思考、不产出可转发事件时，也要持续刷新下游
+	// 链路的 idle timer。SSE 注释不会被客户端当作模型输出。
+	defaultDownstreamHTTPKeepaliveInterval = 30 * time.Second
+	defaultDownstreamSSEKeepaliveInterval  = defaultDownstreamHTTPKeepaliveInterval
+	downstreamSSEKeepaliveComment          = ": keepalive\n\n"
+	downstreamMessagesKeepaliveEvent       = "event: ping\ndata: {\"type\":\"ping\"}\n\n"
 )
 
-// 变量形式只为处理器级测试缩短等待；生产运行保持默认 10 秒。
-var downstreamSSEKeepaliveInterval = defaultDownstreamSSEKeepaliveInterval
+// 变量形式只为处理器级测试缩短等待；生产运行从环境变量读取。
+var downstreamSSEKeepaliveInterval = downstreamSSEKeepaliveIntervalFromEnv()
+
+func downstreamSSEKeepaliveIntervalFromEnv() time.Duration {
+	return durationFromEnv("DOWNSTREAM_HTTP_KEEPALIVE_INTERVAL", defaultDownstreamSSEKeepaliveInterval)
+}
+
+// ConfigureDownstreamKeepaliveFromEnv 在 config.Load 读取 .env 后刷新保活配置。
+// 进程环境变量仍会在包初始化时生效。
+func ConfigureDownstreamKeepaliveFromEnv() {
+	downstreamSSEKeepaliveInterval = downstreamSSEKeepaliveIntervalFromEnv()
+	continuousRetryKeepaliveInterval = downstreamSSEKeepaliveInterval
+	downstreamWSKeepaliveInterval = downstreamWSKeepaliveIntervalFromEnv()
+}
 
 // startDownstreamSSEKeepalive 周期执行 writeKeepalive，直到请求取消、写失败
 // 或调用 stop。stop 会等待 goroutine 完整退出，保证流收尾后不再并发写入。

--- a/proxy/downstream_keepalive_test.go
+++ b/proxy/downstream_keepalive_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 )
 
+// TestDownstreamSSEKeepaliveIntervalFromEnv 验证 HTTP/SSE 保活周期的默认、覆盖和禁用值。
 func TestDownstreamSSEKeepaliveIntervalFromEnv(t *testing.T) {
 	const fallback = defaultDownstreamSSEKeepaliveInterval
 	tests := []struct {
@@ -30,6 +31,7 @@ func TestDownstreamSSEKeepaliveIntervalFromEnv(t *testing.T) {
 	}
 }
 
+// TestDownstreamMessagesKeepaliveEvent 验证 Messages 使用兼容协议的 ping 事件载荷。
 func TestDownstreamMessagesKeepaliveEvent(t *testing.T) {
 	const want = "event: ping\ndata: {\"type\":\"ping\"}\n\n"
 	if downstreamMessagesKeepaliveEvent != want {

--- a/proxy/downstream_keepalive_test.go
+++ b/proxy/downstream_keepalive_test.go
@@ -7,6 +7,36 @@ import (
 	"time"
 )
 
+func TestDownstreamSSEKeepaliveIntervalFromEnv(t *testing.T) {
+	const fallback = defaultDownstreamSSEKeepaliveInterval
+	tests := []struct {
+		name string
+		raw  string
+		want time.Duration
+	}{
+		{name: "default", want: fallback},
+		{name: "custom", raw: "45s", want: 45 * time.Second},
+		{name: "disabled", raw: "0", want: 0},
+		{name: "invalid", raw: "later", want: fallback},
+		{name: "negative", raw: "-1s", want: fallback},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("DOWNSTREAM_HTTP_KEEPALIVE_INTERVAL", test.raw)
+			if got := downstreamSSEKeepaliveIntervalFromEnv(); got != test.want {
+				t.Fatalf("interval = %s, want %s", got, test.want)
+			}
+		})
+	}
+}
+
+func TestDownstreamMessagesKeepaliveEvent(t *testing.T) {
+	const want = "event: ping\ndata: {\"type\":\"ping\"}\n\n"
+	if downstreamMessagesKeepaliveEvent != want {
+		t.Fatalf("Messages keepalive = %q, want %q", downstreamMessagesKeepaliveEvent, want)
+	}
+}
+
 func TestDownstreamSSEKeepaliveStopsAndJoins(t *testing.T) {
 	var writes atomic.Int32
 	firstWrite := make(chan struct{}, 1)

--- a/proxy/downstream_ws_keepalive.go
+++ b/proxy/downstream_ws_keepalive.go
@@ -1,0 +1,32 @@
+package proxy
+
+import (
+	"context"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+const defaultDownstreamWSKeepaliveInterval = 45 * time.Second
+
+var downstreamWSKeepaliveInterval = downstreamWSKeepaliveIntervalFromEnv()
+
+func downstreamWSKeepaliveIntervalFromEnv() time.Duration {
+	return durationFromEnv("DOWNSTREAM_WS_KEEPALIVE_INTERVAL", defaultDownstreamWSKeepaliveInterval)
+}
+
+func startDownstreamWSKeepalive(ctx context.Context, conn *websocket.Conn, cancel context.CancelFunc) func() {
+	if conn == nil {
+		return func() {}
+	}
+	return startDownstreamSSEKeepalive(ctx, downstreamWSKeepaliveInterval, func() bool {
+		if err := conn.WriteControl(websocket.PingMessage, nil, time.Now().Add(responsesWSWriteTimeout)); err != nil {
+			if cancel != nil {
+				cancel()
+			}
+			_ = conn.Close()
+			return false
+		}
+		return true
+	})
+}

--- a/proxy/downstream_ws_keepalive.go
+++ b/proxy/downstream_ws_keepalive.go
@@ -11,10 +11,12 @@ const defaultDownstreamWSKeepaliveInterval = 45 * time.Second
 
 var downstreamWSKeepaliveInterval = downstreamWSKeepaliveIntervalFromEnv()
 
+// downstreamWSKeepaliveIntervalFromEnv 读取下游 WebSocket Ping 周期配置。
 func downstreamWSKeepaliveIntervalFromEnv() time.Duration {
 	return durationFromEnv("DOWNSTREAM_WS_KEEPALIVE_INTERVAL", defaultDownstreamWSKeepaliveInterval)
 }
 
+// startDownstreamWSKeepalive 周期发送 WebSocket Ping，并在写入失败时取消连接。
 func startDownstreamWSKeepalive(ctx context.Context, conn *websocket.Conn, cancel context.CancelFunc) func() {
 	if conn == nil {
 		return func() {}

--- a/proxy/downstream_ws_keepalive_test.go
+++ b/proxy/downstream_ws_keepalive_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gorilla/websocket"
 )
 
+// TestDownstreamWSKeepaliveIntervalFromEnv 验证 WebSocket Ping 周期的配置解析。
 func TestDownstreamWSKeepaliveIntervalFromEnv(t *testing.T) {
 	const fallback = defaultDownstreamWSKeepaliveInterval
 	for _, test := range []struct {
@@ -29,6 +30,7 @@ func TestDownstreamWSKeepaliveIntervalFromEnv(t *testing.T) {
 	}
 }
 
+// TestStartDownstreamWSKeepaliveSendsPing 验证下游连接能收到空 Ping 控制帧。
 func TestStartDownstreamWSKeepaliveSendsPing(t *testing.T) {
 	serverConn, clientConn, cleanup := newDownstreamWSPair(t)
 	defer cleanup()
@@ -68,6 +70,7 @@ func TestStartDownstreamWSKeepaliveSendsPing(t *testing.T) {
 	}
 }
 
+// TestStartDownstreamWSKeepaliveCancelsOnPingFailure 验证 Ping 写入失败会取消请求上下文。
 func TestStartDownstreamWSKeepaliveCancelsOnPingFailure(t *testing.T) {
 	serverConn, _, cleanup := newDownstreamWSPair(t)
 	defer cleanup()
@@ -87,6 +90,7 @@ func TestStartDownstreamWSKeepaliveCancelsOnPingFailure(t *testing.T) {
 	}
 }
 
+// newDownstreamWSPair 创建用于下游 WebSocket 保活测试的本地连接对。
 func newDownstreamWSPair(t *testing.T) (*websocket.Conn, *websocket.Conn, func()) {
 	t.Helper()
 	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}

--- a/proxy/downstream_ws_keepalive_test.go
+++ b/proxy/downstream_ws_keepalive_test.go
@@ -1,0 +1,119 @@
+package proxy
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+func TestDownstreamWSKeepaliveIntervalFromEnv(t *testing.T) {
+	const fallback = defaultDownstreamWSKeepaliveInterval
+	for _, test := range []struct {
+		raw  string
+		want time.Duration
+	}{
+		{raw: "", want: fallback},
+		{raw: "250ms", want: 250 * time.Millisecond},
+		{raw: "0", want: 0},
+		{raw: "-1s", want: fallback},
+		{raw: "invalid", want: fallback},
+	} {
+		t.Setenv("DOWNSTREAM_WS_KEEPALIVE_INTERVAL", test.raw)
+		if got := downstreamWSKeepaliveIntervalFromEnv(); got != test.want {
+			t.Errorf("interval(%q) = %s, want %s", test.raw, got, test.want)
+		}
+	}
+}
+
+func TestStartDownstreamWSKeepaliveSendsPing(t *testing.T) {
+	serverConn, clientConn, cleanup := newDownstreamWSPair(t)
+	defer cleanup()
+	previous := downstreamWSKeepaliveInterval
+	downstreamWSKeepaliveInterval = time.Millisecond
+	defer func() { downstreamWSKeepaliveInterval = previous }()
+
+	pings := make(chan string, 1)
+	clientConn.SetPingHandler(func(payload string) error {
+		select {
+		case pings <- payload:
+		default:
+		}
+		return nil
+	})
+	go func() {
+		for {
+			if _, _, err := clientConn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	stop := startDownstreamWSKeepalive(ctx, serverConn, cancel)
+	defer func() {
+		cancel()
+		stop()
+	}()
+	select {
+	case payload := <-pings:
+		if payload != "" {
+			t.Fatalf("ping payload = %q, want empty", payload)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("downstream websocket ping was not received")
+	}
+}
+
+func TestStartDownstreamWSKeepaliveCancelsOnPingFailure(t *testing.T) {
+	serverConn, _, cleanup := newDownstreamWSPair(t)
+	defer cleanup()
+	previous := downstreamWSKeepaliveInterval
+	downstreamWSKeepaliveInterval = time.Millisecond
+	defer func() { downstreamWSKeepaliveInterval = previous }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	stop := startDownstreamWSKeepalive(ctx, serverConn, cancel)
+	defer stop()
+	_ = serverConn.Close()
+	select {
+	case <-ctx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("ping failure did not cancel downstream websocket context")
+	}
+}
+
+func newDownstreamWSPair(t *testing.T) (*websocket.Conn, *websocket.Conn, func()) {
+	t.Helper()
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	accepted := make(chan *websocket.Conn, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err == nil {
+			accepted <- conn
+		}
+	}))
+	client, _, err := websocket.DefaultDialer.Dial("ws"+server.URL[len("http"):], nil)
+	if err != nil {
+		server.Close()
+		t.Fatalf("dial websocket pair: %v", err)
+	}
+	var serverConn *websocket.Conn
+	select {
+	case serverConn = <-accepted:
+	case <-time.After(time.Second):
+		_ = client.Close()
+		server.Close()
+		t.Fatal("websocket server did not accept connection")
+	}
+	cleanup := func() {
+		_ = serverConn.Close()
+		_ = client.Close()
+		server.Close()
+	}
+	return serverConn, client, cleanup
+}

--- a/proxy/endpoint_keepalive.go
+++ b/proxy/endpoint_keepalive.go
@@ -1,0 +1,55 @@
+package proxy
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/codex2api/auth"
+)
+
+// readAllLimitedWithContinuousRetryKeepalive 将读取上限与请求级保活组合，
+// 用于非流式成功响应及原生协议 JSON 聚合，避免读体阶段长时间没有下游活动。
+func readAllLimitedWithContinuousRetryKeepalive(ctx context.Context, reader io.Reader, limit int64) ([]byte, error) {
+	if limit < 0 {
+		return nil, fmt.Errorf("response body limit must be non-negative")
+	}
+	body, err := readAllWithContinuousRetryKeepalive(ctx, io.LimitReader(reader, limit+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(body)) > limit {
+		return nil, fmt.Errorf("response body exceeds %d bytes", limit)
+	}
+	return body, nil
+}
+
+// activateAnthropicMessagesKeepalive 在选号后应用 Messages 的 Claude 开关，
+// relay 和 Codex 路径始终启用保活。
+func (h *Handler) activateAnthropicMessagesKeepalive(ctx context.Context, account *auth.Account, stream bool) {
+	var store *auth.Store
+	if h != nil {
+		store = h.store
+	}
+	if stream && (account == nil || account.IsClaudeOAuth()) {
+		setContinuousRetryKeepaliveActive(ctx, store != nil && store.ClaudeStreamKeepaliveEnabled())
+		return
+	}
+	setContinuousRetryKeepaliveActive(ctx, true)
+}
+
+// setContinuousRetryKeepaliveActive 支持重试换号时在 relay 与 Claude OAuth
+// 的不同保活策略之间切换。
+func setContinuousRetryKeepaliveActive(ctx context.Context, active bool) {
+	keepalive := continuousRetryKeepaliveForContext(ctx)
+	if keepalive == nil {
+		return
+	}
+	if controller, ok := keepalive.(interface{ SetActive(bool) }); ok {
+		controller.SetActive(active)
+		return
+	}
+	if active {
+		keepalive.Activate()
+	}
+}

--- a/proxy/executor.go
+++ b/proxy/executor.go
@@ -59,7 +59,7 @@ func durationFromEnv(key string, fallback time.Duration) time.Duration {
 	}
 	d, err := time.ParseDuration(raw)
 	if err != nil || d < 0 {
-		log.Printf("[CodexTransport] %s=%q 非法，沿用默认 %s", key, raw, fallback)
+		log.Printf("[Config] %s=%q 非法，沿用默认 %s", key, raw, fallback)
 		return fallback
 	}
 	return d

--- a/proxy/grok_media.go
+++ b/proxy/grok_media.go
@@ -525,6 +525,7 @@ func (h *Handler) forwardGrokImagesRequest(c *gin.Context, inboundEndpoint, imag
 	defer stopRetryDeadline()
 	stopRetryKeepalive := installContinuousRetryHTTPInformationalKeepalive(c)
 	defer stopRetryKeepalive()
+	activateContinuousRetryKeepalive(c.Request.Context())
 	maxRetries := h.getMaxRetries()
 	generalRetries := 0
 	rateLimitRetries := 0

--- a/proxy/grok_native_passthrough_test.go
+++ b/proxy/grok_native_passthrough_test.go
@@ -232,22 +232,22 @@ func TestForwardGrokNativeFailureBeforeVisibleOutputReturnsProtocolHTTPError(t *
 	}
 }
 
-func TestSendGrokNativeHTTPErrorAfterKeepaliveUsesProtocolEvent(t *testing.T) {
+func TestSendGrokNativeHTTPErrorAfterPrecommitKeepalivePreservesHTTPError(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	tests := []struct {
-		name       string
-		protocol   GrokProtocol
-		path       string
-		wantMarker string
+		name     string
+		protocol GrokProtocol
+		path     string
 	}{
-		{name: "responses", protocol: GrokProtocolResponses, path: "/v1/responses", wantMarker: `"type":"response.failed"`},
-		{name: "chat", protocol: GrokProtocolChatCompletions, path: "/v1/chat/completions", wantMarker: `"type":"upstream_error"`},
-		{name: "messages", protocol: GrokProtocolMessages, path: "/v1/messages", wantMarker: "event: error\n"},
+		{name: "responses", protocol: GrokProtocolResponses, path: "/v1/responses"},
+		{name: "chat", protocol: GrokProtocolChatCompletions, path: "/v1/chat/completions"},
+		{name: "messages", protocol: GrokProtocolMessages, path: "/v1/messages"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			recorder := httptest.NewRecorder()
-			ctx, _ := gin.CreateTestContext(recorder)
+			writer := &informationalRecordingWriter{ResponseRecorder: recorder}
+			ctx, _ := gin.CreateTestContext(writer)
 			ctx.Request = httptest.NewRequest(http.MethodPost, tc.path, nil)
 			stop := installContinuousRetrySSEKeepalive(ctx, true, "text/event-stream")
 			defer stop()
@@ -264,8 +264,11 @@ func TestSendGrokNativeHTTPErrorAfterKeepaliveUsesProtocolEvent(t *testing.T) {
 				failureMessage: "upstream busy",
 			})
 
-			if recorder.Code != http.StatusOK || !strings.Contains(recorder.Body.String(), tc.wantMarker) {
-				t.Fatalf("committed protocol error = status %d body %q", recorder.Code, recorder.Body.String())
+			if len(writer.informational) != 1 || writer.informational[0] != http.StatusProcessing {
+				t.Fatalf("informational statuses = %v, want [%d]", writer.informational, http.StatusProcessing)
+			}
+			if recorder.Code != http.StatusServiceUnavailable || !strings.Contains(recorder.Body.String(), "upstream busy") {
+				t.Fatalf("final HTTP error = status %d body %q", recorder.Code, recorder.Body.String())
 			}
 		})
 	}

--- a/proxy/grok_native_passthrough_test.go
+++ b/proxy/grok_native_passthrough_test.go
@@ -232,7 +232,7 @@ func TestForwardGrokNativeFailureBeforeVisibleOutputReturnsProtocolHTTPError(t *
 	}
 }
 
-func TestSendGrokNativeHTTPErrorAfterPrecommitKeepalivePreservesHTTPError(t *testing.T) {
+func TestSendGrokNativeErrorAfterInitialKeepaliveUsesSSE(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	tests := []struct {
 		name     string
@@ -246,8 +246,7 @@ func TestSendGrokNativeHTTPErrorAfterPrecommitKeepalivePreservesHTTPError(t *tes
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			recorder := httptest.NewRecorder()
-			writer := &informationalRecordingWriter{ResponseRecorder: recorder}
-			ctx, _ := gin.CreateTestContext(writer)
+			ctx, _ := gin.CreateTestContext(recorder)
 			ctx.Request = httptest.NewRequest(http.MethodPost, tc.path, nil)
 			stop := installContinuousRetrySSEKeepalive(ctx, true, "text/event-stream")
 			defer stop()
@@ -264,11 +263,9 @@ func TestSendGrokNativeHTTPErrorAfterPrecommitKeepalivePreservesHTTPError(t *tes
 				failureMessage: "upstream busy",
 			})
 
-			if len(writer.informational) != 1 || writer.informational[0] != http.StatusProcessing {
-				t.Fatalf("informational statuses = %v, want [%d]", writer.informational, http.StatusProcessing)
-			}
-			if recorder.Code != http.StatusServiceUnavailable || !strings.Contains(recorder.Body.String(), "upstream busy") {
-				t.Fatalf("final HTTP error = status %d body %q", recorder.Code, recorder.Body.String())
+			body := recorder.Body.String()
+			if recorder.Code != http.StatusOK || !strings.Contains(body, downstreamSSEKeepaliveComment) || !strings.Contains(body, "upstream busy") {
+				t.Fatalf("committed SSE error = status %d body %q", recorder.Code, body)
 			}
 		})
 	}

--- a/proxy/grok_native_passthrough_test.go
+++ b/proxy/grok_native_passthrough_test.go
@@ -201,6 +201,8 @@ func TestForwardGrokNativeTypelessEventErrorStaysPrivateAcrossProtocols(t *testi
 	}
 }
 
+// TestForwardGrokNativeFailureBeforeVisibleOutputReturnsProtocolHTTPError 验证首个可见事件前
+// 的失败仍返回协议对应的 HTTP 错误，而不会伪造成功流。
 func TestForwardGrokNativeFailureBeforeVisibleOutputReturnsProtocolHTTPError(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	tests := []struct {
@@ -232,6 +234,8 @@ func TestForwardGrokNativeFailureBeforeVisibleOutputReturnsProtocolHTTPError(t *
 	}
 }
 
+// TestSendGrokNativeErrorAfterInitialKeepaliveUsesSSE 验证首个保活提交 SSE 后，
+// Grok 各协议的错误仍以协议事件返回。
 func TestSendGrokNativeErrorAfterInitialKeepaliveUsesSSE(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	tests := []struct {

--- a/proxy/grok_native_passthrough_test.go
+++ b/proxy/grok_native_passthrough_test.go
@@ -239,13 +239,14 @@ func TestForwardGrokNativeFailureBeforeVisibleOutputReturnsProtocolHTTPError(t *
 func TestSendGrokNativeErrorAfterInitialKeepaliveUsesSSE(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	tests := []struct {
-		name     string
-		protocol GrokProtocol
-		path     string
+		name       string
+		protocol   GrokProtocol
+		path       string
+		wantMarker string
 	}{
-		{name: "responses", protocol: GrokProtocolResponses, path: "/v1/responses"},
-		{name: "chat", protocol: GrokProtocolChatCompletions, path: "/v1/chat/completions"},
-		{name: "messages", protocol: GrokProtocolMessages, path: "/v1/messages"},
+		{name: "responses", protocol: GrokProtocolResponses, path: "/v1/responses", wantMarker: `"type":"response.failed"`},
+		{name: "chat", protocol: GrokProtocolChatCompletions, path: "/v1/chat/completions", wantMarker: `"error":{"code":"upstream_stream_break"`},
+		{name: "messages", protocol: GrokProtocolMessages, path: "/v1/messages", wantMarker: "event: error\n"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -268,7 +269,10 @@ func TestSendGrokNativeErrorAfterInitialKeepaliveUsesSSE(t *testing.T) {
 			})
 
 			body := recorder.Body.String()
-			if recorder.Code != http.StatusOK || !strings.Contains(body, downstreamSSEKeepaliveComment) || !strings.Contains(body, "upstream busy") {
+			if recorder.Code != http.StatusOK ||
+				!strings.Contains(body, downstreamSSEKeepaliveComment) ||
+				!strings.Contains(body, tc.wantMarker) ||
+				!strings.Contains(body, "upstream busy") {
 				t.Fatalf("committed SSE error = status %d body %q", recorder.Code, body)
 			}
 		})

--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -6613,6 +6613,7 @@ func (h *Handler) ResponsesCompact(c *gin.Context) {
 	}
 }
 
+// ChatCompletions 处理 OpenAI Chat Completions 请求，并在流式响应中发送协议保活。
 func (h *Handler) ChatCompletions(c *gin.Context) {
 	// 1. 读取请求体
 	rawBody, err := readRawRequestBody(c)

--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -5323,7 +5323,7 @@ func (h *Handler) Responses(c *gin.Context) {
 			// 思考截断自动续想（默认关闭）：开启时用折叠状态机包裹 forward，
 			// 命中 518n-2 截断指纹则用同一账号续发上游并折叠成单响应；
 			// 关闭时保持原有逐事件透传路径，字节级零变化。请求级 keepalive
-			// 统一负责响应提交前的 102 和提交后的 SSE 注释。
+			// 统一负责首个模型事件前后的 SSE 注释。
 			if contEnabled {
 				requestKeepaliveOwnsWrites := continuousRetryKeepaliveActive(c.Request.Context()) && continuousRetryKeepaliveInterval > 0
 				fold := &continueFold{

--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -1028,7 +1028,7 @@ func forwardGrokNativeResponseObserved(c *gin.Context, resp *http.Response, prot
 	privateAttempt := output != nil && output != c.Writer
 	resp.Header.Del(grokNativeRouteHeader)
 	if !streaming {
-		body, err := readAllLimited(resp.Body, grokMaxDecodedBody)
+		body, err := readAllLimitedWithContinuousRetryKeepalive(c.Request.Context(), resp.Body, grokMaxDecodedBody)
 		if err != nil {
 			return nil, classifyStreamOutcome(nil, err, nil, false), false, 0
 		}
@@ -3942,9 +3942,7 @@ func (h *Handler) Responses(c *gin.Context) {
 	defer stopRetryDeadline()
 	stopRetryKeepalive := installContinuousRetrySSEKeepalive(c, isStream, "text/event-stream")
 	defer stopRetryKeepalive()
-	if continuousRetryBuffersAttempts(continuousRetryPolicy) {
-		activateContinuousRetryKeepalive(c.Request.Context())
-	}
+	activateContinuousRetryKeepalive(c.Request.Context())
 
 	// 3. 带重试的上游请求
 	maxRetries := h.getMaxRetries()
@@ -4245,7 +4243,7 @@ func (h *Handler) Responses(c *gin.Context) {
 					wsHTTPFallback.LogHTTPAttemptCompletion("/v1/responses", account.ID(), attempt+1, durationMs, 0, resp.StatusCode)
 				}
 				retryAfter := normalizedRetryAfter(resp.Header.Get("Retry-After"))
-				errBody, _ := io.ReadAll(resp.Body)
+				errBody, _ := readAllWithContinuousRetryKeepalive(c.Request.Context(), resp.Body)
 				rememberContinuousRetryHTTPFailure(c.Request.Context(), resp, errBody)
 				resp.Body.Close()
 				if continuousRetryCommitExpired(c, continuousRetryProtocolResponses) {
@@ -4636,7 +4634,7 @@ func (h *Handler) Responses(c *gin.Context) {
 				}
 			} else {
 				var respBody []byte
-				respBody, readErr = io.ReadAll(resp.Body)
+				respBody, readErr = readAllWithContinuousRetryKeepalive(c.Request.Context(), resp.Body)
 				if readErr == nil {
 					if isEmptyIncompleteResponseBody(respBody) {
 						respBody = synthesizeEmptyIncompleteFailureBody(respBody)
@@ -4995,7 +4993,7 @@ func (h *Handler) Responses(c *gin.Context) {
 				wsHTTPFallback.LogHTTPAttemptCompletion("/v1/responses", account.ID(), attempt+1, durationMs, 0, resp.StatusCode)
 			}
 			retryAfter := normalizedRetryAfter(resp.Header.Get("Retry-After"))
-			errBody, _ := io.ReadAll(resp.Body)
+			errBody, _ := readAllWithContinuousRetryKeepalive(c.Request.Context(), resp.Body)
 			rememberContinuousRetryHTTPFailure(c.Request.Context(), resp, errBody)
 			resp.Body.Close()
 			if continuousRetryCommitExpired(c, continuousRetryProtocolResponses) {
@@ -5324,40 +5322,10 @@ func (h *Handler) Responses(c *gin.Context) {
 
 			// 思考截断自动续想（默认关闭）：开启时用折叠状态机包裹 forward，
 			// 命中 518n-2 截断指纹则用同一账号续发上游并折叠成单响应；
-			// 关闭时保持原有逐事件透传路径，字节级零变化。
-			// 默认（未启用自动续想）路径也可能在 xhigh/max 的长推理阶段数十秒
-			// 没有可转发帧。定期写标准 SSE 注释，避免本机反代/Tailscale
-			// 把健康长流误判为空闲连接。自动续想路径已有自己的隐藏轮保活，
-			// 缓冲式持续重试下 streamWriter 写的是私有缓冲、真实心跳由 request
-			// 级 keepalive 负责，两种情况都不重复启动第二个 ticker。
-			stopDownstreamKeepalive := func() {}
-			if !contEnabled && !continuousRetryBuffersAttempts(continuousRetryPolicy) {
-				stopDownstreamKeepalive = startDownstreamSSEKeepalive(c.Request.Context(), downstreamSSEKeepaliveInterval, func() bool {
-					downstreamMu.Lock()
-					defer downstreamMu.Unlock()
-					if c.Request.Context().Err() != nil {
-						clientGone = true
-						return false
-					}
-					if clientGone {
-						return false
-					}
-					// 首个真实字节前不能写注释，否则会提前提交 HTTP 200，
-					// 破坏首包前 response.failed 的真实状态码与换号重试语义。
-					if !wroteAnyBody {
-						return true
-					}
-					if err := streamWriter.WriteSSEComment(downstreamSSEKeepaliveComment); err != nil {
-						writeErr = err
-						clientGone = true
-						return false
-					}
-					return true
-				})
-			}
+			// 关闭时保持原有逐事件透传路径，字节级零变化。请求级 keepalive
+			// 统一负责响应提交前的 102 和提交后的 SSE 注释。
 			if contEnabled {
-				requestKeepaliveOwnsWrites := continuousRetryBuffersAttempts(continuousRetryPolicy) &&
-					continuousRetryKeepaliveActive(c.Request.Context()) && continuousRetryKeepaliveInterval > 0
+				requestKeepaliveOwnsWrites := continuousRetryKeepaliveActive(c.Request.Context()) && continuousRetryKeepaliveInterval > 0
 				fold := &continueFold{
 					trace:     func() upstreamTraceSnapshot { return snapshotUpstreamTrace(c.Request.Context()) },
 					baseBody:  upstreamBody,
@@ -5380,9 +5348,8 @@ func (h *Handler) Responses(c *gin.Context) {
 					keepalive: func() bool {
 						downstreamMu.Lock()
 						defer downstreamMu.Unlock()
-						// Buffered retry modes use the request-level heartbeat, which
-						// writes to the real ResponseWriter. Keep the write on this fold
-						// tick so hidden-round reads and heartbeats remain serialized.
+						// 请求级心跳写入真实 ResponseWriter；保留在折叠 ticker
+						// 内执行，使隐藏轮读取与心跳写入串行。
 						if requestKeepaliveOwnsWrites {
 							if keepalive := continuousRetryKeepaliveForContext(c.Request.Context()); keepalive != nil {
 								if err := keepalive.Keepalive(); err != nil {
@@ -5454,7 +5421,6 @@ func (h *Handler) Responses(c *gin.Context) {
 			} else {
 				readErr = readSSEStreamWithContinuousRetryKeepalive(c.Request.Context(), resp.Body, forwardWithEvent)
 			}
-			stopDownstreamKeepalive()
 			// 仅在真的写过 body 时才做收尾 flush:flusher.Flush 会先提交 HTTP 200 header,
 			// 零写入时提前 flush 会让循环外的 c.JSON(4xx) 失效(status 已定型为 200)。
 			if writeErr == nil && wroteAnyBody {
@@ -5878,6 +5844,9 @@ func (h *Handler) ResponsesCompact(c *gin.Context) {
 	rememberContinuousRetryPolicyForRequest(c, continuousRetryPolicy)
 	stopRetryDeadline := installContinuousRetryHTTPDeadline(c, continuousRetryPolicy, continuousRetryProtocolResponses)
 	defer stopRetryDeadline()
+	stopRetryKeepalive := installContinuousRetryHTTPInformationalKeepalive(c)
+	defer stopRetryKeepalive()
+	activateContinuousRetryKeepalive(c.Request.Context())
 	sessionIdentity := resolveRequestSessionIdentity(c.Request.Header, rawBody)
 	apiKeyID := requestAPIKeyID(c)
 	affinityKey := sessionAffinityKey(sessionIdentity.affinityID, apiKeyID)
@@ -6042,7 +6011,9 @@ func (h *Handler) ResponsesCompact(c *gin.Context) {
 				attemptEffectiveModel = mappedModel
 				attemptLogEffectiveModel = usageEffectiveModelForMapping(logModel, attemptEffectiveModel, true)
 			}
-			resp, reqErr := ExecuteOpenAIResponsesCompactRequest(c.Request.Context(), account, upstreamBody, proxyURL, downstreamHeaders)
+			resp, reqErr := executeHTTPWithContinuousRetryKeepalive(c.Request.Context(), func() (*http.Response, error) {
+				return ExecuteOpenAIResponsesCompactRequest(c.Request.Context(), account, upstreamBody, proxyURL, downstreamHeaders)
+			})
 			durationMs := int(time.Since(start).Milliseconds())
 
 			if reqErr != nil {
@@ -6079,7 +6050,7 @@ func (h *Handler) ResponsesCompact(c *gin.Context) {
 			}
 
 			if resp.StatusCode != http.StatusOK {
-				errBody, _ := io.ReadAll(resp.Body)
+				errBody, _ := readAllWithContinuousRetryKeepalive(c.Request.Context(), resp.Body)
 				rememberContinuousRetryHTTPFailure(c.Request.Context(), resp, errBody)
 				resp.Body.Close()
 				if continuousRetryCommitExpired(c, continuousRetryProtocolResponses) {
@@ -6157,7 +6128,7 @@ func (h *Handler) ResponsesCompact(c *gin.Context) {
 				return
 			}
 
-			respBody, readErr := io.ReadAll(resp.Body)
+			respBody, readErr := readAllWithContinuousRetryKeepalive(c.Request.Context(), resp.Body)
 			resp.Body.Close()
 			if readErr != nil {
 				totalDuration := int(time.Since(start).Milliseconds())
@@ -6281,9 +6252,13 @@ func (h *Handler) ResponsesCompact(c *gin.Context) {
 		var reqErr error
 		if compactViaResponses {
 			upstreamEndpointLabel = "/v1/responses"
-			resp, reqErr = ExecuteRequest(c.Request.Context(), account, appendCompactionTriggerToResponsesBody(codexBody), upstreamSessionID, proxyURL, apiKey, deviceCfg, downstreamHeaders, false)
+			resp, reqErr = executeHTTPWithContinuousRetryKeepalive(c.Request.Context(), func() (*http.Response, error) {
+				return ExecuteRequest(c.Request.Context(), account, appendCompactionTriggerToResponsesBody(codexBody), upstreamSessionID, proxyURL, apiKey, deviceCfg, downstreamHeaders, false)
+			})
 		} else {
-			resp, reqErr = ExecuteCompactRequest(c.Request.Context(), account, codexBody, upstreamSessionID, proxyURL, apiKey, deviceCfg, downstreamHeaders)
+			resp, reqErr = executeHTTPWithContinuousRetryKeepalive(c.Request.Context(), func() (*http.Response, error) {
+				return ExecuteCompactRequest(c.Request.Context(), account, codexBody, upstreamSessionID, proxyURL, apiKey, deviceCfg, downstreamHeaders)
+			})
 		}
 		durationMs := int(time.Since(start).Milliseconds())
 
@@ -6321,7 +6296,7 @@ func (h *Handler) ResponsesCompact(c *gin.Context) {
 		}
 
 		if resp.StatusCode != http.StatusOK {
-			errBody, _ := io.ReadAll(resp.Body)
+			errBody, _ := readAllWithContinuousRetryKeepalive(c.Request.Context(), resp.Body)
 			rememberContinuousRetryHTTPFailure(c.Request.Context(), resp, errBody)
 			resp.Body.Close()
 			if continuousRetryCommitExpired(c, continuousRetryProtocolResponses) {
@@ -6405,9 +6380,9 @@ func (h *Handler) ResponsesCompact(c *gin.Context) {
 		var readErr error
 		var compactFailedPayload []byte
 		if compactViaResponses {
-			respBody, compactFailedPayload, readErr = collectCompactResponsesSSE(resp.Body)
+			respBody, compactFailedPayload, readErr = collectCompactResponsesSSEWithContinuousRetryKeepalive(c.Request.Context(), resp.Body)
 		} else {
-			respBody, readErr = io.ReadAll(resp.Body)
+			respBody, readErr = readAllWithContinuousRetryKeepalive(c.Request.Context(), resp.Body)
 		}
 		resp.Body.Close()
 		if readErr != nil {
@@ -6744,9 +6719,7 @@ func (h *Handler) ChatCompletions(c *gin.Context) {
 	defer stopRetryDeadline()
 	stopRetryKeepalive := installContinuousRetrySSEKeepalive(c, isStream, "text/event-stream")
 	defer stopRetryKeepalive()
-	if continuousRetryBuffersAttempts(continuousRetryPolicy) {
-		activateContinuousRetryKeepalive(c.Request.Context())
-	}
+	activateContinuousRetryKeepalive(c.Request.Context())
 
 	sessionIdentity := resolveRequestSessionIdentity(c.Request.Header, codexBody)
 	accountFilter = applyAffinityGroupRouting(c, sessionIdentity, accountFilter)
@@ -7010,7 +6983,7 @@ func (h *Handler) ChatCompletions(c *gin.Context) {
 			if wsHTTPFallback.ForceHTTP() && !useWebsocket {
 				wsHTTPFallback.LogHTTPAttemptCompletion("/v1/chat/completions", account.ID(), attempt+1, durationMs, 0, resp.StatusCode)
 			}
-			errBody, _ := io.ReadAll(resp.Body)
+			errBody, _ := readAllWithContinuousRetryKeepalive(c.Request.Context(), resp.Body)
 			rememberContinuousRetryHTTPFailure(c.Request.Context(), resp, errBody)
 			resp.Body.Close()
 			if continuousRetryCommitExpired(c, continuousRetryProtocolChat) {
@@ -7253,42 +7226,7 @@ func (h *Handler) ChatCompletions(c *gin.Context) {
 			// 但继续读上游直到 response.completed/failed，以拿到准确 usage。
 			clientGone := false
 			var pendingFirstTokenChunks bytes.Buffer
-			// downstreamMu 串行化翻译写路径与其共享状态(clientGone/writeErr/
-			// wroteAnyBody/streamWriter):下游保活 goroutine 与翻译回调并发写
-			// 同一个 ResponseWriter,必须互斥。
-			var downstreamMu sync.Mutex
-			// 与 /v1/responses 同一套下游保活:首个内容帧之后上游长推理期间定期
-			// 写 SSE 注释,避免反代/CDN 把健康长流当空闲连接掐断(issue #623)。
-			// 缓冲式持续重试下 streamWriter 写的是私有缓冲,真实下游心跳由
-			// request 级 keepalive 负责,不再起第二个。
-			stopDownstreamKeepalive := func() {}
-			if !continuousRetryBuffersAttempts(continuousRetryPolicy) {
-				stopDownstreamKeepalive = startDownstreamSSEKeepalive(c.Request.Context(), downstreamSSEKeepaliveInterval, func() bool {
-					downstreamMu.Lock()
-					defer downstreamMu.Unlock()
-					if c.Request.Context().Err() != nil {
-						clientGone = true
-						return false
-					}
-					if clientGone {
-						return false
-					}
-					// 首个真实字节前不能写注释,否则会提前提交 HTTP 200,
-					// 破坏首包前 response.failed 的真实状态码与换号重试语义。
-					if !wroteAnyBody {
-						return true
-					}
-					if err := streamWriter.WriteSSEComment(downstreamSSEKeepaliveComment); err != nil {
-						writeErr = err
-						clientGone = true
-						return false
-					}
-					return true
-				})
-			}
 			readErr = readSSEStreamWithContinuousRetryKeepalive(c.Request.Context(), resp.Body, func(sseEvent string, data []byte) bool {
-				downstreamMu.Lock()
-				defer downstreamMu.Unlock()
 				parsed := gjson.ParseBytes(data)
 				eventType := normalizedUpstreamSSEEventType(sseEvent, data)
 				if eventType == "response.failed" {
@@ -7434,8 +7372,6 @@ func (h *Handler) ChatCompletions(c *gin.Context) {
 				}
 				return true
 			})
-			// stop 会等保活 goroutine 完整退出,之后的收尾写入不再有并发方。
-			stopDownstreamKeepalive()
 			// 仅在真的写过 body 时才做收尾 flush:flusher.Flush 会先提交 HTTP 200 header,
 			// 零写入时提前 flush 会让循环外的 c.JSON(4xx) 失效(status 已定型为 200)。
 			if writeErr == nil && wroteAnyBody {

--- a/proxy/handler_anthropic.go
+++ b/proxy/handler_anthropic.go
@@ -9,7 +9,6 @@ import (
 	"log"
 	"net/http"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/codex2api/auth"
@@ -533,11 +532,9 @@ func (h *Handler) Messages(c *gin.Context) {
 	defer h.ReleaseAPIKeyScopeConcurrency(c)
 	stopRetryDeadline := installContinuousRetryHTTPDeadline(c, continuousRetryPolicy, continuousRetryProtocolAnthropic)
 	defer stopRetryDeadline()
-	stopRetryKeepalive := installContinuousRetrySSEKeepalive(c, isStream, "text/event-stream; charset=utf-8")
+	stopRetryKeepalive := installContinuousRetryMessagesKeepalive(c, isStream)
 	defer stopRetryKeepalive()
-	if continuousRetryBuffersAttempts(continuousRetryPolicy) {
-		activateContinuousRetryKeepalive(c.Request.Context())
-	}
+	h.activateAnthropicMessagesKeepalive(c.Request.Context(), nil, isStream)
 
 	reasoningEffort := extractReasoningEffort(routingBody)
 	serviceTier := extractServiceTier(routingBody)
@@ -691,9 +688,9 @@ func (h *Handler) Messages(c *gin.Context) {
 		ttftGuard := newFirstTokenTimeoutGuard(attemptFirstTokenTimeout, upstreamCancel)
 		var resp *http.Response
 		var reqErr error
+		h.activateAnthropicMessagesKeepalive(c.Request.Context(), account, isStream)
 		if account.IsClaudeOAuth() {
 			// 首字前保活：长推理期间让下游能区分"上游在思考"与"连接已死"。
-			activateClaudeStreamKeepalive(c.Request.Context(), h.store, account, isStream)
 			// Claude Code OAuth 账号本身说 Anthropic Messages API：不翻译成 Codex，
 			// 直接把原始入站 body 透传到 api.anthropic.com/v1/messages；返回的响应
 			// 已是原生 Anthropic SSE，打上原生路由标记复用既有透传链路。
@@ -908,7 +905,7 @@ func (h *Handler) Messages(c *gin.Context) {
 			if wsHTTPFallback.ForceHTTP() && !useWebsocket {
 				wsHTTPFallback.LogHTTPAttemptCompletion("/v1/messages", account.ID(), attempt+1, durationMs, 0, resp.StatusCode)
 			}
-			errBody, readErr := readAllLimited(resp.Body, upstreamErrorBodyReadMaxBytes)
+			errBody, readErr := readAllLimitedWithContinuousRetryKeepalive(c.Request.Context(), resp.Body, upstreamErrorBodyReadMaxBytes)
 			if readErr != nil {
 				errBody = []byte(`{"error":{"message":"Upstream error response exceeded the safe read limit","type":"api_error"}}`)
 			}
@@ -1245,45 +1242,14 @@ func (h *Handler) Messages(c *gin.Context) {
 			streamAttempt = h.newContinuousRetryStreamAttempt(continuousRetryBuffersAttempts(continuousRetryPolicy), c.Writer, flusher)
 			streamWriter := h.newAttemptStreamFlushWriter(c, streamAttempt, c.Writer, flusher)
 			var pendingFirstTokenEvents bytes.Buffer
-			// downstreamMu 串行化翻译写路径与其共享状态(writeErr/wroteAnyBody/
-			// streamWriter):下面的下游保活 goroutine 与翻译回调并发写同一个
-			// ResponseWriter,必须互斥,否则注释可能插进半个 SSE 事件里。
-			var downstreamMu sync.Mutex
-			// 首个内容帧之后上游长推理/等工具边界期间可能数十秒无可转发帧,与
-			// /v1/responses 一样定期写标准 SSE 注释,避免反代/CDN/隧道把健康长流
-			// 当空闲连接掐断(issue #623)。缓冲式持续重试下 streamWriter 写的是
-			// 私有缓冲,真实下游心跳由 request 级 keepalive 负责,不再起第二个。
-			stopDownstreamKeepalive := func() {}
-			if !continuousRetryBuffersAttempts(continuousRetryPolicy) {
-				stopDownstreamKeepalive = startDownstreamSSEKeepalive(c.Request.Context(), downstreamSSEKeepaliveInterval, func() bool {
-					downstreamMu.Lock()
-					defer downstreamMu.Unlock()
-					if writeErr != nil || c.Request.Context().Err() != nil {
-						return false
-					}
-					// 首个真实字节前不能写注释,否则会提前提交 HTTP 200,
-					// 破坏首包前 response.failed 的真实状态码与换号重试语义。
-					if !wroteAnyBody {
-						return true
-					}
-					if err := streamWriter.WriteSSEComment(downstreamSSEKeepaliveComment); err != nil {
-						// 下游已断:翻译回调只会在下一帧到达时才发现,上游静默期间
-						// 会一直阻塞在读上,这里主动取消上游读让本 attempt 尽快收尾。
-						writeErr = err
-						upstreamCancel()
-						return false
-					}
-					return true
-				})
-			}
+			// 请求级 Messages keepalive 在响应提交前发送 102，提交后发送
+			// Anthropic 原生 ping；翻译写入与保活不会再由独立 ticker 并发。
 			// contentStarted 用严格口径（isFirstTokenResult）跟踪"首个真实内容帧"，
 			// 专供流提交决策（缓冲/重试窗口/failed 抑制）使用；ttftRecorded 按
 			// first_token_mode 可能是 loose 口径，只用于首字统计。loose 模式会把
 			// output_item.added 等纯结构帧当"首字"，若拿它做流提交门，结构帧一到
 			// 就落盘 200，首包前静默重试窗口被过早关闭（issue #435）。
 			readErr = readSSEStreamWithContinuousRetryKeepalive(c.Request.Context(), resp.Body, func(sseEvent string, data []byte) bool {
-				downstreamMu.Lock()
-				defer downstreamMu.Unlock()
 				// 保活写失败已判定下游断开:不再翻译/写入,停止读取。
 				if writeErr != nil {
 					return false
@@ -1421,8 +1387,6 @@ func (h *Handler) Messages(c *gin.Context) {
 
 				return !isResponsesTerminalEvent(eventType)
 			})
-			// stop 会等保活 goroutine 完整退出,之后的收尾写入不再有并发方。
-			stopDownstreamKeepalive()
 			// 仅在真的写过 body 时才做收尾 flush：flusher.Flush 会先提交 HTTP 200 header，
 			// 零写入时提前 flush 会让循环外按真实错误码返回的 JSON 失效（status 已定型为 200）。
 			if writeErr == nil && wroteAnyBody {

--- a/proxy/handler_anthropic.go
+++ b/proxy/handler_anthropic.go
@@ -1242,7 +1242,7 @@ func (h *Handler) Messages(c *gin.Context) {
 			streamAttempt = h.newContinuousRetryStreamAttempt(continuousRetryBuffersAttempts(continuousRetryPolicy), c.Writer, flusher)
 			streamWriter := h.newAttemptStreamFlushWriter(c, streamAttempt, c.Writer, flusher)
 			var pendingFirstTokenEvents bytes.Buffer
-			// 请求级 Messages keepalive 在响应提交前发送 102，提交后发送
+			// 请求级 Messages keepalive 从首个模型事件前开始发送
 			// Anthropic 原生 ping；翻译写入与保活不会再由独立 ticker 并发。
 			// contentStarted 用严格口径（isFirstTokenResult）跟踪"首个真实内容帧"，
 			// 专供流提交决策（缓冲/重试窗口/failed 抑制）使用；ttftRecorded 按

--- a/proxy/handler_anthropic_stream_failure_test.go
+++ b/proxy/handler_anthropic_stream_failure_test.go
@@ -50,7 +50,7 @@ func newAnthropicStreamFailureTestHandler(t *testing.T, serve func(call int32, w
 func invokeAnthropicMessagesStream(t *testing.T, handler *Handler) *httptest.ResponseRecorder {
 	t.Helper()
 	recorder := httptest.NewRecorder()
-	ctx, _ := gin.CreateTestContext(recorder)
+	ctx, _ := gin.CreateTestContext(&informationalRecordingWriter{ResponseRecorder: recorder})
 	body := `{"model":"claude-opus-4-6","max_tokens":128,"stream":true,"messages":[{"role":"user","content":"hello"}]}`
 	ctx.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(body))
 	ctx.Request.Header.Set("Content-Type", "application/json")
@@ -190,14 +190,19 @@ func TestMessagesResponseFailedCyberPolicyEntersUnifiedAuditAndCandidateQueue(t 
 // 能在上游几十毫秒的静默里观察到心跳；测试结束恢复默认值。
 func shortenDownstreamSSEKeepalive(t *testing.T) {
 	t.Helper()
-	previousInterval := downstreamSSEKeepaliveInterval
-	t.Cleanup(func() { downstreamSSEKeepaliveInterval = previousInterval })
+	previousSSEInterval := downstreamSSEKeepaliveInterval
+	previousRetryInterval := continuousRetryKeepaliveInterval
+	t.Cleanup(func() {
+		downstreamSSEKeepaliveInterval = previousSSEInterval
+		continuousRetryKeepaliveInterval = previousRetryInterval
+	})
 	downstreamSSEKeepaliveInterval = 5 * time.Millisecond
+	continuousRetryKeepaliveInterval = 5 * time.Millisecond
 }
 
 // TestMessagesStreamKeepsDownstreamAliveDuringUpstreamSilence 验证 issue #623 修复：
 // 首个内容帧之后上游静默（长推理/等工具边界）期间，/v1/messages 翻译流要像
-// /v1/responses 一样定期写 SSE 注释刷新下游 idle timer，且注释不能插进事件中间。
+// Anthropic 原生协议一样定期写 ping 刷新下游 idle timer，且事件不能插入帧中间。
 func TestMessagesStreamKeepsDownstreamAliveDuringUpstreamSilence(t *testing.T) {
 	shortenDownstreamSSEKeepalive(t)
 	handler, calls := newAnthropicStreamFailureTestHandler(t, func(call int32, w http.ResponseWriter) {
@@ -220,10 +225,15 @@ func TestMessagesStreamKeepsDownstreamAliveDuringUpstreamSilence(t *testing.T) {
 		t.Fatalf("status = %d, want 200; body=%q", recorder.Code, body)
 	}
 	firstContent := strings.Index(body, "started")
-	keepalive := strings.Index(body, downstreamSSEKeepaliveComment)
 	resumed := strings.Index(body, "-resumed")
+	keepalive := -1
+	if firstContent >= 0 {
+		if offset := strings.Index(body[firstContent:], downstreamMessagesKeepaliveEvent); offset >= 0 {
+			keepalive = firstContent + offset
+		}
+	}
 	if firstContent < 0 || keepalive < 0 || resumed < 0 {
-		t.Fatalf("stream must carry first content, a keepalive comment and the resumed content; body=%q", body)
+		t.Fatalf("stream must carry first content, a ping and the resumed content; body=%q", body)
 	}
 	if keepalive < firstContent || keepalive > resumed {
 		t.Fatalf("keepalive must land inside the upstream silence window (after %d, before %d), got %d; body=%q", firstContent, resumed, keepalive, body)
@@ -231,10 +241,10 @@ func TestMessagesStreamKeepsDownstreamAliveDuringUpstreamSilence(t *testing.T) {
 	if !strings.Contains(body, "message_stop") {
 		t.Fatalf("stream should still end cleanly; body=%q", body)
 	}
-	// 注释必须独占一个 SSE 帧（以空行分隔），不能和 event/data 行混在同一帧里。
+	// ping 必须独占一个 SSE 帧（以空行分隔），不能和 event/data 行混在同一帧里。
 	for frame := range strings.SplitSeq(body, "\n\n") {
-		if strings.Contains(frame, ": keepalive") && strings.TrimSpace(frame) != ": keepalive" {
-			t.Fatalf("keepalive comment interleaved with an SSE frame: %q", frame)
+		if strings.Contains(frame, "event: ping") && strings.TrimSpace(frame) != strings.TrimSpace(downstreamMessagesKeepaliveEvent) {
+			t.Fatalf("ping interleaved with an SSE frame: %q", frame)
 		}
 	}
 	if got := calls.Load(); got != 1 {
@@ -245,13 +255,10 @@ func TestMessagesStreamKeepsDownstreamAliveDuringUpstreamSilence(t *testing.T) {
 // TestMessagesStreamPreContentBreakRetriesTransparently 验证 issue #435 修复：
 // 首个真实内容帧之前的结构帧（output_item.added 等）只缓冲不落盘，
 // 此窗口内上游断流仍可静默换号/重试，下游最终拿到一条完整干净的成功响应。
-// 第一轮静默时间刻意超过下游保活间隔（issue #623）：首字前绝不能写注释，
-// 否则 200 提前落盘，透明重试窗口被心跳自己关掉。
 func TestMessagesStreamPreContentBreakRetriesTransparently(t *testing.T) {
-	shortenDownstreamSSEKeepalive(t)
 	handler, calls := newAnthropicStreamFailureTestHandler(t, func(call int32, w http.ResponseWriter) {
 		if call == 1 {
-			// 第一轮：只发结构帧、静默超过心跳间隔后断流（正文永远没来）
+			// 第一轮：只发结构帧后断流（正文永远没来）。
 			writeCodexSSE(w,
 				`{"type":"response.created","response":{"id":"resp_retry_1"}}`,
 				`{"type":"response.output_item.added","item":{"type":"reasoning"}}`,
@@ -284,10 +291,6 @@ func TestMessagesStreamPreContentBreakRetriesTransparently(t *testing.T) {
 	}
 	if !strings.Contains(body, "message_stop") {
 		t.Fatalf("successful retry should end with message_stop; body=%q", body)
-	}
-	// 第一轮静默期间心跳 ticker 已多次触发，但首字前不得写出任何字节。
-	if keepalive := strings.Index(body, downstreamSSEKeepaliveComment); keepalive >= 0 && keepalive < strings.Index(body, "retried") {
-		t.Fatalf("keepalive comment must not be written before the first real content; body=%q", body)
 	}
 	if got := calls.Load(); got != 2 {
 		t.Fatalf("upstream calls = %d, want 2 (break + transparent retry)", got)

--- a/proxy/handler_anthropic_stream_failure_test.go
+++ b/proxy/handler_anthropic_stream_failure_test.go
@@ -47,6 +47,7 @@ func newAnthropicStreamFailureTestHandler(t *testing.T, serve func(call int32, w
 	return NewHandler(store, nil, &config.Config{AllowAnonymousV1: true}, nil), &calls
 }
 
+// invokeAnthropicMessagesStream 调用 Messages 流处理器并返回测试响应记录器。
 func invokeAnthropicMessagesStream(t *testing.T, handler *Handler) *httptest.ResponseRecorder {
 	t.Helper()
 	recorder := httptest.NewRecorder()

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -1628,11 +1628,13 @@ func TestResponsesHTTPIngressKeepsDownstreamAliveDuringUpstreamSilence(t *testin
 
 	previousExec := WebsocketExecuteFunc
 	previousSettings := CurrentRuntimeSettings()
-	previousInterval := downstreamSSEKeepaliveInterval
+	previousSSEInterval := downstreamSSEKeepaliveInterval
+	previousRetryInterval := continuousRetryKeepaliveInterval
 	t.Cleanup(func() {
 		WebsocketExecuteFunc = previousExec
 		ApplyRuntimeSettings(previousSettings)
-		downstreamSSEKeepaliveInterval = previousInterval
+		downstreamSSEKeepaliveInterval = previousSSEInterval
+		continuousRetryKeepaliveInterval = previousRetryInterval
 	})
 
 	nextSettings := previousSettings
@@ -1640,6 +1642,7 @@ func TestResponsesHTTPIngressKeepsDownstreamAliveDuringUpstreamSilence(t *testin
 	nextSettings.CodexContinueThinking = false
 	ApplyRuntimeSettings(nextSettings)
 	downstreamSSEKeepaliveInterval = 5 * time.Millisecond
+	continuousRetryKeepaliveInterval = 5 * time.Millisecond
 
 	WebsocketExecuteFunc = func(ctx context.Context, account *auth.Account, requestBody []byte, sessionID string, proxyOverride string, apiKey string, deviceCfg *DeviceProfileConfig, headers http.Header, poolRouteKey string) (*http.Response, error) {
 		pr, pw := io.Pipe()

--- a/proxy/handler_test.go
+++ b/proxy/handler_test.go
@@ -1623,6 +1623,8 @@ func TestResponsesHTTPIngressFallsBackToHTTPWhenForcedWebsocketMessageTooBig(t *
 	}
 }
 
+// TestResponsesHTTPIngressKeepsDownstreamAliveDuringUpstreamSilence 验证 HTTP SSE
+// 入站请求在上游静默期间仍向下游发送保活。
 func TestResponsesHTTPIngressKeepsDownstreamAliveDuringUpstreamSilence(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/proxy/images.go
+++ b/proxy/images.go
@@ -82,7 +82,6 @@ const (
 	MaxImageEditInputCount = 16
 
 	imageStreamConnectedComment = ": connected\n\n"
-	imageStreamKeepaliveComment = ": keepalive\n\n"
 
 	// imageCloudURLTTL 控制 response_format=url 时返回的预签名云直链有效期。
 	imageCloudURLTTL = time.Hour
@@ -90,8 +89,6 @@ const (
 	imageOAuthUnavailableCooldown = 30 * time.Minute
 	imageModelTextMaxBytes        = 600
 )
-
-var imageStreamKeepaliveInterval = 15 * time.Second
 
 // imagesMainModelFallbacks 是驱动主模型被上游按"不支持"拒绝时的候选序列,
 // 按 free/plus/pro 三档 manifest 的交集从便宜到贵排列。
@@ -1569,9 +1566,7 @@ func (h *Handler) forwardImagesRequest(c *gin.Context, inboundEndpoint, requestM
 	defer stopRetryDeadline()
 	stopRetryKeepalive := installContinuousRetrySSEKeepalive(c, stream, "text/event-stream")
 	defer stopRetryKeepalive()
-	if continuousRetryBuffersAttempts(continuousRetryPolicy) {
-		activateContinuousRetryKeepalive(c.Request.Context())
-	}
+	activateContinuousRetryKeepalive(c.Request.Context())
 	maxRetries := h.getMaxRetries()
 	maxRateLimitRetries := h.getMaxRateLimitRetries()
 	generalRetries := 0
@@ -1723,7 +1718,7 @@ func (h *Handler) forwardImagesRequest(c *gin.Context, inboundEndpoint, requestM
 		}
 
 		if resp.StatusCode != http.StatusOK {
-			errBody, _ := io.ReadAll(resp.Body)
+			errBody, _ := readAllWithContinuousRetryKeepalive(c.Request.Context(), resp.Body)
 			rememberContinuousRetryHTTPFailure(c.Request.Context(), resp, errBody)
 			resp.Body.Close()
 			if continuousRetryCommitExpired(c, continuousRetryProtocolResponses) {
@@ -2656,7 +2651,7 @@ func collectImagesResponse(ctx context.Context, body io.Reader, responseFormat, 
 		modelText      strings.Builder
 	)
 	requireTerminal := len(requireSuccessfulTerminal) > 0 && requireSuccessfulTerminal[0]
-	err := ReadSSEStreamWithEvent(body, func(event string, data []byte) bool {
+	err := readSSEStreamWithContinuousRetryKeepalive(ctx, body, func(event string, data []byte) bool {
 		collectImageModelText(&modelText, data)
 		if meta, eventCreatedAt, ok := extractImageMetaFromLifecycleEvent(data); ok {
 			mergeImageMeta(&firstMeta, meta)
@@ -2856,12 +2851,7 @@ func (h *Handler) streamImagesResponse(c *gin.Context, body io.Reader, responseF
 	if err := writeKeepalive(imageStreamConnectedComment); err != nil {
 		return nil, 0, 0, imageUsageLogInfo{}, false, getReadErr()
 	}
-	stopKeepalive := startImageStreamKeepalive(c.Request.Context(), imageStreamKeepaliveInterval, func() bool {
-		return writeKeepalive(imageStreamKeepaliveComment) == nil
-	})
-	defer stopKeepalive()
-
-	err := ReadSSEStreamWithEvent(body, func(event string, data []byte) bool {
+	err := readSSEStreamWithContinuousRetryKeepalive(c.Request.Context(), body, func(event string, data []byte) bool {
 		if getReadErr() != nil {
 			return false
 		}
@@ -2962,7 +2952,6 @@ func (h *Handler) streamImagesResponse(c *gin.Context, body io.Reader, responseF
 		}
 		return true
 	})
-	stopKeepalive()
 	writeMu.Lock()
 	if finalizeErr := streamWriter.Finalize(); finalizeErr != nil && readErr == nil {
 		if streamAttempt != nil {
@@ -3014,41 +3003,6 @@ func (h *Handler) streamImagesResponse(c *gin.Context, body io.Reader, responseF
 	}
 	writeMu.Unlock()
 	return usage, imageCount, firstTokenMs, imageLogInfo, wroteImageOutput, getReadErr()
-}
-
-func startImageStreamKeepalive(ctx context.Context, interval time.Duration, writeKeepalive func() bool) func() {
-	if interval <= 0 || writeKeepalive == nil {
-		return func() {}
-	}
-	if ctx == nil {
-		ctx = context.Background()
-	}
-	done := make(chan struct{})
-	exited := make(chan struct{})
-	var stopOnce sync.Once
-	go func() {
-		defer close(exited)
-		ticker := time.NewTicker(interval)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ticker.C:
-				if !writeKeepalive() {
-					return
-				}
-			case <-ctx.Done():
-				return
-			case <-done:
-				return
-			}
-		}
-	}()
-	return func() {
-		stopOnce.Do(func() {
-			close(done)
-		})
-		<-exited
-	}
 }
 
 func imageGenerationFailureError(payload []byte) error {

--- a/proxy/images.go
+++ b/proxy/images.go
@@ -2286,6 +2286,16 @@ func applyImageUpscalePlan(ctx context.Context, plan imageUpscalePlan, results [
 	return results
 }
 
+// applyImageUpscalePlanWithKeepalive 在图片超分期间保持下游连接有协议流量。
+func applyImageUpscalePlanWithKeepalive(ctx context.Context, plan imageUpscalePlan, results []imageCallResult) ([]imageCallResult, error) {
+	if !plan.enabled() {
+		return results, nil
+	}
+	return runWithContinuousRetryKeepalive(ctx, func() []imageCallResult {
+		return applyImageUpscalePlan(ctx, plan, results)
+	})
+}
+
 func imageFormatFromContentType(contentType string) string {
 	switch strings.ToLower(strings.TrimSpace(contentType)) {
 	case "image/jpeg", "image/jpg":
@@ -2691,7 +2701,12 @@ func collectImagesResponse(ctx context.Context, body io.Reader, responseFormat, 
 				readErr = classifyImageNoOutput(modelText.String())
 				return false
 			}
-			results = applyImageUpscalePlan(ctx, upscalePlan, results)
+			var upscaleErr error
+			results, upscaleErr = applyImageUpscalePlanWithKeepalive(ctx, upscalePlan, results)
+			if upscaleErr != nil {
+				readErr = upscaleErr
+				return false
+			}
 			out, readErr = buildImagesAPIResponse(ctx, results, createdAt, usageRaw, firstMeta, responseFormat, urlFor)
 			imageLogInfo = imageUsageLogInfoFromImages(results)
 			return false
@@ -2722,7 +2737,10 @@ func collectImagesResponse(ctx context.Context, body io.Reader, responseFormat, 
 			for i := range pendingResults {
 				mergeImageMeta(&pendingResults[i], firstMeta)
 			}
-			pendingResults = applyImageUpscalePlan(ctx, upscalePlan, pendingResults)
+			pendingResults, readErr = applyImageUpscalePlanWithKeepalive(ctx, upscalePlan, pendingResults)
+			if readErr != nil {
+				return nil, usage, 0, imageLogInfo, readErr
+			}
 			out, readErr = buildImagesAPIResponse(ctx, pendingResults, createdAt, nil, firstMeta, responseFormat, urlFor)
 			if readErr != nil {
 				return nil, usage, 0, imageLogInfo, readErr
@@ -2917,8 +2935,16 @@ func (h *Handler) streamImagesResponse(c *gin.Context, body io.Reader, responseF
 				setReadErr(err)
 				return false
 			}
-			// 超分期间 keepalive 注释帧仍在发送,下游连接不会因此空闲超时。
-			results = applyImageUpscalePlan(c.Request.Context(), upscalePlan, results)
+			// 超分期间由独立的请求级保活循环继续发送注释帧。
+			var upscaleErr error
+			results, upscaleErr = applyImageUpscalePlanWithKeepalive(c.Request.Context(), upscalePlan, results)
+			if upscaleErr != nil {
+				if wroteImageOutput {
+					_ = writeEvent("error", buildImagesStreamErrorPayload(upscaleErr.Error()))
+				}
+				setReadErr(upscaleErr)
+				return false
+			}
 			eventName := streamPrefix + ".completed"
 			for _, image := range results {
 				mergeImageMeta(&image, streamMeta)
@@ -2974,7 +3000,14 @@ func (h *Handler) streamImagesResponse(c *gin.Context, body io.Reader, responseF
 		_ = writeRaw("", true)
 	}
 	if imageCount == 0 && len(pendingResults) > 0 && getReadErr() == nil && streamAttempt == nil {
-		pendingResults = applyImageUpscalePlan(c.Request.Context(), upscalePlan, pendingResults)
+		var upscaleErr error
+		pendingResults, upscaleErr = applyImageUpscalePlanWithKeepalive(c.Request.Context(), upscalePlan, pendingResults)
+		if upscaleErr != nil {
+			setReadErr(upscaleErr)
+		}
+		if getReadErr() != nil {
+			return usage, imageCount, firstTokenMs, imageLogInfo, wroteImageOutput, getReadErr()
+		}
 		eventName := streamPrefix + ".completed"
 		for _, image := range pendingResults {
 			mergeImageMeta(&image, streamMeta)

--- a/proxy/images.go
+++ b/proxy/images.go
@@ -1547,6 +1547,7 @@ func (h *Handler) nextImageAccount(c *gin.Context, apiKeyID int64, exclude map[i
 	return h.nextAccountForSessionWithFilter("", apiKeyID, exclude, h.applyScopeBudgetFilter(c, fallbackFilter))
 }
 
+// forwardImagesRequest 执行 Images 请求的账号调度、上游重试、响应聚合和下游输出。
 func (h *Handler) forwardImagesRequest(c *gin.Context, inboundEndpoint, requestModel, logModel, logEffectiveModel string, responsesBody []byte, responseFormat, streamPrefix string, stream bool) {
 	if strings.TrimSpace(logModel) == "" {
 		logModel = requestModel
@@ -2638,6 +2639,7 @@ func imageErrorPrefersSameAccountRetry(err error) bool {
 	return outcome != nil && outcome.kind == imageNoOutputEmpty
 }
 
+// collectImagesResponse 聚合 Images 上游 SSE，并在读取期间维持请求级下游保活。
 func collectImagesResponse(ctx context.Context, body io.Reader, responseFormat, fallbackModel string, urlFor imageURLBuilder, upscalePlan imageUpscalePlan, requireSuccessfulTerminal ...bool) ([]byte, *UsageInfo, int, imageUsageLogInfo, error) {
 	var (
 		out            []byte
@@ -2733,6 +2735,7 @@ func collectImagesResponse(ctx context.Context, body io.Reader, responseFormat, 
 	return out, usage, len(gjson.GetBytes(out, "data").Array()), imageLogInfo, nil
 }
 
+// streamImagesResponse 将 Images 上游事件转发为下游 SSE，并插入协议保活帧。
 func (h *Handler) streamImagesResponse(c *gin.Context, body io.Reader, responseFormat, streamPrefix, fallbackModel string, start time.Time, upscalePlan imageUpscalePlan, attempts ...*continuousRetryStreamAttempt) (*UsageInfo, int, int, imageUsageLogInfo, bool, error) {
 	c.Header("Content-Type", "text/event-stream")
 	c.Header("Cache-Control", "no-cache")

--- a/proxy/images_test.go
+++ b/proxy/images_test.go
@@ -1011,6 +1011,7 @@ func TestForwardImagesExplicitToolMissingCoolsModel(t *testing.T) {
 	}
 }
 
+// TestForwardImagesEmptyTerminalRetriesSameAccountOnce 验证空终态会在同一账号上重试一次。
 func TestForwardImagesEmptyTerminalRetriesSameAccountOnce(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	previousRuntime := CurrentRuntimeSettings()
@@ -1065,6 +1066,8 @@ func TestForwardImagesEmptyTerminalRetriesSameAccountOnce(t *testing.T) {
 	}
 }
 
+// TestForwardImagesInitialKeepaliveCommitsSSEFailure 验证 Images 首个保活提交 SSE 后，
+// 本地失败会转换为协议错误事件。
 func TestForwardImagesInitialKeepaliveCommitsSSEFailure(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	previousRuntime := CurrentRuntimeSettings()

--- a/proxy/images_test.go
+++ b/proxy/images_test.go
@@ -1065,7 +1065,7 @@ func TestForwardImagesEmptyTerminalRetriesSameAccountOnce(t *testing.T) {
 	}
 }
 
-func TestForwardImagesCommittedKeepaliveEndsWithSSEFailure(t *testing.T) {
+func TestForwardImagesPrecommitKeepalivePreservesHTTPFailure(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	previousRuntime := CurrentRuntimeSettings()
 	previousResin := resinCfg.Load()
@@ -1100,17 +1100,18 @@ func TestForwardImagesCommittedKeepaliveEndsWithSSEFailure(t *testing.T) {
 	handler := NewHandler(store, nil, &config.Config{AllowAnonymousV1: true}, nil)
 
 	recorder := httptest.NewRecorder()
-	c, _ := gin.CreateTestContext(recorder)
+	writer := &informationalRecordingWriter{ResponseRecorder: recorder}
+	c, _ := gin.CreateTestContext(writer)
 	c.Request = httptest.NewRequest(http.MethodPost, "/v1/images/generations", nil)
 	responsesBody := []byte(`{"model":"gpt-5.4","input":"draw a test image","tools":[{"type":"image_generation","model":"gpt-image-2"}],"stream":true}`)
 	handler.forwardImagesRequest(c, "/v1/images/generations", "gpt-image-2", "gpt-image-2", "gpt-image-2", responsesBody, "b64_json", "image_generation", true)
 
 	body := recorder.Body.String()
-	if recorder.Code != http.StatusOK || !strings.HasPrefix(body, continuousRetryKeepaliveComment) {
-		t.Fatalf("heartbeat did not commit SSE response: status=%d body=%q", recorder.Code, body)
+	if len(writer.informational) == 0 || writer.informational[0] != http.StatusProcessing {
+		t.Fatalf("informational statuses = %v, want HTTP 102", writer.informational)
 	}
-	if !strings.Contains(body, `"type":"response.failed"`) || !strings.Contains(body, "stop now") {
-		t.Fatalf("committed stream missing terminal response.failed: %q", body)
+	if recorder.Code != http.StatusTeapot || !strings.Contains(body, "stop now") {
+		t.Fatalf("final HTTP error = status %d body %q", recorder.Code, body)
 	}
 }
 
@@ -1352,72 +1353,6 @@ func TestBuildImageErrorUsageLogRecordsFailure(t *testing.T) {
 	}
 	if logInput.ImageCount != 1 || logInput.ImageWidth != 1024 || logInput.ImageFormat != "png" {
 		t.Fatalf("image fields = %#v, want count=1 width=1024 format=png", logInput)
-	}
-}
-
-func TestStartImageStreamKeepaliveStopsWhenWriterFails(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	var mu sync.Mutex
-	writes := 0
-	wrote := make(chan struct{}, 1)
-	stop := startImageStreamKeepalive(ctx, time.Millisecond, func() bool {
-		mu.Lock()
-		writes++
-		mu.Unlock()
-		select {
-		case wrote <- struct{}{}:
-		default:
-		}
-		return false
-	})
-	defer stop()
-
-	select {
-	case <-wrote:
-	case <-time.After(100 * time.Millisecond):
-		t.Fatal("keepalive did not write")
-	}
-	time.Sleep(10 * time.Millisecond)
-	mu.Lock()
-	finalWrites := writes
-	mu.Unlock()
-	if finalWrites != 1 {
-		t.Fatalf("keepalive kept writing after writer failure: got %d writes, want 1", finalWrites)
-	}
-}
-
-func TestStartImageStreamKeepaliveStopWaitsForWriter(t *testing.T) {
-	entered := make(chan struct{})
-	release := make(chan struct{})
-	var enteredOnce sync.Once
-	stop := startImageStreamKeepalive(context.Background(), time.Millisecond, func() bool {
-		enteredOnce.Do(func() { close(entered) })
-		<-release
-		return false
-	})
-
-	select {
-	case <-entered:
-	case <-time.After(100 * time.Millisecond):
-		t.Fatal("keepalive writer did not start")
-	}
-	stopped := make(chan struct{})
-	go func() {
-		stop()
-		close(stopped)
-	}()
-	select {
-	case <-stopped:
-		t.Fatal("stop returned while keepalive writer was still running")
-	case <-time.After(10 * time.Millisecond):
-	}
-	close(release)
-	select {
-	case <-stopped:
-	case <-time.After(100 * time.Millisecond):
-		t.Fatal("stop did not join keepalive goroutine")
 	}
 }
 

--- a/proxy/images_test.go
+++ b/proxy/images_test.go
@@ -1065,7 +1065,7 @@ func TestForwardImagesEmptyTerminalRetriesSameAccountOnce(t *testing.T) {
 	}
 }
 
-func TestForwardImagesPrecommitKeepalivePreservesHTTPFailure(t *testing.T) {
+func TestForwardImagesInitialKeepaliveCommitsSSEFailure(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	previousRuntime := CurrentRuntimeSettings()
 	previousResin := resinCfg.Load()
@@ -1100,18 +1100,14 @@ func TestForwardImagesPrecommitKeepalivePreservesHTTPFailure(t *testing.T) {
 	handler := NewHandler(store, nil, &config.Config{AllowAnonymousV1: true}, nil)
 
 	recorder := httptest.NewRecorder()
-	writer := &informationalRecordingWriter{ResponseRecorder: recorder}
-	c, _ := gin.CreateTestContext(writer)
+	c, _ := gin.CreateTestContext(recorder)
 	c.Request = httptest.NewRequest(http.MethodPost, "/v1/images/generations", nil)
 	responsesBody := []byte(`{"model":"gpt-5.4","input":"draw a test image","tools":[{"type":"image_generation","model":"gpt-image-2"}],"stream":true}`)
 	handler.forwardImagesRequest(c, "/v1/images/generations", "gpt-image-2", "gpt-image-2", "gpt-image-2", responsesBody, "b64_json", "image_generation", true)
 
 	body := recorder.Body.String()
-	if len(writer.informational) == 0 || writer.informational[0] != http.StatusProcessing {
-		t.Fatalf("informational statuses = %v, want HTTP 102", writer.informational)
-	}
-	if recorder.Code != http.StatusTeapot || !strings.Contains(body, "stop now") {
-		t.Fatalf("final HTTP error = status %d body %q", recorder.Code, body)
+	if recorder.Code != http.StatusOK || !strings.Contains(body, downstreamSSEKeepaliveComment) || !strings.Contains(body, `"type":"response.failed"`) || !strings.Contains(body, "stop now") {
+		t.Fatalf("committed SSE error = status %d body %q", recorder.Code, body)
 	}
 }
 

--- a/proxy/live_sideband.go
+++ b/proxy/live_sideband.go
@@ -52,18 +52,24 @@ func (h *Handler) LiveSideband(c *gin.Context) {
 		go h.liveCalls().finalize(record)
 		return
 	}
-	defer func() { _ = downstream.Close() }()
+	proxyCtx, cancel := context.WithCancel(c.Request.Context())
+	var upstream *websocket.Conn
+	stopDownstreamKeepalive := startDownstreamWSKeepalive(proxyCtx, downstream, cancel)
+	defer func() {
+		cancel()
+		_ = downstream.Close()
+		if upstream != nil {
+			_ = upstream.Close()
+		}
+		stopDownstreamKeepalive()
+	}()
 
-	upstream, err := h.dialLiveSideband(c.Request.Context(), record)
+	upstream, err = h.dialLiveSideband(proxyCtx, record)
 	if err != nil {
 		_ = downstream.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseInternalServerErr, "live sideband unavailable"))
 		h.liveCalls().finalize(record)
 		return
 	}
-	defer func() { _ = upstream.Close() }()
-
-	proxyCtx, cancel := context.WithCancel(c.Request.Context())
-	defer cancel()
 	errCh := make(chan error, 2)
 	go func() { errCh <- copyLiveSideband(proxyCtx, upstream, downstream) }()
 	go func() { errCh <- copyLiveSideband(proxyCtx, downstream, upstream) }()
@@ -78,8 +84,10 @@ func copyLiveSideband(ctx context.Context, dst, src *websocket.Conn) error {
 	}
 	go func() {
 		<-ctx.Done()
-		_ = src.SetReadDeadline(time.Now())
-		_ = dst.SetWriteDeadline(time.Now())
+		// Gorilla 允许 Close 与读写并发，直接关闭可同时解除两端阻塞，
+		// 也避免与 SetReadDeadline/SetWriteDeadline 竞争。
+		_ = src.Close()
+		_ = dst.Close()
 	}()
 	for {
 		if err := ctx.Err(); err != nil {

--- a/proxy/live_sideband.go
+++ b/proxy/live_sideband.go
@@ -78,6 +78,7 @@ func (h *Handler) LiveSideband(c *gin.Context) {
 	h.liveCalls().finalize(record)
 }
 
+// copyLiveSideband 在两个 WebSocket 连接之间双向复制一条数据流。
 func copyLiveSideband(ctx context.Context, dst, src *websocket.Conn) error {
 	if dst == nil || src == nil {
 		return errLiveCallNotFound

--- a/proxy/realtime_ws.go
+++ b/proxy/realtime_ws.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -56,8 +57,15 @@ func (h *Handler) RealtimeWebSocket(c *gin.Context) {
 	if err != nil {
 		return
 	}
-	defer conn.Close()
 	conn.SetReadLimit(int64(security.MaxRequestBodySize))
+	requestCtx, cancel := context.WithCancel(c.Request.Context())
+	c.Request = c.Request.WithContext(requestCtx)
+	stopDownstreamKeepalive := startDownstreamWSKeepalive(requestCtx, conn, cancel)
+	defer func() {
+		cancel()
+		_ = conn.Close()
+		stopDownstreamKeepalive()
+	}()
 
 	state := realtimeTextSession{Model: strings.TrimSpace(c.Query("model"))}
 	if err := writeResponsesWSMessage(conn, marshalRealtimeServerEvent(map[string]any{

--- a/proxy/responses_ws.go
+++ b/proxy/responses_ws.go
@@ -239,9 +239,11 @@ func (h *Handler) ResponsesWebSocket(c *gin.Context) {
 	conn.SetReadLimit(int64(security.MaxRequestBodySize))
 	requestCtx, messages, readPumpDone, cancel := startResponsesWSReadPump(c.Request.Context(), conn)
 	c.Request = c.Request.WithContext(requestCtx)
+	stopDownstreamKeepalive := startDownstreamWSKeepalive(requestCtx, conn, cancel)
 	defer func() {
 		cancel()
 		_ = conn.Close()
+		stopDownstreamKeepalive()
 		<-readPumpDone
 	}()
 
@@ -510,11 +512,6 @@ func (h *Handler) forwardResponsesWebSocketTurn(c *gin.Context, conn *websocket.
 		}
 		stopRetryDeadline()
 	}()
-	stopRetryKeepalive := installContinuousRetryWSKeepalive(c, conn)
-	defer stopRetryKeepalive()
-	if continuousRetryBuffersAttempts(continuousRetryPolicy) {
-		activateContinuousRetryKeepalive(c.Request.Context())
-	}
 	// The continuous selector is independent from the legacy finite WebSocket
 	// silent-retry switch. Selected failures use its unlimited budget even when
 	// the legacy switch is disabled; unselected failures retain old semantics.


### PR DESCRIPTION
## 背景

当 Codex2API 位于 Cloudflare 或 Nginx 等反向代理之后时，上游长时间没有产生可转发字节会触发代理的空闲读超时，即使模型仍在正常推理、TCP 连接仍然建立。Cloudflare 的 Proxy Read Timeout 默认为 125 秒，超时后返回 524；Nginx `proxy_read_timeout` 默认为 60 秒，并且同样按两次读取之间的空闲时间计算。

在排查过程中还发现，部分被 OpenAI 标记为 Cyber 风险的账号会在 Responses 流中出现：

```json
{
  "type": "response.metadata",
  "response_id": "resp_xxxxxx",
  "sequence_number": 2,
  "metadata": {
    "type": "safety_buffering",
    "use_cases": [
      "cyber"
    ],
    "reasons": [
      "user_risk"
    ],
    "retry_model": "gpt-5.6-luna"
  }
}
```

对这类账号的实际请求进行排查后，观察到上游会等待整个 Turn 推理完成，然后才将结果一次性发送给 Codex2API。这会让 HTTP/SSE 和 WebSocket 在推理期间长时间没有任何下游流量，容易被 Cloudflare 或其他反代当作空闲连接关闭。

初版曾尝试在 SSE 最终响应提交前周期发送 `102 Processing`。实际使用 `/v1/responses`、Codex `supports_websockets = false` 经过 Cloudflare 测试时，后台仍稳定在 125.0 秒被取消。Cloudflare 官方文档说明：虽然 Cloudflare 会转发源站的 `102`，但收到 `102` 后仍要求在 125 秒内收到最终响应，否则连接会失败。因此 `102` 不能作为长期 SSE 心跳。

## 变更

- 对 `/v1/responses`、`/v1/chat/completions`、`/v1/messages`、`/v1/responses/compact`、`/v1/alpha/search`、`/v1/images/generations` 和 `/v1/images/edits` 覆盖等待响应头、读取响应体及读取 SSE 的全周期保活。
- 流式 HTTP 在首个保活周期到达时建立最终的 `200 text/event-stream` 响应，并立即 Flush 协议内心跳。Responses、Chat Completions 和 Images 使用 SSE 注释 `: keepalive`，Messages 使用 Anthropic 原生 `event: ping`。
- 心跳提交 SSE 200 后，后续上游错误通过对应流协议的错误事件返回，不能再修改 HTTP 状态码。
- 非流式 JSON 仍使用 `102 Processing` 作为有限的尽力保活，以保留最终 JSON 状态码和响应体；受 Cloudflare 在 `102` 后等待最终响应的 125 秒限制，它不能无限延长非流式请求。
- 修复配置 API Key 模型请求次数限制时的保活状态：额度准入前不提交 SSE，准入成功后立即激活心跳，覆盖随后可能长时间无响应头的上游请求。
- Responses、Realtime 和 Live Sideband WebSocket 在整个下游连接生命周期内发送空 Ping 控制帧；Ping 写入失败时取消并关闭连接。
- 新增 `DOWNSTREAM_HTTP_KEEPALIVE_INTERVAL`（默认 `30s`）和 `DOWNSTREAM_WS_KEEPALIVE_INTERVAL`（默认 `45s`）；使用 Go duration，`0` 可禁用。
- 图片完成事件进入超分处理后，流式和非流式 Images 路径都在阻塞超分期间继续运行独立的请求级保活循环，避免长时间图像处理造成下游空闲。
- 保活是固定周期，正常模型输出不会重置计时器。Claude OAuth 流式保活继续受 `stream_keepalive_enabled` 控制。视频、异步 image jobs 和 `POST /v1/live` 不在本次范围内。

## 参考文档

- Cloudflare 1xx informational responses（`102` 后仍需在 125 秒内收到最终响应）: https://developers.cloudflare.com/support/troubleshooting/http-status-codes/1xx-informational
- Cloudflare Error 524 / 125 秒 Proxy Read Timeout: https://developers.cloudflare.com/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/error-524/
- Cloudflare connection limits: https://developers.cloudflare.com/fundamentals/reference/connection-limits/
- Cloudflare WebSockets 空闲连接与 ping/pong 建议: https://developers.cloudflare.com/network/websockets/
- WHATWG Server-sent events authoring notes（使用以冒号开头的注释行维持代理连接）: https://html.spec.whatwg.org/multipage/server-sent-events.html#authoring-notes
- Nginx `proxy_read_timeout`: https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_read_timeout
- Nginx WebSocket proxying（默认 60 秒无数据关闭，可用 ping 帧重置）: https://nginx.org/en/docs/http/websocket.html

## 验证

```text
go test . ./config -count=1
go test ./proxy -count=1 -skip '^(TestUTLSTransport.*|TestReleaseEvictedClientClosesUTLSConnections)$'
go test -race ./proxy -run 'Test(ModelRequestQuotaActivatesSSEKeepaliveAfterAdmission|ContinuousRetrySSEKeepaliveCommitsHeartbeatBeforeFirstEvent|SendGrokNativeErrorAfterInitialKeepaliveUsesSSE|RunWithContinuousRetryKeepaliveDuringBlockingOperation|ForwardImagesInitialKeepaliveCommitsSSEFailure|ResponsesHTTPIngressKeepsDownstreamAliveDuringUpstreamSilence|MessagesStreamKeepsDownstreamAliveDuringUpstreamSilence)' -count=1
```

保活的协议单测、端点静默上游测试、额度准入回归测试、竞态测试，以及除既有 uTLS/Go 1.27 兼容性测试组之外的 `proxy` 全量测试已通过。

> [!NOTE]
> 初版基于 `102` 的 SSE 实现已经在实际 Cloudflare 链路复现 125.0 秒取消；本次修订后的 `200 SSE + comment/ping` 已通过实际 Cloudflare 链路手动验证，确认上游长时间无模型输出时下游连接仍能收到保活数据。CodeRabbit 提出的协议错误事件断言和图片超分阻塞阶段保活问题已在最新提交中修复。PR 当前已 Ready for review。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable keepalive intervals for downstream HTTP, SSE, and WebSocket connections.
  - HTTP and streaming endpoints now provide periodic heartbeat signals during slow or silent responses; WebSocket channels send ping messages.
  - Keepalive coverage includes Responses, Chat, Images, Messages, Realtime, and Live Sideband connections.
  - Non-streaming HTTP requests can receive periodic `102 Processing` signals while awaiting results.
  - Keepalives can be disabled by setting the interval to `0`.

- **Documentation**
  - Documented supported duration formats, defaults, configuration variables, and endpoint behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->